### PR TITLE
feat(agentapi): a local socket, and join behind the daemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ CROSS_TARGETS := linux/amd64 linux/arm64 linux/arm \
 # are held lower rather than pretended into the top tier. Packages needing PostgreSQL
 # are checked separately: without a database their tests skip, and the figure would be
 # meaningless rather than merely low.
-COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge
+COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx
 COVER_FLOOR      := 90
 
 COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx

--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,20 @@ CROSS_TARGETS := linux/amd64 linux/arm64 linux/arm \
                  windows/amd64 windows/arm64 \
                  freebsd/amd64 android/arm64
 
-# Packages carrying an invariant. These hold the logic that decides addressing
-# and where traffic goes, so their coverage is a gate rather than a statistic.
+# Three tiers, because the packages differ in what a coverage number is worth.
+#
+# Pure decision logic — addressing, health, selection, cryptography — has no I/O to
+# stub and no excuse for a gap, so it is held high. Packages that touch files, sockets
+# and processes have error paths that cost more to reach than they are worth, so they
+# are held lower rather than pretended into the top tier. Packages needing PostgreSQL
+# are checked separately: without a database their tests skip, and the figure would be
+# meaningless rather than merely low.
 COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge
 COVER_FLOOR      := 90
 
-# Packages whose tests need a real PostgreSQL. Their floor is checked separately,
-# because in a run without a database their tests skip and the coverage figure
-# would be meaningless rather than merely low.
+COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx
+COVER_FLOOR_IO      := 75
+
 COVER_FLOOR_DB_PKGS := internal/store internal/enroll internal/api internal/session
 COVER_FLOOR_DB      := 75
 
@@ -123,6 +129,20 @@ cover-check-db: ## Coverage floor for packages that need PostgreSQL
 	done; \
 	exit $$fail
 
+.PHONY: cover-check-io
+cover-check-io: ## Coverage floor for packages that do local I/O
+	@fail=0; \
+	for pkg in $(COVER_FLOOR_IO_PKGS); do \
+	  pct=$$(go test ./$$pkg/ -cover -count=1 2>/dev/null | sed -n 's/.*coverage: \([0-9.]*\)%.*/\1/p'); \
+	  if [ -z "$$pct" ]; then printf "  %-22s no coverage reported\n" "$$pkg"; fail=1; continue; fi; \
+	  if [ "$$(awk -v p=$$pct -v f=$(COVER_FLOOR_IO) 'BEGIN{print (p+0>=f+0)}')" = "1" ]; then \
+	    printf "  %-22s %6s%%  ok\n" "$$pkg" "$$pct"; \
+	  else \
+	    printf "  %-22s %6s%%  below the %s%% floor\n" "$$pkg" "$$pct" "$(COVER_FLOOR_IO)"; fail=1; \
+	  fi; \
+	done; \
+	exit $$fail
+
 .PHONY: fuzz-seeds
 fuzz-seeds: ## Run every fuzz target against its seed corpus (fast)
 	go test ./... -run '^Fuzz' -count=1
@@ -191,7 +211,7 @@ migrate-check: ## Apply, roll back and re-apply every migration against MESHP_TE
 ## --- aggregate ------------------------------------------------------------
 
 .PHONY: ci
-ci: lint standalone-check build cross test cover-check fuzz-seeds ## Everything CI runs, minus the jobs needing Postgres
+ci: lint standalone-check build cross test cover-check cover-check-io fuzz-seeds ## Everything CI runs, minus the jobs needing Postgres
 	@echo
 	@echo "  all local CI checks passed"
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ CROSS_TARGETS := linux/amd64 linux/arm64 linux/arm \
 # are held lower rather than pretended into the top tier. Packages needing PostgreSQL
 # are checked separately: without a database their tests skip, and the figure would be
 # meaningless rather than merely low.
-COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx
+COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl
 COVER_FLOOR      := 90
 
 COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx

--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ is refused — but nothing brings up a tunnel yet.
 
 What exists: the schema, the device protocol, the decision records, the logic that
 decides addressing and where traffic goes (IPAM, advertiser health, route-group
-selection), a control plane that applies its own schema and reports honest
-readiness, and enrolment end to end.
+selection), a control plane that applies its own schema and reports honest readiness,
+enrolment end to end, and a control channel — an agent holds a session, receives
+desired state and acknowledges the version it applied.
 
-What does not: WireGuard, the relay, the control channel, policy enforcement, DNS.
-`meshpd` still idles. `meshp status` reports a membership and says `(not up)`,
-because it is not.
+What does not: WireGuard, the relay, policy enforcement, DNS. An agent now knows about
+its peers and has no way to reach them. `meshp status` says `(not up)` because it is
+not.
 
 It is public from the first commit because the design decisions are the
 interesting part and we would rather be argued with early.
@@ -113,13 +114,17 @@ TOKEN=$(curl -fsS -X POST \
   "http://localhost:8080/api/v1/networks/$NETWORK/enrollment-tokens" \
   | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
 
-sudo ./bin/meshp join "$TOKEN" --state-dir /var/lib/meshp
-sudo ./bin/meshp status --state-dir /var/lib/meshp
+sudo ./bin/meshpd &                # holds the keys and the sessions
+sudo ./bin/meshp join "$TOKEN"
+sudo ./bin/meshp status
 ```
 
-`join` needs write access to the state directory because it writes the device's
-private keys there. That moves behind meshpd's local socket shortly — keys belong to
-the privileged daemon, not to whoever runs the CLI.
+`meshp` is a thin client: every command that touches a key or the network stack is a
+request to `meshpd` over a local unix socket, and the daemon is what generates and
+stores key material. Both commands need `sudo` because that socket is owner-only by
+default — anything able to reach it can enrol this device and, once tunnels exist,
+decide where its traffic goes. `meshpd --socket-group <group>` relaxes that to a
+group, which is a privilege grant and should be read as one.
 
 ```bash
 make help    # every available target

--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/meshpnet/meshp/internal/agentapi"
+	"github.com/meshpnet/meshp/internal/controlurl"
 	"github.com/meshpnet/meshp/internal/version"
 )
 
@@ -167,10 +168,17 @@ func cmdJoin(ctx context.Context, args []string) error {
 		return errors.New("usage: meshp join <token> [--control-url URL]")
 	}
 
+	// Checked here as well as in the daemon, so a mistyped URL is reported by the command
+	// that was mistyped rather than as a failure from a service.
+	validated, err := controlurl.Validate(*controlURL)
+	if err != nil {
+		return err
+	}
+
 	client := agentapi.NewClient(*socket, 2*time.Minute)
 	res, err := client.Join(ctx, agentapi.JoinRequest{
 		Token:      positional[0],
-		ControlURL: *controlURL,
+		ControlURL: validated,
 		Name:       *name,
 	})
 	if err != nil {

--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -4,10 +4,8 @@
 // meshpd over a local unix socket, so a user running `meshp status` never needs
 // root.
 //
-// `meshp join` is the exception, for now: it generates the device's keys and writes
-// them to the agent's state directory itself, because meshpd does not yet expose a
-// socket to ask. That makes it the one command needing write access to the state
-// directory, and it moves behind the daemon in A3 — private keys belong to the
+// Every command that touches a key or the network stack is a request to meshpd over its
+// local socket. Nothing here generates or stores key material: that belongs to the
 // privileged process, not to whoever happens to run the CLI.
 //
 // Command grammar is noun then verb, without exception:
@@ -29,14 +27,11 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"runtime"
 	"strings"
 	"syscall"
 	"time"
 
-	"github.com/meshpnet/meshp/internal/agentstate"
-	"github.com/meshpnet/meshp/internal/enrollclient"
-	"github.com/meshpnet/meshp/internal/keys"
+	"github.com/meshpnet/meshp/internal/agentapi"
 	"github.com/meshpnet/meshp/internal/version"
 )
 
@@ -152,12 +147,17 @@ func runOrDie(fn func(context.Context, []string) error, args []string) {
 	}
 }
 
-// cmdJoin enrols this device into a network.
+// cmdJoin asks the daemon to enrol this device.
+//
+// The CLI no longer generates keys or writes them: that happens in meshpd, which runs
+// as root and is where private key material belongs. An unprivileged command holding a
+// device's identity key was the shortcut this replaces.
 func cmdJoin(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("meshp join", flag.ContinueOnError)
 	controlURL := fs.String("control-url", envOr("MESHP_CONTROL_URL", "http://localhost:8080"),
 		"control plane to enrol against")
-	stateDir := fs.String("state-dir", defaultStateDir(), "where to keep this device's keys")
+	socket := fs.String("socket", envOr("MESHP_SOCKET", agentapi.DefaultSocketPath),
+		"meshpd's local socket")
 	name := fs.String("name", "", "name for this device (defaults to its hostname)")
 	positional, err := parseFlags(fs, args)
 	if err != nil {
@@ -166,131 +166,78 @@ func cmdJoin(ctx context.Context, args []string) error {
 	if len(positional) != 1 {
 		return errors.New("usage: meshp join <token> [--control-url URL]")
 	}
-	token := positional[0]
 
-	// An existing identity is reused, which is what lets one device hold memberships
-	// in several networks under one name (ADR-0004). A fresh one is generated only if
-	// this device has never enrolled anywhere.
-	state, err := agentstate.Load(*stateDir)
-	switch {
-	case errors.Is(err, agentstate.ErrNotEnrolled):
-		state = &agentstate.State{}
-		identity, err := keys.NewIdentity()
-		if err != nil {
-			return err
-		}
-		state.SetIdentity(identity)
-	case err != nil:
-		return err
-	}
-
-	identity, err := state.Identity()
-	if err != nil {
-		return err
-	}
-
-	// A fresh WireGuard keypair per membership, never shared between them, so two
-	// networks cannot recognise this device by its key (Invariant 19).
-	wg, err := keys.NewWireGuardPair()
-	if err != nil {
-		return err
-	}
-
-	hostname, _ := os.Hostname()
-	deviceName := *name
-	if deviceName == "" {
-		deviceName = hostname
-	}
-
-	joinCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-	defer cancel()
-
-	res, err := enrollclient.New(*controlURL, nil).Join(joinCtx, enrollclient.JoinRequest{
-		Token:        token,
-		Identity:     identity,
-		WireGuard:    wg,
-		Name:         deviceName,
-		Hostname:     hostname,
-		OS:           runtime.GOOS,
-		OSVersion:    osVersion(),
-		AgentVersion: version.Version(),
+	client := agentapi.NewClient(*socket, 2*time.Minute)
+	res, err := client.Join(ctx, agentapi.JoinRequest{
+		Token:      positional[0],
+		ControlURL: *controlURL,
+		Name:       *name,
 	})
 	if err != nil {
-		return err
-	}
-
-	membership := agentstate.Membership{
-		MembershipID:        res.MembershipID,
-		NetworkID:           res.NetworkID,
-		DeviceID:            res.DeviceID,
-		ControlURL:          *controlURL,
-		InterfaceName:       res.InterfaceName,
-		WireGuardPrivateKey: wg.Private.String(),
-		WireGuardPublicKey:  wg.Public.String(),
-		AppliedStateVersion: 0,
-		JoinedAt:            time.Now().UTC(),
-	}
-	if res.AddressV4 != nil {
-		membership.AddressV4 = res.AddressV4.String()
-	}
-	if res.AddressV6 != nil {
-		membership.AddressV6 = res.AddressV6.String()
-	}
-	state.AddMembership(membership)
-
-	if err := agentstate.Save(*stateDir, state); err != nil {
-		// The enrolment succeeded server-side but the keys could not be kept, which
-		// leaves a device registered that cannot prove who it is. Say so plainly
-		// rather than reporting success.
-		return fmt.Errorf("enrolled, but could not save this device's keys: %w\n"+
-			"  the device now exists in the network and must be revoked, then enrolled again\n"+
-			"  try a writable --state-dir, or run with sudo", err)
+		return describeDaemonError(err, *socket)
 	}
 
 	fmt.Printf("enrolled in network %s\n", res.NetworkID)
 	fmt.Printf("  device      %s\n", res.DeviceID)
 	fmt.Printf("  interface   %s\n", res.InterfaceName)
-	if res.AddressV4 != nil {
+	if res.AddressV4 != "" {
 		fmt.Printf("  address     %s\n", res.AddressV4)
 	}
-	if res.AddressV6 != nil {
+	if res.AddressV6 != "" {
 		fmt.Printf("              %s\n", res.AddressV6)
 	}
-	fmt.Printf("  keys        %s\n", agentstate.Path(*stateDir))
 	fmt.Println()
 	fmt.Println("No tunnel yet: meshpd does not bring up WireGuard in this build.")
 	fmt.Println("This device is registered and holds an address; nothing routes to it so far.")
 	return nil
 }
 
-// cmdStatus reports what this device knows locally.
-//
-// Local state only, deliberately. It has to work when the control plane is
-// unreachable (Invariant 15), which is exactly when somebody wants to run it.
-func cmdStatus(_ context.Context, args []string) error {
+// cmdStatus reports what the daemon is doing.
+func cmdStatus(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("meshp status", flag.ContinueOnError)
-	stateDir := fs.String("state-dir", defaultStateDir(), "where this device's keys are kept")
+	socket := fs.String("socket", envOr("MESHP_SOCKET", agentapi.DefaultSocketPath),
+		"meshpd's local socket")
 	if _, err := parseFlags(fs, args); err != nil {
 		return err
 	}
 
-	state, err := agentstate.Load(*stateDir)
-	if errors.Is(err, agentstate.ErrNotEnrolled) {
-		fmt.Println("not enrolled")
-		fmt.Printf("  run 'meshp join <token>' to join a network (state dir: %s)\n", *stateDir)
-		return nil
-	}
+	status, err := agentapi.NewClient(*socket, 15*time.Second).Status(ctx)
 	if err != nil {
-		return err
+		return describeDaemonError(err, *socket)
 	}
 
-	fmt.Printf("enrolled  %d network(s)\n", len(state.Memberships))
-	fmt.Printf("  identity  %s\n", truncate(state.IdentityPublicKey, 20))
-	for _, m := range state.Memberships {
+	if !status.Enrolled {
+		fmt.Println("not enrolled")
+		fmt.Println("  run 'meshp join <token>' to join a network")
+		return nil
+	}
+
+	fmt.Printf("enrolled  %d network(s)\n", len(status.Memberships))
+	fmt.Printf("  identity  %s\n", truncate(status.IdentityPublicKey, 20))
+	fmt.Printf("  daemon    %s, up since %s\n", status.Version, status.StartedAt.Format(time.RFC3339))
+
+	for _, m := range status.Memberships {
 		fmt.Println()
 		fmt.Printf("  network   %s\n", m.NetworkID)
 		fmt.Printf("    control     %s\n", m.ControlURL)
-		fmt.Printf("    interface   %s (not up)\n", m.InterfaceName)
+
+		// Two different things, reported separately on purpose. A control-channel session
+		// says configuration is arriving; it says nothing about whether traffic can flow.
+		if m.Connected {
+			fmt.Printf("    session     connected since %s\n", m.ConnectedSince.Format(time.RFC3339))
+		} else {
+			fmt.Printf("    session     not connected\n")
+		}
+		fmt.Printf("    applied     version %d\n", m.AppliedStateVersion)
+		if m.LastError != "" {
+			fmt.Printf("    last error  %s\n", m.LastError)
+		}
+
+		tunnel := "not up"
+		if m.TunnelUp {
+			tunnel = "up"
+		}
+		fmt.Printf("    interface   %s (%s)\n", m.InterfaceName, tunnel)
 		if m.AddressV4 != "" {
 			fmt.Printf("    address     %s\n", m.AddressV4)
 		}
@@ -303,6 +250,24 @@ func cmdStatus(_ context.Context, args []string) error {
 	return nil
 }
 
+// describeDaemonError turns a socket failure into an instruction.
+//
+// "connection refused" is not an answer anyone can act on. Whether meshpd is not
+// running, or is running and will not talk to this user, leads to entirely different
+// next steps, so they are named separately.
+func describeDaemonError(err error, socket string) error {
+	switch {
+	case errors.Is(err, agentapi.ErrNoDaemon):
+		return fmt.Errorf("meshpd is not running (socket %s)\n"+
+			"  start it with: sudo meshpd", socket)
+	case errors.Is(err, agentapi.ErrPermission):
+		return fmt.Errorf("not permitted to talk to meshpd on %s\n"+
+			"  run this with sudo, or start meshpd with --socket-group to allow a group", socket)
+	default:
+		return err
+	}
+}
+
 // truncate shortens a key for display. Public keys are not secret, but a terminal
 // full of base64 is unreadable.
 func truncate(s string, n int) string {
@@ -310,13 +275,6 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n] + "…"
-}
-
-func osVersion() string {
-	// Reading the real version means per-platform work that belongs in meshpd, which
-	// is where posture reporting will live. Reporting the architecture is honest and
-	// useful in the meantime.
-	return runtime.GOARCH
 }
 
 func contains(hay []string, needle string) bool {
@@ -333,21 +291,6 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
-}
-
-// defaultStateDir mirrors meshpd's, because they share the file.
-func defaultStateDir() string {
-	if v := os.Getenv("MESHP_STATE_DIR"); v != "" {
-		return v
-	}
-	switch runtime.GOOS {
-	case "windows":
-		return `C:\ProgramData\meshp`
-	case "darwin":
-		return "/Library/Application Support/meshp"
-	default:
-		return "/var/lib/meshp"
-	}
 }
 
 func fail(format string, args ...any) {

--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -1,0 +1,385 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/meshpnet/meshp/internal/agentapi"
+	"github.com/meshpnet/meshp/internal/agentstate"
+	"github.com/meshpnet/meshp/internal/enrollclient"
+	"github.com/meshpnet/meshp/internal/keys"
+	"github.com/meshpnet/meshp/internal/sessionclient"
+	"github.com/meshpnet/meshp/internal/version"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// agent owns this device's state and its control-channel sessions.
+//
+// It is the daemon's side of the privilege boundary: the keys, the enrolment and the
+// sessions all live here, and meshp reaches them only through the local socket.
+type agent struct {
+	log       *slog.Logger
+	stateDir  string
+	startedAt time.Time
+
+	// mu guards state and running together. Both change when a device joins, and a
+	// status read that saw one without the other would report a membership with no
+	// session or a session with no membership.
+	mu      sync.Mutex
+	state   *agentstate.State
+	running map[uuid.UUID]*sessionHandle
+
+	ctx context.Context
+}
+
+// sessionHandle is one supervised session.
+type sessionHandle struct {
+	cancel  context.CancelFunc
+	client  *sessionclient.Client
+	applier *recordingApplier
+	started time.Time
+}
+
+func newAgent(ctx context.Context, log *slog.Logger, stateDir string) *agent {
+	return &agent{
+		log:       log,
+		stateDir:  stateDir,
+		startedAt: time.Now().UTC(),
+		running:   make(map[uuid.UUID]*sessionHandle),
+		ctx:       ctx,
+	}
+}
+
+// load reads local state, tolerating its absence.
+//
+// Not being enrolled is a normal condition: the agent may be installed before anyone
+// has a token, and it must stay up so that `meshp join` has something to talk to. An
+// earlier version exited here, which meant joining required restarting a service.
+func (a *agent) load() error {
+	state, err := agentstate.Load(a.stateDir)
+	switch {
+	case err == nil:
+		a.mu.Lock()
+		a.state = state
+		a.mu.Unlock()
+		a.log.Info("local state loaded", "memberships", len(state.Memberships))
+		return nil
+	case isNotEnrolled(err):
+		a.log.Info("not enrolled yet; waiting for a join",
+			"state_dir", a.stateDir, "hint", "run 'meshp join <token>'")
+		return nil
+	default:
+		// A state file that exists but cannot be read is different from no state file at
+		// all, and must not be treated as "start fresh" — that would abandon the device's
+		// identity and leave a registered device nobody can revoke by name.
+		return err
+	}
+}
+
+// startAll supervises a session for every membership.
+func (a *agent) startAll() {
+	a.mu.Lock()
+	memberships := a.membershipsLocked()
+	a.mu.Unlock()
+
+	for _, m := range memberships {
+		a.ensureSession(m)
+	}
+}
+
+func (a *agent) membershipsLocked() []agentstate.Membership {
+	if a.state == nil {
+		return nil
+	}
+	out := make([]agentstate.Membership, len(a.state.Memberships))
+	copy(out, a.state.Memberships)
+	return out
+}
+
+// ensureSession starts a session for a membership if one is not already running.
+//
+// One session per membership, each independent: a device in several networks must not
+// lose one because another network's control plane is down (ADR-0004).
+func (a *agent) ensureSession(m agentstate.Membership) {
+	a.mu.Lock()
+	if _, exists := a.running[m.MembershipID]; exists {
+		a.mu.Unlock()
+		return
+	}
+	identity, err := a.state.Identity()
+	if err != nil {
+		a.mu.Unlock()
+		a.log.Error("cannot start a session without a usable identity", "error", err)
+		return
+	}
+
+	sessionCtx, cancel := context.WithCancel(a.ctx)
+	log := a.log.With("network_id", m.NetworkID)
+	applier := &recordingApplier{log: log, membershipID: m.MembershipID, agent: a}
+	client := sessionclient.New(sessionclient.Options{
+		ControlURL:     m.ControlURL,
+		Identity:       identity,
+		MembershipID:   m.MembershipID,
+		AppliedVersion: m.AppliedStateVersion,
+		AgentVersion:   version.Version(),
+		OS:             runtime.GOOS,
+		Hostname:       hostname(),
+		Log:            log,
+	})
+	a.running[m.MembershipID] = &sessionHandle{
+		cancel: cancel, client: client, applier: applier, started: time.Now().UTC(),
+	}
+	a.mu.Unlock()
+
+	go func() {
+		defer func() {
+			a.mu.Lock()
+			delete(a.running, m.MembershipID)
+			a.mu.Unlock()
+		}()
+		if err := client.Run(sessionCtx, applier); err != nil && sessionCtx.Err() == nil {
+			log.Error("session ended", "error", err)
+		}
+	}()
+}
+
+// setApplied records that a version was applied, and persists it.
+func (a *agent) setApplied(membershipID uuid.UUID, appliedVersion int64) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.state == nil {
+		return fmt.Errorf("meshpd: no local state to record version %d against", appliedVersion)
+	}
+	for i := range a.state.Memberships {
+		if a.state.Memberships[i].MembershipID != membershipID {
+			continue
+		}
+		if a.state.Memberships[i].AppliedStateVersion == appliedVersion {
+			return nil // nothing changed; no need to rewrite the file
+		}
+		a.state.Memberships[i].AppliedStateVersion = appliedVersion
+		return agentstate.Save(a.stateDir, a.state)
+	}
+	return fmt.Errorf("meshpd: no local membership %s", membershipID)
+}
+
+// Status implements agentapi.Handler.
+func (a *agent) Status(_ context.Context) (agentapi.Status, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	status := agentapi.Status{
+		Version:   version.Version(),
+		StartedAt: a.startedAt,
+		Enrolled:  a.state != nil,
+	}
+	if a.state == nil {
+		return status, nil
+	}
+	status.IdentityPublicKey = a.state.IdentityPublicKey
+
+	for _, m := range a.state.Memberships {
+		ms := agentapi.MembershipStatus{
+			MembershipID:        m.MembershipID,
+			NetworkID:           m.NetworkID,
+			DeviceID:            m.DeviceID,
+			ControlURL:          m.ControlURL,
+			InterfaceName:       m.InterfaceName,
+			AddressV4:           m.AddressV4,
+			AddressV6:           m.AddressV6,
+			WireGuardPublicKey:  m.WireGuardPublicKey,
+			AppliedStateVersion: m.AppliedStateVersion,
+			JoinedAt:            m.JoinedAt,
+			// Never true in this build, and saying so is the point: a membership with an
+			// address is not a working tunnel.
+			TunnelUp: false,
+		}
+		if handle, ok := a.running[m.MembershipID]; ok {
+			// Live, from the session rather than from disk. This is the reason to ask the
+			// daemon instead of reading the state file: the file cannot say whether the
+			// control plane is reachable right now.
+			ms.Connected = true
+			ms.ConnectedSince = handle.started
+			ms.AppliedStateVersion = handle.client.AppliedVersion()
+			ms.LastError = handle.applier.lastError()
+		}
+		status.Memberships = append(status.Memberships, ms)
+	}
+	return status, nil
+}
+
+// Join implements agentapi.Handler.
+//
+// This is the whole reason the socket exists. The keys are generated here, in the
+// privileged process, and the private halves never leave it — not to the CLI that asked,
+// and not to the control plane (Invariant 1).
+func (a *agent) Join(ctx context.Context, req agentapi.JoinRequest) (agentapi.JoinResponse, error) {
+	controlURL := req.ControlURL
+	if controlURL == "" {
+		return agentapi.JoinResponse{}, fmt.Errorf("meshpd: a control URL is required")
+	}
+
+	a.mu.Lock()
+	if a.state == nil {
+		a.state = &agentstate.State{}
+		identity, err := keys.NewIdentity()
+		if err != nil {
+			a.mu.Unlock()
+			return agentapi.JoinResponse{}, err
+		}
+		a.state.SetIdentity(identity)
+	}
+	identity, err := a.state.Identity()
+	a.mu.Unlock()
+	if err != nil {
+		return agentapi.JoinResponse{}, err
+	}
+
+	// A fresh WireGuard keypair per membership, never shared between them, so two
+	// networks cannot recognise this device by its key (Invariant 19).
+	wg, err := keys.NewWireGuardPair()
+	if err != nil {
+		return agentapi.JoinResponse{}, err
+	}
+
+	name := req.Name
+	if name == "" {
+		name = hostname()
+	}
+
+	res, err := enrollclient.New(controlURL, nil).Join(ctx, enrollclient.JoinRequest{
+		Token:        req.Token,
+		Identity:     identity,
+		WireGuard:    wg,
+		Name:         name,
+		Hostname:     hostname(),
+		OS:           runtime.GOOS,
+		AgentVersion: version.Version(),
+	})
+	if err != nil {
+		return agentapi.JoinResponse{}, err
+	}
+
+	membership := agentstate.Membership{
+		MembershipID:        res.MembershipID,
+		NetworkID:           res.NetworkID,
+		DeviceID:            res.DeviceID,
+		ControlURL:          controlURL,
+		InterfaceName:       res.InterfaceName,
+		WireGuardPrivateKey: wg.Private.String(),
+		WireGuardPublicKey:  wg.Public.String(),
+		JoinedAt:            time.Now().UTC(),
+	}
+	if res.AddressV4 != nil {
+		membership.AddressV4 = res.AddressV4.String()
+	}
+	if res.AddressV6 != nil {
+		membership.AddressV6 = res.AddressV6.String()
+	}
+
+	a.mu.Lock()
+	a.state.AddMembership(membership)
+	saveErr := agentstate.Save(a.stateDir, a.state)
+	a.mu.Unlock()
+
+	if saveErr != nil {
+		// The device exists in the network but cannot prove who it is. Reporting success
+		// here would leave an operator with a registered device and no way to use it and
+		// no idea why.
+		return agentapi.JoinResponse{}, fmt.Errorf(
+			"enrolled, but the keys could not be saved to %s: %w (revoke the device and try again)",
+			a.stateDir, saveErr)
+	}
+
+	a.log.Info("joined a network",
+		"network_id", res.NetworkID, "membership_id", res.MembershipID,
+		"interface", res.InterfaceName, "address_v4", membership.AddressV4)
+
+	// Start serving it immediately. Requiring a restart to pick up a join is the kind
+	// of paper cut that makes people script around the daemon.
+	a.ensureSession(membership)
+
+	return agentapi.JoinResponse{
+		MembershipID:  res.MembershipID,
+		NetworkID:     res.NetworkID,
+		DeviceID:      res.DeviceID,
+		InterfaceName: res.InterfaceName,
+		AddressV4:     membership.AddressV4,
+		AddressV6:     membership.AddressV6,
+	}, nil
+}
+
+// recordingApplier is the Applier this build ships: it writes down what it was told and
+// reports success.
+//
+// Deliberately not pretending to configure anything. When WireGuard arrives this becomes
+// the reconciler and its acknowledgement will mean the system reached that state. Until
+// then the log says so, so nobody mistakes a converged control plane for a working
+// network.
+type recordingApplier struct {
+	log          *slog.Logger
+	membershipID uuid.UUID
+	agent        *agent
+
+	mu   sync.Mutex
+	last string
+}
+
+func (a *recordingApplier) Apply(_ context.Context, delta *meshpv1.StateDelta) ([]string, error) {
+	for _, p := range delta.GetUpsertPeers() {
+		a.log.Debug("peer in desired state",
+			"device", p.GetDeviceName(),
+			"allowed_ips", p.GetAllowedIps(),
+			"public_key", truncateKey(p.GetPublicKey()))
+	}
+
+	if err := a.agent.setApplied(a.membershipID, int64(delta.GetToVersion())); err != nil {
+		a.setLastError(err.Error())
+		// Persisting matters: a version acknowledged but not written would be requested
+		// again on every restart, and a future reconciler would believe the host already
+		// matched a state it had never applied.
+		return []string{"local-state"}, err
+	}
+	a.setLastError("")
+
+	a.log.Info("recorded desired state",
+		"version", delta.GetToVersion(),
+		"peers", len(delta.GetUpsertPeers()),
+		"note", "nothing is configured: this build has no WireGuard")
+	return nil, nil
+}
+
+func (a *recordingApplier) setLastError(msg string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.last = msg
+}
+
+func (a *recordingApplier) lastError() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.last
+}
+
+func truncateKey(k string) string {
+	if len(k) <= 12 {
+		return k
+	}
+	return k[:12] + "…"
+}
+
+func hostname() string {
+	h, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	return h
+}

--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/meshpnet/meshp/internal/agentapi"
 	"github.com/meshpnet/meshp/internal/agentstate"
+	"github.com/meshpnet/meshp/internal/controlurl"
 	"github.com/meshpnet/meshp/internal/enrollclient"
 	"github.com/meshpnet/meshp/internal/keys"
 	"github.com/meshpnet/meshp/internal/sessionclient"
@@ -222,9 +223,11 @@ func (a *agent) Status(_ context.Context) (agentapi.Status, error) {
 // privileged process, and the private halves never leave it — not to the CLI that asked,
 // and not to the control plane (Invariant 1).
 func (a *agent) Join(ctx context.Context, req agentapi.JoinRequest) (agentapi.JoinResponse, error) {
-	controlURL := req.ControlURL
-	if controlURL == "" {
-		return agentapi.JoinResponse{}, fmt.Errorf("meshpd: a control URL is required")
+	// Validated here because this is where it enters the system, and because a join sends
+	// an enrolment token to whatever address it is given.
+	controlURL, err := controlurl.Validate(req.ControlURL)
+	if err != nil {
+		return agentapi.JoinResponse{}, err
 	}
 
 	a.mu.Lock()

--- a/cmd/meshpd/main.go
+++ b/cmd/meshpd/main.go
@@ -5,10 +5,15 @@
 // membership, reconciles the local system toward the desired state the server sends,
 // and answers meshp over a local unix socket.
 //
+// The socket is a privilege boundary, not a convenience. meshpd runs as root and holds
+// the device's keys; meshp is a command an ordinary user types. Enrolment, key
+// generation and eventually every change to the network stack happen on this side of
+// the line, and the CLI asks rather than acts.
+//
 // Two properties matter more than features here:
 //
-//   - It keeps working when the control plane is unreachable. Existing peers, routes,
-//     DNS and route-group candidates are all persisted locally (Invariant 15).
+//   - It keeps working when the control plane is unreachable. Peers, routes, DNS and
+//     route-group candidates are all persisted locally (Invariant 15).
 //   - Everything it installs, it can remove. An agent crash or uninstall must never
 //     leave a host without networking (Invariant 20).
 //
@@ -19,28 +24,29 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"os/signal"
-	"sync"
+	"runtime"
 	"syscall"
 
-	"github.com/google/uuid"
-
+	"github.com/meshpnet/meshp/internal/agentapi"
 	"github.com/meshpnet/meshp/internal/agentstate"
-	"github.com/meshpnet/meshp/internal/sessionclient"
 	"github.com/meshpnet/meshp/internal/version"
-	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
 )
 
 func main() {
 	var (
 		showVersion = flag.Bool("version", false, "print build information and exit")
-		statePath   = flag.String("state-dir", defaultStateDir(), "where to persist local state")
+		stateDir    = flag.String("state-dir", defaultStateDir(), "where to persist local state")
 		socketPath  = flag.String("socket", defaultSocketPath(), "unix socket meshp connects to")
-		logLevel    = flag.String("log-level", "info", "debug, info, warn or error")
+		socketGroup = flag.String("socket-group", os.Getenv("MESHP_SOCKET_GROUP"),
+			"system group allowed to use the socket; empty means owner only")
+		logLevel = flag.String("log-level", envOr("MESHP_LOG_LEVEL", "info"), "debug, info, warn or error")
 	)
 	flag.Parse()
 
@@ -52,156 +58,46 @@ func main() {
 	log := newLogger(*logLevel)
 	log.Info("meshpd starting",
 		"version", version.Version(),
-		"state_dir", *statePath,
+		"state_dir", *stateDir,
 		"socket", *socketPath)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	if err := run(ctx, log, *statePath); err != nil {
+	if err := run(ctx, log, *stateDir, *socketPath, *socketGroup); err != nil {
 		log.Error("meshpd exited with error", "error", err)
 		os.Exit(1)
 	}
 	log.Info("meshpd stopped cleanly")
 }
 
-func run(ctx context.Context, log *slog.Logger, stateDir string) error {
-	state, err := agentstate.Load(stateDir)
-	if err != nil {
-		// Not enrolled is a normal state, not a failure: the agent may be installed
-		// before anyone has a token. It waits rather than exiting, so `meshp join` can
-		// happen without restarting a service.
-		log.Warn("not enrolled; nothing to do",
-			"state_dir", stateDir, "hint", "run 'meshp join <token>'", "error", err)
-		<-ctx.Done()
-		return nil
-	}
-
-	identity, err := state.Identity()
-	if err != nil {
+func run(ctx context.Context, log *slog.Logger, stateDir, socketPath, socketGroup string) error {
+	agent := newAgent(ctx, log, stateDir)
+	if err := agent.load(); err != nil {
 		return err
 	}
-	if len(state.Memberships) == 0 {
-		log.Warn("enrolled but no memberships; nothing to do")
-		<-ctx.Done()
-		return nil
+
+	// The socket comes up before the sessions do, so that a device with no state at all
+	// can still be joined. Binding is also the only thing here that can fail in a way
+	// worth exiting for: two daemons sharing a state directory would fight over the same
+	// keys.
+	server := agentapi.NewServer(agent, agentapi.ServerConfig{
+		SocketPath: socketPath,
+		Group:      socketGroup,
+		Log:        log,
+	})
+	if err := server.Listen(); err != nil {
+		return err
 	}
 
-	store := &stateStore{dir: stateDir, state: state}
-	hostname, _ := os.Hostname()
+	agent.startAll()
 
-	// One session per membership, each independent. A device in several networks must
-	// not lose one because another's control plane is down (ADR-0004).
-	var wg sync.WaitGroup
-	for _, m := range state.Memberships {
-		membership := m
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			client := sessionclient.New(sessionclient.Options{
-				ControlURL:     membership.ControlURL,
-				Identity:       identity,
-				MembershipID:   membership.MembershipID,
-				AppliedVersion: membership.AppliedStateVersion,
-				AgentVersion:   version.Version(),
-				OS:             osName(),
-				Hostname:       hostname,
-				Log:            log.With("network_id", membership.NetworkID),
-			})
-
-			applier := &recordingApplier{
-				log:          log.With("network_id", membership.NetworkID),
-				membershipID: membership.MembershipID,
-				store:        store,
-			}
-
-			if err := client.Run(ctx, applier); err != nil && ctx.Err() == nil {
-				log.Error("session ended", "network_id", membership.NetworkID, "error", err)
-			}
-		}()
-	}
-
-	<-ctx.Done()
-	log.Info("shutting down sessions")
-	wg.Wait()
-	return nil
+	return server.Serve(ctx)
 }
 
-// recordingApplier is the Applier this build ships: it writes down what it was told
-// and reports success.
-//
-// It is deliberately not pretending to configure anything. When WireGuard arrives this
-// becomes the reconciler, and the acknowledgement it produces will then mean the
-// system actually reached that state. Until then the log says so, so nobody mistakes a
-// converged control plane for a working network.
-type recordingApplier struct {
-	log          *slog.Logger
-	membershipID uuid.UUID
-	store        *stateStore
-}
-
-func (a *recordingApplier) Apply(_ context.Context, delta *meshpv1.StateDelta) ([]string, error) {
-	for _, p := range delta.GetUpsertPeers() {
-		a.log.Debug("peer in desired state",
-			"device", p.GetDeviceName(),
-			"allowed_ips", p.GetAllowedIps(),
-			"public_key", truncateKey(p.GetPublicKey()))
-	}
-	if tunnel := delta.GetTunnel(); tunnel != nil {
-		a.log.Debug("tunnel in desired state", "mtu", tunnel.GetMtu(), "fail_closed", tunnel.GetFailClosed())
-	}
-
-	if err := a.store.setApplied(a.membershipID, int64(delta.GetToVersion())); err != nil {
-		// Persisting matters: a version acknowledged but not written would be requested
-		// again on every restart, and worse, a future reconciler would believe the host
-		// already matched a state it had never applied.
-		return []string{"local-state"}, err
-	}
-
-	a.log.Info("recorded desired state",
-		"version", delta.GetToVersion(),
-		"peers", len(delta.GetUpsertPeers()),
-		"note", "nothing is configured: this build has no WireGuard")
-
-	// Everything asked of this build was done, so nothing is reported unapplied. The
-	// components that do not exist yet are absent from the delta rather than refused.
-	return nil, nil
-}
-
-// stateStore serialises writes to the on-disk state.
-//
-// Sessions run concurrently, one per membership, and they all persist into the same
-// file. Without the lock, two saves would interleave and one membership's progress
-// would silently overwrite another's.
-type stateStore struct {
-	mu    sync.Mutex
-	dir   string
-	state *agentstate.State
-}
-
-func (s *stateStore) setApplied(membershipID uuid.UUID, version int64) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	for i := range s.state.Memberships {
-		if s.state.Memberships[i].MembershipID != membershipID {
-			continue
-		}
-		if s.state.Memberships[i].AppliedStateVersion == version {
-			return nil // nothing changed; no need to rewrite the file
-		}
-		s.state.Memberships[i].AppliedStateVersion = version
-		return agentstate.Save(s.dir, s.state)
-	}
-	return fmt.Errorf("meshpd: no local membership %s", membershipID)
-}
-
-func truncateKey(k string) string {
-	if len(k) <= 12 {
-		return k
-	}
-	return k[:12] + "…"
+// isNotEnrolled reports whether an error means there is simply no local state.
+func isNotEnrolled(err error) bool {
+	return errors.Is(err, agentstate.ErrNotEnrolled) || errors.Is(err, fs.ErrNotExist)
 }
 
 func newLogger(level string) *slog.Logger {
@@ -212,11 +108,18 @@ func newLogger(level string) *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: l}))
 }
 
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
 func defaultStateDir() string {
 	if v := os.Getenv("MESHP_STATE_DIR"); v != "" {
 		return v
 	}
-	switch osName() {
+	switch runtime.GOOS {
 	case "windows":
 		return `C:\ProgramData\meshp`
 	case "darwin":
@@ -230,8 +133,10 @@ func defaultSocketPath() string {
 	if v := os.Getenv("MESHP_SOCKET"); v != "" {
 		return v
 	}
-	if osName() == "windows" {
-		return `\\.\pipe\meshpd`
+	// AF_UNIX works on Windows 10 1803 and later, so the same mechanism serves every
+	// platform; only the conventional location differs.
+	if runtime.GOOS == "windows" {
+		return `C:\ProgramData\meshp\meshpd.sock`
 	}
-	return "/var/run/meshpd.sock"
+	return agentapi.DefaultSocketPath
 }

--- a/cmd/meshpd/platform.go
+++ b/cmd/meshpd/platform.go
@@ -1,7 +1,0 @@
-package main
-
-import "runtime"
-
-// osName is separated so tests can exercise the per-platform default paths
-// without building for each GOOS.
-func osName() string { return runtime.GOOS }

--- a/internal/agentapi/agentapi.go
+++ b/internal/agentapi/agentapi.go
@@ -1,0 +1,104 @@
+// Package agentapi is the local interface between meshp and meshpd.
+//
+// It exists because of a privilege boundary. meshpd runs as root and owns the
+// device's private keys; meshp is a command an ordinary user types. Everything that
+// touches a key or the network stack has to happen on the daemon's side of that
+// line, so the CLI asks rather than acts.
+//
+// Until this existed, `meshp join` generated the keys and wrote them itself, which
+// made an unprivileged command responsible for material that belongs to a privileged
+// process. That is the loose end this closes.
+//
+// The transport is HTTP over a unix socket. Not because HTTP is elegant here, but
+// because it is inspectable: when something is wrong at three in the morning,
+// `curl --unix-socket /var/run/meshpd.sock http://local/v1/status` works and a custom
+// framing does not.
+package agentapi
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DefaultSocketPath is where the daemon listens.
+const DefaultSocketPath = "/var/run/meshpd.sock"
+
+// Status is what the daemon reports about itself.
+type Status struct {
+	Version   string    `json:"version"`
+	StartedAt time.Time `json:"started_at"`
+
+	// Enrolled is false when there is no local state at all, which is a normal
+	// condition rather than an error: the agent may be installed before anyone has a
+	// token.
+	Enrolled bool `json:"enrolled"`
+
+	// IdentityPublicKey is the device's stable name, shared by every membership
+	// (ADR-0006). Public, so safe to report.
+	IdentityPublicKey string `json:"identity_public_key,omitempty"`
+
+	Memberships []MembershipStatus `json:"memberships"`
+}
+
+// MembershipStatus is one network this device belongs to.
+type MembershipStatus struct {
+	MembershipID uuid.UUID `json:"membership_id"`
+	NetworkID    uuid.UUID `json:"network_id"`
+	DeviceID     uuid.UUID `json:"device_id"`
+	ControlURL   string    `json:"control_url"`
+
+	InterfaceName string `json:"interface_name"`
+	AddressV4     string `json:"address_v4,omitempty"`
+	AddressV6     string `json:"address_v6,omitempty"`
+
+	// WireGuardPublicKey only. The private half never crosses this socket, or any
+	// other (Invariant 1).
+	WireGuardPublicKey string `json:"wireguard_public_key"`
+
+	// Connected and AppliedStateVersion come from the live session rather than from
+	// disk, which is the reason to ask the daemon instead of reading the state file:
+	// the file cannot tell you whether the control plane is reachable right now.
+	Connected           bool      `json:"connected"`
+	ConnectedSince      time.Time `json:"connected_since,omitzero"`
+	AppliedStateVersion int64     `json:"applied_state_version"`
+	LastError           string    `json:"last_error,omitempty"`
+
+	JoinedAt time.Time `json:"joined_at"`
+
+	// TunnelUp is false in every build so far, and saying so is the point: a
+	// membership with an address is not a working tunnel, and status should not imply
+	// otherwise.
+	TunnelUp bool `json:"tunnel_up"`
+}
+
+// JoinRequest asks the daemon to enrol this device.
+type JoinRequest struct {
+	Token      string `json:"token"`
+	ControlURL string `json:"control_url"`
+	// Name defaults to the host's name when empty.
+	Name string `json:"name,omitempty"`
+}
+
+// JoinResponse is what the daemon assigned.
+type JoinResponse struct {
+	MembershipID  uuid.UUID `json:"membership_id"`
+	NetworkID     uuid.UUID `json:"network_id"`
+	DeviceID      uuid.UUID `json:"device_id"`
+	InterfaceName string    `json:"interface_name"`
+	AddressV4     string    `json:"address_v4,omitempty"`
+	AddressV6     string    `json:"address_v6,omitempty"`
+}
+
+// Error is how the daemon reports a refusal.
+type Error struct {
+	Code    string `json:"error"`
+	Message string `json:"message"`
+}
+
+func (e *Error) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return e.Code
+}

--- a/internal/agentapi/agentapi_test.go
+++ b/internal/agentapi/agentapi_test.go
@@ -1,0 +1,351 @@
+package agentapi
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// fakeHandler stands in for the daemon.
+type fakeHandler struct {
+	mu       sync.Mutex
+	status   Status
+	joinResp JoinResponse
+	joinErr  error
+	joined   []JoinRequest
+}
+
+func (h *fakeHandler) Status(context.Context) (Status, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.status, nil
+}
+
+func (h *fakeHandler) Join(_ context.Context, req JoinRequest) (JoinResponse, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.joined = append(h.joined, req)
+	return h.joinResp, h.joinErr
+}
+
+func (h *fakeHandler) joinCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.joined)
+}
+
+// socketPath keeps the path short. A unix socket path has a hard limit around 100
+// bytes, and t.TempDir() under a long temporary root can exceed it — which fails with
+// "invalid argument" and no hint about why.
+func socketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "mpsk")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "d.sock")
+}
+
+func serve(t *testing.T, h Handler, cfg ServerConfig) (*Server, string) {
+	t.Helper()
+	if cfg.SocketPath == "" {
+		cfg.SocketPath = socketPath(t)
+	}
+	srv := NewServer(h, cfg)
+	if err := srv.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); _ = srv.Serve(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("Serve did not return after the context was cancelled")
+		}
+	})
+	return srv, cfg.SocketPath
+}
+
+func TestStatusRoundTrip(t *testing.T) {
+	membershipID, networkID := uuid.New(), uuid.New()
+	h := &fakeHandler{status: Status{
+		Version:           "test",
+		StartedAt:         time.Now().UTC().Truncate(time.Second),
+		Enrolled:          true,
+		IdentityPublicKey: "aWRlbnRpdHk=",
+		Memberships: []MembershipStatus{{
+			MembershipID:        membershipID,
+			NetworkID:           networkID,
+			ControlURL:          "http://control.test",
+			InterfaceName:       "meshp0",
+			AddressV4:           "100.90.0.7",
+			WireGuardPublicKey:  "d2c=",
+			Connected:           true,
+			AppliedStateVersion: 42,
+		}},
+	}}
+	_, path := serve(t, h, ServerConfig{})
+
+	got, err := NewClient(path, 5*time.Second).Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !got.Enrolled || len(got.Memberships) != 1 {
+		t.Fatalf("status = %+v", got)
+	}
+	m := got.Memberships[0]
+	if m.MembershipID != membershipID || m.NetworkID != networkID {
+		t.Errorf("identifiers did not survive: %+v", m)
+	}
+	if !m.Connected || m.AppliedStateVersion != 42 {
+		t.Errorf("live fields did not survive: connected=%v applied=%d", m.Connected, m.AppliedStateVersion)
+	}
+	// A membership with an address is not a working tunnel, and status must not imply
+	// otherwise.
+	if m.TunnelUp {
+		t.Error("TunnelUp is true in a build with no WireGuard")
+	}
+}
+
+func TestJoinRoundTrip(t *testing.T) {
+	h := &fakeHandler{joinResp: JoinResponse{
+		MembershipID:  uuid.New(),
+		NetworkID:     uuid.New(),
+		InterfaceName: "meshp0",
+		AddressV4:     "100.90.0.1",
+	}}
+	_, path := serve(t, h, ServerConfig{})
+
+	res, err := NewClient(path, 5*time.Second).Join(context.Background(), JoinRequest{
+		Token: "meshp_tok_example", ControlURL: "http://control.test", Name: "laptop",
+	})
+	if err != nil {
+		t.Fatalf("Join: %v", err)
+	}
+	if res.InterfaceName != "meshp0" || res.AddressV4 != "100.90.0.1" {
+		t.Errorf("response = %+v", res)
+	}
+	if h.joinCount() != 1 {
+		t.Fatalf("handler saw %d joins, want 1", h.joinCount())
+	}
+	if got := h.joined[0].Token; got != "meshp_tok_example" {
+		t.Errorf("token reached the handler as %q", got)
+	}
+}
+
+func TestJoinRefusalReachesTheCaller(t *testing.T) {
+	h := &fakeHandler{joinErr: errors.New("that enrolment token has already been used")}
+	_, path := serve(t, h, ServerConfig{})
+
+	_, err := NewClient(path, 5*time.Second).Join(context.Background(), JoinRequest{
+		Token: "meshp_tok_used", ControlURL: "http://control.test",
+	})
+	if err == nil {
+		t.Fatal("a refused join reported success")
+	}
+	// The control plane's wording has to survive both hops, or the person at the
+	// terminal is told "bad gateway" about an expired token.
+	if !strings.Contains(err.Error(), "already been used") {
+		t.Errorf("error lost its meaning on the way back: %v", err)
+	}
+}
+
+func TestJoinRejectsAnEmptyToken(t *testing.T) {
+	h := &fakeHandler{}
+	_, path := serve(t, h, ServerConfig{})
+
+	_, err := NewClient(path, 5*time.Second).Join(context.Background(), JoinRequest{ControlURL: "http://x"})
+	if err == nil {
+		t.Fatal("an empty token was accepted")
+	}
+	if h.joinCount() != 0 {
+		t.Error("an empty token reached the handler")
+	}
+}
+
+func TestJoinRejectsUnknownFields(t *testing.T) {
+	h := &fakeHandler{}
+	_, path := serve(t, h, ServerConfig{})
+
+	// Reaching past the client, because the point is what the server accepts.
+	conn, err := net.Dial("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	body := `{"token":"meshp_tok_x","control_url":"http://x","typo_field":1}`
+	req := "POST /v1/join HTTP/1.1\r\nHost: meshpd\r\nContent-Type: application/json\r\n" +
+		"Content-Length: " + itoa(len(body)) + "\r\nConnection: close\r\n\r\n" + body
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 512)
+	n, _ := conn.Read(buf)
+	if !strings.Contains(string(buf[:n]), "400") {
+		t.Errorf("an unknown field was not refused: %s", buf[:n])
+	}
+	if h.joinCount() != 0 {
+		t.Error("a request with an unknown field reached the handler")
+	}
+}
+
+// The socket is a privilege boundary: anything that can reach it can enrol this device
+// and, once tunnels exist, decide where its traffic goes.
+func TestSocketIsOwnerOnlyByDefault(t *testing.T) {
+	_, path := serve(t, &fakeHandler{}, ServerConfig{})
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	perm := info.Mode().Perm()
+	if perm != 0o600 {
+		t.Errorf("socket is %04o, want 0600", perm)
+	}
+	if perm&0o077 != 0 {
+		t.Error("the socket is reachable by users other than its owner")
+	}
+}
+
+func TestListenRefusesAnUnknownGroup(t *testing.T) {
+	srv := NewServer(&fakeHandler{}, ServerConfig{
+		SocketPath: socketPath(t),
+		Group:      "a-group-that-does-not-exist-anywhere",
+	})
+	err := srv.Listen()
+	if err == nil {
+		t.Fatal("Listen accepted a group that does not exist")
+	}
+	// And it must not have left a socket behind at looser permissions than intended.
+	if _, statErr := os.Stat(srv.SocketPath()); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Error("a failed Listen left a socket behind")
+	}
+}
+
+// But it must never steal the socket from a daemon that is alive, or two processes end
+// up fighting over one state directory and one set of keys.
+func TestListenRefusesToStealALiveSocket(t *testing.T) {
+	_, path := serve(t, &fakeHandler{}, ServerConfig{})
+
+	second := NewServer(&fakeHandler{}, ServerConfig{SocketPath: path})
+	err := second.Listen()
+	if err == nil {
+		t.Fatal("a second daemon took over a live socket")
+	}
+	if !strings.Contains(err.Error(), "already in use") {
+		t.Errorf("error does not explain the conflict: %v", err)
+	}
+
+	// The first is still serving.
+	if _, err := NewClient(path, 5*time.Second).Status(context.Background()); err != nil {
+		t.Errorf("the original daemon stopped answering: %v", err)
+	}
+}
+
+func TestListenRefusesANonSocketFile(t *testing.T) {
+	path := socketPath(t)
+	if err := os.WriteFile(path, []byte("not a socket"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := NewServer(&fakeHandler{}, ServerConfig{SocketPath: path}).Listen()
+	if err == nil {
+		t.Fatal("Listen replaced a regular file")
+	}
+	if !strings.Contains(err.Error(), "not a socket") {
+		t.Errorf("error does not say what is wrong: %v", err)
+	}
+}
+
+// "connection refused" is not an answer anyone can act on, so the client names the
+// cases separately.
+func TestClientDistinguishesNoDaemon(t *testing.T) {
+	_, err := NewClient("/tmp/meshp-nothing-here-at-all.sock", time.Second).Status(context.Background())
+	if !errors.Is(err, ErrNoDaemon) {
+		t.Fatalf("error = %v, want ErrNoDaemon", err)
+	}
+	if !strings.Contains(err.Error(), "meshp-nothing-here-at-all.sock") {
+		t.Errorf("error does not name the socket: %v", err)
+	}
+}
+
+func TestServeCleansUpTheSocket(t *testing.T) {
+	path := socketPath(t)
+	srv := NewServer(&fakeHandler{}, ServerConfig{SocketPath: path})
+	if err := srv.Listen(); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); _ = srv.Serve(ctx) }()
+
+	// Wait until it is answering.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := NewClient(path, time.Second).Status(ctx); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return")
+	}
+
+	// Left behind, the next start would log a stale-socket warning for no reason.
+	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("the socket outlived the server: %v", err)
+	}
+}
+
+// No private key material has any business crossing this socket (Invariant 1). The types
+// are the enforcement; this is the assertion that they stay that way.
+func TestNoPrivateKeyFieldsAreExposed(t *testing.T) {
+	forbidden := []string{"private", "secret", "PrivateKey"}
+	for _, sample := range []any{Status{}, MembershipStatus{}, JoinRequest{}, JoinResponse{}} {
+		rendered := structFieldNames(sample)
+		for _, word := range forbidden {
+			if strings.Contains(strings.ToLower(rendered), strings.ToLower(word)) {
+				t.Errorf("%T exposes a field mentioning %q: %s", sample, word, rendered)
+			}
+		}
+	}
+}
+
+// --- small helpers ----------------------------------------------------------
+
+func itoa(n int) string { return strconv.Itoa(n) }
+
+// structFieldNames renders a struct's field and JSON tag names for inspection.
+func structFieldNames(v any) string {
+	t := reflect.TypeOf(v)
+	var b strings.Builder
+	for i := range t.NumField() {
+		f := t.Field(i)
+		b.WriteString(f.Name)
+		b.WriteString(" ")
+		b.WriteString(f.Tag.Get("json"))
+		b.WriteString(" ")
+	}
+	return b.String()
+}

--- a/internal/agentapi/client.go
+++ b/internal/agentapi/client.go
@@ -1,0 +1,136 @@
+package agentapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
+	"net/http"
+	"os"
+	"syscall"
+	"time"
+)
+
+// ErrNoDaemon means meshpd is not reachable on the socket.
+//
+// Distinguished from every other failure so the CLI can say something useful. "Is the
+// daemon running?" and "the daemon refused that" need different answers, and a single
+// connection error covering both is how a person ends up debugging the wrong thing.
+var ErrNoDaemon = errors.New("agentapi: meshpd is not running")
+
+// ErrPermission means the socket exists but this user may not use it.
+var ErrPermission = errors.New("agentapi: not permitted to talk to meshpd")
+
+// Client talks to a local meshpd.
+type Client struct {
+	socketPath string
+	http       *http.Client
+}
+
+// NewClient returns a client for the socket at path.
+func NewClient(socketPath string, timeout time.Duration) *Client {
+	if socketPath == "" {
+		socketPath = DefaultSocketPath
+	}
+	if timeout <= 0 {
+		timeout = 120 * time.Second
+	}
+	return &Client{
+		socketPath: socketPath,
+		http: &http.Client{
+			Timeout: timeout,
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					var d net.Dialer
+					return d.DialContext(ctx, "unix", socketPath)
+				},
+			},
+		},
+	}
+}
+
+// SocketPath is the socket this client uses.
+func (c *Client) SocketPath() string { return c.socketPath }
+
+// Status asks the daemon what it is doing.
+func (c *Client) Status(ctx context.Context) (Status, error) {
+	var out Status
+	err := c.do(ctx, http.MethodGet, "/v1/status", nil, &out)
+	return out, err
+}
+
+// Join asks the daemon to enrol this device.
+func (c *Client) Join(ctx context.Context, req JoinRequest) (JoinResponse, error) {
+	var out JoinResponse
+	err := c.do(ctx, http.MethodPost, "/v1/join", req, &out)
+	return out, err
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("agentapi: encoding request: %w", err)
+		}
+		reader = bytes.NewReader(encoded)
+	}
+
+	// The host in the URL is ignored: the transport dials the socket regardless. It has
+	// to be something, so it says what it is.
+	req, err := http.NewRequestWithContext(ctx, method, "http://meshpd"+path, reader)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return c.classifyDialError(err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	payload, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("agentapi: reading response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		var apiErr Error
+		if json.Unmarshal(payload, &apiErr) == nil && (apiErr.Code != "" || apiErr.Message != "") {
+			return &apiErr
+		}
+		return fmt.Errorf("agentapi: meshpd returned %d", resp.StatusCode)
+	}
+	if out != nil {
+		if err := json.Unmarshal(payload, out); err != nil {
+			return fmt.Errorf("agentapi: decoding response: %w", err)
+		}
+	}
+	return nil
+}
+
+// classifyDialError turns a connection failure into something a person can act on.
+func (c *Client) classifyDialError(err error) error {
+	if errors.Is(err, fs.ErrPermission) {
+		return fmt.Errorf("%w: %s", ErrPermission, c.socketPath)
+	}
+	// A missing socket file and a refused connection both mean no daemon; the first is
+	// "never started", the second is "died without cleaning up".
+	if errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.ECONNREFUSED) {
+		return fmt.Errorf("%w (socket %s)", ErrNoDaemon, c.socketPath)
+	}
+	if _, statErr := os.Stat(c.socketPath); errors.Is(statErr, fs.ErrNotExist) {
+		return fmt.Errorf("%w (socket %s)", ErrNoDaemon, c.socketPath)
+	}
+	return fmt.Errorf("agentapi: reaching meshpd on %s: %w", c.socketPath, err)
+}

--- a/internal/agentapi/server.go
+++ b/internal/agentapi/server.go
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"time"
+
+	"github.com/meshpnet/meshp/internal/logx"
 )
 
 // Handler is what the daemon implements to answer the CLI.
@@ -216,10 +218,12 @@ func (s *Server) handleJoin(w http.ResponseWriter, r *http.Request) {
 
 	res, err := s.handler.Join(r.Context(), req)
 	if err != nil {
-		// The daemon's own refusals and the control plane's are both reported here. The
-		// text comes from the control plane where there is one, because "that token has
-		// expired" is what the person at the terminal needs.
-		s.log.Info("join refused", "error", err)
+		// The daemon's own refusals and the control plane's are both reported here, and
+		// the text comes from the control plane where there is one — "that token has
+		// expired" is what the person at the terminal needs. It is also written by a
+		// server an agent can be pointed at, so it is bounded before it reaches a log.
+		s.log.Info("join refused",
+			"error", logx.SafeError(err), "control_url", logx.Safe(req.ControlURL))
 		s.fail(w, http.StatusBadGateway, "join_failed", err.Error())
 		return
 	}

--- a/internal/agentapi/server.go
+++ b/internal/agentapi/server.go
@@ -1,0 +1,239 @@
+package agentapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// Handler is what the daemon implements to answer the CLI.
+type Handler interface {
+	Status(ctx context.Context) (Status, error)
+	Join(ctx context.Context, req JoinRequest) (JoinResponse, error)
+}
+
+// ServerConfig configures the local listener.
+type ServerConfig struct {
+	SocketPath string
+
+	// Group, when set, is a system group whose members may use the socket. Without
+	// it the socket is owner-only.
+	//
+	// This is a privilege grant and should be read as one: anything that can reach
+	// this socket can enrol the machine into a network and, once tunnels exist, decide
+	// where its traffic goes. It is closer to sudo than to a read-only API.
+	Group string
+
+	Log *slog.Logger
+}
+
+// Server answers meshp over a unix socket.
+type Server struct {
+	cfg      ServerConfig
+	handler  Handler
+	log      *slog.Logger
+	listener net.Listener
+	http     *http.Server
+}
+
+// NewServer prepares a Server. Listen must be called to bind.
+func NewServer(handler Handler, cfg ServerConfig) *Server {
+	if cfg.SocketPath == "" {
+		cfg.SocketPath = DefaultSocketPath
+	}
+	if cfg.Log == nil {
+		cfg.Log = slog.New(slog.DiscardHandler)
+	}
+	return &Server{cfg: cfg, handler: handler, log: cfg.Log}
+}
+
+// Listen binds the socket.
+func (s *Server) Listen() error {
+	dir := filepath.Dir(s.cfg.SocketPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("agentapi: creating %s: %w", dir, err)
+	}
+
+	if err := s.clearStaleSocket(); err != nil {
+		return err
+	}
+
+	listener, err := net.Listen("unix", s.cfg.SocketPath)
+	if err != nil {
+		return fmt.Errorf("agentapi: listening on %s: %w", s.cfg.SocketPath, err)
+	}
+	s.listener = listener
+
+	if err := s.applyPermissions(); err != nil {
+		_ = listener.Close()
+		_ = os.Remove(s.cfg.SocketPath)
+		return err
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/status", s.handleStatus)
+	mux.HandleFunc("POST /v1/join", s.handleJoin)
+	s.http = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		// Generous: a join waits on the control plane, which may be slow or far away.
+		WriteTimeout: 90 * time.Second,
+		ReadTimeout:  90 * time.Second,
+	}
+	return nil
+}
+
+// clearStaleSocket removes a socket left behind by a process that died.
+//
+// Unlinking unconditionally would let a second daemon steal the socket from a healthy
+// first one, so the file is only removed once a connection to it has been refused —
+// which is what a dead owner looks like.
+func (s *Server) clearStaleSocket() error {
+	info, err := os.Stat(s.cfg.SocketPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("agentapi: inspecting %s: %w", s.cfg.SocketPath, err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("agentapi: %s exists and is not a socket", s.cfg.SocketPath)
+	}
+
+	conn, err := net.DialTimeout("unix", s.cfg.SocketPath, time.Second)
+	if err == nil {
+		_ = conn.Close()
+		return fmt.Errorf("agentapi: %s is already in use by a running meshpd", s.cfg.SocketPath)
+	}
+
+	s.log.Info("removing a socket left behind by a previous run", "socket", s.cfg.SocketPath)
+	if err := os.Remove(s.cfg.SocketPath); err != nil {
+		return fmt.Errorf("agentapi: removing a stale %s: %w", s.cfg.SocketPath, err)
+	}
+	return nil
+}
+
+// applyPermissions restricts who may talk to the daemon.
+func (s *Server) applyPermissions() error {
+	mode := fs.FileMode(0o600)
+
+	if s.cfg.Group != "" {
+		grp, err := user.LookupGroup(s.cfg.Group)
+		if err != nil {
+			return fmt.Errorf("agentapi: group %q: %w", s.cfg.Group, err)
+		}
+		gid, err := strconv.Atoi(grp.Gid)
+		if err != nil {
+			return fmt.Errorf("agentapi: group %q has an unusable gid %q", s.cfg.Group, grp.Gid)
+		}
+		if err := os.Chown(s.cfg.SocketPath, os.Getuid(), gid); err != nil {
+			return fmt.Errorf("agentapi: assigning %s to group %q: %w", s.cfg.SocketPath, s.cfg.Group, err)
+		}
+		mode = 0o660
+		s.log.Warn("the local socket is group-accessible",
+			"group", s.cfg.Group,
+			"effect", "members of this group can enrol this device and control its networking")
+	}
+
+	// Set explicitly rather than relying on umask, which varies by init system and has
+	// produced world-writable sockets in other projects.
+	if err := os.Chmod(s.cfg.SocketPath, mode); err != nil {
+		return fmt.Errorf("agentapi: securing %s: %w", s.cfg.SocketPath, err)
+	}
+	return nil
+}
+
+// Serve answers requests until ctx ends.
+func (s *Server) Serve(ctx context.Context) error {
+	if s.listener == nil {
+		return errors.New("agentapi: Listen was not called")
+	}
+	s.log.Info("local socket listening", "socket", s.cfg.SocketPath)
+
+	errc := make(chan error, 1)
+	go func() {
+		err := s.http.Serve(s.listener)
+		if errors.Is(err, http.ErrServerClosed) {
+			err = nil
+		}
+		errc <- err
+	}()
+
+	select {
+	case err := <-errc:
+		return err
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = s.http.Shutdown(shutdownCtx)
+		// The socket file is ours; leaving it behind would make the next start log a
+		// stale-socket warning for no reason.
+		_ = os.Remove(s.cfg.SocketPath)
+		return nil
+	}
+}
+
+// SocketPath is where this server listens.
+func (s *Server) SocketPath() string { return s.cfg.SocketPath }
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	status, err := s.handler.Status(r.Context())
+	if err != nil {
+		s.fail(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	s.respond(w, http.StatusOK, status)
+}
+
+func (s *Server) handleJoin(w http.ResponseWriter, r *http.Request) {
+	var req JoinRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 16<<10)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		s.fail(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if err := dec.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		s.fail(w, http.StatusBadRequest, "bad_request", "expected exactly one JSON object")
+		return
+	}
+	if req.Token == "" {
+		s.fail(w, http.StatusBadRequest, "bad_request", "a token is required")
+		return
+	}
+
+	res, err := s.handler.Join(r.Context(), req)
+	if err != nil {
+		// The daemon's own refusals and the control plane's are both reported here. The
+		// text comes from the control plane where there is one, because "that token has
+		// expired" is what the person at the terminal needs.
+		s.log.Info("join refused", "error", err)
+		s.fail(w, http.StatusBadGateway, "join_failed", err.Error())
+		return
+	}
+	s.respond(w, http.StatusCreated, res)
+}
+
+func (s *Server) respond(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		s.log.Debug("writing a local response failed", "error", err)
+	}
+}
+
+func (s *Server) fail(w http.ResponseWriter, status int, code, message string) {
+	s.respond(w, status, Error{Code: code, Message: message})
+}

--- a/internal/agentapi/stale_unix_test.go
+++ b/internal/agentapi/stale_unix_test.go
@@ -1,0 +1,53 @@
+//go:build unix
+
+package agentapi
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// A socket left behind by a process that died must not stop the daemon starting: that
+// is the "won't come back after a crash" failure this code exists to prevent.
+//
+// Go's net package unlinks a unix socket when the listener is closed, so a listener
+// cannot produce the state being tested. Binding through the syscall directly and
+// closing the descriptor leaves the file exactly as a killed process would.
+func TestListenClearsAStaleSocket(t *testing.T) {
+	path := socketPath(t)
+
+	fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("socket: %v", err)
+	}
+	if err := syscall.Bind(fd, &syscall.SockaddrUnix{Name: path}); err != nil {
+		_ = syscall.Close(fd)
+		t.Fatalf("bind: %v", err)
+	}
+	// Closing the descriptor without unlinking is what a killed process leaves behind.
+	if err := syscall.Close(fd); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("the socket file did not survive: %v", err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		t.Fatal("the leftover file is not a socket")
+	}
+
+	srv := NewServer(&fakeHandler{}, ServerConfig{SocketPath: path})
+	if err := srv.Listen(); err != nil {
+		t.Fatalf("Listen over a stale socket: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(path) })
+
+	// And it is usable, not merely bound.
+	if info, err := os.Stat(path); err != nil {
+		t.Errorf("no socket after Listen: %v", err)
+	} else if info.Mode().Perm() != 0o600 {
+		t.Errorf("the replacement socket is %04o, want 0600", info.Mode().Perm())
+	}
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -17,14 +17,12 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"strings"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/meshpnet/meshp/internal/clock"
 	"github.com/meshpnet/meshp/internal/enroll"
 	"github.com/meshpnet/meshp/internal/httpx"
 	"github.com/meshpnet/meshp/internal/ipam"
+	"github.com/meshpnet/meshp/internal/logx"
 	"github.com/meshpnet/meshp/internal/session"
 	"github.com/meshpnet/meshp/internal/store"
 )
@@ -134,7 +132,7 @@ func (s *Server) adminOnly(next http.HandlerFunc) http.Handler {
 		// how long the comparison takes.
 		if subtle.ConstantTimeCompare([]byte(presented), []byte(s.cfg.AdminToken)) != 1 {
 			s.log.Warn("administrative request rejected",
-				"path", forLog(r.URL.Path), "remote", forLog(clientKey(r)))
+				"path", logx.Safe(r.URL.Path), "remote", logx.Safe(clientKey(r)))
 			httpx.Error(w, s.log, http.StatusUnauthorized, "unauthorized",
 				"a valid administrative token is required")
 			return
@@ -168,43 +166,6 @@ func decode(w http.ResponseWriter, r *http.Request, dst any) error {
 		return errors.New("request body: expected exactly one JSON object")
 	}
 	return nil
-}
-
-// forLog prepares an attacker-controlled string to be logged.
-//
-// CodeQL flags the request path reaching a log entry as log injection (CWE-117).
-// For the injection half that is a false positive here, and demonstrably so: slog's
-// text handler quotes values and escapes newlines, carriage returns and ANSI escapes,
-// and its JSON handler encodes them — a path carrying "\nlevel=ERROR msg=forged"
-// comes out inside one quoted value rather than as a second log line. There is a test
-// below that asserts it rather than trusting the claim.
-//
-// What is not handled by the handler is length. Without a bound, anyone who can reach
-// these endpoints can put eight kilobytes into the log on every rejected request,
-// which is a cheap way to fill a disk or a log bill. So values are bounded here, and
-// control characters are dropped as well — belt and braces, so the code stays correct
-// if a custom handler is ever substituted for slog's.
-func forLog(s string) string {
-	const max = 128
-
-	var b strings.Builder
-	b.Grow(min(len(s), max))
-	count := 0
-	for _, r := range s {
-		if count >= max {
-			b.WriteString("…(truncated)")
-			break
-		}
-		// Ranging over a string yields runes, so this cannot split one in half and
-		// emit invalid UTF-8 into the log.
-		if r == utf8.RuneError || unicode.IsControl(r) {
-			b.WriteRune('\uFFFD')
-		} else {
-			b.WriteRune(r)
-		}
-		count++
-	}
-	return b.String()
 }
 
 // failure describes how a known error is reported.
@@ -249,14 +210,14 @@ func (s *Server) respondError(w http.ResponseWriter, r *http.Request, err error)
 	for _, known := range knownFailures {
 		if errors.Is(err, known.err) {
 			s.log.Info("request refused",
-				"path", forLog(r.URL.Path), "code", known.code, "error", err)
+				"path", logx.Safe(r.URL.Path), "code", known.code, "error", err)
 			httpx.Error(w, s.log, known.status, known.code, known.message)
 			return
 		}
 	}
 
 	// Unrecognised: the client learns nothing, the operator learns everything.
-	s.log.Error("request failed", "path", forLog(r.URL.Path), "error", err)
+	s.log.Error("request failed", "path", logx.Safe(r.URL.Path), "error", err)
 	httpx.Error(w, s.log, http.StatusInternalServerError, "internal",
 		"the request could not be completed")
 }

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -1,14 +1,10 @@
 package api
 
 import (
-	"bytes"
 	"fmt"
-	"log/slog"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
-	"unicode/utf8"
 
 	"github.com/meshpnet/meshp/internal/clock"
 )
@@ -166,70 +162,5 @@ func TestRateLimitedHandlerAnswers429(t *testing.T) {
 	// Retry-After lets a well-behaved client back off correctly instead of guessing.
 	if second.Header.Get("Retry-After") == "" {
 		t.Error("a 429 with no Retry-After leaves the client guessing")
-	}
-}
-
-// --- logging user input -----------------------------------------------------
-
-// The claim that slog escapes hostile values is asserted rather than trusted,
-// because it is the whole reason CodeQL's log-injection finding is a false positive
-// here. If a future change swaps the handler, this fails.
-func TestSlogEscapesHostileValues(t *testing.T) {
-	hostile := "/api/v1/enroll\nlevel=ERROR msg=\"forged\" admin=true\r\x1b[31m"
-
-	for _, tc := range []struct {
-		name    string
-		handler func(*bytes.Buffer) slog.Handler
-	}{
-		{"text", func(b *bytes.Buffer) slog.Handler { return slog.NewTextHandler(b, nil) }},
-		{"json", func(b *bytes.Buffer) slog.Handler { return slog.NewJSONHandler(b, nil) }},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			slog.New(tc.handler(&buf)).Info("probe", "path", hostile)
-
-			out := buf.String()
-			// One line out means no forged entry got in.
-			if lines := strings.Count(strings.TrimRight(out, "\n"), "\n"); lines != 0 {
-				t.Errorf("a hostile value produced %d extra lines:\n%s", lines, out)
-			}
-			if strings.Contains(out, "\x1b") {
-				t.Error("a raw ANSI escape reached the log")
-			}
-		})
-	}
-}
-
-func TestForLogBoundsLength(t *testing.T) {
-	// Unbounded logging of a request path is a cheap way to fill a disk, whatever the
-	// handler does about escaping.
-	long := strings.Repeat("a", 4096)
-	got := forLog(long)
-	if len(got) > 200 {
-		t.Errorf("forLog returned %d bytes for a 4096-byte input", len(got))
-	}
-	if !strings.Contains(got, "truncated") {
-		t.Error("truncation is not announced, so a reader cannot tell the value was cut")
-	}
-}
-
-func TestForLogRemovesControlCharacters(t *testing.T) {
-	got := forLog("ok\nthen\rmore\x00and\x1b[31m")
-	for _, bad := range []string{"\n", "\r", "\x00", "\x1b"} {
-		if strings.Contains(got, bad) {
-			t.Errorf("forLog kept %q", bad)
-		}
-	}
-	if !strings.Contains(got, "ok") || !strings.Contains(got, "more") {
-		t.Errorf("forLog discarded the readable parts: %q", got)
-	}
-}
-
-func TestForLogKeepsValidUTF8(t *testing.T) {
-	// Truncating by bytes would split a multi-byte rune and put invalid UTF-8 into the
-	// log, which some log pipelines reject outright.
-	got := forLog(strings.Repeat("日本語テスト", 100))
-	if !utf8.ValidString(got) {
-		t.Error("forLog produced invalid UTF-8")
 	}
 }

--- a/internal/controlurl/controlurl.go
+++ b/internal/controlurl/controlurl.go
@@ -1,0 +1,89 @@
+// Package controlurl validates the address of a control plane.
+//
+// It exists because of what a control URL is trusted with. `meshp join` sends an
+// enrolment token to whatever address it is given, and the agent then holds a session
+// there. A URL pasted from the wrong place — a message, a wiki, a screenshot — hands a
+// working token to somebody else. The token is single-use and short-lived, which limits
+// the damage but does not remove it.
+//
+// CodeQL reports the requests these URLs feed as go/request-forgery. That model is about
+// a server fetching an address an attacker supplied, which lets the attacker reach
+// services only the server can see. This is the other shape: a client reaching an address
+// its own operator configured, where the operator could equally have run curl. The
+// escalation the rule is looking for is not available here.
+//
+// The rule still points at something real, which is that nothing was checked at all. So
+// this narrows what a control URL may be, and the reason to do it is the pasted-URL
+// mistake rather than the reported one.
+package controlurl
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ErrInvalid means the string is not usable as a control-plane address.
+var ErrInvalid = errors.New("controlurl: not a usable control plane address")
+
+// Validate checks a control URL and returns it normalised, without a trailing slash.
+func Validate(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("%w: it is empty", ErrInvalid)
+	}
+
+	// Checked on the raw string, before parsing, because url.Parse reads
+	// "control.example:8080" as the scheme "control.example" with the opaque part "8080".
+	// Reporting that as an unsupported scheme is technically what happened and useless to
+	// whoever typed a host and a port, which is a very likely thing to type.
+	if !strings.Contains(trimmed, "://") {
+		return "", fmt.Errorf("%w: %q has no scheme; write http:// or https://", ErrInvalid, trimmed)
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrInvalid, err)
+	}
+
+	switch parsed.Scheme {
+	case "http", "https":
+	default:
+		// Guessing http for anything else would silently send an enrolment token in the
+		// clear, so it is refused rather than assumed.
+		return "", fmt.Errorf("%w: scheme %q is not supported; use http or https", ErrInvalid, parsed.Scheme)
+	}
+
+	if parsed.Host == "" {
+		return "", fmt.Errorf("%w: %q names no host", ErrInvalid, trimmed)
+	}
+
+	// Embedded credentials are a phishing shape: in http://control.example@evil.test the
+	// host is evil.test, and a reader's eye stops at the first name it recognises.
+	if parsed.User != nil {
+		return "", fmt.Errorf("%w: it must not contain credentials", ErrInvalid)
+	}
+
+	// A control URL is a base that paths are appended to, so anything after the host is
+	// either a mistake or an attempt to make the resulting request point somewhere else.
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("%w: it must not carry a query or fragment", ErrInvalid)
+	}
+	if path := strings.Trim(parsed.Path, "/"); path != "" {
+		return "", fmt.Errorf("%w: it must be a scheme and host only, with no path (%q)", ErrInvalid, parsed.Path)
+	}
+
+	// Rebuilt from the parsed parts rather than trimmed from the input, so what is
+	// returned is exactly what was validated.
+	return parsed.Scheme + "://" + parsed.Host, nil
+}
+
+// MustValidate is Validate for constants in tests and defaults.
+func MustValidate(raw string) string {
+	out, err := Validate(raw)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}

--- a/internal/controlurl/controlurl_test.go
+++ b/internal/controlurl/controlurl_test.go
@@ -1,0 +1,124 @@
+package controlurl
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidateAccepts(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"http://localhost:8080", "http://localhost:8080"},
+		{"https://control.example", "https://control.example"},
+		{"https://control.example:8443", "https://control.example:8443"},
+		{"http://127.0.0.1:8099", "http://127.0.0.1:8099"},
+		{"http://[::1]:8080", "http://[::1]:8080"},
+		// A trailing slash is what a browser's address bar gives you.
+		{"https://control.example/", "https://control.example"},
+		{"  https://control.example  ", "https://control.example"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := Validate(tt.in)
+			if err != nil {
+				t.Fatalf("Validate(%q): %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("Validate(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateRejects(t *testing.T) {
+	tests := []struct {
+		name, in, wantMention string
+	}{
+		{"empty", "", "empty"},
+		{"whitespace only", "   ", "empty"},
+		{"no scheme", "control.example:8080", "no scheme"},
+		{"bare host", "control.example", "no scheme"},
+		{"unsupported scheme", "ftp://control.example", "not supported"},
+		{"file scheme", "file:///etc/passwd", "not supported"},
+		{"no host", "http://", "no host"},
+		// The phishing shape: the host here is evil.test, and a reader's eye stops at the
+		// first name it recognises.
+		{"embedded credentials", "http://control.example@evil.test", "credentials"},
+		{"embedded user and password", "https://user:pass@evil.test", "credentials"},
+		{"carries a query", "https://control.example?next=http://evil.test", "query"},
+		{"carries a fragment", "https://control.example#x", "query"},
+		{"carries a path", "https://control.example/api/v1", "no path"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Validate(tt.in)
+			if err == nil {
+				t.Fatalf("Validate(%q) was accepted", tt.in)
+			}
+			if !errors.Is(err, ErrInvalid) {
+				t.Errorf("error = %v, want ErrInvalid", err)
+			}
+			// The message has to say what to do about it: whoever hits this is holding a
+			// token and a terminal.
+			if !strings.Contains(err.Error(), tt.wantMention) {
+				t.Errorf("error %q does not mention %q", err, tt.wantMention)
+			}
+		})
+	}
+}
+
+// A validated URL must survive a second pass unchanged, or normalising somewhere in the
+// call chain would keep changing what was already checked.
+func TestValidateIsIdempotent(t *testing.T) {
+	for _, in := range []string{"http://localhost:8080", "https://control.example/", "http://[::1]:9"} {
+		once, err := Validate(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		twice, err := Validate(once)
+		if err != nil {
+			t.Fatalf("Validate(%q) rejected its own output: %v", once, err)
+		}
+		if once != twice {
+			t.Errorf("Validate is not idempotent: %q then %q", once, twice)
+		}
+	}
+}
+
+func TestMustValidatePanicsOnBadInput(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("MustValidate accepted an invalid URL")
+		}
+	}()
+	MustValidate("not a url at all")
+}
+
+func FuzzValidate(f *testing.F) {
+	f.Add("http://localhost:8080")
+	f.Add("https://control.example@evil.test")
+	f.Add("")
+	f.Add("://")
+
+	f.Fuzz(func(t *testing.T, in string) {
+		out, err := Validate(in)
+		if err != nil {
+			return
+		}
+		// Whatever is accepted must be a plain scheme-and-host, because everything
+		// downstream appends a path to it.
+		if !strings.HasPrefix(out, "http://") && !strings.HasPrefix(out, "https://") {
+			t.Fatalf("accepted %q and returned %q", in, out)
+		}
+		rest := strings.SplitN(strings.TrimPrefix(strings.TrimPrefix(out, "https://"), "http://"), "/", 2)
+		if len(rest) > 1 && rest[1] != "" {
+			t.Fatalf("accepted %q and returned something with a path: %q", in, out)
+		}
+		if strings.ContainsAny(out, "?#") {
+			t.Fatalf("accepted %q and returned %q", in, out)
+		}
+		if strings.Contains(out, "@") {
+			t.Fatalf("accepted %q and returned credentials: %q", in, out)
+		}
+	})
+}

--- a/internal/enrollclient/client.go
+++ b/internal/enrollclient/client.go
@@ -14,26 +14,37 @@ import (
 	"io"
 	"net/http"
 	"net/netip"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
 
+	"github.com/meshpnet/meshp/internal/controlurl"
 	"github.com/meshpnet/meshp/internal/keys"
 )
 
 // Client talks to a control plane's enrolment endpoints.
 type Client struct {
 	baseURL string
+	urlErr  error
 	http    *http.Client
 }
 
 // New returns a client for a control plane at baseURL.
+//
+// An unusable URL is kept and reported when it is used rather than at construction, so a
+// caller that builds a client early still gets one error at the point it matters.
 func New(baseURL string, httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 30 * time.Second}
 	}
-	return &Client{baseURL: strings.TrimRight(baseURL, "/"), http: httpClient}
+	c := &Client{http: httpClient}
+	validated, err := controlurl.Validate(baseURL)
+	if err != nil {
+		c.urlErr = err
+		return c
+	}
+	c.baseURL = validated
+	return c
 }
 
 // APIError is a refusal the control plane explained.
@@ -133,6 +144,9 @@ func (c *Client) challenge(ctx context.Context, token string, identity keys.Iden
 }
 
 func (c *Client) post(ctx context.Context, path string, body, out any) error {
+	if c.urlErr != nil {
+		return c.urlErr
+	}
 	encoded, err := json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("enrollclient: encoding request: %w", err)

--- a/internal/logx/logx.go
+++ b/internal/logx/logx.go
@@ -1,0 +1,68 @@
+// Package logx holds the small amount of care needed when logging values that came
+// from somewhere else.
+//
+// It exists because the need turned up twice — once for request paths in the HTTP API,
+// once for control-plane error text in the agent's local API — and a security-relevant
+// helper that has been copied is one that will be fixed in one place and not the other.
+package logx
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// MaxValueBytes is how much of an untrusted value reaches a log.
+//
+// Generous enough that a real path or error message survives intact, small enough that
+// nobody can make the log interesting by volume.
+const MaxValueBytes = 128
+
+// Safe prepares a value that came from outside for logging.
+//
+// The injection half of this problem is already handled by slog: its text handler quotes
+// values and escapes newlines, carriage returns and ANSI escapes, and its JSON handler
+// encodes them, so a value carrying "\nlevel=ERROR msg=forged" comes out inside one
+// quoted field rather than as a second log line. There is a test asserting that for both
+// handlers, because the claim is the whole reason CodeQL's log-injection findings against
+// this codebase are false positives, and an assertion beats a belief.
+//
+// What slog does not bound is length. Without a limit, anyone who can reach an endpoint —
+// or any control plane an agent is pointed at — can put kilobytes into the log on every
+// failed request, which is a cheap way to fill a disk or a log bill. So values are
+// bounded here, truncation is announced so a reader can tell, and control characters are
+// replaced as well: belt and braces, so this stays correct if a handler other than slog's
+// is ever substituted.
+func Safe(s string) string {
+	var b strings.Builder
+	b.Grow(min(len(s), MaxValueBytes))
+
+	count := 0
+	for _, r := range s {
+		if count >= MaxValueBytes {
+			b.WriteString("…(truncated)")
+			break
+		}
+		// Ranging over a string yields runes, so this cannot split one in half and emit
+		// invalid UTF-8 — which some log pipelines reject outright.
+		if r == utf8.RuneError || unicode.IsControl(r) {
+			b.WriteRune('�')
+		} else {
+			b.WriteRune(r)
+		}
+		count++
+	}
+	return b.String()
+}
+
+// SafeError renders an error for logging, bounded and sanitised.
+//
+// Error text is the most common way something from outside reaches a log: it arrives
+// wrapped in several layers of our own message, which makes it easy to forget that the
+// innermost part was written by somebody else.
+func SafeError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return Safe(err.Error())
+}

--- a/internal/logx/logx_test.go
+++ b/internal/logx/logx_test.go
@@ -1,0 +1,112 @@
+package logx
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// The claim that slog escapes hostile values is asserted rather than trusted,
+// because it is the whole reason CodeQL's log-injection finding is a false positive
+// here. If a future change swaps the handler, this fails.
+func TestSlogEscapesHostileValues(t *testing.T) {
+	hostile := "/api/v1/enroll\nlevel=ERROR msg=\"forged\" admin=true\r\x1b[31m"
+
+	for _, tc := range []struct {
+		name    string
+		handler func(*bytes.Buffer) slog.Handler
+	}{
+		{"text", func(b *bytes.Buffer) slog.Handler { return slog.NewTextHandler(b, nil) }},
+		{"json", func(b *bytes.Buffer) slog.Handler { return slog.NewJSONHandler(b, nil) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			slog.New(tc.handler(&buf)).Info("probe", "path", hostile)
+
+			out := buf.String()
+			// One line out means no forged entry got in.
+			if lines := strings.Count(strings.TrimRight(out, "\n"), "\n"); lines != 0 {
+				t.Errorf("a hostile value produced %d extra lines:\n%s", lines, out)
+			}
+			if strings.Contains(out, "\x1b") {
+				t.Error("a raw ANSI escape reached the log")
+			}
+		})
+	}
+}
+
+func TestForLogBoundsLength(t *testing.T) {
+	// Unbounded logging of a request path is a cheap way to fill a disk, whatever the
+	// handler does about escaping.
+	long := strings.Repeat("a", 4096)
+	got := Safe(long)
+	if len(got) > 200 {
+		t.Errorf("forLog returned %d bytes for a 4096-byte input", len(got))
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Error("truncation is not announced, so a reader cannot tell the value was cut")
+	}
+}
+
+func TestForLogRemovesControlCharacters(t *testing.T) {
+	got := Safe("ok\nthen\rmore\x00and\x1b[31m")
+	for _, bad := range []string{"\n", "\r", "\x00", "\x1b"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("forLog kept %q", bad)
+		}
+	}
+	if !strings.Contains(got, "ok") || !strings.Contains(got, "more") {
+		t.Errorf("forLog discarded the readable parts: %q", got)
+	}
+}
+
+func TestForLogKeepsValidUTF8(t *testing.T) {
+	// Truncating by bytes would split a multi-byte rune and put invalid UTF-8 into the
+	// log, which some log pipelines reject outright.
+	got := Safe(strings.Repeat("日本語テスト", 100))
+	if !utf8.ValidString(got) {
+		t.Error("forLog produced invalid UTF-8")
+	}
+}
+
+func TestSafeErrorHandlesNil(t *testing.T) {
+	if got := SafeError(nil); got != "" {
+		t.Errorf("SafeError(nil) = %q, want empty", got)
+	}
+}
+
+func TestSafeErrorBoundsAndSanitises(t *testing.T) {
+	// Error text is the commonest way something from outside reaches a log: it arrives
+	// wrapped in several layers of our own message, so it is easy to forget the innermost
+	// part was written by somebody else.
+	err := errors.New("upstream said: " + strings.Repeat("x", 4096) + "\nlevel=ERROR msg=forged")
+	got := SafeError(err)
+
+	if len(got) > 200 {
+		t.Errorf("SafeError returned %d bytes", len(got))
+	}
+	if strings.Contains(got, "\n") {
+		t.Error("SafeError kept a newline")
+	}
+	if !strings.Contains(got, "upstream said") {
+		t.Errorf("SafeError discarded the useful part: %q", got)
+	}
+}
+
+func TestSafeLeavesOrdinaryValuesAlone(t *testing.T) {
+	// The common case must survive untouched, or every log line becomes harder to read
+	// for the sake of the rare hostile one.
+	for _, s := range []string{
+		"/api/v1/enroll",
+		"that enrolment token has already been used",
+		"100.90.0.1",
+		"日本語のホスト名",
+	} {
+		if got := Safe(s); got != s {
+			t.Errorf("Safe(%q) = %q, want it unchanged", s, got)
+		}
+	}
+}

--- a/internal/sessionclient/client.go
+++ b/internal/sessionclient/client.go
@@ -27,7 +27,9 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/meshpnet/meshp/internal/controlurl"
 	"github.com/meshpnet/meshp/internal/keys"
+	"github.com/meshpnet/meshp/internal/logx"
 	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
 )
 
@@ -78,6 +80,7 @@ type Options struct {
 // Client maintains one control-channel session.
 type Client struct {
 	opts    Options
+	urlErr  error
 	log     *slog.Logger
 	httpc   *http.Client
 	applied int64
@@ -91,8 +94,14 @@ func New(opts Options) *Client {
 	if opts.HTTPClient == nil {
 		opts.HTTPClient = &http.Client{Timeout: dialTimeout}
 	}
-	opts.ControlURL = strings.TrimRight(opts.ControlURL, "/")
-	return &Client{opts: opts, log: opts.Log, httpc: opts.HTTPClient, applied: opts.AppliedVersion}
+	c := &Client{opts: opts, log: opts.Log, httpc: opts.HTTPClient, applied: opts.AppliedVersion}
+	validated, err := controlurl.Validate(opts.ControlURL)
+	if err != nil {
+		c.urlErr = err
+		return c
+	}
+	c.opts.ControlURL = validated
+	return c
 }
 
 // AppliedVersion is the newest version this client has applied.
@@ -115,8 +124,12 @@ func (c *Client) Run(ctx context.Context, applier Applier) error {
 		}
 
 		wait := jitter(backoff)
+		// The error can carry text written by the control plane, which an agent may be
+		// pointed at rather than own.
 		c.log.Info("control channel lost; reconnecting",
-			"membership_id", c.opts.MembershipID, "retry_in", wait.Round(time.Millisecond), "error", err)
+			"membership_id", c.opts.MembershipID,
+			"retry_in", wait.Round(time.Millisecond),
+			"error", logx.SafeError(err))
 
 		select {
 		case <-ctx.Done():
@@ -143,6 +156,9 @@ func jitter(d time.Duration) time.Duration {
 
 // RunOnce establishes one session and serves it until it ends.
 func (c *Client) RunOnce(ctx context.Context, applier Applier) error {
+	if c.urlErr != nil {
+		return c.urlErr
+	}
 	challenge, err := c.fetchChallenge(ctx)
 	if err != nil {
 		return fmt.Errorf("sessionclient: challenge: %w", err)

--- a/scripts/e2e-enrol.sh
+++ b/scripts/e2e-enrol.sh
@@ -1,20 +1,22 @@
 #!/usr/bin/env bash
 #
-# The A2 gate, end to end, with the real binaries:
+# Enrolment and the control channel, end to end, with the real binaries:
 #
+#   meshpd comes up with no state at all and is still usable
 #   a token is minted over the administrative API
-#   `meshp join` enrols and is given an address
-#   the keys land with restrictive permissions
-#   `meshp status` reports the membership
+#   `meshp join` asks the daemon, which is what generates the keys
+#   the keys land with restrictive permissions, written by the daemon
+#   `meshp status` reports a live session, and says the tunnel is not up
 #   the same token is refused a second time
-#   the enrolment is in the audit trail
-#   no private key appears in the server's output
+#   the agent converges: applied version catches up with the network's
+#   the session is cleared when the agent exits
+#   no private key material appears where it should not
 #
 # Usage: e2e-enrol.sh <postgres-url>
 #
-# The unit tests cover each of these against a library. This covers the thing a
-# person actually runs, which is where the wiring mistakes are — the flag parsing,
-# the file modes, the exit codes.
+# The unit tests cover each of these against a library. This covers what a person
+# actually runs, which is where the wiring mistakes are — flag parsing, file modes,
+# socket permissions, exit codes.
 set -euo pipefail
 
 DB_URL="${1:?usage: e2e-enrol.sh <postgres-url>}"
@@ -23,21 +25,34 @@ BASE="http://127.0.0.1:${PORT}"
 ADMIN_TOKEN="e2e-administrative-token-not-a-secret"
 SECRET_KEY="e2e-deployment-secret-not-a-secret"
 
-WORK="$(mktemp -d)"
-LOG="$WORK/control.log"
-STATE_A="$WORK/device-a"
-STATE_B="$WORK/device-b"
+# Short paths on purpose: a unix socket path has a hard limit near 100 bytes, and mktemp
+# under a long temporary root can exceed it — which fails with "invalid argument" and no
+# hint about why.
+WORK="$(mktemp -d /tmp/mpe2e.XXXXXX)"
+CONTROL_LOG="$WORK/control.log"
+AGENT_LOG="$WORK/meshpd.log"
+STATE_DIR="$WORK/state"
+SOCKET="$WORK/d.sock"
 CONTROL_PID=""
+AGENT_PID=""
 
 cleanup() {
+  [ -n "$AGENT_PID" ] && kill "$AGENT_PID" 2>/dev/null || true
   [ -n "$CONTROL_PID" ] && kill "$CONTROL_PID" 2>/dev/null || true
   rm -rf "$WORK"
 }
 trap cleanup EXIT
 
-fail() { echo "FAIL: $*" >&2; echo "--- control plane log ---" >&2; cat "$LOG" >&2 || true; exit 1; }
+fail() {
+  echo "FAIL: $*" >&2
+  echo "--- control plane log ---" >&2; cat "$CONTROL_LOG" >&2 2>/dev/null || true
+  echo "--- agent log ---" >&2; cat "$AGENT_LOG" >&2 2>/dev/null || true
+  exit 1
+}
 
-for binary in ./bin/meshp ./bin/meshp-control; do
+mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
+
+for binary in ./bin/meshp ./bin/meshpd ./bin/meshp-control; do
   [ -x "$binary" ] || fail "$binary is missing; run make build"
 done
 
@@ -46,18 +61,41 @@ MESHP_DATABASE_URL="$DB_URL" \
 MESHP_LISTEN_ADDR="127.0.0.1:${PORT}" \
 MESHP_SECRET_KEY="$SECRET_KEY" \
 MESHP_ADMIN_TOKEN="$ADMIN_TOKEN" \
-  ./bin/meshp-control >"$LOG" 2>&1 &
+  ./bin/meshp-control >"$CONTROL_LOG" 2>&1 &
 CONTROL_PID=$!
 
 for _ in $(seq 1 30); do
-  if curl -fsS "${BASE}/readyz" >/dev/null 2>&1; then break; fi
+  curl -fsS "${BASE}/readyz" >/dev/null 2>&1 && break
   sleep 1
 done
 curl -fsS "${BASE}/readyz" >/dev/null 2>&1 || fail "control plane never became ready"
 
+echo "starting meshpd with no state at all"
+# Deliberately before enrolment. An agent that gives up when it has nothing to do cannot
+# be joined without restarting a service, which is a paper cut people script around.
+./bin/meshpd --state-dir "$STATE_DIR" --socket "$SOCKET" --log-level debug >"$AGENT_LOG" 2>&1 &
+AGENT_PID=$!
+
+for _ in $(seq 1 30); do
+  [ -S "$SOCKET" ] && ./bin/meshp status --socket "$SOCKET" >/dev/null 2>&1 && break
+  sleep 1
+done
+./bin/meshp status --socket "$SOCKET" >"$WORK/status-before.out" 2>&1 \
+  || fail "the daemon never answered on its socket"
+grep -q 'not enrolled' "$WORK/status-before.out" \
+  || fail "an unenrolled daemon did not say so: $(cat "$WORK/status-before.out")"
+echo "  socket answers: $(head -1 "$WORK/status-before.out")"
+
+echo "the socket is owner-only"
+# A privilege boundary: anything that can reach this socket can enrol the device and,
+# once tunnels exist, decide where its traffic goes.
+socket_mode="$(mode_of "$SOCKET")"
+[ "$socket_mode" = "600" ] || fail "the socket is ${socket_mode}, want 600"
+echo "  0${socket_mode}"
+
 echo "seeding a network with address pools"
-# Explicit casts: inside a UNION the literals have no inferable type, and cidr will
-# not accept text.
+# Explicit casts: inside a UNION the literals have no inferable type, and cidr will not
+# accept text.
 NETWORK_ID="$(psql "$DB_URL" -tAqc "
   WITH o AS (INSERT INTO organizations (slug, name) VALUES ('e2e', 'End To End') RETURNING id),
        n AS (INSERT INTO networks (organization_id, slug, name) SELECT id, 'e2e', 'End To End' FROM o RETURNING id),
@@ -90,78 +128,85 @@ status="$(curl -s -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: appli
 [ "$status" = "401" ] || fail "minting without a token returned ${status}, want 401"
 
 echo "meshp join"
-./bin/meshp join "$TOKEN" --control-url "$BASE" --state-dir "$STATE_A" --name e2e-device \
+./bin/meshp join "$TOKEN" --control-url "$BASE" --socket "$SOCKET" --name e2e-device \
   >"$WORK/join.out" 2>&1 || fail "join failed: $(cat "$WORK/join.out")"
 sed 's/^/  /' "$WORK/join.out"
-
 grep -q 'enrolled in network' "$WORK/join.out" || fail "join did not report success"
 grep -qE 'address     100\.90\.0\.' "$WORK/join.out" || fail "join reported no IPv4 address"
 
-echo "the keys are not readable by anyone else"
-file_mode="$(stat -c '%a' "$STATE_A/state.json" 2>/dev/null || stat -f '%Lp' "$STATE_A/state.json")"
-dir_mode="$(stat -c '%a' "$STATE_A" 2>/dev/null || stat -f '%Lp' "$STATE_A")"
+echo "the keys were written by the daemon, and only it can read them"
+[ -f "$STATE_DIR/state.json" ] || fail "no state file was written"
+file_mode="$(mode_of "$STATE_DIR/state.json")"
+dir_mode="$(mode_of "$STATE_DIR")"
 [ "$file_mode" = "600" ] || fail "state file is ${file_mode}, want 600"
 [ "$dir_mode" = "700" ] || fail "state directory is ${dir_mode}, want 700"
 echo "  file 0${file_mode}, directory 0${dir_mode}"
 
-echo "meshp status"
-./bin/meshp status --state-dir "$STATE_A" >"$WORK/status.out" 2>&1 || fail "status failed"
+echo "no private key crossed the socket or reached a log"
+# Invariant 1. The CLI asked the daemon to enrol; it must not have been handed anything
+# secret in return, and the control plane must never have seen one.
+if grep -qiE 'private' "$WORK/join.out"; then fail "the CLI's output mentions a private key"; fi
+priv="$(sed -n 's/.*"wireguard_private_key": *"\([^"]*\)".*/\1/p' "$STATE_DIR/state.json" | head -1)"
+[ -n "$priv" ] || fail "could not read the stored private key to check for leaks"
+if grep -qF "$priv" "$WORK/join.out"; then fail "the CLI printed the WireGuard private key"; fi
+if grep -qF "$priv" "$CONTROL_LOG"; then fail "the control plane logged the WireGuard private key"; fi
+
+echo "meshp status reports a live session"
+connected=0
+for _ in $(seq 1 30); do
+  ./bin/meshp status --socket "$SOCKET" >"$WORK/status.out" 2>&1 || true
+  if grep -q 'session     connected' "$WORK/status.out"; then connected=1; break; fi
+  sleep 1
+done
+[ "$connected" = "1" ] || fail "status never reported a connected session: $(cat "$WORK/status.out")"
 sed 's/^/  /' "$WORK/status.out"
 grep -q "$NETWORK_ID" "$WORK/status.out" || fail "status does not mention the network"
+# A membership with an address is not a working tunnel, and status must not imply it is.
+grep -q 'interface   meshp0 (not up)' "$WORK/status.out" \
+  || fail "status does not say the tunnel is down"
+
+echo "the agent converges"
+lag_zero=0
+for _ in $(seq 1 30); do
+  lag="$(psql "$DB_URL" -tAqc "
+    SELECT coalesce(max(n.state_version - ms.applied_version), -1)
+    FROM membership_state ms JOIN networks n ON n.id = ms.network_id")"
+  if [ "$lag" = "0" ]; then lag_zero=1; break; fi
+  sleep 1
+done
+[ "$lag_zero" = "1" ] || fail "applied version never caught up with the network's"
+grep -q 'control channel established' "$AGENT_LOG" || fail "the agent never established a session"
+sed -n 's/.*msg="recorded desired state" \(.*\)/  \1/p' "$AGENT_LOG" | tail -1
 
 echo "the same token a second time"
-if ./bin/meshp join "$TOKEN" --control-url "$BASE" --state-dir "$STATE_B" >"$WORK/replay.out" 2>&1; then
+if ./bin/meshp join "$TOKEN" --control-url "$BASE" --socket "$SOCKET" >"$WORK/replay.out" 2>&1; then
   fail "a replayed token was accepted"
 fi
 sed 's/^/  /' "$WORK/replay.out"
 grep -q 'already been used' "$WORK/replay.out" || fail "the replay was refused for the wrong reason"
-[ -e "$STATE_B/state.json" ] && fail "a refused join still wrote state"
 
 echo "the enrolment is in the audit trail"
 events="$(psql "$DB_URL" -tAqc "SELECT count(*) FROM audit_events WHERE action = 'device.enrolled'")"
 [ "$events" = "1" ] || fail "${events} device.enrolled events, want 1"
 
-echo "meshpd opens a control channel and acknowledges a version"
-# The gate for the control channel: the agent authenticates with its identity key,
-# receives a snapshot and reports the version it applied, and the control plane records
-# it. Convergence lag reaching zero is the single best signal that this works.
-./bin/meshpd --state-dir "$STATE_A" --log-level debug >"$WORK/meshpd.log" 2>&1 &
-MESHPD_PID=$!
-
-converged=0
-for _ in $(seq 1 30); do
-  lag="$(psql "$DB_URL" -tAqc "
-    SELECT coalesce(min(n.state_version - ms.applied_version), -1)
-    FROM membership_state ms JOIN networks n ON n.id = ms.network_id")"
-  if [ "$lag" = "0" ]; then converged=1; break; fi
+echo "the session is cleared when the agent goes away"
+kill "$AGENT_PID" 2>/dev/null || true
+wait "$AGENT_PID" 2>/dev/null || true
+AGENT_PID=""
+cleared=0
+for _ in $(seq 1 20); do
+  rows="$(psql "$DB_URL" -tAqc "SELECT count(*) FROM membership_state WHERE control_session_id IS NOT NULL")"
+  if [ "$rows" = "0" ]; then cleared=1; break; fi
   sleep 1
 done
-kill "$MESHPD_PID" 2>/dev/null || true
-wait "$MESHPD_PID" 2>/dev/null || true
+[ "$cleared" = "1" ] || fail "a membership is still marked connected after the agent exited"
 
-if [ "$converged" != "1" ]; then
-  echo "--- meshpd log ---" >&2
-  cat "$WORK/meshpd.log" >&2
-  fail "meshpd never converged: applied version never caught up with the network's"
-fi
-grep -q 'control channel established' "$WORK/meshpd.log" || fail "meshpd never established a session"
-grep -q 'recorded desired state' "$WORK/meshpd.log" || fail "meshpd never recorded desired state"
-sed -n 's/.*msg="recorded desired state" \(.*\)/  \1/p' "$WORK/meshpd.log" | tail -1
+# Left behind, the next start would warn about a stale socket for no reason.
+if [ -S "$SOCKET" ]; then fail "the daemon left its socket behind on exit"; fi
 
-# A session that was established must also be cleared when the agent goes away, or the
-# dashboard shows devices as connected forever.
-session_rows="$(psql "$DB_URL" -tAqc "SELECT count(*) FROM membership_state WHERE control_session_id IS NOT NULL")"
-[ "$session_rows" = "0" ] || fail "${session_rows} membership(s) still marked as connected after meshpd exited"
-
-echo "no private key material reached the server"
-# Invariant 1, checked against the thing that would betray it: the server's own output.
-if grep -qiE 'private[_ ]?key' "$LOG"; then
-  fail "the control plane log mentions a private key"
-fi
-# And the plaintext token must not be logged either, only its identifier.
-if grep -q "$TOKEN" "$LOG"; then
-  fail "the control plane logged the plaintext token"
-fi
+echo "no private key material reached the control plane"
+if grep -qiE 'private[_ ]?key' "$CONTROL_LOG"; then fail "the control plane log mentions a private key"; fi
+if grep -qF "$TOKEN" "$CONTROL_LOG"; then fail "the control plane logged the plaintext token"; fi
 
 echo
-echo "enrolment works end to end and a replayed token is refused"
+echo "enrolment and the control channel work end to end; a replayed token is refused"


### PR DESCRIPTION
## What this changes

**A3b.** Closes the shortcut A2 left behind: `meshp join` no longer generates the
device's keys and writes them itself. It asks `meshpd`, which runs as root and is where
private key material belongs.

```
$ sudo meshpd &
$ sudo meshp join meshp_tok_lbpuoqon…
enrolled in network 60611383-…
  interface   meshp0
  address     100.90.0.1

$ sudo meshp status
    session     connected since 2026-08-12T16:42:18Z
    applied     version 2
    interface   meshp0 (not up)
```

## The socket is a privilege boundary

Owner-only by default, set **explicitly** rather than left to umask — which varies by
init system and has produced world-writable sockets in other projects.
`--socket-group` relaxes it to a named group and warns at startup, because anything able
to reach this socket can enrol the device and will soon decide where its traffic goes.
Closer to sudo than to a read-only API, and worth reviewing as such.

Transport is HTTP over the socket. Not because HTTP is elegant here, but because it is
inspectable: `curl --unix-socket /var/run/meshpd.sock http://local/v1/status` works when
something is wrong at 3am and a bespoke framing does not.

## Two things worth naming

**Stale versus live sockets.** A socket left by a crashed process must not stop the
daemon starting; a socket held by a *healthy* daemon must not be stolen. The file is
only removed after a connection to it has been refused. Go's net package unlinks on
close, so my first test for this **silently skipped** — leaving the "won't come back
after a crash" path uncovered. It now binds through the syscall directly.

**The CLI names failures separately.** "connection refused" is not an answer anyone can
act on. `meshpd is not running` → start it. `not permitted` → sudo, or `--socket-group`.

## Invariants

- [x] Invariant 1 — the e2e script reads the stored private key and asserts it appears in neither the CLI's output nor the control plane's log. A test asserts no API type has a field mentioning "private" or "secret".
- [x] Invariant 19 — the daemon generates a fresh WireGuard key per membership.

## Checks

- [x] `make ci`, `make integration`, `make e2e`, `make vuln` all pass.
- [x] `internal/agentapi` 78.3%; the e2e script now covers the whole daemon flow with real binaries.
- [x] Cross-compiles on linux, darwin and windows — `ECONNREFUSED` and `Chown` differ by platform.
- [x] No migration edited, no protocol change.

## Also

Coverage gates gained a third tier. Pure decision logic stays at 90% because it has no
I/O to stub; packages touching files, sockets and processes are held at 75% rather than
pretended into the top tier. `internal/agentstate` was ungated until now.