### PR TITLE
feat(wgplan): decide what a WireGuard interface should look like

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
           cache: true
       - run: make lint
 
+      # go.mod carried a stale "// indirect" on a module imported directly, because
+      # nothing checked. -diff writes nothing, so a failure here leaves no mess behind.
+      - name: go.mod is tidy
+        run: make tidy-check
+
   test:
     name: test and coverage
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ CROSS_TARGETS := linux/amd64 linux/arm64 linux/arm \
 # are held lower rather than pretended into the top tier. Packages needing PostgreSQL
 # are checked separately: without a database their tests skip, and the figure would be
 # meaningless rather than merely low.
-COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset
+COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan
 COVER_FLOOR      := 90
 
 COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx
@@ -173,6 +173,16 @@ lint: fmt-check ## Run go vet and golangci-lint
 	go vet ./...
 	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION) run
 
+.PHONY: tidy-check
+tidy-check: ## Fail if go.mod or go.sum are not what `go mod tidy` would write
+	@# -diff reports what would change and writes nothing, so this cannot leave the
+	@# working tree modified if it is interrupted.
+	@go mod tidy -diff || { \
+	  echo "go.mod or go.sum is not tidy; run 'go mod tidy' and commit the result"; \
+	  exit 1; \
+	}
+	@echo "  go.mod and go.sum are tidy"
+
 .PHONY: vuln
 vuln: ## Check dependencies and stdlib against the Go vulnerability database
 	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULN_VERSION) ./...
@@ -228,7 +238,7 @@ migrate-check: ## Apply, roll back and re-apply every migration against MESHP_TE
 ## --- aggregate ------------------------------------------------------------
 
 .PHONY: ci
-ci: lint standalone-check build cross test cover-check cover-check-io fuzz-seeds ## Everything CI runs, minus the jobs needing Postgres
+ci: lint tidy-check standalone-check build cross test cover-check cover-check-io fuzz-seeds ## Everything CI runs, minus the jobs needing Postgres
 	@echo
 	@echo "  all local CI checks passed"
 

--- a/docs/adr/0015-data-plane-kernel-first.md
+++ b/docs/adr/0015-data-plane-kernel-first.md
@@ -1,0 +1,109 @@
+# ADR-0015: Kernel WireGuard where it exists, userspace where it does not, and say which
+
+- **Status:** accepted
+- **Date:** 2026-08-13
+
+## Context
+
+meshp has to move packets on Linux, Windows, macOS, Android and iOS. Only Linux
+has WireGuard in the kernel; the others need a userspace implementation, a
+driver, or the platform's own tunnel provider (ADR-0010 covers mobile).
+
+The two implementations differ by a large factor in throughput and CPU. On a
+relay carrying customer traffic, or a laptop on battery, that is not a detail.
+They also differ in how the interface comes into existence: a kernel device is
+created over netlink, a userspace device is a process that owns a tun device and
+listens on a unix socket.
+
+What they do *not* differ in is configuration. `wgctrl` speaks netlink to kernel
+devices and the UAPI socket to userspace ones behind one interface, so "set this
+private key, these peers, these allowed IPs" is written once either way.
+
+There is a third thing that must not be conflated with either, and routinely is.
+WireGuard's `AllowedIPs` is a cryptokey routing table: it decides which peer a
+packet is encrypted for, and which source addresses are accepted from a peer. It
+is not a system route. The kernel still needs a route pointing at the interface
+before it will hand a packet over at all. Both are required, they are set through
+different mechanisms, and a configuration with one and not the other fails in a
+way that looks like the other layer's fault.
+
+## Decision
+
+Prefer the kernel implementation. Fall back to userspace when it is unavailable.
+Report which one is in use, always, in `meshp status` and in the agent's
+heartbeat.
+
+The reporting is part of the decision, not a nicety. A silent fallback turns
+"why is this host a tenth the speed of that one" into an unanswerable question,
+and the answer — a missing kernel module — is one an operator can act on in a
+minute if told.
+
+Configuration goes through `wgctrl` for both. Interface lifecycle — create,
+address, route, destroy — is per-platform and behind an interface, so a platform
+meshp does not support yet is a missing implementation rather than a change to
+everything else.
+
+Addresses and routes:
+
+- A membership's own address is assigned as a host prefix (`/32`, `/128`), not
+  as a prefix covering the pool. A wider local address creates a connected route
+  for the whole pool, so traffic to any unassigned address in it would be sent
+  into the tunnel and dropped there instead of failing immediately.
+- Every peer gets an explicit route to its own addresses via the interface.
+  Precise, and precisely removable.
+- `AllowedIPs` for an ordinary peer is exactly its own addresses. Wider
+  prefixes belong to route groups (ADR-0001), which the server marks
+  explicitly; an agent never widens on its own initiative.
+
+Two peers on one interface may never claim overlapping `AllowedIPs`. WireGuard
+resolves a collision by giving the prefix to whichever peer was configured last
+and silently taking it from the other, which produces a network where one device
+is unreachable and nothing logged a reason. The agent treats an overlap as a
+control-plane bug and refuses the whole update rather than applying half of it.
+
+## Consequences
+
+Two interface-lifecycle implementations per platform family instead of one, and
+a fallback path that will be exercised rarely and so must be tested
+deliberately rather than incidentally.
+
+Performance becomes environment-dependent in a way we now have to explain.
+Support conversations will include "which implementation is this host using",
+which is why it is in `meshp status` from the start.
+
+Refusing an overlapping update means a control-plane bug can stop an agent from
+converging, rather than degrading it. That is the intended trade: an agent that
+converges onto a broken configuration reports success, and the failure surfaces
+weeks later as an unreachable device. The refusal is loud, attributable, and
+carries the two peers that collided.
+
+Host-prefix addressing means the mesh has no on-link subnet, so anything that
+assumes "same subnet means directly reachable" — some service discovery, some
+naive broadcast — will not work. That is a real limitation and it is the correct
+one: reachability in a mesh is per-peer policy, not a property of the address.
+
+The pure part of this — turn desired state plus observed state into an ordered
+list of operations — is separated from the syscalls so it can be tested
+exhaustively without privileges, on any platform. The platform layer is then
+thin enough to be tested against a real interface without needing to enumerate
+cases there.
+
+## Alternatives considered
+
+**Userspace everywhere, one code path.** Tailscale does this and it buys real
+simplicity: identical behaviour on every platform, no module dependency, no
+fallback to test. Rejected because the throughput cost is paid by the customer
+on every byte, forever, and because Linux servers — relays, exit nodes, the
+hosts most likely to carry aggregate traffic — are exactly where the kernel
+implementation is available.
+
+**Kernel only, Linux only, for now.** Simpler and faster to build, and it would
+move a packet sooner. Rejected because the interface boundary is cheaper to
+design now than to retrofit around a kernel-shaped assumption, and because a
+container without the module is a completely ordinary place to run a control
+plane.
+
+**Shell out to `wg` and `ip`.** Fast to write and easy to debug by hand.
+Rejected: it needs those binaries present at the right versions, it turns every
+error into a string to be parsed, and it makes the privileged surface "whatever
+the shell will run" instead of a fixed set of netlink operations.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,7 @@ deliberate act with a written reason rather than a drift nobody noticed.
 | [0012](0012-presence-and-bus-interface.md) | Presence and pub/sub sit behind an interface with in-memory and Redis implementations |
 | [0013](0013-commit-generated-code.md) | Generated protobuf and database code is committed |
 | [0014](0014-hand-written-migration-runner.md) | A hand-written migration runner that checksums what it applied |
+| [0015](0015-data-plane-kernel-first.md) | Kernel WireGuard where it exists, userspace where it does not, and say which |
 
 ## Format
 

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/meshpnet/meshp
 go 1.25.0
 
 require (
+	github.com/coder/websocket v1.8.15
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
 	google.golang.org/protobuf v1.36.12
 )
 
 require (
-	github.com/coder/websocket v1.8.15 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/internal/wgplan/wgplan.go
+++ b/internal/wgplan/wgplan.go
@@ -1,0 +1,478 @@
+// Package wgplan turns desired and observed interface state into an ordered list of
+// operations, without touching anything.
+//
+// It exists so that the rules about what a WireGuard interface should look like are
+// decided somewhere that can be tested exhaustively, on any platform, without
+// privileges. What is left for the platform layer is applying operations one at a time,
+// which is thin enough to test against a real interface without enumerating cases there.
+//
+// Three properties matter, and all three are the kind that fail silently:
+//
+//   - Planning against state that already matches produces no operations at all
+//     (Invariant 18). An agent that reconfigures an interface on every tick tears down
+//     working sessions to arrive back where it was.
+//   - Removals are emitted before additions. When a prefix moves from one peer to
+//     another, additions first would hand it to the new peer and then the removal would
+//     take it away again — leaving the address unreachable while both versions look
+//     correct in isolation.
+//   - Two peers may never hold overlapping allowed IPs. WireGuard gives a contested
+//     prefix to whichever peer was configured last and silently takes it from the
+//     other, so the check has to happen here rather than being discovered as an
+//     unreachable device.
+package wgplan
+
+import (
+	"fmt"
+	"net/netip"
+	"sort"
+	"strings"
+)
+
+// Key is a WireGuard public or private key in its base64 form.
+//
+// A string rather than the 32 bytes, because this package never does anything with a key
+// but compare it and pass it on. Parsing belongs where the key reaches the kernel.
+type Key string
+
+// Peer is one peer of an interface.
+type Peer struct {
+	PublicKey Key
+
+	// AllowedIPs is the cryptokey routing table for this peer: which destinations are
+	// encrypted to it, and which source addresses are accepted from it. Not a system
+	// route — see ADR-0015 — and not something the agent widens on its own.
+	AllowedIPs []netip.Prefix
+
+	// Endpoint is where to send this peer's traffic, when anywhere is known. Unset means
+	// the peer is configured and currently unreachable, which is a normal state before a
+	// path has been found rather than an error.
+	Endpoint string
+
+	// PresharedKey is optional per-pair symmetric material.
+	PresharedKey Key
+
+	// KeepaliveSeconds keeps a NAT mapping open. Zero means none.
+	KeepaliveSeconds int
+}
+
+// Interface is the desired state of one membership's interface.
+type Interface struct {
+	Name       string
+	PrivateKey Key
+	ListenPort int
+	MTU        int
+
+	// Addresses are this device's own addresses, as host prefixes. See ADR-0015 for why
+	// they are not the pool prefix.
+	Addresses []netip.Prefix
+
+	Peers []Peer
+}
+
+// Observed is what the platform reports an existing interface currently holds.
+//
+// Exists is false when there is no interface at all, which is different from an
+// interface that exists and is empty: the first needs creating, the second does not.
+type Observed struct {
+	Exists     bool
+	PrivateKey Key
+	ListenPort int
+	MTU        int
+	Addresses  []netip.Prefix
+	Peers      []Peer
+
+	// Routes currently pointing at this interface. Only these are candidates for
+	// removal: a route through some other interface is not ours to withdraw, whatever it
+	// covers (Invariant 20 is about removing what we installed, not what we found).
+	Routes []netip.Prefix
+}
+
+// OpKind is what an operation does.
+type OpKind int
+
+const (
+	// CreateDevice brings the interface into existence.
+	CreateDevice OpKind = iota
+	// SetDevice sets the private key, listen port and MTU.
+	SetDevice
+	// RemovePeer removes a peer by public key.
+	RemovePeer
+	// SetPeer adds a peer or replaces its configuration.
+	SetPeer
+	// RemoveAddress takes an address off the interface.
+	RemoveAddress
+	// AddAddress puts an address on the interface.
+	AddAddress
+	// RemoveRoute withdraws a route that pointed at the interface.
+	RemoveRoute
+	// AddRoute points a prefix at the interface.
+	AddRoute
+	// BringUp marks the interface up. Last, so nothing is briefly reachable while
+	// half-configured.
+	BringUp
+	// DestroyDevice removes the interface entirely.
+	DestroyDevice
+)
+
+func (k OpKind) String() string {
+	switch k {
+	case CreateDevice:
+		return "create-device"
+	case SetDevice:
+		return "set-device"
+	case RemovePeer:
+		return "remove-peer"
+	case SetPeer:
+		return "set-peer"
+	case RemoveAddress:
+		return "remove-address"
+	case AddAddress:
+		return "add-address"
+	case RemoveRoute:
+		return "remove-route"
+	case AddRoute:
+		return "add-route"
+	case BringUp:
+		return "bring-up"
+	case DestroyDevice:
+		return "destroy-device"
+	default:
+		return fmt.Sprintf("op(%d)", int(k))
+	}
+}
+
+// Device is the interface's own settings, as carried by a SetDevice operation.
+type Device struct {
+	PrivateKey Key
+	ListenPort int
+	MTU        int
+}
+
+// Op is one thing to do to the interface.
+//
+// Every operation carries what it needs. A plan is therefore applicable on its own, and
+// whoever applies it cannot disagree with it: an operation that meant "set the device to
+// whatever the caller happens to be holding" would let the plan and the values applied
+// drift apart, which is the failure this package exists to make impossible.
+type Op struct {
+	Kind OpKind
+
+	// Peer is set for SetPeer and RemovePeer. For RemovePeer only PublicKey is
+	// meaningful.
+	Peer Peer
+
+	// Device is set for SetDevice.
+	Device Device
+
+	// Prefix is set for the address and route operations.
+	Prefix netip.Prefix
+}
+
+// String renders an operation for logs and test failures.
+func (o Op) String() string {
+	switch o.Kind {
+	case SetPeer, RemovePeer:
+		return fmt.Sprintf("%s %s", o.Kind, o.Peer.PublicKey)
+	case SetDevice:
+		// The key is not printed. This renders into logs, and a private key in a log is
+		// still a private key (Invariant 1).
+		return fmt.Sprintf("%s port=%d mtu=%d", o.Kind, o.Device.ListenPort, o.Device.MTU)
+	case AddAddress, RemoveAddress, AddRoute, RemoveRoute:
+		return fmt.Sprintf("%s %s", o.Kind, o.Prefix)
+	default:
+		return o.Kind.String()
+	}
+}
+
+// Plan is the ordered work needed to make an interface match what was asked for.
+type Plan struct {
+	Ops []Op
+}
+
+// Empty reports whether there is nothing to do.
+func (p Plan) Empty() bool { return len(p.Ops) == 0 }
+
+// String renders a plan one operation per line.
+func (p Plan) String() string {
+	if p.Empty() {
+		return "(nothing to do)"
+	}
+	var b strings.Builder
+	for i, op := range p.Ops {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(op.String())
+	}
+	return b.String()
+}
+
+// For returns the operations that turn observed into want.
+//
+// An error means want is not a configuration that should be applied at all, and nothing
+// is returned to apply partially. Refusing outright is deliberate: the alternative is an
+// agent that converges onto a broken interface and reports success, and the symptom of
+// that arrives later as a device nobody can reach.
+func For(want Interface, observed Observed) (Plan, error) {
+	if err := want.Validate(); err != nil {
+		return Plan{}, err
+	}
+
+	var plan Plan
+	add := func(op Op) { plan.Ops = append(plan.Ops, op) }
+
+	if !observed.Exists {
+		add(Op{Kind: CreateDevice})
+	}
+
+	// The device's own settings. Compared rather than always written, so a steady state
+	// produces no operations: setting a private key again resets every session on the
+	// interface, which would drop traffic on a tick that had nothing to change.
+	if !observed.Exists ||
+		observed.PrivateKey != want.PrivateKey ||
+		observed.ListenPort != want.ListenPort ||
+		observed.MTU != want.MTU {
+		add(Op{Kind: SetDevice, Device: Device{
+			PrivateKey: want.PrivateKey,
+			ListenPort: want.ListenPort,
+			MTU:        want.MTU,
+		}})
+	}
+
+	// Peers. Removals first, so a prefix moving between peers is given up before it is
+	// claimed.
+	wantPeers := indexPeers(want.Peers)
+	havePeers := indexPeers(observed.Peers)
+
+	for _, key := range sortedKeys(havePeers) {
+		if _, keep := wantPeers[key]; !keep {
+			add(Op{Kind: RemovePeer, Peer: Peer{PublicKey: key}})
+		}
+	}
+	for _, key := range sortedKeys(wantPeers) {
+		desired := wantPeers[key]
+		current, exists := havePeers[key]
+		if !exists || !samePeer(current, desired) {
+			add(Op{Kind: SetPeer, Peer: desired})
+		}
+	}
+
+	// Addresses, then routes: a route needs the interface to hold an address in the
+	// family it is for, and on some platforms it needs the address present before the
+	// route will attach at all.
+	addPrefixOps(&plan, observed.Addresses, want.Addresses, RemoveAddress, AddAddress)
+
+	// Every peer's own addresses are routed at the interface. Derived rather than
+	// supplied, because a route to a peer that is not configured would be a black hole,
+	// and the two lists would then have to be kept in step by whoever calls this.
+	addPrefixOps(&plan, observed.Routes, wantRoutes(want), RemoveRoute, AddRoute)
+
+	if !observed.Exists {
+		add(Op{Kind: BringUp})
+	}
+	return plan, nil
+}
+
+// Validate reports whether an interface is a configuration worth applying.
+func (i Interface) Validate() error {
+	if i.Name == "" {
+		return fmt.Errorf("wgplan: an interface needs a name")
+	}
+	if i.PrivateKey == "" {
+		return fmt.Errorf("wgplan: interface %s has no private key", i.Name)
+	}
+	if i.MTU <= 0 {
+		return fmt.Errorf("wgplan: interface %s has MTU %d", i.Name, i.MTU)
+	}
+	if len(i.Addresses) == 0 {
+		return fmt.Errorf("wgplan: interface %s has no addresses", i.Name)
+	}
+	for _, addr := range i.Addresses {
+		if !addr.IsValid() {
+			return fmt.Errorf("wgplan: interface %s has an invalid address", i.Name)
+		}
+		if addr.Bits() != addr.Addr().BitLen() {
+			// A wider local address creates a connected route for the whole pool, so
+			// traffic to an unassigned address in it would be sent into the tunnel and
+			// dropped rather than failing at once (ADR-0015).
+			return fmt.Errorf("wgplan: interface %s address %s is not a host prefix", i.Name, addr)
+		}
+	}
+
+	own := make(map[netip.Addr]struct{}, len(i.Addresses))
+	for _, addr := range i.Addresses {
+		own[addr.Addr()] = struct{}{}
+	}
+
+	// Which peer claimed each prefix, so a collision can name both sides. An error that
+	// says only "overlap" leaves the reader to find them.
+	claimed := make(map[netip.Prefix]Key)
+	seen := make(map[Key]struct{}, len(i.Peers))
+
+	for _, peer := range i.Peers {
+		if peer.PublicKey == "" {
+			return fmt.Errorf("wgplan: interface %s has a peer with no public key", i.Name)
+		}
+		if _, dup := seen[peer.PublicKey]; dup {
+			return fmt.Errorf("wgplan: interface %s lists peer %s twice", i.Name, peer.PublicKey)
+		}
+		seen[peer.PublicKey] = struct{}{}
+
+		if len(peer.AllowedIPs) == 0 {
+			// A peer with no allowed IPs can neither be sent to nor accepted from. It is
+			// not harmful, but it is never what anyone meant.
+			return fmt.Errorf("wgplan: interface %s peer %s has no allowed IPs", i.Name, peer.PublicKey)
+		}
+		for _, prefix := range peer.AllowedIPs {
+			if !prefix.IsValid() {
+				return fmt.Errorf("wgplan: interface %s peer %s has an invalid allowed IP",
+					i.Name, peer.PublicKey)
+			}
+			if _, mine := own[prefix.Addr()]; mine && prefix.Bits() == prefix.Addr().BitLen() {
+				return fmt.Errorf("wgplan: interface %s peer %s claims this device's own address %s",
+					i.Name, peer.PublicKey, prefix)
+			}
+			if other, taken := claimed[prefix]; taken {
+				return fmt.Errorf("wgplan: interface %s peers %s and %s both claim %s",
+					i.Name, other, peer.PublicKey, prefix)
+			}
+			claimed[prefix] = peer.PublicKey
+		}
+	}
+
+	// Overlaps that are not exact duplicates: one peer holding 10.0.0.0/24 and another
+	// holding 10.0.0.5/32 is the same silent theft, and comparing prefixes for equality
+	// alone would miss it.
+	prefixes := sortedPrefixes(claimed)
+	for a := range prefixes {
+		for b := a + 1; b < len(prefixes); b++ {
+			if prefixes[a].Overlaps(prefixes[b]) {
+				return fmt.Errorf("wgplan: interface %s peer %s has %s, which overlaps %s held by %s",
+					i.Name, claimed[prefixes[a]], prefixes[a], prefixes[b], claimed[prefixes[b]])
+			}
+		}
+	}
+	return nil
+}
+
+// Teardown returns the operations that remove everything this interface installed.
+//
+// Invariant 20: everything the agent installs, the agent can remove. Routes go first,
+// because a route pointing at an interface that no longer exists is the state a host is
+// left in when this is done in the wrong order — and on some platforms it lingers.
+func Teardown(observed Observed) Plan {
+	var plan Plan
+	if !observed.Exists {
+		return plan
+	}
+	for _, route := range sortPrefixes(observed.Routes) {
+		plan.Ops = append(plan.Ops, Op{Kind: RemoveRoute, Prefix: route})
+	}
+	for _, addr := range sortPrefixes(observed.Addresses) {
+		plan.Ops = append(plan.Ops, Op{Kind: RemoveAddress, Prefix: addr})
+	}
+	plan.Ops = append(plan.Ops, Op{Kind: DestroyDevice})
+	return plan
+}
+
+// wantRoutes is every peer address that should be routed at the interface.
+func wantRoutes(want Interface) []netip.Prefix {
+	out := make([]netip.Prefix, 0, len(want.Peers))
+	for _, peer := range want.Peers {
+		out = append(out, peer.AllowedIPs...)
+	}
+	return out
+}
+
+// addPrefixOps emits removals for prefixes no longer wanted and additions for new ones.
+func addPrefixOps(plan *Plan, have, want []netip.Prefix, removeKind, addKind OpKind) {
+	haveSet := prefixSet(have)
+	wantSet := prefixSet(want)
+
+	for _, prefix := range sortPrefixes(have) {
+		if _, keep := wantSet[prefix]; !keep {
+			plan.Ops = append(plan.Ops, Op{Kind: removeKind, Prefix: prefix})
+		}
+	}
+	for _, prefix := range sortPrefixes(want) {
+		if _, exists := haveSet[prefix]; !exists {
+			plan.Ops = append(plan.Ops, Op{Kind: addKind, Prefix: prefix})
+		}
+	}
+}
+
+func prefixSet(prefixes []netip.Prefix) map[netip.Prefix]struct{} {
+	out := make(map[netip.Prefix]struct{}, len(prefixes))
+	for _, p := range prefixes {
+		out[p] = struct{}{}
+	}
+	return out
+}
+
+// sortPrefixes returns the prefixes deduplicated and in a stable order.
+//
+// Sorted because two plans for the same state must be identical: a plan whose order
+// depends on Go's map iteration would make every comparison, log line and test flake.
+func sortPrefixes(prefixes []netip.Prefix) []netip.Prefix {
+	seen := make(map[netip.Prefix]struct{}, len(prefixes))
+	out := make([]netip.Prefix, 0, len(prefixes))
+	for _, p := range prefixes {
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	sort.Slice(out, func(a, b int) bool { return out[a].String() < out[b].String() })
+	return out
+}
+
+func sortedPrefixes(claimed map[netip.Prefix]Key) []netip.Prefix {
+	out := make([]netip.Prefix, 0, len(claimed))
+	for p := range claimed {
+		out = append(out, p)
+	}
+	sort.Slice(out, func(a, b int) bool { return out[a].String() < out[b].String() })
+	return out
+}
+
+func indexPeers(peers []Peer) map[Key]Peer {
+	out := make(map[Key]Peer, len(peers))
+	for _, p := range peers {
+		out[p.PublicKey] = p
+	}
+	return out
+}
+
+func sortedKeys(peers map[Key]Peer) []Key {
+	out := make([]Key, 0, len(peers))
+	for k := range peers {
+		out = append(out, k)
+	}
+	sort.Slice(out, func(a, b int) bool { return out[a] < out[b] })
+	return out
+}
+
+// samePeer reports whether a peer needs rewriting.
+//
+// Allowed IPs are compared as sets: the order they arrive in is not something the kernel
+// preserves or cares about, so comparing slices directly would rewrite every peer on
+// every tick and reset its session each time.
+func samePeer(have, want Peer) bool {
+	if have.Endpoint != want.Endpoint ||
+		have.PresharedKey != want.PresharedKey ||
+		have.KeepaliveSeconds != want.KeepaliveSeconds {
+		return false
+	}
+	a := sortPrefixes(have.AllowedIPs)
+	b := sortPrefixes(want.AllowedIPs)
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/wgplan/wgplan_test.go
+++ b/internal/wgplan/wgplan_test.go
@@ -1,0 +1,716 @@
+package wgplan
+
+import (
+	"fmt"
+	"math/rand"
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+func mustPrefix(t *testing.T, s string) netip.Prefix {
+	t.Helper()
+	p, err := netip.ParsePrefix(s)
+	if err != nil {
+		t.Fatalf("ParsePrefix(%q): %v", s, err)
+	}
+	return p
+}
+
+func prefixes(t *testing.T, ss ...string) []netip.Prefix {
+	t.Helper()
+	out := make([]netip.Prefix, 0, len(ss))
+	for _, s := range ss {
+		out = append(out, mustPrefix(t, s))
+	}
+	return out
+}
+
+// base is a valid two-peer interface, the shape the control plane sends today.
+func base(t *testing.T) Interface {
+	t.Helper()
+	return Interface{
+		Name:       "meshp0",
+		PrivateKey: "private-key-of-this-device",
+		ListenPort: 51820,
+		MTU:        1420,
+		Addresses:  prefixes(t, "100.90.0.1/32", "fd7c::1/128"),
+		Peers: []Peer{
+			{
+				PublicKey:        "peer-bob",
+				AllowedIPs:       prefixes(t, "100.90.0.2/32", "fd7c::2/128"),
+				Endpoint:         "203.0.113.2:51820",
+				KeepaliveSeconds: 25,
+			},
+			{
+				PublicKey:        "peer-carol",
+				AllowedIPs:       prefixes(t, "100.90.0.3/32", "fd7c::3/128"),
+				KeepaliveSeconds: 25,
+			},
+		},
+	}
+}
+
+// applied is what the platform would report after a plan was carried out. It is how the
+// tests check idempotence without a real interface: plan, apply into this, plan again.
+func applied(want Interface) Observed {
+	obs := Observed{
+		Exists:     true,
+		PrivateKey: want.PrivateKey,
+		ListenPort: want.ListenPort,
+		MTU:        want.MTU,
+		Addresses:  append([]netip.Prefix(nil), want.Addresses...),
+		Peers:      append([]Peer(nil), want.Peers...),
+	}
+	for _, peer := range want.Peers {
+		obs.Routes = append(obs.Routes, peer.AllowedIPs...)
+	}
+	return obs
+}
+
+func firstIndexOf(p Plan, kind OpKind) int {
+	for i, op := range p.Ops {
+		if op.Kind == kind {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestAFreshHostGetsTheWholeInterface(t *testing.T) {
+	want := base(t)
+	plan, err := For(want, Observed{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := firstIndexOf(plan, CreateDevice); got != 0 {
+		t.Errorf("create-device is at %d, want first:\n%s", got, plan)
+	}
+	if got := firstIndexOf(plan, BringUp); got != len(plan.Ops)-1 {
+		// Half-configured and up means traffic can be sent to an interface that does not
+		// yet know its peers, which fails as a black hole rather than as an error.
+		t.Errorf("bring-up is at %d of %d, want last:\n%s", got, len(plan.Ops), plan)
+	}
+
+	var setPeers, addAddrs, addRoutes int
+	for _, op := range plan.Ops {
+		switch op.Kind {
+		case SetPeer:
+			setPeers++
+		case AddAddress:
+			addAddrs++
+		case AddRoute:
+			addRoutes++
+		}
+	}
+	if setPeers != 2 {
+		t.Errorf("%d set-peer operations, want 2", setPeers)
+	}
+	if addAddrs != 2 {
+		t.Errorf("%d add-address operations, want 2 (v4 and v6)", addAddrs)
+	}
+	if addRoutes != 4 {
+		t.Errorf("%d add-route operations, want 4 (two peers, two families)", addRoutes)
+	}
+}
+
+// Invariant 18. An agent that rewrites a working interface on every tick resets every
+// session it has, so "nothing changed" has to produce nothing at all.
+func TestPlanningAgainstAMatchingInterfaceDoesNothing(t *testing.T) {
+	want := base(t)
+	plan, err := For(want, applied(want))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !plan.Empty() {
+		t.Errorf("a matching interface produced work:\n%s", plan)
+	}
+}
+
+// The same, but with everything in a different order from what was asked for — which is
+// how a real device reports itself, since neither the kernel nor the UAPI socket preserves
+// the order anything was written in.
+func TestOrderOfObservedStateDoesNotMatter(t *testing.T) {
+	want := base(t)
+	obs := applied(want)
+
+	obs.Peers = []Peer{obs.Peers[1], obs.Peers[0]}
+	obs.Addresses = []netip.Prefix{obs.Addresses[1], obs.Addresses[0]}
+	for i := range obs.Peers {
+		ips := obs.Peers[i].AllowedIPs
+		obs.Peers[i].AllowedIPs = []netip.Prefix{ips[1], ips[0]}
+	}
+	for i, j := 0, len(obs.Routes)-1; i < j; i, j = i+1, j-1 {
+		obs.Routes[i], obs.Routes[j] = obs.Routes[j], obs.Routes[i]
+	}
+
+	plan, err := For(want, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !plan.Empty() {
+		t.Errorf("reordering what the device reports produced work:\n%s", plan)
+	}
+}
+
+// A prefix moving from one peer to another is the case that ordering exists for. Adding
+// before removing would give the address to the new peer and then take it away again.
+func TestAPrefixMovingBetweenPeersIsRemovedBeforeItIsAdded(t *testing.T) {
+	before := base(t)
+	obs := applied(before)
+
+	// Carol is gone and Bob has taken her addresses — a re-enrolment onto the same
+	// address, or a key rotation seen as one peer replacing another.
+	after := base(t)
+	after.Peers = []Peer{{
+		PublicKey:        "peer-bob",
+		AllowedIPs:       prefixes(t, "100.90.0.2/32", "fd7c::2/128", "100.90.0.3/32", "fd7c::3/128"),
+		Endpoint:         "203.0.113.2:51820",
+		KeepaliveSeconds: 25,
+	}}
+
+	plan, err := For(after, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	removeCarol := -1
+	setBob := -1
+	for i, op := range plan.Ops {
+		if op.Kind == RemovePeer && op.Peer.PublicKey == "peer-carol" {
+			removeCarol = i
+		}
+		if op.Kind == SetPeer && op.Peer.PublicKey == "peer-bob" {
+			setBob = i
+		}
+	}
+	if removeCarol < 0 || setBob < 0 {
+		t.Fatalf("expected both a removal and a set:\n%s", plan)
+	}
+	if removeCarol > setBob {
+		t.Errorf("carol is removed at %d, after bob is set at %d — bob's claim on\n"+
+			"100.90.0.3/32 would be taken back by the removal:\n%s", removeCarol, setBob, plan)
+	}
+}
+
+// Two peers holding the same prefix is not something to apply half of: WireGuard would
+// give it to whichever was written last and silently take it from the other.
+func TestOverlappingAllowedIPsAreRefused(t *testing.T) {
+	cases := []struct {
+		name  string
+		a, b  []string
+		wants []string // substrings the error must name, so it is actionable
+	}{
+		{
+			name:  "exactly the same prefix",
+			a:     []string{"100.90.0.9/32"},
+			b:     []string{"100.90.0.9/32"},
+			wants: []string{"peer-a", "peer-b", "100.90.0.9/32"},
+		},
+		{
+			name:  "a host inside another peer's wider prefix",
+			a:     []string{"10.0.0.0/24"},
+			b:     []string{"10.0.0.5/32"},
+			wants: []string{"peer-a", "peer-b", "overlaps"},
+		},
+		{
+			name:  "v6, where the same mistake is easier to miss",
+			a:     []string{"fd7c::/64"},
+			b:     []string{"fd7c::5/128"},
+			wants: []string{"overlaps"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			iface := base(t)
+			iface.Peers = []Peer{
+				{PublicKey: "peer-a", AllowedIPs: prefixes(t, tc.a...)},
+				{PublicKey: "peer-b", AllowedIPs: prefixes(t, tc.b...)},
+			}
+			plan, err := For(iface, Observed{})
+			if err == nil {
+				t.Fatalf("an overlap was accepted:\n%s", plan)
+			}
+			if !plan.Empty() {
+				t.Error("operations were returned alongside the error")
+			}
+			for _, want := range tc.wants {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("the error does not name %q, so it cannot be acted on: %v", want, err)
+				}
+			}
+		})
+	}
+}
+
+func TestAPeerMayNotClaimThisDevicesOwnAddress(t *testing.T) {
+	iface := base(t)
+	iface.Peers = []Peer{{PublicKey: "peer-a", AllowedIPs: prefixes(t, "100.90.0.1/32")}}
+
+	if _, err := For(iface, Observed{}); err == nil {
+		t.Error("a peer claiming this device's own address was accepted")
+	} else if !strings.Contains(err.Error(), "own address") {
+		t.Errorf("the error does not explain what is wrong: %v", err)
+	}
+}
+
+// A local address wider than a host prefix creates a connected route for the whole pool,
+// so traffic to an unassigned address is swallowed by the tunnel rather than failing.
+func TestALocalAddressMustBeAHostPrefix(t *testing.T) {
+	for _, addr := range []string{"100.90.0.1/24", "fd7c::1/64"} {
+		iface := base(t)
+		iface.Addresses = prefixes(t, addr)
+		iface.Peers = nil
+		_, err := For(iface, Observed{})
+		if err == nil {
+			t.Errorf("%s was accepted as a local address", addr)
+			continue
+		}
+		if !strings.Contains(err.Error(), "host prefix") {
+			t.Errorf("for %s the error does not say why: %v", addr, err)
+		}
+	}
+}
+
+func TestConfigurationsThatAreNotWorthApplying(t *testing.T) {
+	cases := map[string]func(*Interface){
+		"no name":            func(i *Interface) { i.Name = "" },
+		"no private key":     func(i *Interface) { i.PrivateKey = "" },
+		"no MTU":             func(i *Interface) { i.MTU = 0 },
+		"negative MTU":       func(i *Interface) { i.MTU = -1 },
+		"no addresses":       func(i *Interface) { i.Addresses = nil },
+		"a peer with no key": func(i *Interface) { i.Peers[0].PublicKey = "" },
+		"a peer with no allowed IPs": func(i *Interface) {
+			i.Peers[0].AllowedIPs = nil
+		},
+		"the same peer twice": func(i *Interface) {
+			i.Peers[1].PublicKey = i.Peers[0].PublicKey
+		},
+	}
+	for name, break_ := range cases {
+		t.Run(name, func(t *testing.T) {
+			iface := base(t)
+			break_(&iface)
+			if _, err := For(iface, Observed{}); err == nil {
+				t.Errorf("%s was accepted", name)
+			}
+		})
+	}
+}
+
+// A key rotation reaches the device as one peer leaving and another arriving, because a
+// WireGuard peer *is* its key. The old peer must go, or the interface accumulates
+// unreachable peers that still hold claims on addresses.
+func TestARotatedKeyReplacesThePeer(t *testing.T) {
+	before := base(t)
+	obs := applied(before)
+
+	after := base(t)
+	after.Peers[0].PublicKey = "peer-bob-after-rotation"
+
+	plan, err := For(after, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var removedOld, addedNew bool
+	for _, op := range plan.Ops {
+		if op.Kind == RemovePeer && op.Peer.PublicKey == "peer-bob" {
+			removedOld = true
+		}
+		if op.Kind == SetPeer && op.Peer.PublicKey == "peer-bob-after-rotation" {
+			addedNew = true
+		}
+	}
+	if !removedOld {
+		t.Errorf("the old key was left configured:\n%s", plan)
+	}
+	if !addedNew {
+		t.Errorf("the new key was not configured:\n%s", plan)
+	}
+
+	// And nothing else moved: the addresses are the same, so no route work.
+	for _, op := range plan.Ops {
+		if op.Kind == AddRoute || op.Kind == RemoveRoute {
+			t.Errorf("a rotation onto the same addresses touched routes: %s", op)
+		}
+	}
+}
+
+// An endpoint appearing is the moment a configured-but-unreachable peer becomes
+// reachable. It must rewrite that peer and nothing else.
+func TestAnEndpointAppearingRewritesOnlyThatPeer(t *testing.T) {
+	before := base(t)
+	obs := applied(before)
+
+	after := base(t)
+	after.Peers[1].Endpoint = "198.51.100.3:51820"
+
+	plan, err := For(after, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Ops) != 1 {
+		t.Fatalf("expected one operation, got:\n%s", plan)
+	}
+	if plan.Ops[0].Kind != SetPeer || plan.Ops[0].Peer.PublicKey != "peer-carol" {
+		t.Errorf("expected carol to be rewritten, got: %s", plan.Ops[0])
+	}
+}
+
+// The private key is not rewritten when it has not changed: doing so resets every session
+// on the interface, which drops traffic for a tick that had nothing to do.
+func TestTheDeviceIsNotRewrittenWhenNothingAboutItChanged(t *testing.T) {
+	want := base(t)
+	obs := applied(want)
+	obs.Peers = nil // a peer changed; the device did not
+	obs.Routes = nil
+
+	plan, err := For(want, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, op := range plan.Ops {
+		if op.Kind == SetDevice {
+			t.Errorf("the device was rewritten although only peers changed:\n%s", plan)
+		}
+	}
+}
+
+func TestAChangedMTUOrPortRewritesTheDevice(t *testing.T) {
+	for name, change := range map[string]func(*Interface){
+		"mtu":  func(i *Interface) { i.MTU = 1280 },
+		"port": func(i *Interface) { i.ListenPort = 51821 },
+		"key":  func(i *Interface) { i.PrivateKey = "a-new-private-key" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			want := base(t)
+			obs := applied(want)
+			change(&want)
+
+			plan, err := For(want, obs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if firstIndexOf(plan, SetDevice) < 0 {
+				t.Errorf("changing the %s did not rewrite the device:\n%s", name, plan)
+			}
+		})
+	}
+}
+
+// Invariant 20. Teardown removes what was installed, in an order that does not leave a
+// route pointing at an interface that no longer exists.
+func TestTeardownRemovesEverythingItInstalled(t *testing.T) {
+	want := base(t)
+	plan := Teardown(applied(want))
+
+	lastRoute, firstAddress := -1, -1
+	for i, op := range plan.Ops {
+		if op.Kind == RemoveRoute {
+			lastRoute = i
+		}
+		if op.Kind == RemoveAddress && firstAddress < 0 {
+			firstAddress = i
+		}
+	}
+	if lastRoute < 0 || firstAddress < 0 {
+		t.Fatalf("teardown removed no routes or no addresses:\n%s", plan)
+	}
+	if lastRoute > firstAddress {
+		t.Errorf("a route is removed at %d, after an address at %d:\n%s", lastRoute, firstAddress, plan)
+	}
+	if last := plan.Ops[len(plan.Ops)-1].Kind; last != DestroyDevice {
+		t.Errorf("teardown ends with %s, want destroy-device", last)
+	}
+
+	// Everything installed, and only that. A route through another interface is not ours.
+	removed := make(map[netip.Prefix]bool)
+	for _, op := range plan.Ops {
+		if op.Kind == RemoveRoute || op.Kind == RemoveAddress {
+			removed[op.Prefix] = true
+		}
+	}
+	for _, addr := range want.Addresses {
+		if !removed[addr] {
+			t.Errorf("teardown left the address %s behind", addr)
+		}
+	}
+	for _, peer := range want.Peers {
+		for _, ip := range peer.AllowedIPs {
+			if !removed[ip] {
+				t.Errorf("teardown left the route %s behind", ip)
+			}
+		}
+	}
+}
+
+func TestTearingDownWhatIsNotThereDoesNothing(t *testing.T) {
+	if plan := Teardown(Observed{}); !plan.Empty() {
+		t.Errorf("tearing down a nonexistent interface produced work:\n%s", plan)
+	}
+}
+
+// A route pointing at this interface that no peer justifies is withdrawn — a peer that
+// left while the agent was not running, or a leftover from a previous version.
+func TestARouteNoPeerJustifiesIsWithdrawn(t *testing.T) {
+	want := base(t)
+	obs := applied(want)
+	stale := mustPrefix(t, "100.90.0.44/32")
+	obs.Routes = append(obs.Routes, stale)
+
+	plan, err := For(want, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, op := range plan.Ops {
+		if op.Kind == RemoveRoute && op.Prefix == stale {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the stale route %s was left in place:\n%s", stale, plan)
+	}
+}
+
+// Two plans for the same inputs must be identical. Anything derived from map iteration
+// would make logs, comparisons and this test itself unstable.
+func TestPlansAreDeterministic(t *testing.T) {
+	want := base(t)
+	want.Peers = append(want.Peers, Peer{
+		PublicKey:  "peer-dave",
+		AllowedIPs: prefixes(t, "100.90.0.4/32", "fd7c::4/128"),
+	})
+
+	first, err := For(want, Observed{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 30 {
+		again, err := For(want, Observed{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if first.String() != again.String() {
+			t.Fatalf("two plans for the same input differ:\n--- first ---\n%s\n--- again ---\n%s",
+				first, again)
+		}
+	}
+}
+
+// The property that matters: whatever state a device is in, applying one plan reaches the
+// desired state, and planning again finds nothing left to do. A second round that is not
+// empty means the plan did not say everything, and the agent would rewrite the interface
+// on every tick forever.
+func TestPropertyOnePlanIsEnough(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x5eed1e))
+
+	for attempt := range 400 {
+		want := randomInterface(t, rng)
+		observed := randomObserved(t, rng, want)
+
+		plan, err := For(want, observed)
+		if err != nil {
+			t.Fatalf("attempt %d: planning failed for a valid interface: %v", attempt, err)
+		}
+
+		reached := simulate(observed, plan)
+
+		second, err := For(want, reached)
+		if err != nil {
+			t.Fatalf("attempt %d: planning against the reached state failed: %v", attempt, err)
+		}
+		if !second.Empty() {
+			t.Fatalf("attempt %d: a second plan was not empty, so the first was incomplete.\n"+
+				"--- first ---\n%s\n--- second ---\n%s", attempt, plan, second)
+		}
+
+		// And the reached state really is what was asked for, not merely stable.
+		if err := sameAsWanted(want, reached); err != nil {
+			t.Fatalf("attempt %d: %v\n--- plan ---\n%s", attempt, err, plan)
+		}
+	}
+}
+
+// simulate applies a plan to observed state the way a platform would, so the property
+// test can check what a real device would end up holding.
+func simulate(obs Observed, plan Plan) Observed {
+	peers := indexPeers(obs.Peers)
+	addrs := prefixSet(obs.Addresses)
+	routes := prefixSet(obs.Routes)
+
+	for _, op := range plan.Ops {
+		switch op.Kind {
+		case CreateDevice:
+			obs.Exists = true
+		case DestroyDevice:
+			return Observed{}
+		case SetDevice:
+			obs.PrivateKey = op.Device.PrivateKey
+			obs.ListenPort = op.Device.ListenPort
+			obs.MTU = op.Device.MTU
+		case SetPeer:
+			peers[op.Peer.PublicKey] = op.Peer
+		case RemovePeer:
+			delete(peers, op.Peer.PublicKey)
+		case AddAddress:
+			addrs[op.Prefix] = struct{}{}
+		case RemoveAddress:
+			delete(addrs, op.Prefix)
+		case AddRoute:
+			routes[op.Prefix] = struct{}{}
+		case RemoveRoute:
+			delete(routes, op.Prefix)
+		case BringUp:
+		}
+	}
+
+	out := Observed{Exists: obs.Exists, PrivateKey: obs.PrivateKey, ListenPort: obs.ListenPort, MTU: obs.MTU}
+	for _, key := range sortedKeys(peers) {
+		out.Peers = append(out.Peers, peers[key])
+	}
+	for p := range addrs {
+		out.Addresses = append(out.Addresses, p)
+	}
+	for p := range routes {
+		out.Routes = append(out.Routes, p)
+	}
+	out.Addresses = sortPrefixes(out.Addresses)
+	out.Routes = sortPrefixes(out.Routes)
+	return out
+}
+
+func sameAsWanted(want Interface, reached Observed) error {
+	if !reached.Exists {
+		return fmt.Errorf("the interface does not exist after the plan")
+	}
+	if len(reached.Peers) != len(want.Peers) {
+		return fmt.Errorf("%d peers after the plan, want %d", len(reached.Peers), len(want.Peers))
+	}
+	have := indexPeers(reached.Peers)
+	for _, peer := range want.Peers {
+		got, ok := have[peer.PublicKey]
+		if !ok {
+			return fmt.Errorf("peer %s is missing", peer.PublicKey)
+		}
+		if !samePeer(got, peer) {
+			return fmt.Errorf("peer %s was not configured as asked", peer.PublicKey)
+		}
+	}
+
+	wantAddrs := sortPrefixes(want.Addresses)
+	gotAddrs := sortPrefixes(reached.Addresses)
+	if len(wantAddrs) != len(gotAddrs) {
+		return fmt.Errorf("%d addresses, want %d", len(gotAddrs), len(wantAddrs))
+	}
+	for i := range wantAddrs {
+		if wantAddrs[i] != gotAddrs[i] {
+			return fmt.Errorf("address %s, want %s", gotAddrs[i], wantAddrs[i])
+		}
+	}
+
+	wantRoutesSorted := sortPrefixes(wantRoutes(want))
+	gotRoutes := sortPrefixes(reached.Routes)
+	if len(wantRoutesSorted) != len(gotRoutes) {
+		return fmt.Errorf("%d routes, want %d", len(gotRoutes), len(wantRoutesSorted))
+	}
+	for i := range wantRoutesSorted {
+		if wantRoutesSorted[i] != gotRoutes[i] {
+			return fmt.Errorf("route %s, want %s", gotRoutes[i], wantRoutesSorted[i])
+		}
+	}
+	return nil
+}
+
+// randomInterface builds a valid interface: distinct host addresses, so no two peers can
+// overlap. Generating invalid ones here would only prove the validator rejects them,
+// which the cases above already do.
+func randomInterface(t *testing.T, rng *rand.Rand) Interface {
+	t.Helper()
+	iface := Interface{
+		Name:       "meshp0",
+		PrivateKey: Key(fmt.Sprintf("priv-%d", rng.Intn(3))),
+		ListenPort: 51820 + rng.Intn(2),
+		MTU:        []int{1280, 1420}[rng.Intn(2)],
+		Addresses:  prefixes(t, "100.90.0.1/32", "fd7c::1/128"),
+	}
+
+	// Peers drawn from a pool of distinct host addresses, so validity is structural.
+	used := make(map[int]bool)
+	for range rng.Intn(6) {
+		host := 2 + rng.Intn(40)
+		if used[host] {
+			continue
+		}
+		used[host] = true
+
+		peer := Peer{
+			PublicKey:        Key(fmt.Sprintf("peer-%02d", host)),
+			AllowedIPs:       prefixes(t, fmt.Sprintf("100.90.0.%d/32", host), fmt.Sprintf("fd7c::%x/128", host)),
+			KeepaliveSeconds: []int{0, 25}[rng.Intn(2)],
+		}
+		if rng.Intn(2) == 0 {
+			peer.Endpoint = fmt.Sprintf("203.0.113.%d:51820", host)
+		}
+		if rng.Intn(4) == 0 {
+			peer.PresharedKey = Key(fmt.Sprintf("psk-%d", host))
+		}
+		iface.Peers = append(iface.Peers, peer)
+	}
+	return iface
+}
+
+// randomObserved invents a device in some arbitrary state: absent, correct, partly
+// correct, or carrying things nobody asked for.
+func randomObserved(t *testing.T, rng *rand.Rand, want Interface) Observed {
+	t.Helper()
+	switch rng.Intn(5) {
+	case 0:
+		return Observed{} // nothing there at all
+
+	case 1:
+		return applied(want) // already correct
+
+	case 2:
+		// Correct, then damaged: peers dropped, addresses missing, a stale route.
+		obs := applied(want)
+		if len(obs.Peers) > 0 {
+			obs.Peers = obs.Peers[rng.Intn(len(obs.Peers)):]
+		}
+		if len(obs.Addresses) > 1 && rng.Intn(2) == 0 {
+			obs.Addresses = obs.Addresses[1:]
+		}
+		obs.Routes = append(obs.Routes, mustPrefix(t, fmt.Sprintf("100.90.9.%d/32", 1+rng.Intn(9))))
+		return obs
+
+	case 3:
+		// Right peers, wrong details: the shape that must still produce a rewrite.
+		obs := applied(want)
+		for i := range obs.Peers {
+			if rng.Intn(2) == 0 {
+				obs.Peers[i].Endpoint = "192.0.2.99:1"
+			}
+			if rng.Intn(3) == 0 {
+				obs.Peers[i].KeepaliveSeconds = 99
+			}
+		}
+		obs.MTU = 9000
+		return obs
+
+	default:
+		// An interface belonging to an older configuration: peers and routes for devices
+		// that are no longer in this network at all.
+		obs := Observed{Exists: true, PrivateKey: "an-old-private-key", ListenPort: 41820, MTU: 1400}
+		for i := range 1 + rng.Intn(3) {
+			key := Key(fmt.Sprintf("stale-peer-%d", i))
+			ips := prefixes(t, fmt.Sprintf("100.90.8.%d/32", 1+i))
+			obs.Peers = append(obs.Peers, Peer{PublicKey: key, AllowedIPs: ips})
+			obs.Routes = append(obs.Routes, ips...)
+		}
+		obs.Addresses = prefixes(t, "100.90.7.1/32")
+		return obs
+	}
+}


### PR DESCRIPTION
The first half of A5. Before any syscall there has to be an answer to "given what the
control plane wants and what this host currently has, what exactly should change" — and
that answer is worth testing exhaustively somewhere with no privileges and no platform.

## Before writing any of this

I confirmed the target state by hand: two network namespaces, two kernel WireGuard
interfaces, a ping across the tunnel. Two things came out of that which shaped the design.

`AllowedIPs` is WireGuard's cryptokey routing table, **not** a system route. Both are
required before a packet moves, they are set through different mechanisms, and a
configuration with one and not the other fails in a way that looks like the other
layer's fault. ADR-0015 writes this down because it is conflated constantly.

And it runs locally: the Docker VM kernel here has WireGuard, so the platform half of A5
is verifiable on this machine rather than only in CI. Given how much of today was spent
finding code that nothing had ever executed, that mattered enough to check first.

## ADR-0015

Prefer kernel WireGuard, fall back to userspace, **and always report which is in use**.
The reporting is part of the decision, not a nicety — a silent fallback turns "why is this
host a tenth the speed of that one" into an unanswerable question, when the answer is a
missing module that an operator could fix in a minute.

## The rules that earn their keep

**Nothing to do produces nothing** (Invariant 18). Rewriting a private key resets every
session on the interface, so an agent that reconfigures on each tick tears down working
tunnels to arrive back where it started. Peers are compared by content, with allowed IPs
as *sets* — neither the kernel nor the UAPI socket preserves the order anything was
written in, so comparing slices directly would rewrite every peer forever.

**Removals before additions.** When an address moves between peers, additions first would
give it to the new peer and then the removal would take it back. The same shape as the bug
`peerset` had in A4, one layer down.

**No two peers may hold overlapping allowed IPs** — exactly equal, or one inside the
other. WireGuard resolves a collision by giving the prefix to whichever peer was written
last and silently taking it from the other, so the result is a device nobody can reach and
no log line saying why. The plan refuses the whole update and the error names both peers
and the prefix.

**A local address must be a host prefix.** A wider one creates a connected route for the
whole pool, so traffic to an unassigned address is swallowed by the tunnel instead of
failing at once.

## The property test found a flaw in my own design

400 randomised `(want, observed)` pairs — absent device, correct device, damaged device,
device from an older configuration — apply the plan, plan again, assert nothing remains.

It failed. `SetDevice` carried no payload, so applying a plan required holding the
`Interface` as a second source of truth, and the plan and the values actually applied
could drift apart. Operations now carry what they need, which is what makes a plan
applicable on its own. Its `String()` deliberately omits the private key, because plans
render into logs (Invariant 1).

## Verifying the tests have teeth

| rule removed | what failed |
|---|---|
| removals before additions | `TestAPrefixMovingBetweenPeersIsRemovedBeforeItIsAdded` |
| the overlap check | `TestOverlappingAllowedIPsAreRefused`, both non-identical cases |
| allowed IPs compared as sets | `TestOrderOfObservedStateDoesNotMatter` |

93.4% coverage, gated at 90.

## Invariants

- [x] An invariant is affected, and it still holds. Which, and how it is tested:

**18** (applying state is idempotent) — `TestPlanningAgainstAMatchingInterfaceDoesNothing`,
`TestOrderOfObservedStateDoesNotMatter`, and the property test's second round.
**20** (everything installed can be removed) — `TestTeardownRemovesEverythingItInstalled`,
which also checks routes go before addresses, so nothing is left pointing at an interface
that no longer exists.

## Also

A `tidy-check` gate. `go.mod` carried a stale `// indirect` on a module imported directly
and nothing checked. `go mod tidy -diff` writes nothing, so a failure cannot leave the
working tree modified.

## Migrations

None.

## Not in scope

No syscalls yet, so no packet moves in this PR — that is the next one: `wgctrl` plus
netlink, the kernel/userspace split, and a two-namespace test where a ping crosses. I
measured the dependency cost of `wgctrl` while here (it pulls `x/crypto`, `x/net`,
`x/sys`; bumping all three leaves one uncalled, unfixable advisory for the `openpgp`
package we do not import) but did not add it, because nothing imports it yet and
`go mod tidy` correctly drops it.