### PR TITLE
feat(meshpd): the daemon brings up a real tunnel, and keeps it up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,15 +231,35 @@ jobs:
       # The unit tests cover each step against a library. This covers what a person
       # actually runs — flag parsing, file modes, exit codes — which is where the
       # wiring mistakes live.
-      - name: enrol a device end to end
+      - run: sudo apt-get install -y --no-install-recommends wireguard-tools
+
+      # The script is invoked directly below rather than through `make e2e`, which depends
+      # on `build` — so the binaries have to be built here.
+      - run: make build
+
+      # Under sudo, so the tunnel assertions in the script actually execute. They skip
+      # without the privilege to create interfaces, and a skip here is a silent pass: the
+      # assertions would only ever have run on a developer's machine.
+      - name: enrol a device end to end, with a real tunnel
         run: |
+          set -o pipefail
           {
             echo "### Enrolment end to end"
             echo
             echo '```'
-            make e2e
+            sudo -E env "PATH=$PATH" ./scripts/e2e-enrol.sh "$MESHP_TEST_DATABASE_URL" 2>&1 | tee e2e.log
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: the tunnel assertions were not skipped
+        run: |
+          if grep -q "skipped: needs Linux, root" e2e.log; then
+            echo "the end-to-end tunnel assertions skipped, so they gate nothing"
+            exit 1
+          fi
+          grep -q "up, kernel" e2e.log \
+            || { echo "the end-to-end run never reported a kernel tunnel"; exit 1; }
+          echo "the tunnel came up and was asserted"
 
   migrations-immutable:
     name: migrations are append only

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ CROSS_TARGETS := linux/amd64 linux/arm64 linux/arm \
 COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan
 COVER_FLOOR      := 90
 
-COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx
+COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx internal/tunnel
 COVER_FLOOR_IO      := 75
 
 COVER_FLOOR_DB_PKGS := internal/store internal/enroll internal/api internal/session
@@ -233,6 +233,13 @@ image: ## Build the container image (VERSION and COMMIT are stamped in)
 image-smoke: image ## Start the image against MESHP_TEST_DATABASE_URL and wait for readiness
 	@test -n "$(MESHP_TEST_DATABASE_URL)" || { echo "set MESHP_TEST_DATABASE_URL"; exit 2; }
 	@MESHP_IMAGE=$(IMAGE) MESHP_DATABASE_URL="$(MESHP_TEST_DATABASE_URL)" ./scripts/image-smoke.sh
+
+.PHONY: e2e-tunnel
+e2e-tunnel: ## Run the end-to-end enrolment with real tunnels, in a privileged Linux container
+	@# The whole stack where a tunnel is actually possible: control plane, two daemons,
+	@# real interfaces. On macOS the plain `make e2e` skips the tunnel assertions, so this
+	@# is the only way to exercise them from here.
+	@./scripts/e2e-tunnel.sh
 
 .PHONY: dataplane
 dataplane: ## Run the data-plane tests against real interfaces, in a privileged Linux container

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ make e2e          # enrol a device against a real database, start to finish
 make image        # build the server-side container image
 make image-smoke  # start that image against a real database and wait for readiness
 make dataplane    # real WireGuard interfaces, and a packet across a tunnel
+make e2e-tunnel   # the whole stack on Linux, with tunnels that really come up
 ```
 
 `make ci` deliberately excludes the container build and the data plane: one needs Docker,

--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -195,8 +195,12 @@ func cmdJoin(ctx context.Context, args []string) error {
 		fmt.Printf("              %s\n", res.AddressV6)
 	}
 	fmt.Println()
-	fmt.Println("No tunnel yet: meshpd does not bring up WireGuard in this build.")
-	fmt.Println("This device is registered and holds an address; nothing routes to it so far.")
+	// What is true here differs by platform and by privilege, so it is not asserted:
+	// the daemon knows, and `meshp status` asks it. What is true everywhere is the
+	// limitation below.
+	fmt.Println("The daemon is bringing up the interface; run 'meshp status' to see whether it did.")
+	fmt.Println("Peers carry no endpoints yet, so devices in this network know about each")
+	fmt.Println("other and cannot reach each other. That arrives with the relay.")
 	return nil
 }
 
@@ -244,6 +248,11 @@ func cmdStatus(ctx context.Context, args []string) error {
 		tunnel := "not up"
 		if m.TunnelUp {
 			tunnel = "up"
+			if m.TunnelKind != "" {
+				// Which implementation, because the difference in throughput is large and
+				// there is otherwise no way to tell from here (ADR-0015).
+				tunnel = "up, " + m.TunnelKind
+			}
 		}
 		fmt.Printf("    interface   %s (%s)\n", m.InterfaceName, tunnel)
 		if m.AddressV4 != "" {

--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -18,7 +19,9 @@ import (
 	"github.com/meshpnet/meshp/internal/keys"
 	"github.com/meshpnet/meshp/internal/peerset"
 	"github.com/meshpnet/meshp/internal/sessionclient"
+	"github.com/meshpnet/meshp/internal/tunnel"
 	"github.com/meshpnet/meshp/internal/version"
+	"github.com/meshpnet/meshp/internal/wglink"
 )
 
 // agent owns this device's state and its control-channel sessions.
@@ -30,6 +33,11 @@ type agent struct {
 	stateDir  string
 	startedAt time.Time
 
+	// reconcileEvery is how often the interface is checked against desired state even
+	// when nothing has changed. Zero switches it off, which is only useful in tests that
+	// want to observe drift rather than have it corrected.
+	reconcileEvery time.Duration
+
 	// mu guards state and running together. Both change when a device joins, and a
 	// status read that saw one without the other would report a membership with no
 	// session or a session with no membership.
@@ -37,24 +45,65 @@ type agent struct {
 	state   *agentstate.State
 	running map[uuid.UUID]*sessionHandle
 
+	// link is the host's interface manager, opened once and shared: it holds netlink
+	// sockets, and a device in several networks would otherwise open a pair for each.
+	// Opened lazily on the first session, because it needs privileges and a daemon that
+	// refused to start without them could not report why it has no tunnel.
+	linkOnce sync.Once
+	link     wglink.Link
+	linkErr  error
+
 	ctx context.Context
+}
+
+// reconcilerFor returns something to converge this membership's interface, or nil when this
+// platform or this process cannot manage one.
+//
+// Nil rather than an error, because there is nothing to do about it here and it is not a
+// reason to refuse the session: the control channel is still worth having, the device is
+// still enrolled, and `meshp status` still has something true to report. What would be wrong
+// is claiming a tunnel exists.
+func (a *agent) reconcilerFor(m agentstate.Membership, log *slog.Logger) *tunnel.Reconciler {
+	a.linkOnce.Do(func() {
+		a.link, a.linkErr = wglink.New()
+		switch {
+		case errors.Is(a.linkErr, wglink.ErrUnsupported):
+			a.log.Warn("no tunnel on this platform",
+				"os", runtime.GOOS,
+				"note", "devices enrol and hold addresses; nothing routes to them")
+		case a.linkErr != nil:
+			a.log.Error("cannot manage WireGuard interfaces",
+				"error", a.linkErr,
+				"hint", "meshpd needs to run with enough privilege to create network interfaces")
+		}
+	})
+	if a.link == nil {
+		return nil
+	}
+	return tunnel.New(a.link, tunnel.Membership{
+		InterfaceName: m.InterfaceName,
+		PrivateKey:    m.WireGuardPrivateKey,
+		AddressV4:     m.AddressV4,
+		AddressV6:     m.AddressV6,
+	}, log)
 }
 
 // sessionHandle is one supervised session.
 type sessionHandle struct {
 	cancel  context.CancelFunc
 	client  *sessionclient.Client
-	applier *recordingApplier
+	applier *deviceApplier
 	started time.Time
 }
 
-func newAgent(ctx context.Context, log *slog.Logger, stateDir string) *agent {
+func newAgent(ctx context.Context, log *slog.Logger, stateDir string, reconcileEvery time.Duration) *agent {
 	return &agent{
-		log:       log,
-		stateDir:  stateDir,
-		startedAt: time.Now().UTC(),
-		running:   make(map[uuid.UUID]*sessionHandle),
-		ctx:       ctx,
+		log:            log,
+		stateDir:       stateDir,
+		startedAt:      time.Now().UTC(),
+		reconcileEvery: reconcileEvery,
+		running:        make(map[uuid.UUID]*sessionHandle),
+		ctx:            ctx,
 	}
 }
 
@@ -123,7 +172,12 @@ func (a *agent) ensureSession(m agentstate.Membership) {
 
 	sessionCtx, cancel := context.WithCancel(a.ctx)
 	log := a.log.With("network_id", m.NetworkID)
-	applier := &recordingApplier{log: log, membershipID: m.MembershipID, agent: a}
+	applier := &deviceApplier{
+		log:          log,
+		membershipID: m.MembershipID,
+		agent:        a,
+		reconciler:   a.reconcilerFor(m, log),
+	}
 	client := sessionclient.New(sessionclient.Options{
 		ControlURL:   m.ControlURL,
 		Identity:     identity,
@@ -148,6 +202,27 @@ func (a *agent) ensureSession(m agentstate.Membership) {
 			log.Error("session ended", "error", err)
 		}
 	}()
+
+	// Converge on a timer as well as on arrival. Desired state changing is not the only
+	// thing that can make an interface wrong, and nothing else would notice.
+	go a.reconcileLoop(sessionCtx, applier)
+}
+
+// reconcileLoop re-applies desired state periodically for as long as the session lives.
+func (a *agent) reconcileLoop(ctx context.Context, applier *deviceApplier) {
+	if a.reconcileEvery <= 0 {
+		return
+	}
+	ticker := time.NewTicker(a.reconcileEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			applier.reconcile(ctx)
+		}
+	}
 }
 
 // setApplied records that a version was applied, and persists it.
@@ -198,8 +273,8 @@ func (a *agent) Status(_ context.Context) (agentapi.Status, error) {
 			WireGuardPublicKey:  m.WireGuardPublicKey,
 			AppliedStateVersion: m.AppliedStateVersion,
 			JoinedAt:            m.JoinedAt,
-			// Never true in this build, and saying so is the point: a membership with an
-			// address is not a working tunnel.
+			// Only ever true from a live reconciler below. A membership read from disk says
+			// nothing about whether an interface is up right now.
 			TunnelUp: false,
 		}
 		if handle, ok := a.running[m.MembershipID]; ok {
@@ -210,6 +285,7 @@ func (a *agent) Status(_ context.Context) (agentapi.Status, error) {
 			ms.ConnectedSince = handle.started
 			ms.AppliedStateVersion = handle.client.AppliedVersion()
 			ms.LastError = handle.applier.lastError()
+			ms.TunnelUp, ms.TunnelKind = handle.applier.tunnelStatus()
 		}
 		status.Memberships = append(status.Memberships, ms)
 	}
@@ -319,23 +395,39 @@ func (a *agent) Join(ctx context.Context, req agentapi.JoinRequest) (agentapi.Jo
 	}, nil
 }
 
-// recordingApplier is the Applier this build ships: it writes down what it was told and
-// reports success.
+// deviceApplier converges the interface and records how far this device has got.
 //
-// Deliberately not pretending to configure anything. When WireGuard arrives this becomes
-// the reconciler and its acknowledgement will mean the system reached that state. Until
-// then the log says so, so nobody mistakes a converged control plane for a working
-// network.
-type recordingApplier struct {
+// Two jobs rather than one because they fail independently and both matter. Converging is
+// what makes the network work; persisting the version is what makes `meshp status` and the
+// control plane agree about what this device has — a version acknowledged but never written
+// is requested again on every restart, and reported as applied while the state file says
+// otherwise.
+//
+// The interface comes first. Recording a version this host has not reached would tell the
+// control plane the device is converged when it is not, and the convergence metric is the
+// one thing that would otherwise show a broken agent.
+type deviceApplier struct {
 	log          *slog.Logger
 	membershipID uuid.UUID
 	agent        *agent
 
+	// reconciler is nil where there is no data-plane implementation. The device is then
+	// enrolled, holds an address and has no tunnel — a state it reports rather than hides.
+	reconciler *tunnel.Reconciler
+
 	mu   sync.Mutex
 	last string
+
+	// lastState is the desired state most recently applied, kept so it can be applied
+	// again without the control plane sending it again.
+	//
+	// Keeping it is only safe because the set handed to an Applier belongs to it
+	// (Invariant 22). If it were the session's live set, this would be re-applying
+	// whatever the session had folded in by then rather than what was last converged on.
+	lastState *peerset.Set
 }
 
-func (a *recordingApplier) Apply(_ context.Context, state *peerset.Set) ([]string, error) {
+func (a *deviceApplier) Apply(ctx context.Context, state *peerset.Set) ([]string, error) {
 	for _, p := range state.Peers() {
 		a.log.Debug("peer in desired state",
 			"device", p.GetDeviceName(),
@@ -343,31 +435,88 @@ func (a *recordingApplier) Apply(_ context.Context, state *peerset.Set) ([]strin
 			"public_key", truncateKey(p.GetPublicKey()))
 	}
 
+	if a.reconciler != nil {
+		unapplied, err := a.reconciler.Apply(ctx, state)
+		if err != nil {
+			a.setLastError(err.Error())
+			return unapplied, err
+		}
+	}
+
 	if err := a.agent.setApplied(a.membershipID, int64(state.Version())); err != nil {
 		a.setLastError(err.Error())
-		// Persisting matters for reporting: a version acknowledged but never written leaves
-		// `meshp status` and the audit trail disagreeing about what this device has.
 		return []string{"local-state"}, err
 	}
 	a.setLastError("")
 
-	a.log.Info("recorded desired state",
-		"version", state.Version(),
-		"peers", state.Len(),
-		"note", "nothing is configured: this build has no WireGuard")
+	a.mu.Lock()
+	a.lastState = state
+	a.mu.Unlock()
+
+	if a.reconciler == nil {
+		a.log.Info("recorded desired state",
+			"version", state.Version(),
+			"peers", state.Len(),
+			"note", "no tunnel: this platform has no data-plane implementation in this build")
+	}
 	return nil, nil
 }
 
-func (a *recordingApplier) setLastError(msg string) {
+func (a *deviceApplier) setLastError(msg string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.last = msg
 }
 
-func (a *recordingApplier) lastError() string {
+func (a *deviceApplier) lastError() string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return a.last
+	if a.last != "" {
+		return a.last
+	}
+	if a.reconciler != nil {
+		return a.reconciler.Status().LastError
+	}
+	return ""
+}
+
+// reconcile applies the last known desired state again.
+//
+// Called on a timer, because desired state arriving is not the only thing that can make an
+// interface wrong. An operator can take it down, another process can remove an address, a
+// crash can leave it half configured — and none of those cause the control plane to send
+// anything, so without this the agent would sit next to a broken interface indefinitely
+// believing itself converged.
+//
+// Safe to run as often as one likes because planning against a correct interface produces no
+// operations at all (Invariant 18). A reconcile that finds nothing wrong costs two netlink
+// reads and touches nothing, which is what makes a periodic tick affordable rather than a
+// source of churn.
+func (a *deviceApplier) reconcile(ctx context.Context) {
+	if a.reconciler == nil {
+		return
+	}
+	a.mu.Lock()
+	state := a.lastState
+	a.mu.Unlock()
+	if state == nil {
+		return // nothing has been applied yet; there is nothing to restore it to
+	}
+
+	if _, err := a.reconciler.Apply(ctx, state); err != nil {
+		a.setLastError(err.Error())
+		return
+	}
+	a.setLastError("")
+}
+
+// tunnelStatus reports what the data plane is doing, or nothing when there is none.
+func (a *deviceApplier) tunnelStatus() (up bool, kind string) {
+	if a.reconciler == nil {
+		return false, ""
+	}
+	st := a.reconciler.Status()
+	return st.Up, string(st.Kind)
 }
 
 func truncateKey(k string) string {

--- a/cmd/meshpd/main.go
+++ b/cmd/meshpd/main.go
@@ -33,6 +33,7 @@ import (
 	"os/signal"
 	"runtime"
 	"syscall"
+	"time"
 
 	"github.com/meshpnet/meshp/internal/agentapi"
 	"github.com/meshpnet/meshp/internal/agentstate"
@@ -47,6 +48,14 @@ func main() {
 		socketGroup = flag.String("socket-group", os.Getenv("MESHP_SOCKET_GROUP"),
 			"system group allowed to use the socket; empty means owner only")
 		logLevel = flag.String("log-level", envOr("MESHP_LOG_LEVEL", "info"), "debug, info, warn or error")
+
+		// How often the interface is checked against desired state even when nothing has
+		// changed. A minute is a compromise: drift is corrected without waiting for the
+		// next state update, and a converged interface costs two netlink reads to confirm
+		// (Invariant 18 is what makes that true). Zero switches it off.
+		reconcileEvery = flag.Duration("reconcile-interval",
+			envDuration("MESHP_RECONCILE_INTERVAL", time.Minute),
+			"how often to re-apply desired state to the interface; 0 disables")
 	)
 	flag.Parse()
 
@@ -59,20 +68,21 @@ func main() {
 	log.Info("meshpd starting",
 		"version", version.Version(),
 		"state_dir", *stateDir,
-		"socket", *socketPath)
+		"socket", *socketPath,
+		"reconcile_interval", *reconcileEvery)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	if err := run(ctx, log, *stateDir, *socketPath, *socketGroup); err != nil {
+	if err := run(ctx, log, *stateDir, *socketPath, *socketGroup, *reconcileEvery); err != nil {
 		log.Error("meshpd exited with error", "error", err)
 		os.Exit(1)
 	}
 	log.Info("meshpd stopped cleanly")
 }
 
-func run(ctx context.Context, log *slog.Logger, stateDir, socketPath, socketGroup string) error {
-	agent := newAgent(ctx, log, stateDir)
+func run(ctx context.Context, log *slog.Logger, stateDir, socketPath, socketGroup string, reconcileEvery time.Duration) error {
+	agent := newAgent(ctx, log, stateDir, reconcileEvery)
 	if err := agent.load(); err != nil {
 		return err
 	}
@@ -106,6 +116,21 @@ func newLogger(level string) *slog.Logger {
 		l = slog.LevelInfo
 	}
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: l}))
+}
+
+// envDuration reads a Go duration from the environment, falling back rather than refusing
+// to start: a malformed interval is a cosmetic mistake and should not keep a device offline.
+func envDuration(key string, fallback time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "meshpd: %s=%q is not a duration; using %s\n", key, v, fallback)
+		return fallback
+	}
+	return d
 }
 
 func envOr(key, fallback string) string {

--- a/internal/agentapi/agentapi.go
+++ b/internal/agentapi/agentapi.go
@@ -66,10 +66,18 @@ type MembershipStatus struct {
 
 	JoinedAt time.Time `json:"joined_at"`
 
-	// TunnelUp is false in every build so far, and saying so is the point: a
-	// membership with an address is not a working tunnel, and status should not imply
-	// otherwise.
+	// TunnelUp is whether a WireGuard interface is configured and up for this
+	// membership. A membership with an address and no tunnel is a normal state, and
+	// status must not imply otherwise.
 	TunnelUp bool `json:"tunnel_up"`
+
+	// TunnelKind is which WireGuard implementation is behind the interface: "kernel" or
+	// "userspace". Empty when there is no tunnel.
+	//
+	// Reported because the difference is large and otherwise invisible (ADR-0015). An
+	// operator asking why one host is a fraction of another's throughput should be able
+	// to see the answer instead of inferring it.
+	TunnelKind string `json:"tunnel_kind,omitempty"`
 }
 
 // JoinRequest asks the daemon to enrol this device.

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -1,0 +1,283 @@
+// Package tunnel converges one membership's WireGuard interface on what the control plane
+// asked for.
+//
+// It is the join between three things that deliberately do not know about each other:
+// peerset holds what the server said, wgplan decides what an interface should look like,
+// and wglink talks to the kernel. This package translates and sequences, and holds no rules
+// of its own — anything that looks like a rule belongs in wgplan, where it can be tested
+// without privileges.
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"strings"
+	"sync"
+
+	"github.com/meshpnet/meshp/internal/peerset"
+	"github.com/meshpnet/meshp/internal/wglink"
+	"github.com/meshpnet/meshp/internal/wgplan"
+)
+
+// defaultMTU is used when the server has not said what the MTU should be.
+//
+// 1420 leaves room for WireGuard's overhead inside a 1500-byte path. A starting point
+// rather than a measurement, and the same number the control plane sends today.
+const defaultMTU = 1420
+
+// Membership is what this package needs to know about the device's place in a network.
+type Membership struct {
+	InterfaceName string
+
+	// PrivateKey is this membership's WireGuard private key. One key per membership, never
+	// shared (Invariant 19).
+	PrivateKey string
+
+	// AddressV4 and AddressV6 are this device's own addresses. Either may be empty.
+	AddressV4 string
+	AddressV6 string
+}
+
+// Reconciler applies desired state to a real interface.
+//
+// Safe for concurrent use: the daemon's status command reads what it last reported while a
+// session may be applying the next state.
+type Reconciler struct {
+	link       wglink.Link
+	membership Membership
+	log        *slog.Logger
+
+	mu       sync.Mutex
+	kind     wglink.Kind
+	up       bool
+	lastErr  string
+	appliedV uint64
+}
+
+// New returns a Reconciler for one membership.
+func New(link wglink.Link, m Membership, log *slog.Logger) *Reconciler {
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	return &Reconciler{link: link, membership: m, log: log, kind: wglink.KindUnknown}
+}
+
+// Status is what the daemon reports about this tunnel.
+type Status struct {
+	Up             bool
+	Kind           wglink.Kind
+	LastError      string
+	AppliedVersion uint64
+}
+
+// Status reports the tunnel's current state.
+func (r *Reconciler) Status() Status {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return Status{Up: r.up, Kind: r.kind, LastError: r.lastErr, AppliedVersion: r.appliedV}
+}
+
+// Apply makes the interface match state.
+//
+// This is the sessionclient.Applier contract: it receives the whole desired state rather
+// than a delta, because a reconciler given a target is idempotent by construction
+// (Invariant 18), and the set it is given is its own to keep (Invariant 22).
+//
+// The returned components are the parts that did not converge, which the agent reports back
+// so the control plane knows this device is not where it says it is.
+func (r *Reconciler) Apply(_ context.Context, state *peerset.Set) ([]string, error) {
+	want, err := Desired(r.membership, state)
+	if err != nil {
+		// A description the kernel would refuse, or one wgplan judged unsafe. Reported
+		// rather than approximated: applying part of a rejected configuration is how an
+		// agent ends up in a state nobody described.
+		r.fail(err)
+		return []string{"peers"}, err
+	}
+
+	observed, err := r.link.Observe(want.Name)
+	if err != nil {
+		r.fail(err)
+		return []string{"interface"}, err
+	}
+
+	plan, err := wgplan.For(want, observed)
+	if err != nil {
+		r.fail(err)
+		return []string{"peers"}, err
+	}
+
+	if !plan.Empty() {
+		r.log.Debug("converging the interface", "interface", want.Name, "operations", len(plan.Ops))
+		if err := wglink.ApplyPlan(r.link, want.Name, plan); err != nil {
+			r.fail(err)
+			return []string{"interface"}, err
+		}
+		r.log.Info("interface converged",
+			"interface", want.Name,
+			"version", state.Version(),
+			"peers", len(want.Peers),
+			"operations", len(plan.Ops))
+	}
+
+	// Which implementation ended up behind it, read rather than assumed. ADR-0015 requires
+	// this to be reportable: a silent userspace fallback makes a tenfold difference in
+	// throughput an unanswerable question.
+	kind, kindErr := r.link.Kind(want.Name)
+	if kindErr != nil {
+		kind = wglink.KindUnknown
+	}
+
+	r.mu.Lock()
+	r.kind = kind
+	r.up = true
+	r.lastErr = ""
+	r.appliedV = state.Version()
+	r.mu.Unlock()
+	return nil, nil
+}
+
+// Teardown removes everything this membership installed (Invariant 20).
+func (r *Reconciler) Teardown() error {
+	name := r.membership.InterfaceName
+	observed, err := r.link.Observe(name)
+	if err != nil {
+		return err
+	}
+	if err := wglink.ApplyPlan(r.link, name, wgplan.Teardown(observed)); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	r.up = false
+	r.kind = wglink.KindUnknown
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *Reconciler) fail(err error) {
+	r.mu.Lock()
+	r.up = false
+	r.lastErr = err.Error()
+	r.mu.Unlock()
+
+	// Unsupported is expected on platforms without an implementation, and logging it as an
+	// error on every state update would bury the ones that matter.
+	if errors.Is(err, wglink.ErrUnsupported) {
+		r.log.Debug("no tunnel on this platform", "error", err)
+		return
+	}
+	r.log.Error("could not converge the interface", "error", err)
+}
+
+// Desired turns a membership and the state it was sent into an interface description.
+//
+// Separate and exported so it can be tested without a kernel: everything here is a
+// translation that can be wrong in a way no type would catch — an address rendered as a
+// pool prefix instead of a host prefix, a peer's allowed IPs dropped because one entry
+// failed to parse.
+func Desired(m Membership, state *peerset.Set) (wgplan.Interface, error) {
+	if m.PrivateKey == "" {
+		return wgplan.Interface{}, errors.New("tunnel: this membership has no WireGuard private key")
+	}
+
+	iface := wgplan.Interface{
+		Name:       m.InterfaceName,
+		PrivateKey: wgplan.Key(m.PrivateKey),
+		MTU:        defaultMTU,
+		// Any port. A device in several networks needs an interface for each (ADR-0004), so
+		// they cannot all ask for one port, and nothing distributes ports yet.
+		ListenPort: 0,
+	}
+
+	if mtu := int(state.Tunnel().GetMtu()); mtu > 0 {
+		iface.MTU = mtu
+	}
+
+	for _, addr := range []string{m.AddressV4, m.AddressV6} {
+		if addr == "" {
+			continue
+		}
+		prefix, err := hostPrefix(addr)
+		if err != nil {
+			return wgplan.Interface{}, fmt.Errorf("tunnel: this device's address %q: %w", addr, err)
+		}
+		iface.Addresses = append(iface.Addresses, prefix)
+	}
+	if len(iface.Addresses) == 0 {
+		return wgplan.Interface{}, errors.New("tunnel: this membership holds no addresses")
+	}
+
+	for _, peer := range state.Peers() {
+		converted, err := peerFrom(peer.GetPublicKey(), peer.GetAllowedIps(),
+			peer.GetEndpoints(), int(peer.GetPersistentKeepaliveSeconds()))
+		if err != nil {
+			// Refused rather than skipped. A peer quietly dropped is a device that cannot be
+			// reached, with everything reporting success.
+			return wgplan.Interface{}, fmt.Errorf("tunnel: peer %s: %w",
+				truncate(peer.GetPublicKey()), err)
+		}
+		iface.Peers = append(iface.Peers, converted)
+	}
+	return iface, nil
+}
+
+func peerFrom(publicKey string, allowedIPs, endpoints []string, keepalive int) (wgplan.Peer, error) {
+	peer := wgplan.Peer{
+		PublicKey:        wgplan.Key(publicKey),
+		KeepaliveSeconds: keepalive,
+	}
+	for _, cidr := range allowedIPs {
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			return wgplan.Peer{}, fmt.Errorf("allowed IP %q: %w", cidr, err)
+		}
+		peer.AllowedIPs = append(peer.AllowedIPs, prefix)
+	}
+
+	// The first endpoint only. The list is ordered best-first and choosing between them is
+	// the agent's job once there is something to choose with (ADR-0003); WireGuard holds one
+	// endpoint per peer, so until then the server's first preference is the only answer.
+	// Empty is normal and means relay-only, which today means unreachable.
+	if len(endpoints) > 0 {
+		if _, err := netip.ParseAddrPort(endpoints[0]); err != nil {
+			return wgplan.Peer{}, fmt.Errorf("endpoint %q: %w", endpoints[0], err)
+		}
+		peer.Endpoint = endpoints[0]
+	}
+	return peer, nil
+}
+
+// hostPrefix renders an address as a single-host prefix.
+//
+// Accepts a bare address or one already carrying a prefix length, and requires the result
+// to name exactly one host. A wider local address creates a connected route for the whole
+// pool, so traffic to an unassigned address in it is swallowed by the tunnel rather than
+// failing at once (ADR-0015).
+func hostPrefix(addr string) (netip.Prefix, error) {
+	if strings.Contains(addr, "/") {
+		prefix, err := netip.ParsePrefix(addr)
+		if err != nil {
+			return netip.Prefix{}, err
+		}
+		if prefix.Bits() != prefix.Addr().BitLen() {
+			return netip.Prefix{}, fmt.Errorf("is not a single host")
+		}
+		return netip.PrefixFrom(prefix.Addr().Unmap(), prefix.Addr().BitLen()), nil
+	}
+	parsed, err := netip.ParseAddr(addr)
+	if err != nil {
+		return netip.Prefix{}, err
+	}
+	parsed = parsed.Unmap()
+	return netip.PrefixFrom(parsed, parsed.BitLen()), nil
+}
+
+func truncate(key string) string {
+	if len(key) <= 12 {
+		return key
+	}
+	return key[:12] + "…"
+}

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -1,0 +1,517 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/meshpnet/meshp/internal/peerset"
+	"github.com/meshpnet/meshp/internal/wglink"
+	"github.com/meshpnet/meshp/internal/wgplan"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// fakeLink records what it was asked to do and answers as a device would.
+//
+// A fake here, unlike in wglink, because what is under test is the sequencing and the
+// translation — not the kernel. wglink's own tests use a real interface for the parts only
+// a kernel can answer.
+type fakeLink struct {
+	observed wgplan.Observed
+	applied  []wgplan.Op
+	kind     wglink.Kind
+
+	observeErr error
+	failOn     wgplan.OpKind
+	failErr    error
+	closed     bool
+}
+
+func newFakeLink() *fakeLink {
+	return &fakeLink{kind: wglink.KindKernel, failOn: -1}
+}
+
+func (f *fakeLink) Observe(string) (wgplan.Observed, error) {
+	if f.observeErr != nil {
+		return wgplan.Observed{}, f.observeErr
+	}
+	return f.observed, nil
+}
+
+func (f *fakeLink) Apply(_ string, op wgplan.Op) error {
+	if op.Kind == f.failOn {
+		return f.failErr
+	}
+	f.applied = append(f.applied, op)
+
+	// Enough of a device to make a second reconcile meaningful.
+	switch op.Kind {
+	case wgplan.CreateDevice:
+		f.observed.Exists = true
+	case wgplan.DestroyDevice:
+		f.observed = wgplan.Observed{}
+	case wgplan.BringUp:
+		f.observed.Up = true
+	case wgplan.SetDevice:
+		f.observed.PrivateKey = op.Device.PrivateKey
+		f.observed.MTU = op.Device.MTU
+		f.observed.ListenPort = 43521 // as a kernel does when asked for any
+	case wgplan.SetPeer:
+		f.observed.Peers = append(f.observed.Peers, op.Peer)
+	case wgplan.RemovePeer:
+		var kept []wgplan.Peer
+		for _, p := range f.observed.Peers {
+			if p.PublicKey != op.Peer.PublicKey {
+				kept = append(kept, p)
+			}
+		}
+		f.observed.Peers = kept
+	case wgplan.AddAddress:
+		f.observed.Addresses = append(f.observed.Addresses, op.Prefix)
+	case wgplan.AddRoute:
+		f.observed.Routes = append(f.observed.Routes, op.Prefix)
+	case wgplan.RemoveAddress:
+		f.observed.Addresses = without(f.observed.Addresses, op.Prefix)
+	case wgplan.RemoveRoute:
+		f.observed.Routes = without(f.observed.Routes, op.Prefix)
+	}
+	return nil
+}
+
+func without(prefixes []netip.Prefix, drop netip.Prefix) []netip.Prefix {
+	var out []netip.Prefix
+	for _, p := range prefixes {
+		if p != drop {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func (f *fakeLink) Kind(string) (wglink.Kind, error) { return f.kind, nil }
+func (f *fakeLink) Close() error                     { f.closed = true; return nil }
+
+func (f *fakeLink) count(kind wgplan.OpKind) int {
+	var n int
+	for _, op := range f.applied {
+		if op.Kind == kind {
+			n++
+		}
+	}
+	return n
+}
+
+// A real WireGuard key, because wgplan does not parse keys but the translation must carry
+// them through unchanged.
+const (
+	ourKey   = "yAnz5TF+lXXJte14tji3zlMNq+hd2rYUIgJBgB3fBmk="
+	bobKey   = "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg="
+	carolKey = "TrMvSoP4jYQlY6RIzBgbssQqY3vxI2Pi+y71lOWWXX0="
+)
+
+func membership() Membership {
+	return Membership{
+		InterfaceName: "meshp0",
+		PrivateKey:    ourKey,
+		AddressV4:     "100.90.0.1",
+		AddressV6:     "fd7c::1",
+	}
+}
+
+// stateWith builds what the control plane would have sent.
+func stateWith(version uint64, peers ...*meshpv1.Peer) *peerset.Set {
+	s := peerset.New()
+	s.Apply(&meshpv1.StateDelta{
+		FromVersion: 0,
+		ToVersion:   version,
+		UpsertPeers: peers,
+		Tunnel:      &meshpv1.TunnelConfig{Mtu: 1420},
+	})
+	return s
+}
+
+func peer(key string, ips ...string) *meshpv1.Peer {
+	return &meshpv1.Peer{
+		PublicKey:                  key,
+		AllowedIps:                 ips,
+		PersistentKeepaliveSeconds: 25,
+		DeviceName:                 "device-" + key[:4],
+	}
+}
+
+func TestApplyBringsUpAnInterfaceAndReportsIt(t *testing.T) {
+	link := newFakeLink()
+	r := New(link, membership(), nil)
+
+	state := stateWith(7, peer(bobKey, "100.90.0.2/32", "fd7c::2/128"))
+	unapplied, err := r.Apply(context.Background(), state)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(unapplied) != 0 {
+		t.Errorf("reported %v as unapplied", unapplied)
+	}
+
+	if link.count(wgplan.CreateDevice) != 1 {
+		t.Error("the interface was not created")
+	}
+	if link.count(wgplan.SetPeer) != 1 {
+		t.Errorf("%d peers configured, want 1", link.count(wgplan.SetPeer))
+	}
+	if link.count(wgplan.AddAddress) != 2 {
+		t.Errorf("%d addresses added, want 2", link.count(wgplan.AddAddress))
+	}
+	if link.count(wgplan.AddRoute) != 2 {
+		t.Errorf("%d routes added, want 2", link.count(wgplan.AddRoute))
+	}
+
+	status := r.Status()
+	if !status.Up {
+		t.Error("the tunnel is not reported as up")
+	}
+	if status.Kind != wglink.KindKernel {
+		t.Errorf("kind is %q, want kernel", status.Kind)
+	}
+	if status.AppliedVersion != 7 {
+		t.Errorf("applied version is %d, want 7", status.AppliedVersion)
+	}
+	if status.LastError != "" {
+		t.Errorf("last error is %q, want empty", status.LastError)
+	}
+}
+
+// Invariant 18, through the whole stack: the second time round there is nothing to do.
+func TestApplyingTheSameStateTwiceTouchesNothingTheSecondTime(t *testing.T) {
+	link := newFakeLink()
+	r := New(link, membership(), nil)
+	state := stateWith(7, peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	first := len(link.applied)
+	if first == 0 {
+		t.Fatal("the first apply did nothing")
+	}
+
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if len(link.applied) != first {
+		t.Errorf("the second apply did %d more operations: %v",
+			len(link.applied)-first, link.applied[first:])
+	}
+}
+
+// A failure part-way through must be reported as not applied, and must not claim the
+// version: an agent that says it reached a state it did not is invisible to the one metric
+// that would show it is broken.
+func TestAFailedApplyIsReportedAndDoesNotClaimTheVersion(t *testing.T) {
+	link := newFakeLink()
+	link.failOn = wgplan.AddRoute
+	link.failErr = errors.New("network is down")
+
+	r := New(link, membership(), nil)
+	unapplied, err := r.Apply(context.Background(), stateWith(9, peer(bobKey, "100.90.0.2/32")))
+	if err == nil {
+		t.Fatal("a failing operation was reported as success")
+	}
+	if len(unapplied) == 0 {
+		t.Error("nothing was reported as unapplied")
+	}
+
+	status := r.Status()
+	if status.Up {
+		t.Error("the tunnel is reported up after a failed apply")
+	}
+	if status.AppliedVersion == 9 {
+		t.Error("the failed version was recorded as applied")
+	}
+	if !strings.Contains(status.LastError, "network is down") {
+		t.Errorf("the last error does not carry the cause: %q", status.LastError)
+	}
+	// And it says which operation, because "apply failed" on a long plan is not actionable.
+	if !strings.Contains(err.Error(), "add-route") {
+		t.Errorf("the error does not name the operation that failed: %v", err)
+	}
+}
+
+// A platform with no implementation is a normal state, not a crash: the device is enrolled,
+// holds an address, and has no tunnel. It has to be able to say so.
+func TestAnUnsupportedPlatformIsReportedRatherThanFatal(t *testing.T) {
+	link := newFakeLink()
+	link.observeErr = wglink.ErrUnsupported
+
+	r := New(link, membership(), nil)
+	unapplied, err := r.Apply(context.Background(), stateWith(3, peer(bobKey, "100.90.0.2/32")))
+	if !errors.Is(err, wglink.ErrUnsupported) {
+		t.Fatalf("expected ErrUnsupported, got %v", err)
+	}
+	if len(unapplied) == 0 {
+		t.Error("nothing was reported as unapplied")
+	}
+	if status := r.Status(); status.Up {
+		t.Error("a tunnel is reported up on a platform that cannot make one")
+	}
+}
+
+// A peer whose description cannot be applied stops the whole update. Skipping it would leave
+// a device unreachable with everything reporting success.
+func TestAPeerThatCannotBeTranslatedRefusesTheUpdate(t *testing.T) {
+	cases := map[string]*meshpv1.Peer{
+		"an allowed IP that is not a prefix": {
+			PublicKey:  bobKey,
+			AllowedIps: []string{"not-a-prefix"},
+		},
+		"an endpoint that is not an address and port": {
+			PublicKey:  bobKey,
+			AllowedIps: []string{"100.90.0.2/32"},
+			Endpoints:  []string{"example.com"},
+		},
+	}
+	for name, p := range cases {
+		t.Run(name, func(t *testing.T) {
+			link := newFakeLink()
+			r := New(link, membership(), nil)
+			if _, err := r.Apply(context.Background(), stateWith(4, p)); err == nil {
+				t.Fatal("the update was accepted")
+			}
+			if len(link.applied) != 0 {
+				t.Errorf("operations were applied despite the refusal: %v", link.applied)
+			}
+		})
+	}
+}
+
+// Invariant 20.
+func TestTeardownRemovesTheInterface(t *testing.T) {
+	link := newFakeLink()
+	r := New(link, membership(), nil)
+	if _, err := r.Apply(context.Background(), stateWith(2, peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.Teardown(); err != nil {
+		t.Fatalf("Teardown: %v", err)
+	}
+	if link.count(wgplan.DestroyDevice) != 1 {
+		t.Error("the interface was not destroyed")
+	}
+	if link.observed.Exists {
+		t.Error("the interface still exists")
+	}
+	if r.Status().Up {
+		t.Error("the tunnel is still reported up")
+	}
+}
+
+// --- translation ------------------------------------------------------------
+
+func TestDesiredRendersAddressesAsHostPrefixes(t *testing.T) {
+	m := membership()
+	m.AddressV4 = "100.90.0.1"
+	m.AddressV6 = "fd7c::1"
+
+	iface, err := Desired(m, stateWith(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"100.90.0.1/32", "fd7c::1/128"}
+	if len(iface.Addresses) != len(want) {
+		t.Fatalf("%d addresses, want %d", len(iface.Addresses), len(want))
+	}
+	for i, w := range want {
+		if got := iface.Addresses[i].String(); got != w {
+			t.Errorf("address %d is %s, want %s", i, got, w)
+		}
+	}
+}
+
+// A pool prefix where a host prefix belongs would create a connected route for the whole
+// pool, so traffic to an unassigned address is swallowed by the tunnel (ADR-0015).
+func TestDesiredRefusesAnAddressThatIsNotOneHost(t *testing.T) {
+	for _, addr := range []string{"100.90.0.1/24", "fd7c::1/64"} {
+		m := membership()
+		m.AddressV4 = addr
+		m.AddressV6 = ""
+		if _, err := Desired(m, stateWith(1)); err == nil {
+			t.Errorf("%s was accepted", addr)
+		}
+	}
+}
+
+// An address already carrying /32 is what the daemon's state file may hold, and must be
+// accepted rather than rejected as malformed.
+func TestDesiredAcceptsAnAddressThatAlreadyCarriesItsPrefix(t *testing.T) {
+	m := membership()
+	m.AddressV4 = "100.90.0.1/32"
+	m.AddressV6 = "fd7c::1/128"
+
+	iface, err := Desired(m, stateWith(1))
+	if err != nil {
+		t.Fatalf("Desired: %v", err)
+	}
+	if len(iface.Addresses) != 2 {
+		t.Fatalf("%d addresses, want 2", len(iface.Addresses))
+	}
+}
+
+func TestDesiredRefusesAMembershipWithNothingToWorkFrom(t *testing.T) {
+	t.Run("no private key", func(t *testing.T) {
+		m := membership()
+		m.PrivateKey = ""
+		if _, err := Desired(m, stateWith(1)); err == nil {
+			t.Error("a membership with no private key was accepted")
+		}
+	})
+	t.Run("no addresses", func(t *testing.T) {
+		m := membership()
+		m.AddressV4, m.AddressV6 = "", ""
+		if _, err := Desired(m, stateWith(1)); err == nil {
+			t.Error("a membership with no addresses was accepted")
+		}
+	})
+}
+
+// The MTU comes from the server when it says one, because the server is what knows about
+// the path (ADR-0011 will make this matter more).
+func TestDesiredTakesTheMTUFromTheServer(t *testing.T) {
+	state := peerset.New()
+	state.Apply(&meshpv1.StateDelta{
+		FromVersion: 0, ToVersion: 1,
+		Tunnel: &meshpv1.TunnelConfig{Mtu: 1280},
+	})
+
+	iface, err := Desired(membership(), state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if iface.MTU != 1280 {
+		t.Errorf("MTU is %d, want the server's 1280", iface.MTU)
+	}
+}
+
+// And a sane default when it does not, rather than zero — which wgplan rejects, so an
+// interface would never come up at all.
+func TestDesiredFallsBackToADefaultMTU(t *testing.T) {
+	state := peerset.New()
+	state.Apply(&meshpv1.StateDelta{FromVersion: 0, ToVersion: 1})
+
+	iface, err := Desired(membership(), state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if iface.MTU != defaultMTU {
+		t.Errorf("MTU is %d, want the default %d", iface.MTU, defaultMTU)
+	}
+	if err := iface.Validate(); err != nil {
+		t.Errorf("the default does not produce a usable interface: %v", err)
+	}
+}
+
+// A peer with no endpoint is configured and unreachable, which is the honest state of every
+// peer today: nothing discovers endpoints yet.
+func TestAPeerWithNoEndpointIsStillConfigured(t *testing.T) {
+	iface, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(iface.Peers) != 1 {
+		t.Fatalf("%d peers, want 1", len(iface.Peers))
+	}
+	if iface.Peers[0].Endpoint != "" {
+		t.Errorf("endpoint is %q, want empty", iface.Peers[0].Endpoint)
+	}
+	if len(iface.Peers[0].AllowedIPs) != 1 {
+		t.Error("the peer's allowed IPs were lost")
+	}
+}
+
+// The server sends endpoints best-first; WireGuard holds one. Choosing among them is the
+// agent's job once there is something to choose with (ADR-0003).
+func TestTheFirstEndpointIsUsed(t *testing.T) {
+	p := peer(bobKey, "100.90.0.2/32")
+	p.Endpoints = []string{"203.0.113.2:51820", "198.51.100.2:51820"}
+
+	iface, err := Desired(membership(), stateWith(1, p))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := iface.Peers[0].Endpoint; got != "203.0.113.2:51820" {
+		t.Errorf("endpoint is %q, want the first one offered", got)
+	}
+}
+
+// Any port, because a device in several networks needs an interface for each (ADR-0004) and
+// they cannot all ask for the same one.
+func TestNoParticularPortIsRequested(t *testing.T) {
+	iface, err := Desired(membership(), stateWith(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if iface.ListenPort != 0 {
+		t.Errorf("listen port is %d, want 0 meaning any", iface.ListenPort)
+	}
+}
+
+// The key is carried through untouched. wgplan does not parse keys, so a translation that
+// mangled one would only fail at the kernel, on a real host, with a confusing message.
+func TestKeysArePassedThroughUnchanged(t *testing.T) {
+	iface, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(iface.PrivateKey) != ourKey {
+		t.Errorf("the private key was altered: %q", iface.PrivateKey)
+	}
+	if string(iface.Peers[0].PublicKey) != bobKey {
+		t.Errorf("the peer's key was altered: %q", iface.Peers[0].PublicKey)
+	}
+}
+
+// Applying the same state again repairs an interface that something else changed.
+//
+// This is what the daemon's periodic reconcile relies on: nothing arrives from the control
+// plane when an operator takes an interface down or another process removes an address, so
+// convergence has to come from re-applying what is already known. Verified end to end in the
+// tunnel e2e, where a second daemon takes the interface over and the first puts it back.
+func TestReapplyingTheSameStateRepairsADamagedInterface(t *testing.T) {
+	link := newFakeLink()
+	r := New(link, membership(), nil)
+	state := stateWith(5, peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+
+	// Something else has been at it: an address gone, a peer gone, the link down.
+	link.observed.Addresses = nil
+	link.observed.Peers = link.observed.Peers[:1]
+	link.observed.Up = false
+	link.applied = nil
+
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatalf("re-applying: %v", err)
+	}
+
+	if link.count(wgplan.AddAddress) == 0 {
+		t.Error("the missing address was not put back")
+	}
+	if link.count(wgplan.BringUp) == 0 {
+		t.Error("the interface was left down")
+	}
+	if link.count(wgplan.SetPeer) == 0 {
+		t.Error("the missing peer was not put back")
+	}
+
+	// And it is now correct: a further pass finds nothing to do.
+	link.applied = nil
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if len(link.applied) != 0 {
+		t.Errorf("the repair did not converge; a third pass still wants: %v", link.applied)
+	}
+}

--- a/scripts/e2e-enrol.sh
+++ b/scripts/e2e-enrol.sh
@@ -73,7 +73,7 @@ curl -fsS "${BASE}/readyz" >/dev/null 2>&1 || fail "control plane never became r
 echo "starting meshpd with no state at all"
 # Deliberately before enrolment. An agent that gives up when it has nothing to do cannot
 # be joined without restarting a service, which is a paper cut people script around.
-./bin/meshpd --state-dir "$STATE_DIR" --socket "$SOCKET" --log-level debug >"$AGENT_LOG" 2>&1 &
+./bin/meshpd --reconcile-interval 2s --state-dir "$STATE_DIR" --socket "$SOCKET" --log-level debug >"$AGENT_LOG" 2>&1 &
 AGENT_PID=$!
 
 for _ in $(seq 1 30); do
@@ -169,9 +169,18 @@ done
 [ "$connected" = "1" ] || fail "status never reported a connected session: $(cat "$WORK/status.out")"
 sed 's/^/  /' "$WORK/status.out"
 grep -q "$NETWORK_ID" "$WORK/status.out" || fail "status does not mention the network"
-# A membership with an address is not a working tunnel, and status must not imply it is.
-grep -q 'interface   meshp0 (not up)' "$WORK/status.out" \
-  || fail "status does not say the tunnel is down"
+# Status must say what is actually true, in either direction: a membership with an address
+# is not a working tunnel, and a working tunnel must not be reported as absent. Which one to
+# expect is decided by the platform rather than assumed, because this assertion once said
+# "always down" and outlived the build it was written for.
+if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" = "0" ] && ip link add dev wgprobe0 type wireguard 2>/dev/null; then
+  ip link del dev wgprobe0
+  grep -qE 'interface   meshp0 \(up' "$WORK/status.out" \
+    || fail "a tunnel is possible here but status says it is not up"
+else
+  grep -q 'interface   meshp0 (not up)' "$WORK/status.out" \
+    || fail "no tunnel is possible here, but status claims one"
+fi
 
 echo "the agent converges"
 lag_zero=0
@@ -201,7 +210,7 @@ TOKEN2="$(curl -fsS -X POST \
 # A second daemon, so the first has a peer to be told about.
 STATE_DIR2="$WORK/state2"
 SOCKET2="$WORK/d2.sock"
-./bin/meshpd --state-dir "$STATE_DIR2" --socket "$SOCKET2" --log-level debug >"$WORK/meshpd2.log" 2>&1 &
+./bin/meshpd --reconcile-interval 2s --state-dir "$STATE_DIR2" --socket "$SOCKET2" --log-level debug >"$WORK/meshpd2.log" 2>&1 &
 AGENT2_PID=$!
 for _ in $(seq 1 30); do
   [ -S "$SOCKET2" ] && ./bin/meshp status --socket "$SOCKET2" >/dev/null 2>&1 && break
@@ -225,6 +234,72 @@ if [ "$got_delta" != "1" ]; then
   fail "the first agent was sent a snapshot rather than a delta when a peer joined"
 fi
 sed -n 's/.*msg="applied desired state" \(.*snapshot=false.*\)/  \1/p' "$AGENT_LOG" | tail -1
+
+# Only where a tunnel is possible: Linux, with the privilege to create interfaces and a
+# kernel that can. Skipped rather than failed elsewhere, because "enrolled with no tunnel"
+# is a real supported state and this script has to pass on a laptop too.
+if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" = "0" ] && ip link add dev wgprobe type wireguard 2>/dev/null; then
+  ip link del dev wgprobe
+  echo "the interface really comes up"
+
+  up=0
+  for _ in $(seq 1 20); do
+    if ./bin/meshp status --socket "$SOCKET" 2>/dev/null | grep -qE "interface   meshp0 \((up|up, )"; then
+      up=1; break
+    fi
+    sleep 1
+  done
+  if [ "$up" != "1" ]; then
+    echo "--- status ---" >&2; ./bin/meshp status --socket "$SOCKET" >&2 || true
+    echo "--- agent log ---" >&2; tail -30 "$AGENT_LOG" >&2
+    fail "the interface never came up"
+  fi
+  ./bin/meshp status --socket "$SOCKET" | sed -n 's/^\(    interface .*\)/  \1/p'
+
+  # And it is the kernel implementation, not a silent userspace fallback (ADR-0015).
+  ./bin/meshp status --socket "$SOCKET" | grep -q "up, kernel" \
+    || fail "the tunnel is up but not reported as the kernel implementation"
+
+  # The second daemon in this script shares this host, and the control plane gives both
+  # devices the interface name meshp0 — so while it was running the two fought over the same
+  # interface and the last one to reconcile won. That is an artefact of running two devices
+  # on one host, not something a real deployment does, and it is why the assertions below
+  # come after that daemon has been stopped.
+  #
+  # It does make this a stronger test than it was meant to be: the first daemon has to
+  # notice that its interface was taken from it and put it back, with nothing from the
+  # control plane to prompt it. That only works because reconciling happens on a timer as
+  # well as on arrival.
+  echo "  the interface is restored after another process took it over"
+  healed=0
+  for _ in $(seq 1 20); do
+    if ip addr show dev meshp0 2>/dev/null | grep -q "100.90.${OCTET}.1/32"; then healed=1; break; fi
+    sleep 1
+  done
+  if [ "$healed" != "1" ]; then
+    echo "--- interface ---" >&2; ip addr show dev meshp0 >&2 || true
+    echo "--- wg ---" >&2; wg show meshp0 >&2 || true
+    echo "--- agent log ---" >&2; tail -20 "$AGENT_LOG" >&2
+    fail "the interface never got this device's address back"
+  fi
+
+  # The peer that joined second is configured, with a host route only. A wider prefix would
+  # mean one peer absorbing traffic for every other device in the network.
+  if command -v wg >/dev/null 2>&1; then
+    wg show meshp0 allowed-ips | grep -qE "100\.90\.${OCTET}\.2/32" \
+      || { wg show meshp0 >&2; fail "the peer is not configured on the interface"; }
+    if wg show meshp0 allowed-ips | grep -qE "/(2[0-9]|1[0-9]|[0-9])\b"; then
+      wg show meshp0 allowed-ips >&2
+      fail "a peer holds a prefix wider than a single host"
+    fi
+    echo "  peer configured with host routes only"
+  fi
+
+  # And the routes the agent installed are its own, not the kernel's.
+  ip route show dev meshp0 | grep -q "100.90.${OCTET}.2" \
+    || { ip route show dev meshp0 >&2; fail "no route to the peer via the interface"; }
+  echo "  route to the peer installed"
+fi
 
 echo "the same token a second time"
 if ./bin/meshp join "$TOKEN" --control-url "$BASE" --socket "$SOCKET" >"$WORK/replay.out" 2>&1; then

--- a/scripts/e2e-tunnel.sh
+++ b/scripts/e2e-tunnel.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Run the end-to-end enrolment inside a privileged Linux container, so the tunnel
+# assertions in e2e-enrol.sh actually execute.
+#
+# `make e2e` on macOS skips them: there is no way to create a WireGuard interface there in
+# this build. Skipping is right for a laptop and wrong for a gate, so this exists to make
+# the same script run where the interfaces are real. CI runs e2e-enrol.sh directly on a
+# Linux runner and gets the same coverage without Docker.
+set -euo pipefail
+
+NETWORK="meshp-e2e-$$"
+PG="meshp-e2e-pg-$$"
+GO_IMAGE="${GO_IMAGE:-golang:1.25}"
+
+cleanup() {
+  docker rm -f "$PG" >/dev/null 2>&1 || true
+  docker network rm "$NETWORK" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+cleanup
+
+docker network create "$NETWORK" >/dev/null
+docker run -d --name "$PG" --network "$NETWORK" \
+  -e POSTGRES_USER=meshp -e POSTGRES_PASSWORD=meshp -e POSTGRES_DB=meshp \
+  postgres:16-alpine >/dev/null
+
+echo "waiting for postgres"
+for _ in $(seq 1 40); do
+  if docker exec "$PG" pg_isready -U meshp -d meshp >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+
+# Debian rather than Alpine: the daemon is built here and run here, and a glibc image
+# avoids a cgo/musl mismatch being mistaken for a networking problem.
+#
+# An anonymous volume over /src/bin so the container builds its own binaries. Without it the
+# host's are visible, make considers them current, and Linux tries to run a darwin binary —
+# which it reports as "Exec format error" from inside a readiness timeout. It also keeps the
+# host's bin/ as it was, so `make e2e` on the host afterwards does not silently run Linux
+# binaries that make believes are up to date.
+docker run --rm --privileged \
+  --network "$NETWORK" \
+  -v "$PWD":/src -w /src \
+  -v /src/bin \
+  -v "$(go env GOMODCACHE)":/go/pkg/mod \
+  -e MESHP_TEST_DATABASE_URL="postgres://meshp:meshp@${PG}:5432/meshp?sslmode=disable" \
+  "$GO_IMAGE" bash -c '
+set -e
+apt-get update -qq >/dev/null
+apt-get install -y -qq --no-install-recommends iproute2 wireguard-tools postgresql-client >/dev/null
+make build
+./scripts/e2e-enrol.sh "$MESHP_TEST_DATABASE_URL"
+'


### PR DESCRIPTION
`recordingApplier` wrote down what it was told and reported success. It is gone. `meshpd`
now converges a real WireGuard interface:

```
    network   7803fe27-2fc9-45cd-b417-dc981c85e4f5
      session     connected since 2026-08-13T05:55:29Z
      applied     version 2
      interface   meshp0 (up, kernel)
      address     100.90.2.1
                  fd7c:6d65:7368:2::1
```

`internal/tunnel` is the join between three packages that deliberately do not know about
each other: `peerset` holds what the server said, `wgplan` decides what an interface should
look like, `wglink` talks to the kernel. It translates and sequences and holds no rules of
its own. A peer whose allowed IPs or endpoint cannot be parsed refuses the **whole** update
rather than being skipped — a peer quietly dropped is a device nobody can reach, with
everything reporting success.

## What the end-to-end run exposed

Two devices on one host both get the interface name `meshp0` from the control plane, so the
second daemon in the e2e took the interface over from the first. That is an artefact of the
test rather than a deployment — but it showed something real: **the agent only reconciled
when desired state arrived.** An operator taking an interface down, another process removing
an address, a half-finished crash — none of those make the control plane send anything, so
the agent would sit next to a broken interface indefinitely believing itself converged.

It now reconciles on a timer as well: `--reconcile-interval`, default one minute. That is
affordable only because planning against a correct interface produces no operations at all
(Invariant 18) — a tick that finds nothing wrong costs two netlink reads and touches nothing.

It is also the first thing to depend on **Invariant 22**: the applier keeps the state it was
given so it can apply it again, which is only sound because that set belongs to it rather
than to the session. That invariant was added in #9 on reasoning alone; this is the use that
justifies it.

So the e2e now asserts the *repair* rather than the original happy path — the first daemon
has to notice its interface was taken and put it back, unprompted:

```
the interface really comes up
      interface   meshp0 (up, kernel)
  the interface is restored after another process took it over
  peer configured with host routes only
  route to the peer installed
```

It also checks the tunnel came up as the **kernel** implementation and not a silent
userspace fallback (ADR-0015), and that no peer holds a prefix wider than a single host.

## Two assertions that had outlived their build

The e2e asserted `interface meshp0 (not up)` unconditionally — true when written, false now.
It decides which to expect from the platform, and fails either way round: a tunnel reported
absent where one is possible is as wrong as one claimed where it is not.

And `meshp join` printed "meshpd does not bring up WireGuard in this build", which is simply
false on Linux. It no longer claims either way — the daemon knows, and `meshp status` asks
it — and instead says what is true everywhere: peers carry no endpoints, so devices in a
network know about each other and cannot reach each other.

## Invariants

- [x] An invariant is affected, and it still holds. Which, and how it is tested:

**18** — `TestApplyingTheSameStateTwiceTouchesNothingTheSecondTime`, and the periodic
reconcile depends on it entirely.
**22** — the applier retains the set it was handed; `TestReapplyingTheSameStateRepairsADamagedInterface`
covers the repair that relies on it.
**20** — `TestTeardownRemovesTheInterface`.
**1** — unchanged, and the e2e still asserts no private key crosses the socket or reaches a
log.

## Where no tunnel is possible

The reconciler is nil rather than an error. The device is enrolled, holds an address, has no
tunnel, and reports exactly that — the true state on macOS and Windows today.
`TestAnUnsupportedPlatformIsReportedRatherThanFatal` covers it, and `make e2e` on macOS
passes with the tunnel assertions skipped.

## Running it

```bash
make e2e-tunnel
```

The whole stack in a privileged Linux container, with an anonymous volume over `bin/` so the
host's binaries are neither used nor replaced. Without that, `make` considered the darwin
binaries current and Linux reported `Exec format error` from inside a readiness timeout —
the same stale-binary trap as before, in a new place.

## Migrations

None.

## Not in scope

Still no endpoints, so two enrolled devices cannot reach each other even with tunnels up on
both. That is A6: relay first, then ICE (ADR-0002). `internal/tunnel` already takes the
server's first endpoint when one is offered, so the agent side of it is ready for the
control plane to start sending them.