### PR TITLE
fix(wgplan): a peer's endpoint is evidence, not drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@
 BUF_VERSION      := v1.47.2
 SQLC_VERSION     := v1.27.0
 GOLANGCI_VERSION := v2.12.2
+
+# The linter as a binary rather than `go run` each time: it has to be invoked once per
+# platform, and re-linking it for every invocation is the slowest part of linting.
+LINT_BIN := $(CURDIR)/bin/golangci-lint
 GOVULN_VERSION   := v1.6.0
 
 VERSION  := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
@@ -173,9 +177,26 @@ fmt-check: ## Fail if any Go file is not gofmt clean
 	echo "  all files are gofmt clean"
 
 .PHONY: lint
-lint: fmt-check ## Run go vet and golangci-lint
+lint: $(LINT_BIN) fmt-check ## Run go vet and golangci-lint
 	go vet ./...
-	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION) run
+	$(LINT_BIN) run
+
+$(LINT_BIN):
+	GOBIN=$(CURDIR)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION)
+
+.PHONY: lint-cross
+lint-cross: $(LINT_BIN) ## Lint the code for platforms this host is not
+	@# A //go:build linux file is invisible to a lint run on macOS, and a darwin one is
+	@# invisible in CI. With a data plane per platform coming, "it linted on my machine"
+	@# stops meaning anything unless each platform is asked for by name.
+	@# The linter is built for this host and told which platform to analyse. Building it
+	@# with GOOS set would cross-compile the linter itself, which this host cannot run.
+	@for os in linux darwin windows; do \
+	  if [ "$$os" = "$$(go env GOOS)" ]; then continue; fi; \
+	  echo "  linting for $$os"; \
+	  GOOS=$$os $(LINT_BIN) run || exit 1; \
+	done
+	@echo "  other platforms are clean"
 
 .PHONY: tidy-check
 tidy-check: ## Fail if go.mod or go.sum are not what `go mod tidy` would write
@@ -260,7 +281,7 @@ migrate-check: ## Apply, roll back and re-apply every migration against MESHP_TE
 ## --- aggregate ------------------------------------------------------------
 
 .PHONY: ci
-ci: lint tidy-check standalone-check build cross test cover-check cover-check-io fuzz-seeds ## Everything CI runs, minus the jobs needing Postgres
+ci: lint lint-cross tidy-check standalone-check build cross test cover-check cover-check-io fuzz-seeds ## Everything CI runs, minus the jobs needing Postgres
 	@echo
 	@echo "  all local CI checks passed"
 

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/meshpnet/meshp/internal/peerset"
 	"github.com/meshpnet/meshp/internal/wglink"
@@ -59,7 +60,27 @@ func (f *fakeLink) Apply(_ string, op wgplan.Op) error {
 		f.observed.MTU = op.Device.MTU
 		f.observed.ListenPort = 43521 // as a kernel does when asked for any
 	case wgplan.SetPeer:
-		f.observed.Peers = append(f.observed.Peers, op.Peer)
+		// Replace by key, and treat an empty endpoint as "leave the endpoint alone" — both
+		// as the kernel does. A fake that appended instead would hold duplicates, and one
+		// that cleared the endpoint would hide the roaming case entirely.
+		next := op.Peer
+		replaced := false
+		for i, existing := range f.observed.Peers {
+			if existing.PublicKey != next.PublicKey {
+				continue
+			}
+			if next.Endpoint == "" {
+				next.Endpoint = existing.Endpoint
+				next.HasHandshake = existing.HasHandshake
+				next.HandshakeAge = existing.HandshakeAge
+			}
+			f.observed.Peers[i] = next
+			replaced = true
+			break
+		}
+		if !replaced {
+			f.observed.Peers = append(f.observed.Peers, next)
+		}
 	case wgplan.RemovePeer:
 		var kept []wgplan.Peer
 		for _, p := range f.observed.Peers {
@@ -513,5 +534,41 @@ func TestReapplyingTheSameStateRepairsADamagedInterface(t *testing.T) {
 	}
 	if len(link.applied) != 0 {
 		t.Errorf("the repair did not converge; a third pass still wants: %v", link.applied)
+	}
+}
+
+// The reconciler must not undo roaming. A peer that moved and is talking from its new
+// address keeps it, even though the control plane still names the old one — otherwise every
+// reconcile tick would break a working path (see wgplan's endpoint rules, and wglink's
+// TestALearnedEndpointIsNotTreatedAsDrift against a real kernel).
+func TestReconcilingDoesNotUndoRoaming(t *testing.T) {
+	link := newFakeLink()
+	r := New(link, membership(), nil)
+
+	p := peer(bobKey, "100.90.0.2/32")
+	p.Endpoints = []string{"203.0.113.2:51820"}
+	state := stateWith(3, p)
+
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bob has moved, and the device knows because his traffic arrives from somewhere else.
+	for i := range link.observed.Peers {
+		link.observed.Peers[i].Endpoint = "198.51.100.9:33445"
+		link.observed.Peers[i].HasHandshake = true
+		link.observed.Peers[i].HandshakeAge = 20 * time.Second
+	}
+	link.applied = nil
+
+	// The control plane has not caught up and still says the old address.
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if len(link.applied) != 0 {
+		t.Errorf("reconciling replaced a working endpoint with a stale one: %v", link.applied)
+	}
+	if got := link.observed.Peers[0].Endpoint; got != "198.51.100.9:33445" {
+		t.Errorf("the peer's endpoint is now %q, want where it actually is", got)
 	}
 }

--- a/internal/wglink/packet_linux_test.go
+++ b/internal/wglink/packet_linux_test.go
@@ -239,3 +239,136 @@ func TestAPacketCrossesTheTunnel(t *testing.T) {
 		t.Errorf("the tunnel stopped working after a reconcile: %v\n%s", err, out)
 	}
 }
+
+// WireGuard learns a peer's endpoint from the traffic it receives: the kernel updates it to
+// the source of the most recent authenticated packet, which is how roaming works at all.
+//
+// So the kernel's endpoint for a peer is frequently one meshp never configured, and it is
+// better information than anything the control plane has — it is where that peer actually
+// is. A reconciler that treats it as drift and writes its own value back would undo roaming
+// on a timer, and would never stop finding work to do (Invariant 18).
+//
+// This is the case with no configured endpoint at all, which is what every peer looks like
+// until endpoint discovery exists: B does not know where A is, A knows where B is, and one
+// ping from A teaches B.
+func TestALearnedEndpointIsNotTreatedAsDrift(t *testing.T) {
+	if !privileged() {
+		t.Skip("needs root to create namespaces and interfaces")
+	}
+	if _, err := exec.LookPath("ip"); err != nil {
+		t.Skip("needs iproute2")
+	}
+
+	const (
+		nsA, nsB             = "meshpRA", "meshpRB"
+		underlayA, underlayB = "10.98.0.1", "10.98.0.2"
+		portA, portB         = 51830, 51831
+		meshA, meshB         = "100.93.0.1", "100.93.0.2"
+	)
+
+	cleanup := func() {
+		_ = exec.Command("ip", "netns", "del", nsA).Run()
+		_ = exec.Command("ip", "netns", "del", nsB).Run()
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	run(t, "ip", "netns", "add", nsA)
+	run(t, "ip", "netns", "add", nsB)
+	run(t, "ip", "link", "add", "vRA", "type", "veth", "peer", "name", "vRB")
+	run(t, "ip", "link", "set", "vRA", "netns", nsA)
+	run(t, "ip", "link", "set", "vRB", "netns", nsB)
+	run(t, "ip", "-n", nsA, "addr", "add", underlayA+"/24", "dev", "vRA")
+	run(t, "ip", "-n", nsA, "link", "set", "vRA", "up")
+	run(t, "ip", "-n", nsB, "addr", "add", underlayB+"/24", "dev", "vRB")
+	run(t, "ip", "-n", nsB, "link", "set", "vRB", "up")
+
+	privA, err := wgtypes.GeneratePrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	privB, err := wgtypes.GeneratePrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A knows where B is. B knows nothing about where A is — no endpoint at all.
+	wantA := wgplan.Interface{
+		Name: "meshp0", PrivateKey: wgplan.Key(privA.String()), ListenPort: portA, MTU: 1420,
+		Addresses: []netip.Prefix{netip.MustParsePrefix(meshA + "/32")},
+		Peers: []wgplan.Peer{{
+			PublicKey:        wgplan.Key(privB.PublicKey().String()),
+			AllowedIPs:       []netip.Prefix{netip.MustParsePrefix(meshB + "/32")},
+			Endpoint:         fmt.Sprintf("%s:%d", underlayB, portB),
+			KeepaliveSeconds: 25,
+		}},
+	}
+	wantB := wgplan.Interface{
+		Name: "meshp0", PrivateKey: wgplan.Key(privB.String()), ListenPort: portB, MTU: 1420,
+		Addresses: []netip.Prefix{netip.MustParsePrefix(meshB + "/32")},
+		Peers: []wgplan.Peer{{
+			PublicKey:  wgplan.Key(privA.PublicKey().String()),
+			AllowedIPs: []netip.Prefix{netip.MustParsePrefix(meshA + "/32")},
+			// No endpoint: this is every peer, before discovery exists.
+			KeepaliveSeconds: 25,
+		}},
+	}
+
+	for ns, want := range map[string]wgplan.Interface{nsA: wantA, nsB: wantB} {
+		netnsRun(t, ns, func() {
+			l, err := New()
+			if err != nil {
+				t.Fatalf("%s: %v", ns, err)
+			}
+			defer func() { _ = l.Close() }()
+			obs, err := l.Observe(want.Name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan, err := wgplan.For(want, obs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := ApplyPlan(l, want.Name, plan); err != nil {
+				t.Fatalf("%s: %v", ns, err)
+			}
+		})
+	}
+
+	// A initiates. B now knows where A is, having been told by the packet rather than by us.
+	if out, err := exec.Command("ip", "netns", "exec", nsA,
+		"ping", "-c", "2", "-W", "5", meshB).CombinedOutput(); err != nil {
+		t.Fatalf("the tunnel did not come up, so nothing was learned: %v\n%s", err, out)
+	}
+
+	netnsRun(t, nsB, func() {
+		l, err := New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = l.Close() }()
+
+		obs, err := l.Observe(wantB.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(obs.Peers) != 1 {
+			t.Fatalf("%d peers, want 1", len(obs.Peers))
+		}
+		learned := obs.Peers[0].Endpoint
+		if learned == "" {
+			t.Fatal("the kernel reports no endpoint, so it learned nothing and this test proves nothing")
+		}
+		t.Logf("B learned A's endpoint from traffic: %s", learned)
+
+		// The claim: knowing less than the kernel is not a reason to overwrite it.
+		plan, err := wgplan.For(wantB, obs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !plan.Empty() {
+			t.Errorf("a learned endpoint was treated as drift; every reconcile would rewrite\n"+
+				"the peer and undo roaming:\n%s", plan)
+		}
+	})
+}

--- a/internal/wglink/wglink_linux.go
+++ b/internal/wglink/wglink_linux.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/jsimonetti/rtnetlink/v2"
@@ -25,6 +26,13 @@ import (
 // makes it a WireGuard device — keys and peers — and speaks netlink to a kernel device or
 // the UAPI socket to a userspace one, so the same code configures either (ADR-0015).
 type linux struct {
+	// mu serialises operations. mdlayher/netlink documents its Conn as safe for concurrent
+	// use; wgctrl's client makes no such promise, and one of these is shared by every
+	// membership on the host, each with its own reconcile timer. Netlink operations take
+	// microseconds and reconciles are a minute apart, so serialising costs nothing and
+	// removes a class of failure that would only appear on a device in several networks.
+	mu sync.Mutex
+
 	rt *rtnetlink.Conn
 	wg *wgctrl.Client
 }
@@ -48,6 +56,9 @@ func (l *linux) Close() error {
 }
 
 func (l *linux) Kind(name string) (Kind, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
 	dev, err := l.wg.Device(name)
 	if err != nil {
 		return KindUnknown, fmt.Errorf("wglink: reading %s: %w", name, err)
@@ -64,6 +75,9 @@ func (l *linux) Kind(name string) (Kind, error) {
 
 // Observe reports what the interface currently holds.
 func (l *linux) Observe(name string) (wgplan.Observed, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
 	iface, gone, err := lookup(name)
 	if err != nil {
 		return wgplan.Observed{}, err
@@ -153,6 +167,9 @@ func (l *linux) routes(index uint32) ([]netip.Prefix, error) {
 
 // Apply carries out one operation.
 func (l *linux) Apply(name string, op wgplan.Op) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
 	switch op.Kind {
 	case wgplan.CreateDevice:
 		return l.createDevice(name)
@@ -446,6 +463,12 @@ func peerFromDevice(peer wgtypes.Peer) wgplan.Peer {
 	out := wgplan.Peer{
 		PublicKey:        wgplan.Key(peer.PublicKey.String()),
 		KeepaliveSeconds: int(peer.PersistentKeepaliveInterval.Seconds()),
+	}
+	// Whether this peer's current endpoint is working, which is what decides whether
+	// replacing it would be a repair or would undo roaming.
+	if !peer.LastHandshakeTime.IsZero() {
+		out.HasHandshake = true
+		out.HandshakeAge = time.Since(peer.LastHandshakeTime)
 	}
 	if peer.Endpoint != nil {
 		out.Endpoint = peer.Endpoint.String()

--- a/internal/wglink/wglink_linux_test.go
+++ b/internal/wglink/wglink_linux_test.go
@@ -3,6 +3,7 @@
 package wglink
 
 import (
+	"fmt"
 	"net/netip"
 	"os/exec"
 	"strings"
@@ -333,5 +334,84 @@ func TestANonWireGuardInterfaceIsRefused(t *testing.T) {
 		t.Error("a non-WireGuard interface was adopted")
 	} else if !strings.Contains(err.Error(), "not a WireGuard interface") {
 		t.Errorf("the error does not explain the problem: %v", err)
+	}
+}
+
+// Anything whose written form differs from the form the kernel reports back is a field the
+// diff can never satisfy: the peer is rewritten on every reconcile, its session resets each
+// time, and nothing looks wrong because both values are individually correct. Invariant 18
+// is the guard, and these are the fields most likely to breach it.
+func TestEveryPeerFieldSurvivesARoundTripThroughTheKernel(t *testing.T) {
+	l := requireInterfaces(t)
+
+	psk := genKey(t)
+	cases := map[string]wgplan.Peer{
+		"an IPv4 endpoint": {
+			Endpoint: "203.0.113.9:51820",
+		},
+		"an IPv6 endpoint, where the bracketed form could differ": {
+			Endpoint: "[2001:db8::9]:51820",
+		},
+		"a preshared key, which some interfaces decline to report": {
+			PresharedKey: psk,
+		},
+		"a keepalive": {
+			KeepaliveSeconds: 25,
+		},
+		"all of them at once": {
+			Endpoint:         "[2001:db8::9]:51820",
+			PresharedKey:     psk,
+			KeepaliveSeconds: 25,
+		},
+	}
+
+	i := 0
+	for name, tweak := range cases {
+		name, tweak := name, tweak
+		i++
+		iface := fmt.Sprintf("wgrt%d", i)
+		t.Run(name, func(t *testing.T) {
+			removeInterface(t, l, iface)
+			t.Cleanup(func() { removeInterface(t, l, iface) })
+
+			want := wanted(t, iface)
+			want.Peers[0].Endpoint = tweak.Endpoint
+			want.Peers[0].PresharedKey = tweak.PresharedKey
+			want.Peers[0].KeepaliveSeconds = tweak.KeepaliveSeconds
+
+			obs, err := l.Observe(iface)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan, err := wgplan.For(want, obs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := ApplyPlan(l, iface, plan); err != nil {
+				t.Fatal(err)
+			}
+
+			obs, err = l.Observe(iface)
+			if err != nil {
+				t.Fatal(err)
+			}
+			again, err := wgplan.For(want, obs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !again.Empty() {
+				got := "no peers"
+				if len(obs.Peers) > 0 {
+					p := obs.Peers[0]
+					got = fmt.Sprintf("endpoint=%q psk_set=%t keepalive=%d",
+						p.Endpoint, p.PresharedKey != "", p.KeepaliveSeconds)
+				}
+				t.Errorf("this peer would be rewritten on every reconcile.\n"+
+					"asked for: endpoint=%q psk_set=%t keepalive=%d\n"+
+					"kernel reports: %s\nplan:\n%s",
+					want.Peers[0].Endpoint, want.Peers[0].PresharedKey != "",
+					want.Peers[0].KeepaliveSeconds, got, again)
+			}
+		})
 	}
 }

--- a/internal/wglink/wglink_linux_test.go
+++ b/internal/wglink/wglink_linux_test.go
@@ -367,7 +367,6 @@ func TestEveryPeerFieldSurvivesARoundTripThroughTheKernel(t *testing.T) {
 
 	i := 0
 	for name, tweak := range cases {
-		name, tweak := name, tweak
 		i++
 		iface := fmt.Sprintf("wgrt%d", i)
 		t.Run(name, func(t *testing.T) {

--- a/internal/wgplan/wgplan.go
+++ b/internal/wgplan/wgplan.go
@@ -26,6 +26,7 @@ import (
 	"net/netip"
 	"sort"
 	"strings"
+	"time"
 )
 
 // Key is a WireGuard public or private key in its base64 form.
@@ -53,7 +54,22 @@ type Peer struct {
 
 	// KeepaliveSeconds keeps a NAT mapping open. Zero means none.
 	KeepaliveSeconds int
+
+	// HasHandshake and HandshakeAge describe whether this peer has completed a handshake
+	// and how long ago. Reported by the device; meaningless in a desired peer and never
+	// compared. They exist because whether a peer's current endpoint is working decides
+	// whether replacing it is a repair or a regression.
+	HasHandshake bool
+	HandshakeAge time.Duration
 }
+
+// endpointGrace is how recently a peer must have handshaked for its endpoint to count as
+// working.
+//
+// WireGuard abandons a session after REJECT_AFTER_TIME — 180 seconds — so a peer that has
+// not handshaked within that is not reaching anyone at its current endpoint. Inside it, the
+// endpoint is carrying traffic, and evidence beats the control plane's opinion.
+const endpointGrace = 180 * time.Second
 
 // Interface is the desired state of one membership's interface.
 type Interface struct {
@@ -278,8 +294,12 @@ func For(want Interface, observed Observed) (Plan, error) {
 	for _, key := range sortedKeys(wantPeers) {
 		desired := wantPeers[key]
 		current, exists := havePeers[key]
-		if !exists || !samePeer(current, desired) {
+		if !exists {
 			add(Op{Kind: SetPeer, Peer: desired})
+			continue
+		}
+		if write, peer := resolvePeer(current, desired); write {
+			add(Op{Kind: SetPeer, Peer: peer})
 		}
 	}
 
@@ -480,14 +500,63 @@ func sortedKeys(peers map[Key]Peer) []Key {
 	return out
 }
 
-// samePeer reports whether a peer needs rewriting.
+// resolvePeer decides whether an existing peer needs rewriting, and with what.
+//
+// Everything but the endpoint is a straightforward comparison. The endpoint is not, because
+// it is the one field the device changes on its own: WireGuard updates a peer's endpoint to
+// the source of the most recent authenticated packet, which is how roaming works. So the
+// value the kernel holds is frequently one nobody configured, and it is better information
+// than the control plane has — it is where that peer actually is, as opposed to where it was
+// last thought to be.
+//
+// The returned peer carries an empty endpoint to mean "leave the endpoint alone", which is
+// how a peer can have its allowed IPs corrected without having a working path taken away
+// from it at the same time.
+func resolvePeer(have, want Peer) (bool, Peer) {
+	keep := keepObservedEndpoint(have, want)
+
+	out := want
+	if keep {
+		out.Endpoint = ""
+	}
+
+	if !sameApartFromEndpoint(have, want) {
+		return true, out
+	}
+	if !keep && have.Endpoint != want.Endpoint {
+		return true, out
+	}
+	return false, out
+}
+
+// keepObservedEndpoint reports whether the device's endpoint should be left as it is.
+func keepObservedEndpoint(have, want Peer) bool {
+	switch {
+	case want.Endpoint == "":
+		// Nothing to offer. Whatever the device has — configured earlier, or learned from
+		// traffic — is more than we know, and this is every peer's state until endpoint
+		// discovery exists.
+		return true
+	case have.Endpoint == "":
+		return false // nothing there; ours is the only candidate
+	case have.Endpoint == want.Endpoint:
+		return false // identical, so writing and keeping are the same thing
+	default:
+		// They differ. If the current one is carrying traffic, replacing it with a guess is
+		// a regression rather than a repair — the peer has moved and told us so. If it is
+		// not, the candidate is worth trying, which is as much failover as exists until the
+		// agent consumes candidate lists (ADR-0003).
+		return have.HasHandshake && have.HandshakeAge <= endpointGrace
+	}
+}
+
+// sameApartFromEndpoint compares everything the control plane decides outright.
 //
 // Allowed IPs are compared as sets: the order they arrive in is not something the kernel
 // preserves or cares about, so comparing slices directly would rewrite every peer on
 // every tick and reset its session each time.
-func samePeer(have, want Peer) bool {
-	if have.Endpoint != want.Endpoint ||
-		have.PresharedKey != want.PresharedKey ||
+func sameApartFromEndpoint(have, want Peer) bool {
+	if have.PresharedKey != want.PresharedKey ||
 		have.KeepaliveSeconds != want.KeepaliveSeconds {
 		return false
 	}

--- a/internal/wgplan/wgplan_test.go
+++ b/internal/wgplan/wgplan_test.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 	"strings"
 	"testing"
+	"time"
 )
 
 func mustPrefix(t *testing.T, s string) netip.Prefix {
@@ -582,7 +583,18 @@ func simulate(obs Observed, plan Plan) Observed {
 				obs.ListenPort = op.Device.ListenPort
 			}
 		case SetPeer:
-			peers[op.Peer.PublicKey] = op.Peer
+			// An empty endpoint means "leave the endpoint alone", which is what the kernel
+			// does when a peer is configured without one. A simulation that cleared it here
+			// would never exercise the case this exists for.
+			next := op.Peer
+			if next.Endpoint == "" {
+				if existing, ok := peers[next.PublicKey]; ok {
+					next.Endpoint = existing.Endpoint
+					next.HasHandshake = existing.HasHandshake
+					next.HandshakeAge = existing.HandshakeAge
+				}
+			}
+			peers[next.PublicKey] = next
 		case RemovePeer:
 			delete(peers, op.Peer.PublicKey)
 		case AddAddress:
@@ -625,8 +637,15 @@ func sameAsWanted(want Interface, reached Observed) error {
 		if !ok {
 			return fmt.Errorf("peer %s is missing", peer.PublicKey)
 		}
-		if !samePeer(got, peer) {
+		if !sameApartFromEndpoint(got, peer) {
 			return fmt.Errorf("peer %s was not configured as asked", peer.PublicKey)
+		}
+		// The endpoint is deliberately not required to equal what was asked for: a peer
+		// whose current endpoint is working keeps it, because the device knows where that
+		// peer is and the control plane only knows where it was. What must hold is that a
+		// peer with nowhere to be reached got the candidate we had.
+		if got.Endpoint == "" && peer.Endpoint != "" {
+			return fmt.Errorf("peer %s was left with no endpoint although one was offered", peer.PublicKey)
 		}
 	}
 
@@ -716,11 +735,27 @@ func randomObserved(t *testing.T, rng *rand.Rand, want Interface) Observed {
 		return obs
 
 	case 3:
-		// Right peers, wrong details: the shape that must still produce a rewrite.
+		// Right peers, wrong details: the shape that must still produce a rewrite. The
+		// endpoints and handshake states are varied deliberately, because whether an
+		// endpoint may be replaced depends on whether the current one is working.
 		obs := applied(want)
 		for i := range obs.Peers {
-			if rng.Intn(2) == 0 {
+			switch rng.Intn(4) {
+			case 0:
+				// Somewhere else entirely, and talking: roaming. Must be left alone.
 				obs.Peers[i].Endpoint = "192.0.2.99:1"
+				obs.Peers[i].HasHandshake = true
+				obs.Peers[i].HandshakeAge = time.Duration(rng.Intn(120)) * time.Second
+			case 1:
+				// Somewhere else, and silent: worth replacing.
+				obs.Peers[i].Endpoint = "192.0.2.99:1"
+				obs.Peers[i].HasHandshake = rng.Intn(2) == 0
+				obs.Peers[i].HandshakeAge = time.Duration(200+rng.Intn(600)) * time.Second
+			case 2:
+				// Learned from traffic when we had nothing to offer.
+				obs.Peers[i].Endpoint = "198.51.100.7:41234"
+				obs.Peers[i].HasHandshake = true
+				obs.Peers[i].HandshakeAge = 5 * time.Second
 			}
 			if rng.Intn(3) == 0 {
 				obs.Peers[i].KeepaliveSeconds = 99
@@ -800,5 +835,177 @@ func TestAnInterfaceThatIsDownIsBroughtUp(t *testing.T) {
 		if op.Kind != BringUp {
 			t.Errorf("raising a down interface also did: %s", op)
 		}
+	}
+}
+
+// --- endpoints ---------------------------------------------------------------
+//
+// WireGuard updates a peer's endpoint to the source of the most recent authenticated
+// packet: that is how roaming works. So the device's value is frequently one nobody
+// configured, and it is better information than the control plane has — where the peer
+// actually is, rather than where it was last thought to be. Demonstrated against a real
+// kernel in wglink's TestALearnedEndpointIsNotTreatedAsDrift.
+
+func withPeer(t *testing.T, p Peer) Interface {
+	t.Helper()
+	iface := base(t)
+	p.AllowedIPs = prefixes(t, "100.90.0.2/32")
+	iface.Peers = []Peer{p}
+	return iface
+}
+
+// Knowing nothing is not a reason to overwrite what the device learned.
+func TestAnEndpointLearnedFromTrafficIsLeftAlone(t *testing.T) {
+	want := withPeer(t, Peer{PublicKey: "peer-bob", KeepaliveSeconds: 25})
+
+	obs := applied(want)
+	obs.Peers[0].Endpoint = "198.51.100.7:41234" // learned, never configured
+	obs.Peers[0].HasHandshake = true
+	obs.Peers[0].HandshakeAge = 5 * time.Second
+
+	plan, err := For(want, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !plan.Empty() {
+		t.Errorf("a learned endpoint was treated as drift:\n%s", plan)
+	}
+}
+
+// A peer that has moved and is talking from its new address keeps it. Replacing a working
+// path with a stale guess is a regression, not a repair.
+func TestAWorkingEndpointSurvivesADifferentCandidate(t *testing.T) {
+	want := withPeer(t, Peer{
+		PublicKey:        "peer-bob",
+		Endpoint:         "203.0.113.2:51820", // where the server thinks bob is
+		KeepaliveSeconds: 25,
+	})
+
+	obs := applied(want)
+	obs.Peers[0].Endpoint = "198.51.100.9:33445" // where bob actually is
+	obs.Peers[0].HasHandshake = true
+	obs.Peers[0].HandshakeAge = 30 * time.Second
+
+	plan, err := For(want, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !plan.Empty() {
+		t.Errorf("a working endpoint was replaced by the control plane's guess:\n%s", plan)
+	}
+}
+
+// But an endpoint that is not working is worth replacing: as much failover as exists until
+// the agent consumes candidate lists (ADR-0003).
+func TestASilentEndpointIsReplacedByTheCandidate(t *testing.T) {
+	want := withPeer(t, Peer{
+		PublicKey:        "peer-bob",
+		Endpoint:         "203.0.113.2:51820",
+		KeepaliveSeconds: 25,
+	})
+
+	obs := applied(want)
+	obs.Peers[0].Endpoint = "198.51.100.9:33445"
+	obs.Peers[0].HasHandshake = true
+	obs.Peers[0].HandshakeAge = 10 * time.Minute // well past REJECT_AFTER_TIME
+
+	plan, err := For(want, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstIndexOf(plan, SetPeer) < 0 {
+		t.Fatalf("a dead endpoint was left in place:\n%s", plan)
+	}
+	for _, op := range plan.Ops {
+		if op.Kind == SetPeer && op.Peer.Endpoint != "203.0.113.2:51820" {
+			t.Errorf("the candidate was not written: endpoint is %q", op.Peer.Endpoint)
+		}
+	}
+}
+
+// A peer that has never handshaked has nothing worth keeping.
+func TestAPeerThatNeverHandshakedTakesTheCandidate(t *testing.T) {
+	want := withPeer(t, Peer{
+		PublicKey:        "peer-bob",
+		Endpoint:         "203.0.113.2:51820",
+		KeepaliveSeconds: 25,
+	})
+
+	obs := applied(want)
+	obs.Peers[0].Endpoint = "198.51.100.9:33445"
+	obs.Peers[0].HasHandshake = false
+
+	plan, err := For(want, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstIndexOf(plan, SetPeer) < 0 {
+		t.Errorf("a peer that never handshaked kept an endpoint that has never worked:\n%s", plan)
+	}
+}
+
+// A peer with nowhere to be reached takes whatever is offered.
+func TestAPeerWithNoEndpointTakesTheCandidate(t *testing.T) {
+	want := withPeer(t, Peer{
+		PublicKey:        "peer-bob",
+		Endpoint:         "203.0.113.2:51820",
+		KeepaliveSeconds: 25,
+	})
+
+	obs := applied(want)
+	obs.Peers[0].Endpoint = ""
+
+	plan, err := For(want, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, op := range plan.Ops {
+		if op.Kind == SetPeer && op.Peer.Endpoint == "203.0.113.2:51820" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("a peer with no endpoint was not given the one on offer:\n%s", plan)
+	}
+}
+
+// The case that makes "leave the endpoint alone" a separate idea from "do nothing": a peer
+// whose allowed IPs are wrong and whose endpoint is working must have one fixed without
+// losing the other.
+func TestAPeersAddressesAreCorrectedWithoutDisturbingAWorkingEndpoint(t *testing.T) {
+	want := withPeer(t, Peer{
+		PublicKey:        "peer-bob",
+		Endpoint:         "203.0.113.2:51820",
+		KeepaliveSeconds: 25,
+	})
+
+	obs := applied(want)
+	obs.Peers[0].AllowedIPs = prefixes(t, "100.90.0.99/32") // wrong
+	obs.Peers[0].Endpoint = "198.51.100.9:33445"            // working
+	obs.Peers[0].HasHandshake = true
+	obs.Peers[0].HandshakeAge = time.Second
+
+	plan, err := For(want, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wrote bool
+	for _, op := range plan.Ops {
+		if op.Kind != SetPeer {
+			continue
+		}
+		wrote = true
+		if op.Peer.Endpoint != "" {
+			t.Errorf("the working endpoint would be overwritten with %q; an empty endpoint\n"+
+				"is how the plan says to leave it alone", op.Peer.Endpoint)
+		}
+		if len(op.Peer.AllowedIPs) != 1 || op.Peer.AllowedIPs[0].String() != "100.90.0.2/32" {
+			t.Errorf("the allowed IPs were not corrected: %v", op.Peer.AllowedIPs)
+		}
+	}
+	if !wrote {
+		t.Errorf("wrong allowed IPs were left in place:\n%s", plan)
 	}
 }


### PR DESCRIPTION
WireGuard updates a peer's endpoint to the source of the most recent authenticated packet.
That is how roaming works — and it means the value the kernel holds is frequently one nobody
configured, and is *better information* than the control plane has: where the peer actually
is, rather than where it was last thought to be.

The reconciler compared endpoints like any other field, so it would have written its own
value back on every tick. I demonstrated it against a real kernel before fixing it, in the
case every peer is in until endpoint discovery exists — A knows where B is, B knows nothing,
and one ping teaches B:

```
    packet_linux_test.go:362: B learned A's endpoint from traffic: 10.98.0.1:51830
    packet_linux_test.go:370: a learned endpoint was treated as drift; every reconcile
    would rewrite the peer and undo roaming
--- FAIL: TestALearnedEndpointIsNotTreatedAsDrift (5.56s)
```

**Nothing populates endpoints yet, so this was not reachable in production.** It becomes
reachable the moment A6 lands, and the symptom would have been roaming devices dropping
every reconcile interval while both sides looked correctly configured — the kind of thing
that gets diagnosed as "flaky WiFi" for a month.

## The rule

An opinion is not evidence:

| control plane says | device has | action |
|---|---|---|
| nothing | anything | leave it — this is every peer today |
| an endpoint | nothing | write ours |
| an endpoint | a different one, carrying traffic | leave it — the peer moved and said so |
| an endpoint | a different one, silent | write ours |

"Carrying traffic" is a handshake within `REJECT_AFTER_TIME` (180s), after which WireGuard
has abandoned the session — so a peer that has not handshaked within it is not reaching
anyone at that address. Observed peers now carry whether they ever handshaked and how long
ago, computed by the platform so `wgplan` stays free of clocks and stays deterministic.

That last row is as much failover as exists until the agent consumes candidate lists
(ADR-0003), and it is the reason not to simply pin the endpoint forever.

The distinction also needs a way for a plan to say *"correct this peer's addresses and leave
its endpoint alone"*, so an empty endpoint in a `SetPeer` means exactly that — which is also
what `wgctrl` does with one. `TestAPeersAddressesAreCorrectedWithoutDisturbingAWorkingEndpoint`
is the case that makes it a separate idea from "do nothing".

## Two more risks of the same class

Any field whose written form differs from the form the kernel reports back can never satisfy
the diff: the peer is rewritten every reconcile, its session resets each time, and nothing
looks wrong because both values are individually correct. Tested against a real interface,
because nothing else can answer it:

- **an IPv6 endpoint**, where the bracketed form could differ
- **a preshared key**, which an interface is entitled not to report at all

Both survive on this kernel. If a userspace implementation differs, the test says so instead
of the session resetting every minute forever.

## Also

The `wgctrl` client is shared by every membership on the host, each with its own reconcile
timer, and its concurrency guarantee is undocumented — `mdlayher/netlink` documents its
`Conn` as safe, `wgctrl` says nothing. Operations are serialised: microseconds, once a
minute, against a failure that would only appear on a device in several networks.

And `internal/tunnel`'s fake appended peers rather than replacing them, and did not model the
empty-endpoint rule. A fake that models the device wrongly is a test that passes while
reality fails.

## Invariants

- [x] An invariant is affected, and it still holds. Which, and how it is tested:

**18** — this was a breach of it: the plan never converged for a peer with a learned
endpoint. The property test now generates roaming, silent and learned endpoints, and
`TestASecondPlanAgainstARealInterfaceIsEmpty` plus the new round-trip test cover it against
a real kernel.

## Teeth

Reverting `keepObservedEndpoint` to the old always-compare behaviour fails four tests in
`wgplan` — including the property test — and `TestReconcilingDoesNotUndoRoaming` in
`tunnel`. The property test only catches it because its generator was extended to produce
these cases; it would have passed otherwise, which is the same gap that let the
listen-port-zero bug through in #12.

## Migrations

None.