### PR TITLE
feat(meshpd): remember the port an interface settled on

### DIFF
--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -255,6 +255,9 @@ func cmdStatus(ctx context.Context, args []string) error {
 			}
 		}
 		fmt.Printf("    interface   %s (%s)\n", m.InterfaceName, tunnel)
+		if m.ListenPort != 0 {
+			fmt.Printf("    listening   udp/%d\n", m.ListenPort)
+		}
 		if m.AddressV4 != "" {
 			fmt.Printf("    address     %s\n", m.AddressV4)
 		}

--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -85,6 +85,7 @@ func (a *agent) reconcilerFor(m agentstate.Membership, log *slog.Logger) *tunnel
 		PrivateKey:    m.WireGuardPrivateKey,
 		AddressV4:     m.AddressV4,
 		AddressV6:     m.AddressV6,
+		ListenPort:    m.ListenPort,
 	}, log)
 }
 
@@ -246,6 +247,34 @@ func (a *agent) setApplied(membershipID uuid.UUID, appliedVersion int64) error {
 	return fmt.Errorf("meshpd: no local membership %s", membershipID)
 }
 
+// setListenPort records the port an interface settled on.
+//
+// Written only when it changes, which after the first time is almost never: the point of
+// persisting it is that the next start asks for the same port, so peers keep working
+// endpoints and NAT mappings survive a restart.
+func (a *agent) setListenPort(membershipID uuid.UUID, port int) error {
+	if port == 0 {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.state == nil {
+		return fmt.Errorf("meshpd: no local state to record a listen port against")
+	}
+	for i := range a.state.Memberships {
+		if a.state.Memberships[i].MembershipID != membershipID {
+			continue
+		}
+		if a.state.Memberships[i].ListenPort == port {
+			return nil
+		}
+		a.state.Memberships[i].ListenPort = port
+		return agentstate.Save(a.stateDir, a.state)
+	}
+	return fmt.Errorf("meshpd: no local membership %s", membershipID)
+}
+
 // Status implements agentapi.Handler.
 func (a *agent) Status(_ context.Context) (agentapi.Status, error) {
 	a.mu.Lock()
@@ -286,6 +315,9 @@ func (a *agent) Status(_ context.Context) (agentapi.Status, error) {
 			ms.AppliedStateVersion = handle.client.AppliedVersion()
 			ms.LastError = handle.applier.lastError()
 			ms.TunnelUp, ms.TunnelKind = handle.applier.tunnelStatus()
+			if handle.applier.reconciler != nil {
+				ms.ListenPort = handle.applier.reconciler.Status().ListenPort
+			}
 		}
 		status.Memberships = append(status.Memberships, ms)
 	}
@@ -452,6 +484,18 @@ func (a *deviceApplier) Apply(ctx context.Context, state *peerset.Set) ([]string
 	a.mu.Lock()
 	a.lastState = state
 	a.mu.Unlock()
+
+	// Keep whatever port the interface settled on, so the next start asks for the same one.
+	// A failure here costs port stability, not connectivity, so it is logged rather than
+	// reported as an unapplied component.
+	if a.reconciler != nil {
+		if port := a.reconciler.Status().ListenPort; port != 0 {
+			if err := a.agent.setListenPort(a.membershipID, port); err != nil {
+				a.log.Warn("could not record the interface's listen port",
+					"port", port, "error", err)
+			}
+		}
+	}
 
 	if a.reconciler == nil {
 		a.log.Info("recorded desired state",

--- a/internal/agentapi/agentapi.go
+++ b/internal/agentapi/agentapi.go
@@ -71,6 +71,12 @@ type MembershipStatus struct {
 	// status must not imply otherwise.
 	TunnelUp bool `json:"tunnel_up"`
 
+	// ListenPort is the UDP port the interface listens on. Zero when there is no tunnel.
+	//
+	// Reported because an operator opening a firewall or a port forward needs it, and
+	// because it is what peers will be told once endpoints are distributed.
+	ListenPort int `json:"listen_port,omitempty"`
+
 	// TunnelKind is which WireGuard implementation is behind the interface: "kernel" or
 	// "userspace". Empty when there is no tunnel.
 	//

--- a/internal/agentstate/state.go
+++ b/internal/agentstate/state.go
@@ -73,6 +73,15 @@ type Membership struct {
 	WireGuardPrivateKey string `json:"wireguard_private_key"` // base64
 	WireGuardPublicKey  string `json:"wireguard_public_key"`  // base64
 
+	// ListenPort is the UDP port this membership's interface listens on, kept so it
+	// survives a restart.
+	//
+	// Stability matters once peers are told where to send packets: a port that changes on
+	// every start invalidates the endpoint every other device holds, and drops any NAT
+	// mapping that was keeping a path open. Zero means one has not been chosen yet, which
+	// is what an older state file reads as — so there is nothing to migrate.
+	ListenPort int `json:"listen_port,omitempty"`
+
 	AppliedStateVersion int64     `json:"applied_state_version"`
 	JoinedAt            time.Time `json:"joined_at"`
 }

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -39,6 +39,11 @@ type Membership struct {
 	// AddressV4 and AddressV6 are this device's own addresses. Either may be empty.
 	AddressV4 string
 	AddressV6 string
+
+	// ListenPort is the UDP port to ask for. Zero asks for any, which is what a membership
+	// that has never come up says; the port the device settles on is reported back so it
+	// can be kept for next time.
+	ListenPort int
 }
 
 // Reconciler applies desired state to a real interface.
@@ -55,6 +60,7 @@ type Reconciler struct {
 	up       bool
 	lastErr  string
 	appliedV uint64
+	port     int
 }
 
 // New returns a Reconciler for one membership.
@@ -71,13 +77,19 @@ type Status struct {
 	Kind           wglink.Kind
 	LastError      string
 	AppliedVersion uint64
+
+	// ListenPort is the port the interface is actually listening on, which is the kernel's
+	// choice when none was asked for. Worth reporting: it is what an operator opening a
+	// firewall needs, and what peers will eventually be told.
+	ListenPort int
 }
 
 // Status reports the tunnel's current state.
 func (r *Reconciler) Status() Status {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return Status{Up: r.up, Kind: r.kind, LastError: r.lastErr, AppliedVersion: r.appliedV}
+	return Status{Up: r.up, Kind: r.kind, LastError: r.lastErr,
+		AppliedVersion: r.appliedV, ListenPort: r.port}
 }
 
 // Apply makes the interface match state.
@@ -131,11 +143,19 @@ func (r *Reconciler) Apply(_ context.Context, state *peerset.Set) ([]string, err
 		kind = wglink.KindUnknown
 	}
 
+	// The port the device settled on, read rather than assumed: asking for any means the
+	// kernel chose, and its choice is the thing worth keeping.
+	port := want.ListenPort
+	if after, err := r.link.Observe(want.Name); err == nil && after.ListenPort != 0 {
+		port = after.ListenPort
+	}
+
 	r.mu.Lock()
 	r.kind = kind
 	r.up = true
 	r.lastErr = ""
 	r.appliedV = state.Version()
+	r.port = port
 	r.mu.Unlock()
 	return nil, nil
 }
@@ -187,9 +207,10 @@ func Desired(m Membership, state *peerset.Set) (wgplan.Interface, error) {
 		Name:       m.InterfaceName,
 		PrivateKey: wgplan.Key(m.PrivateKey),
 		MTU:        defaultMTU,
-		// Any port. A device in several networks needs an interface for each (ADR-0004), so
-		// they cannot all ask for one port, and nothing distributes ports yet.
-		ListenPort: 0,
+		// The port this membership settled on before, or any if it has never come up. A
+		// device in several networks needs an interface for each (ADR-0004), so they cannot
+		// share one fixed port.
+		ListenPort: m.ListenPort,
 	}
 
 	if mtu := int(state.Tunnel().GetMtu()); mtu > 0 {

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -465,18 +465,6 @@ func TestTheFirstEndpointIsUsed(t *testing.T) {
 	}
 }
 
-// Any port, because a device in several networks needs an interface for each (ADR-0004) and
-// they cannot all ask for the same one.
-func TestNoParticularPortIsRequested(t *testing.T) {
-	iface, err := Desired(membership(), stateWith(1))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if iface.ListenPort != 0 {
-		t.Errorf("listen port is %d, want 0 meaning any", iface.ListenPort)
-	}
-}
-
 // The key is carried through untouched. wgplan does not parse keys, so a translation that
 // mangled one would only fail at the kernel, on a real host, with a confusing message.
 func TestKeysArePassedThroughUnchanged(t *testing.T) {
@@ -570,5 +558,46 @@ func TestReconcilingDoesNotUndoRoaming(t *testing.T) {
 	}
 	if got := link.observed.Peers[0].Endpoint; got != "198.51.100.9:33445" {
 		t.Errorf("the peer's endpoint is now %q, want where it actually is", got)
+	}
+}
+
+// The port the device settled on is reported back, so the daemon can keep it. Asking for any
+// port means the kernel chooses, and its choice is the thing worth remembering.
+func TestTheSettledListenPortIsReported(t *testing.T) {
+	link := newFakeLink()
+	r := New(link, membership(), nil) // no port asked for
+
+	if _, err := r.Apply(context.Background(), stateWith(1, peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if got := r.Status().ListenPort; got != 43521 {
+		t.Errorf("reported listen port %d, want the one the device chose (43521)", got)
+	}
+}
+
+// A membership that already has a port asks for it again. Without this, every restart moves
+// the port, which invalidates the endpoint every peer holds and drops any NAT mapping that
+// was keeping a path open.
+func TestARememberedPortIsAskedForAgain(t *testing.T) {
+	m := membership()
+	m.ListenPort = 51999
+
+	iface, err := Desired(m, stateWith(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if iface.ListenPort != 51999 {
+		t.Errorf("asked for port %d, want the remembered 51999", iface.ListenPort)
+	}
+}
+
+// A membership that has never come up asks for any port.
+func TestAMembershipWithNoPortAsksForAny(t *testing.T) {
+	iface, err := Desired(membership(), stateWith(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if iface.ListenPort != 0 {
+		t.Errorf("asked for port %d, want 0 meaning any", iface.ListenPort)
 	}
 }

--- a/internal/wglink/wglink_linux_test.go
+++ b/internal/wglink/wglink_linux_test.go
@@ -414,3 +414,76 @@ func TestEveryPeerFieldSurvivesARoundTripThroughTheKernel(t *testing.T) {
 		})
 	}
 }
+
+// A port asked for by name is the port the interface listens on, and the kernel's own choice
+// is reported when none was asked for. Both matter: the first is what makes a port survive a
+// restart, and the second is what there is to remember in the first place.
+func TestAListenPortIsHonouredAndReported(t *testing.T) {
+	l := requireInterfaces(t)
+
+	t.Run("the kernel chooses when nothing is asked for", func(t *testing.T) {
+		const name = "wgp0"
+		removeInterface(t, l, name)
+		t.Cleanup(func() { removeInterface(t, l, name) })
+
+		want := wanted(t, name)
+		want.ListenPort = 0
+		obs, err := l.Observe(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		plan, err := wgplan.For(want, obs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := ApplyPlan(l, name, plan); err != nil {
+			t.Fatal(err)
+		}
+		obs, err = l.Observe(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if obs.ListenPort == 0 {
+			t.Error("the kernel reported no port, so there is nothing to remember")
+		}
+	})
+
+	t.Run("a remembered port is honoured", func(t *testing.T) {
+		const name = "wgp1"
+		removeInterface(t, l, name)
+		t.Cleanup(func() { removeInterface(t, l, name) })
+
+		want := wanted(t, name)
+		want.ListenPort = 51987
+
+		obs, err := l.Observe(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		plan, err := wgplan.For(want, obs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := ApplyPlan(l, name, plan); err != nil {
+			t.Fatal(err)
+		}
+
+		obs, err = l.Observe(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if obs.ListenPort != 51987 {
+			t.Errorf("the interface listens on %d, want the 51987 that was asked for", obs.ListenPort)
+		}
+
+		// And nothing wants to change it, which is what makes the port stable rather than
+		// merely set once.
+		again, err := wgplan.For(want, obs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !again.Empty() {
+			t.Errorf("a honoured port still produced work:\n%s", again)
+		}
+	})
+}

--- a/scripts/e2e-enrol.sh
+++ b/scripts/e2e-enrol.sh
@@ -159,22 +159,37 @@ priv="$(sed -n 's/.*"wireguard_private_key": *"\([^"]*\)".*/\1/p' "$STATE_DIR/st
 if grep -qF "$priv" "$WORK/join.out"; then fail "the CLI printed the WireGuard private key"; fi
 if grep -qF "$priv" "$CONTROL_LOG"; then fail "the control plane logged the WireGuard private key"; fi
 
-echo "meshp status reports a live session"
-connected=0
-for _ in $(seq 1 30); do
-  ./bin/meshp status --socket "$SOCKET" >"$WORK/status.out" 2>&1 || true
-  if grep -q 'session     connected' "$WORK/status.out"; then connected=1; break; fi
-  sleep 1
-done
-[ "$connected" = "1" ] || fail "status never reported a connected session: $(cat "$WORK/status.out")"
-sed 's/^/  /' "$WORK/status.out"
-grep -q "$NETWORK_ID" "$WORK/status.out" || fail "status does not mention the network"
-# Status must say what is actually true, in either direction: a membership with an address
-# is not a working tunnel, and a working tunnel must not be reported as absent. Which one to
-# expect is decided by the platform rather than assumed, because this assertion once said
-# "always down" and outlived the build it was written for.
+# Whether a tunnel is possible here at all, decided once and reused. Deciding it rather than
+# assuming it is why this section survives both a laptop and a privileged Linux runner.
+tunnel_possible=0
 if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" = "0" ] && ip link add dev wgprobe0 type wireguard 2>/dev/null; then
   ip link del dev wgprobe0
+  tunnel_possible=1
+fi
+
+echo "meshp status reports a live session"
+# Waits for the session *and*, where one is possible, for the tunnel. Waiting only for the
+# session made this race: the interface comes up a moment after the first state arrives, so
+# an assertion on the same snapshot passed or failed depending on timing. A flaky gate is
+# worse than no gate — it teaches people to run it again.
+ready=0
+for _ in $(seq 1 30); do
+  ./bin/meshp status --socket "$SOCKET" >"$WORK/status.out" 2>&1 || true
+  if grep -q 'session     connected' "$WORK/status.out"; then
+    if [ "$tunnel_possible" = "0" ] || grep -qE 'interface   meshp0 \(up' "$WORK/status.out"; then
+      ready=1; break
+    fi
+  fi
+  sleep 1
+done
+[ "$ready" = "1" ] || fail "status never reported a live session and tunnel: $(cat "$WORK/status.out")"
+sed 's/^/  /' "$WORK/status.out"
+grep -q "$NETWORK_ID" "$WORK/status.out" || fail "status does not mention the network"
+
+# Status must say what is actually true, in either direction: a membership with an address is
+# not a working tunnel, and a working tunnel must not be reported as absent. This assertion
+# once said "always down" and outlived the build it was written for.
+if [ "$tunnel_possible" = "1" ]; then
   grep -qE 'interface   meshp0 \(up' "$WORK/status.out" \
     || fail "a tunnel is possible here but status says it is not up"
 else
@@ -238,8 +253,7 @@ sed -n 's/.*msg="applied desired state" \(.*snapshot=false.*\)/  \1/p' "$AGENT_L
 # Only where a tunnel is possible: Linux, with the privilege to create interfaces and a
 # kernel that can. Skipped rather than failed elsewhere, because "enrolled with no tunnel"
 # is a real supported state and this script has to pass on a laptop too.
-if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" = "0" ] && ip link add dev wgprobe type wireguard 2>/dev/null; then
-  ip link del dev wgprobe
+if [ "$tunnel_possible" = "1" ]; then
   echo "the interface really comes up"
 
   up=0
@@ -299,6 +313,41 @@ if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" = "0" ] && ip link add dev wgprob
   ip route show dev meshp0 | grep -q "100.90.${OCTET}.2" \
     || { ip route show dev meshp0 >&2; fail "no route to the peer via the interface"; }
   echo "  route to the peer installed"
+
+  # The listen port survives a restart, which is what keeps the endpoints peers hold valid
+  # and any NAT mapping alive.
+  #
+  # The interface is deleted before restarting on purpose. It outlives the daemon by design
+  # (Invariant 15: a control-plane outage does not interrupt established networking), so a
+  # restart on its own would find the port already correct and prove nothing about whether
+  # anything was remembered.
+  port_before="$(./bin/meshp status --socket "$SOCKET" | sed -n 's|.*listening   udp/\([0-9]*\).*|\1|p')"
+  [ -n "$port_before" ] || { ./bin/meshp status --socket "$SOCKET" >&2; fail "status does not report a listen port"; }
+  echo "  listening on udp/${port_before}"
+
+  grep -q "\"listen_port\": *${port_before}" "$STATE_DIR/state.json" \
+    || { fail "the listen port was not written to local state"; }
+
+  kill "$AGENT_PID" 2>/dev/null || true
+  wait "$AGENT_PID" 2>/dev/null || true
+  ip link del meshp0
+  ./bin/meshpd --reconcile-interval 2s --state-dir "$STATE_DIR" --socket "$SOCKET" \
+    --log-level debug >>"$AGENT_LOG" 2>&1 &
+  AGENT_PID=$!
+
+  back=0
+  for _ in $(seq 1 25); do
+    if [ -S "$SOCKET" ] && ./bin/meshp status --socket "$SOCKET" 2>/dev/null | grep -qE 'interface   meshp0 \(up'; then
+      back=1; break
+    fi
+    sleep 1
+  done
+  [ "$back" = "1" ] || { tail -20 "$AGENT_LOG" >&2; fail "the interface did not come back after a restart"; }
+
+  port_after="$(./bin/meshp status --socket "$SOCKET" | sed -n 's|.*listening   udp/\([0-9]*\).*|\1|p')"
+  [ "$port_after" = "$port_before" ] \
+    || fail "the listen port changed across a restart: ${port_before} then ${port_after}"
+  echo "  the same port after a restart and a deleted interface"
 fi
 
 echo "the same token a second time"


### PR DESCRIPTION
Groundwork for A6, landed before it rather than with it. Once the control plane tells peers
where to send packets, a port that changes on every start invalidates the endpoint every
other device holds and drops any NAT mapping that was keeping a path open.

Nothing asks for a *particular* port. A device in several networks needs an interface for
each (ADR-0004) and they cannot share one, and a fixed default would collide with whatever
else on the host already uses the conventional WireGuard port. So the kernel chooses, meshpd
reads back what it chose, and asks for that one next time. An older state file has no port
recorded and reads as zero — which is exactly "choose one", so there is nothing to migrate.

`meshp status` reports it, because an operator opening a firewall or a port forward needs the
number, and because it is what peers will be told:

```
      interface   meshp0 (up, kernel)
      listening   udp/49956
```

## The test deletes the interface before restarting

The interface outlives the daemon by design — Invariant 15, a control-plane outage does not
interrupt established networking. So a plain restart would find the port already correct and
prove nothing about whether anything was remembered. The end-to-end run kills the daemon,
deletes `meshp0`, and starts it again:

```
  listening on udp/49956
  the same port after a restart and a deleted interface
```

It also asserts the port reached the state file, so "remembered" means written rather than
merely held in memory.

## A race I introduced in #13, fixed

The status assertions ran against a snapshot taken by a loop that waited for the session but
not for the tunnel — and the interface comes up a moment after the first state arrives. So
the assertion passed or failed on timing; it failed once in two runs here. The loop now waits
for both, and whether a tunnel is possible at all is decided once and reused rather than
probed twice.

A flaky gate is worse than no gate: it teaches people to run it again. Three consecutive
clean runs of `make e2e-tunnel` after the fix.

## Invariants

- [x] An invariant is affected, and it still holds. Which, and how it is tested:

**15** — the interface surviving the daemon is what makes the restart test meaningful, and
the test depends on it.
**18** — `TestAListenPortIsHonouredAndReported` checks a honoured port produces no further
work, so a remembered port is stable rather than merely set once.

## Migrations

None. The new state-file field is absent in older files and reads as zero.

## Not in scope

The port is not yet reported to the control plane — that is the next step, and it has an
ordering trap worth recording: on a device's *first* join the interface does not exist at
hello time, so the port is unknown then and only becomes known after the first state is
applied. The agent will need to be able to report it after the fact, not only in the hello.