### PR TITLE
feat(relayproto): the framing a relay forwards by

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ CROSS_TARGETS := linux/amd64 linux/arm64 linux/arm \
 # are held lower rather than pretended into the top tier. Packages needing PostgreSQL
 # are checked separately: without a database their tests skip, and the figure would be
 # meaningless rather than merely low.
-COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan
+COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan internal/relayproto
 COVER_FLOOR      := 90
 
 COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx internal/tunnel

--- a/internal/relayproto/relayproto.go
+++ b/internal/relayproto/relayproto.go
@@ -1,0 +1,225 @@
+// Package relayproto is the framing between an agent and a relay.
+//
+// A relay forwards WireGuard packets between devices that cannot reach each other
+// directly. It must not be able to read what it forwards, which means it cannot work out
+// where a packet is going: WireGuard's transport packets carry a receiver index chosen by
+// the receiver, and a handshake carries the initiator's static key encrypted. So the
+// destination travels outside the WireGuard packet, in a header this package defines
+// (ADR-0016).
+//
+// It is deliberately the smallest thing that works. Every frame is one UDP datagram —
+// there is no length prefix, because the datagram already has a length, and inventing one
+// would only create a way for the two to disagree. Decoding never allocates for the
+// payload: it returns a sub-slice of the buffer it was given, so a relay forwarding at
+// volume does no copying per packet.
+package relayproto
+
+import (
+	"errors"
+	"fmt"
+)
+
+// KeyLen is the length of a raw WireGuard public key.
+const KeyLen = 32
+
+// HeaderLen is the size of every frame's header: one type byte and one key.
+const HeaderLen = 1 + KeyLen
+
+// MTU arithmetic.
+//
+// A relayed packet is a WireGuard packet inside a relay frame inside UDP inside IP, and if
+// the total exceeds the path MTU the result is fragmentation or silent loss of large
+// packets only — which presents as "most things work but some sites hang", the single
+// hardest network fault to attribute. So the numbers are written out rather than guessed.
+//
+//	1500  a conventional Ethernet path
+//	 -40  IPv6 header, the larger of the two so one number is safe for both
+//	  -8  UDP header
+//	 -33  this package's header (type + key)
+//	 -32  WireGuard's own transport header and authentication tag
+//	----
+//	1387
+//
+// A direct path pays neither the relay header nor the outer UDP twice and can carry the
+// conventional 1420. Relayed traffic cannot, and the server has to know which a peer is
+// using before it tells the agent an MTU.
+const (
+	// MaxPayload is the largest WireGuard packet a frame may carry.
+	MaxPayload = 1500 - 40 - 8 - HeaderLen
+
+	// RelayedTunnelMTU is the tunnel MTU that keeps a relayed packet inside a 1500-byte
+	// path. Smaller than the 1420 a direct path allows, which is the cost of relaying.
+	RelayedTunnelMTU = MaxPayload - 32
+)
+
+// Type is what a frame is for.
+type Type uint8
+
+const (
+	// TypeInvalid is not a frame. Zero is rejected deliberately: a buffer of zeroes is
+	// the most likely thing to arrive by accident, and it should not decode.
+	TypeInvalid Type = 0
+
+	// TypeHello identifies an agent to a relay. The key is the sender's WireGuard public
+	// key and the payload is the token the control plane issued (ADR-0016: the relay holds
+	// no copy of the device database and verifies a signature instead).
+	TypeHello Type = 1
+
+	// TypeWelcome accepts a hello. The key is the relay's own, and the payload is the
+	// address the relay observed the agent at — the server-reflexive candidate, which is
+	// the thing that cannot be inferred from the control channel's TCP source address.
+	TypeWelcome Type = 2
+
+	// TypeRefused rejects a hello. The payload is a reason, for logs rather than for
+	// branching on.
+	TypeRefused Type = 3
+
+	// TypeSend carries a WireGuard packet from an agent to a relay. The key is the peer it
+	// is *for*.
+	TypeSend Type = 4
+
+	// TypeRecv carries a WireGuard packet from a relay to an agent. The key is the peer it
+	// came *from*, which is what tells the agent which loopback socket to deliver it on.
+	//
+	// The same layout as TypeSend with the key meaning the opposite end. Two types rather
+	// than one because "the other party" reads clearly in a diagram and disastrously in
+	// code: a relay that forwarded a frame without rewriting the key would send every
+	// packet back to its sender, and nothing about a single type would have caught it.
+	TypeRecv Type = 5
+
+	// TypePing keeps the agent's NAT mapping to the relay open and measures the path. The
+	// key is the sender's own; the payload is opaque and echoed back.
+	TypePing Type = 6
+
+	// TypePong echoes a ping.
+	TypePong Type = 7
+)
+
+func (t Type) String() string {
+	switch t {
+	case TypeHello:
+		return "hello"
+	case TypeWelcome:
+		return "welcome"
+	case TypeRefused:
+		return "refused"
+	case TypeSend:
+		return "send"
+	case TypeRecv:
+		return "recv"
+	case TypePing:
+		return "ping"
+	case TypePong:
+		return "pong"
+	default:
+		return fmt.Sprintf("type(%d)", uint8(t))
+	}
+}
+
+// carriesPayload reports whether a type is allowed to have one.
+//
+// Ping and pong carry opaque bytes, hello carries a token, and the data types carry a
+// packet — so every type may. This exists for the reverse question: whether an empty
+// payload is acceptable, answered per type in Validate.
+func (t Type) valid() bool { return t >= TypeHello && t <= TypePong }
+
+// Errors returned by Decode. Distinguished because a relay logs them at different levels:
+// a truncated datagram is the internet being the internet, while an unknown type from an
+// authenticated agent means the two ends disagree about the protocol.
+var (
+	// ErrShort means the datagram is smaller than a header.
+	ErrShort = errors.New("relayproto: frame is shorter than a header")
+
+	// ErrUnknownType means the type byte is not one this version knows.
+	ErrUnknownType = errors.New("relayproto: unknown frame type")
+
+	// ErrTooLarge means the payload will not fit a frame.
+	ErrTooLarge = errors.New("relayproto: payload is larger than a frame allows")
+
+	// ErrEmptyPayload means a type that requires a payload arrived without one.
+	ErrEmptyPayload = errors.New("relayproto: frame carries no payload")
+)
+
+// Key is a raw WireGuard public key.
+//
+// An array rather than a slice so that a frame cannot be built with a key of the wrong
+// length, and so that keys compare and map by value.
+type Key [KeyLen]byte
+
+// Frame is one datagram between an agent and a relay.
+type Frame struct {
+	Type Type
+
+	// Key is the other end: the destination for a send, the source for a recv, and the
+	// sender's own for a hello or a ping.
+	Key Key
+
+	// Payload is the frame's contents. For the data types it is a WireGuard packet, and
+	// after Decode it aliases the buffer that was decoded — so it must be used or copied
+	// before that buffer is reused.
+	Payload []byte
+}
+
+// Encode writes a frame into dst and returns the bytes written.
+//
+// dst is supplied by the caller so a relay can reuse one buffer per connection rather than
+// allocating per packet. A dst that is too small is an error rather than a silent
+// truncation: a truncated WireGuard packet fails authentication at the far end, which
+// would present as a peer that handshakes and then goes quiet.
+func (f Frame) Encode(dst []byte) (int, error) {
+	if err := f.Validate(); err != nil {
+		return 0, err
+	}
+	need := HeaderLen + len(f.Payload)
+	if len(dst) < need {
+		return 0, fmt.Errorf("relayproto: buffer holds %d bytes, frame needs %d", len(dst), need)
+	}
+	dst[0] = byte(f.Type)
+	copy(dst[1:HeaderLen], f.Key[:])
+	copy(dst[HeaderLen:], f.Payload)
+	return need, nil
+}
+
+// Validate reports whether a frame is one that may be sent.
+func (f Frame) Validate() error {
+	if !f.Type.valid() {
+		return fmt.Errorf("%w: %d", ErrUnknownType, uint8(f.Type))
+	}
+	if len(f.Payload) > MaxPayload {
+		return fmt.Errorf("%w: %d bytes, limit %d", ErrTooLarge, len(f.Payload), MaxPayload)
+	}
+	switch f.Type {
+	case TypeHello, TypeSend, TypeRecv:
+		// A hello with no token authenticates nobody, and a data frame with no packet is
+		// a hole in a WireGuard session that the far end would wait out.
+		if len(f.Payload) == 0 {
+			return fmt.Errorf("%w: a %s frame must carry one", ErrEmptyPayload, f.Type)
+		}
+	}
+	return nil
+}
+
+// Decode reads a frame from a datagram.
+//
+// The returned frame's payload aliases buf: nothing is copied, because a relay's whole job
+// is forwarding and a copy per packet is a cost paid on every byte of every customer's
+// traffic. Callers that keep a payload beyond the next read must copy it themselves.
+func Decode(buf []byte) (Frame, error) {
+	if len(buf) < HeaderLen {
+		return Frame{}, fmt.Errorf("%w: %d bytes, need at least %d", ErrShort, len(buf), HeaderLen)
+	}
+
+	f := Frame{Type: Type(buf[0])}
+	copy(f.Key[:], buf[1:HeaderLen])
+	if payload := buf[HeaderLen:]; len(payload) > 0 {
+		f.Payload = payload
+	}
+
+	// Validated after parsing rather than before, so the error can say which type it was
+	// and how big it was. An unknown type is the interesting case: it means the two ends
+	// disagree about the protocol, and that is worth naming rather than dropping.
+	if err := f.Validate(); err != nil {
+		return Frame{}, err
+	}
+	return f, nil
+}

--- a/internal/relayproto/relayproto_test.go
+++ b/internal/relayproto/relayproto_test.go
@@ -1,0 +1,241 @@
+package relayproto
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func testKey(b byte) Key {
+	var k Key
+	for i := range k {
+		k[i] = b
+	}
+	return k
+}
+
+func TestAFrameSurvivesARoundTrip(t *testing.T) {
+	for _, typ := range []Type{TypeHello, TypeWelcome, TypeRefused, TypeSend, TypeRecv, TypePing, TypePong} {
+		t.Run(typ.String(), func(t *testing.T) {
+			want := Frame{Type: typ, Key: testKey(0xAB), Payload: []byte("a wireguard packet, notionally")}
+
+			buf := make([]byte, HeaderLen+MaxPayload)
+			n, err := want.Encode(buf)
+			if err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+			if n != HeaderLen+len(want.Payload) {
+				t.Errorf("encoded %d bytes, want %d", n, HeaderLen+len(want.Payload))
+			}
+
+			got, err := Decode(buf[:n])
+			if err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+			if got.Type != want.Type {
+				t.Errorf("type is %s, want %s", got.Type, want.Type)
+			}
+			if got.Key != want.Key {
+				t.Error("the key did not survive")
+			}
+			if !bytes.Equal(got.Payload, want.Payload) {
+				t.Errorf("payload is %q, want %q", got.Payload, want.Payload)
+			}
+		})
+	}
+}
+
+// A relay forwarding at volume must not copy a payload per packet, so Decode returns a
+// sub-slice of the buffer. That is a deliberate sharing decision and worth pinning: if it
+// ever starts copying, the cost is paid on every byte of every customer's traffic.
+func TestDecodeDoesNotCopyThePayload(t *testing.T) {
+	buf := make([]byte, HeaderLen+4)
+	buf[0] = byte(TypeSend)
+	copy(buf[HeaderLen:], []byte{1, 2, 3, 4})
+
+	f, err := Decode(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf[HeaderLen] = 9
+	if f.Payload[0] != 9 {
+		t.Error("the payload was copied; a relay would pay for that on every packet")
+	}
+}
+
+// A buffer of zeroes is the likeliest thing to arrive by accident — a misdirected datagram,
+// a scanner, a bug at the far end. It must not decode into a valid frame.
+func TestAllZeroesIsNotAFrame(t *testing.T) {
+	if _, err := Decode(make([]byte, 200)); !errors.Is(err, ErrUnknownType) {
+		t.Errorf("a datagram of zeroes decoded with %v, want an unknown type", err)
+	}
+}
+
+func TestShortDatagramsAreRefused(t *testing.T) {
+	for _, n := range []int{0, 1, HeaderLen - 1} {
+		buf := make([]byte, n)
+		if n > 0 {
+			buf[0] = byte(TypeSend)
+		}
+		if _, err := Decode(buf); !errors.Is(err, ErrShort) {
+			t.Errorf("a %d-byte datagram decoded with %v, want ErrShort", n, err)
+		}
+	}
+}
+
+// A header with no payload is a valid frame for a type that does not need one, and not for
+// a type that does: a hello with no token authenticates nobody, and a data frame with no
+// packet is a gap in a WireGuard session that the far end waits out.
+func TestPayloadIsRequiredWhereItMeansSomething(t *testing.T) {
+	header := make([]byte, HeaderLen)
+
+	for _, typ := range []Type{TypeHello, TypeSend, TypeRecv} {
+		header[0] = byte(typ)
+		if _, err := Decode(header); !errors.Is(err, ErrEmptyPayload) {
+			t.Errorf("an empty %s decoded with %v, want ErrEmptyPayload", typ, err)
+		}
+	}
+	for _, typ := range []Type{TypeWelcome, TypeRefused, TypePing, TypePong} {
+		header[0] = byte(typ)
+		if _, err := Decode(header); err != nil {
+			t.Errorf("an empty %s was refused: %v", typ, err)
+		}
+	}
+}
+
+func TestUnknownTypesAreRefused(t *testing.T) {
+	// Everything outside the range this version knows, including the values a later
+	// version would use — an agent talking to an older relay should be told, not ignored.
+	for _, b := range []byte{0, 8, 9, 100, 255} {
+		buf := make([]byte, HeaderLen+1)
+		buf[0] = b
+		if _, err := Decode(buf); !errors.Is(err, ErrUnknownType) {
+			t.Errorf("type %d decoded with %v, want ErrUnknownType", b, err)
+		}
+	}
+}
+
+func TestAnOversizedPayloadIsRefused(t *testing.T) {
+	f := Frame{Type: TypeSend, Key: testKey(1), Payload: make([]byte, MaxPayload+1)}
+	if _, err := f.Encode(make([]byte, 4096)); !errors.Is(err, ErrTooLarge) {
+		t.Errorf("an oversized payload encoded with %v, want ErrTooLarge", err)
+	}
+	// And exactly at the limit is fine, because an off-by-one here would silently cap the
+	// largest packet a tunnel can carry.
+	f.Payload = make([]byte, MaxPayload)
+	if _, err := f.Encode(make([]byte, 4096)); err != nil {
+		t.Errorf("a payload of exactly MaxPayload was refused: %v", err)
+	}
+}
+
+// Truncation must be an error rather than a short write. A truncated WireGuard packet fails
+// authentication at the far end, so the symptom would be a peer that handshakes and then
+// goes quiet — with nothing pointing at the relay.
+func TestEncodingIntoATooSmallBufferFails(t *testing.T) {
+	f := Frame{Type: TypeSend, Key: testKey(2), Payload: []byte("0123456789")}
+	if _, err := f.Encode(make([]byte, HeaderLen+len(f.Payload)-1)); err == nil {
+		t.Error("a frame was encoded into a buffer too small to hold it")
+	}
+	if _, err := f.Encode(make([]byte, HeaderLen+len(f.Payload))); err != nil {
+		t.Errorf("a frame was refused by a buffer of exactly the right size: %v", err)
+	}
+}
+
+// The MTU arithmetic, asserted rather than trusted. Getting it wrong produces loss of large
+// packets only, which presents as "most things work but some sites hang" — the hardest
+// network fault to attribute, and the reason the numbers are written out in the source.
+func TestARelayedPacketFitsAConventionalPath(t *testing.T) {
+	const (
+		ipv6Header = 40
+		udpHeader  = 8
+		wgOverhead = 32
+		path       = 1500
+	)
+
+	onTheWire := ipv6Header + udpHeader + HeaderLen + RelayedTunnelMTU + wgOverhead
+	if onTheWire > path {
+		t.Errorf("a full relayed packet is %d bytes on the wire, over a %d path", onTheWire, path)
+	}
+	if onTheWire != path {
+		t.Errorf("a full relayed packet is %d bytes, leaving %d unused — the MTU is smaller "+
+			"than it needs to be, which costs throughput on every relayed byte",
+			onTheWire, path-onTheWire)
+	}
+
+	// And it is genuinely smaller than a direct path allows, which is the cost being
+	// accounted for. 1420 is the conventional direct-path figure.
+	if RelayedTunnelMTU >= 1420 {
+		t.Errorf("the relayed MTU is %d, which does not account for the relay header",
+			RelayedTunnelMTU)
+	}
+
+	// A frame holding the largest packet such a tunnel produces must fit MaxPayload.
+	if RelayedTunnelMTU+wgOverhead > MaxPayload {
+		t.Errorf("a %d-byte tunnel produces packets of %d, over the %d a frame holds",
+			RelayedTunnelMTU, RelayedTunnelMTU+wgOverhead, MaxPayload)
+	}
+}
+
+// Send and recv share a layout and mean opposite ends. The risk is a relay that forwards a
+// frame without rewriting it, which would return every packet to its sender — so the types
+// must not be interchangeable by accident.
+func TestSendAndRecvAreDistinct(t *testing.T) {
+	if TypeSend == TypeRecv {
+		t.Fatal("send and recv are the same type; a relay could forward without rewriting")
+	}
+	buf := make([]byte, HeaderLen+1)
+	buf[0] = byte(TypeSend)
+	buf[HeaderLen] = 1
+
+	f, err := Decode(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Type != TypeSend {
+		t.Errorf("decoded as %s, want send", f.Type)
+	}
+}
+
+// Decode must not panic, index out of range, or accept anything Validate would refuse,
+// whatever arrives on a public UDP port — which is the one part of a relay that anyone on
+// the internet can reach without authenticating.
+func FuzzDecode(f *testing.F) {
+	f.Add([]byte{})
+	f.Add(make([]byte, HeaderLen))
+	f.Add(make([]byte, HeaderLen+1))
+
+	for _, typ := range []Type{TypeHello, TypeWelcome, TypeSend, TypeRecv, TypePing, TypePong} {
+		buf := make([]byte, HeaderLen+8)
+		buf[0] = byte(typ)
+		f.Add(buf)
+	}
+
+	oversized := make([]byte, HeaderLen+MaxPayload+1)
+	oversized[0] = byte(TypeSend)
+	f.Add(oversized)
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		frame, err := Decode(data)
+		if err != nil {
+			return
+		}
+
+		// Anything that decoded must be something we would send back out, or the two
+		// directions disagree about what is valid.
+		if err := frame.Validate(); err != nil {
+			t.Fatalf("Decode accepted a frame Validate refuses: %v", err)
+		}
+
+		// And it must re-encode to exactly what arrived. A decoder that loses or invents a
+		// byte in a relay is a corrupted WireGuard packet, which fails authentication far
+		// away from the cause.
+		out := make([]byte, len(data))
+		n, err := frame.Encode(out)
+		if err != nil {
+			t.Fatalf("a decoded frame would not re-encode: %v", err)
+		}
+		if n != len(data) || !bytes.Equal(out[:n], data) {
+			t.Fatalf("re-encoding changed the datagram:\n got %x\nwant %x", out[:n], data)
+		}
+	})
+}


### PR DESCRIPTION
The first piece of the relay, and the piece both ends need before either can be written.
Pure, so it can be tested exhaustively and fuzzed without a socket.

A relay must not be able to read what it forwards, and WireGuard gives it no help in finding
a destination — transport packets carry a receiver index chosen by the *receiver*, and a
handshake carries the initiator's static key encrypted. So the destination travels outside
the WireGuard packet: one type byte and one key (ADR-0016).

## Decisions worth reviewing

**One frame per datagram, no length prefix.** The datagram already has a length; adding one
only creates a way for the two to disagree.

**Decode returns a sub-slice, not a copy.** A relay's whole job is forwarding, and a copy per
packet is a cost paid on every byte of every customer's traffic. `TestDecodeDoesNotCopyThePayload`
pins it, because that is exactly the property a later refactor loses quietly.

**Send and receive are separate types despite an identical layout.** "The other party" reads
clearly in a diagram and disastrously in code: a relay that forwarded a frame without
rewriting the key would return every packet to its sender, and one shared type would not have
caught it.

**A datagram of zeroes does not decode**, since it is the likeliest thing to arrive by
accident. Unknown types are refused rather than ignored — including values a later version
would use, so an agent talking to an older relay is told rather than dropped.

## The MTU arithmetic is asserted, not trusted

```
1500  a conventional path
 -40  IPv6 header, the larger of the two so one number is safe for both
  -8  UDP header
 -33  this header
 -32  WireGuard's transport header and authentication tag
----
1387
```

33 bytes less than the 1420 a direct path carries. The test asserts a full relayed packet is
**exactly** 1500 on the wire — too large fragments, and too small wastes throughput on every
relayed byte, so both directions fail the test.

Getting this wrong loses large packets *only*, which presents as "most things work but some
sites hang" — the hardest network fault to attribute. Worth arithmetic rather than a guess.

## Fuzzed, and for more than panics

The decoder is the one part of a relay anyone on the internet can reach without
authenticating. `FuzzDecode` asserts that anything which decodes also re-encodes to **exactly**
the bytes that arrived — a decoder that loses or invents a byte corrupts a WireGuard packet,
which then fails authentication far from the cause.

```
fuzz: elapsed: 45s, execs: 9647583 (203131/sec), new interesting: 4 (total: 14)
PASS
```

97.2% coverage, gated at 90.

## Invariants

- [x] No invariant is affected.

## Migrations

None.

## What follows

The relay server and the agent's side of it. The agent part is where the design earns or
loses its keep: a loopback socket per peer, the kernel sending to `127.0.0.1:Px`, and packets
written back *from* that socket so the kernel sees them arriving from the endpoint it has
configured. Then the adverse-NAT harness — symmetric and port-restricted, via iptables in
containers — built alongside rather than after.