### PR TITLE
ci: build the container image, and prove it starts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# The Dockerfile does COPY . . after its dependency layer, so everything not listed
+# here is sent to the daemon and lands in a build layer. Two reasons to be strict:
+# the context is uploaded on every build, and .git carries the whole history into a
+# layer that has no use for it.
+.git
+.github
+.gitignore
+.dockerignore
+
+# Build output. Copying host binaries into a build that is about to produce its own
+# is pure waste, and on a different architecture they would not run anyway.
+bin/
+dist/
+coverage.out
+coverage.*.out
+*.test
+
+# Editor and agent state. Never in an image, never in a layer.
+.claude/
+.cursor/
+.aider*
+.continue/
+.idea/
+.vscode/
+*.swp
+
+# Documentation and local scripts the image does not need. Migrations are embedded in
+# the binary and also copied deliberately by the Dockerfile, so they are not excluded.
+docs/
+deploy/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,12 +348,62 @@ jobs:
 
   # A single check for branch protection to require. Without this, protection has
   # to name every job, and renaming or adding one silently stops being enforced.
+  image:
+    name: container image
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: meshp
+          POSTGRES_PASSWORD: meshp
+          POSTGRES_DB: meshp
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U meshp -d meshp"
+          --health-interval 3s --health-timeout 3s --health-retries 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Until this job existed nothing built the Dockerfile at all, so it could have
+      # been broken for weeks without anything saying so — and the dependency bumps
+      # that only touch it had no check to pass.
+      - name: build
+        run: make image VERSION=ci-${{ github.sha }} COMMIT=${{ github.sha }}
+
+      # A binary whose -X paths are wrong still builds, still runs, and reports
+      # "dev" forever. Nothing else notices, and the first person to need the
+      # version of a running container is debugging an incident.
+      - name: the image reports the version it was stamped with
+        run: |
+          out="$(docker run --rm meshp:ci --version)"
+          echo "$out"
+          echo "$out" | grep -q "ci-${{ github.sha }}" \
+            || { echo "the image does not carry the version it was built with"; exit 1; }
+          echo "$out" | grep -q "${{ github.sha }}" \
+            || { echo "the image does not carry its commit"; exit 1; }
+
+      - name: it does not run as root
+        run: |
+          uid="$(docker run --rm --entrypoint id meshp:ci -u)"
+          echo "uid=$uid"
+          [ "$uid" != "0" ] || { echo "the image runs as root"; exit 1; }
+
+      # The real question: does the thing we ship start, migrate and become ready.
+      # Building it only proves the compiler was happy.
+      - name: it starts, migrates and reports ready
+        run: ./scripts/image-smoke.sh
+        env:
+          MESHP_IMAGE: meshp:ci
+          MESHP_DATABASE_URL: postgres://meshp:meshp@127.0.0.1:5432/meshp?sslmode=disable
+
   ci-required:
     name: ci
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
-    needs: [lint, test, cross, proto, integration, migrations, migrations-immutable, standalone, vuln, fuzz-seeds, dco]
+    needs: [lint, test, cross, proto, integration, migrations, migrations-immutable, standalone, image, vuln, fuzz-seeds, dco]
     steps:
       - name: report
         run: |

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ GOVULN_VERSION   := v1.6.0
 
 VERSION  := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT   := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+
+# The container image tag. Overridable so CI can build a throwaway tag without
+# clobbering whatever a developer has locally.
+IMAGE    ?= meshp:ci
 LDFLAGS  := -X github.com/meshpnet/meshp/internal/version.version=$(VERSION) \
             -X github.com/meshpnet/meshp/internal/version.commit=$(COMMIT)
 
@@ -202,6 +206,19 @@ standalone-check: ## Invariant 12: the core must not depend on the commercial la
 e2e: build ## Enrol a device end to end against MESHP_TEST_DATABASE_URL
 	@test -n "$(MESHP_TEST_DATABASE_URL)" || { echo "set MESHP_TEST_DATABASE_URL"; exit 2; }
 	@./scripts/e2e-enrol.sh "$(MESHP_TEST_DATABASE_URL)"
+
+.PHONY: image
+image: ## Build the container image (VERSION and COMMIT are stamped in)
+	docker build \
+	  --build-arg VERSION=$(VERSION) \
+	  --build-arg COMMIT=$(COMMIT) \
+	  -f deploy/docker/Dockerfile \
+	  -t $(IMAGE) .
+
+.PHONY: image-smoke
+image-smoke: image ## Start the image against MESHP_TEST_DATABASE_URL and wait for readiness
+	@test -n "$(MESHP_TEST_DATABASE_URL)" || { echo "set MESHP_TEST_DATABASE_URL"; exit 2; }
+	@MESHP_IMAGE=$(IMAGE) MESHP_DATABASE_URL="$(MESHP_TEST_DATABASE_URL)" ./scripts/image-smoke.sh
 
 .PHONY: migrate-check
 migrate-check: ## Apply, roll back and re-apply every migration against MESHP_TEST_DATABASE_URL

--- a/README.md
+++ b/README.md
@@ -127,10 +127,15 @@ decide where its traffic goes. `meshpd --socket-group <group>` relaxes that to a
 group, which is a privilege grant and should be read as one.
 
 ```bash
-make help    # every available target
-make ci      # everything CI runs, except the jobs that need Postgres
-make e2e     # enrol a device against a real database, start to finish
+make help         # every available target
+make ci           # everything CI runs, except the jobs that need Postgres or Docker
+make e2e          # enrol a device against a real database, start to finish
+make image        # build the server-side container image
+make image-smoke  # start that image against a real database and wait for readiness
 ```
+
+`make ci` deliberately excludes the container build: it needs Docker and adds a minute
+to a target meant to be run constantly. CI gates it instead.
 
 ## How this is tested
 

--- a/scripts/image-smoke.sh
+++ b/scripts/image-smoke.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Start the container image against a real PostgreSQL and wait for it to report ready.
+#
+# Building an image proves the compiler was happy. This proves the thing we would actually
+# ship starts, finds its database, applies its own schema and says so — which is the part
+# that breaks when an entrypoint, a base image or an embedded migration changes.
+#
+# Readiness is the assertion rather than liveness on purpose: /healthz answers as soon as
+# the process is listening, so a container that can never reach its database still passes a
+# liveness check. Readiness is what a load balancer would believe.
+#
+# Usage: image-smoke.sh
+#   MESHP_IMAGE           image to run (default meshp:ci)
+#   MESHP_DATABASE_URL    where the container should connect
+#   MESHP_IMAGE_NETWORK   docker network (default host)
+set -euo pipefail
+
+IMAGE="${MESHP_IMAGE:-meshp:ci}"
+DB_URL="${MESHP_DATABASE_URL:?set MESHP_DATABASE_URL}"
+PORT="${MESHP_IMAGE_PORT:-8099}"
+NAME="meshp-smoke-$$"
+
+# Host networking is what a Linux CI runner wants: the PostgreSQL service publishes its port
+# on the runner, and the container reaches it at 127.0.0.1. It is not what a laptop can do —
+# Docker Desktop does not share the host namespace — so the network is a parameter, and the
+# script is runnable in both places. Two of these scripts have already been fixed today for
+# working in exactly one environment.
+NETWORK="${MESHP_IMAGE_NETWORK:-host}"
+
+fail() {
+  echo "FAIL: $*" >&2
+  echo "--- container log ---" >&2
+  docker logs "$NAME" 2>&1 | tail -40 >&2 || true
+  exit 1
+}
+
+cleanup() {
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# On host networking the container shares the runner's interfaces, so it binds loopback and
+# nothing is published — binding 0.0.0.0 there would expose the control plane on the runner.
+# On any other network it has a namespace of its own, so it binds 0.0.0.0 within it and the
+# port is published to reach it from here.
+if [ "$NETWORK" = "host" ]; then
+  net_args=(--network host)
+  bind="127.0.0.1:${PORT}"
+else
+  net_args=(--network "$NETWORK" -p "127.0.0.1:${PORT}:${PORT}")
+  bind="0.0.0.0:${PORT}"
+fi
+
+echo "starting ${IMAGE} on network ${NETWORK}"
+docker run -d --name "$NAME" "${net_args[@]}" \
+  -e MESHP_DATABASE_URL="$DB_URL" \
+  -e MESHP_LISTEN_ADDR="$bind" \
+  -e MESHP_SECRET_KEY="image-smoke-secret-not-a-secret" \
+  -e MESHP_LOG_LEVEL="debug" \
+  "$IMAGE" >/dev/null
+
+# Liveness first, so a container that never listens at all is reported as that rather than
+# as a readiness timeout thirty seconds later.
+for _ in $(seq 1 20); do
+  if curl -fsS "http://127.0.0.1:${PORT}/healthz" >/dev/null 2>&1; then
+    echo "  healthz answers"
+    break
+  fi
+  docker inspect -f '{{.State.Running}}' "$NAME" 2>/dev/null | grep -q true \
+    || fail "the container exited before it listened"
+  sleep 1
+done
+curl -fsS "http://127.0.0.1:${PORT}/healthz" >/dev/null 2>&1 \
+  || fail "the container never answered /healthz"
+
+# Then readiness, which requires the schema to be current — so this covers the migrations
+# embedded in the binary rather than the ones in the repository.
+ready=0
+for _ in $(seq 1 40); do
+  code="$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT}/readyz" || true)"
+  if [ "$code" = "200" ]; then ready=1; break; fi
+  docker inspect -f '{{.State.Running}}' "$NAME" 2>/dev/null | grep -q true \
+    || fail "the container exited while coming up"
+  sleep 1
+done
+[ "$ready" = "1" ] || fail "the container never became ready (last /readyz was ${code:-no response})"
+echo "  readyz answers 200"
+
+# Migrations are embedded, so the copy in the image is documentation. Check it is there all
+# the same: an operator reading a container to find out what it applied should find it.
+docker run --rm --entrypoint ls "$IMAGE" /usr/share/meshp/migrations >/dev/null \
+  || fail "the image carries no copy of the migrations"
+
+# And the other binary in the image runs, since nothing else covers it.
+docker run --rm --entrypoint /usr/local/bin/meshp-relay "$IMAGE" --version >/dev/null \
+  || fail "meshp-relay does not run in the image"
+
+echo
+echo "the image starts, migrates and reports ready"


### PR DESCRIPTION
`deploy/docker/Dockerfile` was built by nothing — no CI job, no Makefile target. It
could have been broken for weeks with nothing to say so, and the two open Dependabot
PRs that touch only that file had no check to pass. It builds, as it turns out, but
that was luck rather than knowledge.

## What the job asserts beyond "it compiled"

**The image reports the version it was stamped with.** A wrong `-X` path still builds,
still runs, and reports `dev` forever. Nothing else notices, and the first person to
need the version of a running container is already debugging an incident. (The paths
were right — checked against the Makefile's.)

**It does not run as root.**

**It starts, finds its database, applies its own embedded migrations, and reports ready.**
Readiness rather than liveness is the assertion on purpose: `/healthz` answers as soon
as the process listens, so a container that can never reach its database passes a
liveness check. Pointed at a host that does not exist, the script reports exactly that
difference:

    healthz answers
    FAIL: the container never became ready (last /readyz was 503)

**And `meshp-relay` runs**, which nothing else covered.

## Verified in both environments, not just one

`scripts/image-smoke.sh` takes its docker network as a parameter rather than hardcoding
`--network host`. Host networking is what a Linux runner wants — the Postgres service
publishes on the runner, the container reaches 127.0.0.1 — and it is not something a
laptop can do. Two scripts were fixed earlier today for working in exactly one
environment; this one is checked in both. Locally, against a containerised PostgreSQL,
the image applied both migrations itself:

    $ psql -tAc "SELECT version || ' ' || name FROM schema_migrations ORDER BY version"
    1 init
    2 state_changes

Image is 26.8MB, non-root uid 65532.

## Also

A `.dockerignore`. `COPY . .` was sending `.git` and `bin/` to the daemon on every
build — the history into a layer that has no use for it, and host binaries into a build
about to produce its own for a possibly different architecture.

`make ci` deliberately excludes this: it needs Docker and adds a minute to a target
meant to be run constantly. The README says so, rather than leaving the omission to be
discovered.

## Invariants

- [x] No invariant is affected.

## Migrations

None.

## Follow-on

With this in place, [#1](https://github.com/meshpnet/meshp/pull/1) (alpine 3.21 → 3.24)
has something to pass and can be merged. [#2](https://github.com/meshpnet/meshp/pull/2)
(golang 1.25 → 1.26-alpine) stays open deliberately: `go.mod` says 1.25.0 and every
workflow pins `GO_VERSION: "1.25"`, so taking it would mean shipping a binary compiled
by a toolchain nothing tests with. Moving to 1.26 should change CI and the Dockerfile
together.