### PR TITLE
docs: say which sibling repos exist, and how to land a change

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,22 +166,33 @@ it is not a fork and it does not unlock features that are disabled here.
 
 Related repositories:
 
-| Repo | What |
-|---|---|
-| [`meshp`](https://github.com/meshpnet/meshp) | this one — agent, CLI, control plane, relay |
-| `meshp-ios` | iOS client |
-| `meshp-android` | Android client |
-| `meshp-testlab` | network-namespace conformance suite, including NAT types and failover |
-| `meshp-sdk` | generated API clients |
-| `meshp-web` | website and documentation |
+| Repo | What | Status |
+|---|---|---|
+| [`meshp`](https://github.com/meshpnet/meshp) | this one — agent, CLI, control plane, relay | public |
+| `meshp-ios` | iOS client | not started |
+| `meshp-android` | Android client | not started |
+| `meshp-testlab` | network-namespace conformance suite, including NAT types and failover | not started |
+| `meshp-sdk` | generated API clients | not started |
+| `meshp-web` | website and documentation | private, empty |
 
-Issues and discussions for **all** of these live in this repository.
+Issues and discussions for **all** of these live in this repository — the
+satellite repositories have their issue trackers disabled on purpose, so there is
+one place to look rather than twelve.
 
 ## Contributing
 
 Read [`docs/adr/`](docs/adr/) first — if you disagree with a decision there,
-that disagreement is more valuable to us than a patch. Contributions require a
-DCO sign-off (`git commit -s`).
+that disagreement is more valuable to us than a patch.
+
+```bash
+make ci        # everything the pull request will check, minus the Postgres jobs
+git commit -s  # sign-off is required and enforced
+```
+
+`main` is protected: changes arrive by pull request, the aggregate `ci` check has
+to pass, and force-pushes and deletions are refused. Branches must be current with
+`main` before merging, so expect to rebase rather than merge. Squash and rebase
+merges only — history stays linear.
 
 ## Security
 


### PR DESCRIPTION
## What this changes

The repository table listed six repositories as if all six existed; only `meshp`
does. It also predated `main` being protected, so nothing told a contributor that
changes arrive by pull request or that branches must be current before merging.

This is also the first pull request through the new protection, so it doubles as
a check that the path actually works: that `ci` runs and can be satisfied, and
that the two pull-request-only jobs — sign-off and append-only migrations —
finally execute instead of skipping.

## Invariants

- [x] No invariant is affected.

## Decisions

- [x] This follows the existing ADRs.

## Checks

- [x] `make ci` passes locally.
- [x] Commits are signed off (`git commit -s`).
- [x] Documentation only — no migration, no protocol change.