### PR TITLE
feat(relay): the forwarding core, and what it refuses to do

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ CROSS_TARGETS := linux/amd64 linux/arm64 linux/arm \
 # are held lower rather than pretended into the top tier. Packages needing PostgreSQL
 # are checked separately: without a database their tests skip, and the figure would be
 # meaningless rather than merely low.
-COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan internal/relayproto
+COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan internal/relayproto internal/relay
 COVER_FLOOR      := 90
 
 COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx internal/tunnel

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -1,0 +1,363 @@
+// Package relay forwards WireGuard packets between devices that cannot reach each other
+// directly.
+//
+// The forwarding decisions live here and the socket does not: Handle takes a datagram and
+// returns what to send, so every rule can be tested without a network. What is left outside
+// is a read loop and a write, which is little enough to be obviously correct.
+//
+// A relay is the one part of meshp that anyone on the internet can send to without
+// authenticating, so most of the rules here are about what it refuses to do:
+//
+//   - It never replies to a sender it has not authenticated with more bytes than arrived, so
+//     it cannot be pointed at a spoofed source address and used to amplify traffic at
+//     someone else. That is enforced here rather than left to the caller to remember.
+//   - It forwards only between keys that presented a valid token for the same network. It
+//     does not evaluate ACLs, because those are enforced at the destination (ADR-0007) and a
+//     second implementation of the same policy would diverge quietly.
+//   - It changes where a key is reachable only on a fresh authenticated hello. A public key
+//     is public, so accepting a new address from a mere data frame would let anyone redirect
+//     another device's traffic to themselves by asserting its key.
+package relay
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"sync"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/clock"
+	"github.com/meshpnet/meshp/internal/relayproto"
+)
+
+// DefaultIdle is how long a session survives without being heard from.
+//
+// Long enough to outlast a quiet tunnel — agents send keepalives every 25 seconds and
+// re-hello periodically — and short enough that a relay's memory reflects who is actually
+// connected rather than everyone who ever was.
+const DefaultIdle = 5 * time.Minute
+
+// Authenticator decides whether a token grants the use of a key on a network.
+//
+// An interface because the relay must not be able to mint what it verifies: the control
+// plane signs, the relay checks a signature, and the relay holds no copy of the device
+// database (ADR-0016).
+type Authenticator interface {
+	// Authenticate reports which key and network a token grants, or an error. The error
+	// text reaches a log, never the wire.
+	Authenticate(token []byte) (key relayproto.Key, network string, err error)
+}
+
+// Out is a datagram to send.
+type Out struct {
+	To    netip.AddrPort
+	Frame relayproto.Frame
+}
+
+// Session is a connected agent.
+type Session struct {
+	Key      relayproto.Key
+	Network  string
+	Addr     netip.AddrPort
+	LastSeen time.Time
+}
+
+// Stats are counters worth exposing: every one of them is a question someone asks when a
+// relay is not working.
+type Stats struct {
+	Sessions           int
+	HelloAccepted      uint64
+	HelloRefused       uint64
+	Forwarded          uint64
+	DroppedNoSession   uint64
+	DroppedWrongAddr   uint64
+	DroppedNoPeer      uint64
+	DroppedOtherNet    uint64
+	DroppedUndecodable uint64
+	Expired            uint64
+}
+
+// Server is one relay.
+type Server struct {
+	auth Authenticator
+	clk  clock.Clock
+	idle time.Duration
+	log  *slog.Logger
+
+	// selfKey identifies this relay in the frames it originates, so an agent can tell a
+	// welcome from this relay apart from one from another.
+	selfKey relayproto.Key
+
+	mu    sync.Mutex
+	byKey map[relayproto.Key]*Session
+	stats Stats
+}
+
+// Config configures a Server.
+type Config struct {
+	Auth    Authenticator
+	SelfKey relayproto.Key
+	Idle    time.Duration
+	Clock   clock.Clock
+	Log     *slog.Logger
+}
+
+// New returns a Server.
+func New(cfg Config) (*Server, error) {
+	if cfg.Auth == nil {
+		return nil, errors.New("relay: an authenticator is required; a relay that forwards for anyone is an open proxy")
+	}
+	if cfg.Clock == nil {
+		cfg.Clock = clock.System{}
+	}
+	if cfg.Idle <= 0 {
+		cfg.Idle = DefaultIdle
+	}
+	if cfg.Log == nil {
+		cfg.Log = slog.New(slog.DiscardHandler)
+	}
+	return &Server{
+		auth:    cfg.Auth,
+		clk:     cfg.Clock,
+		idle:    cfg.Idle,
+		log:     cfg.Log,
+		selfKey: cfg.SelfKey,
+		byKey:   make(map[relayproto.Key]*Session),
+	}, nil
+}
+
+// Handle processes one datagram and returns what to send in response.
+//
+// Returning the replies rather than writing them keeps every rule testable without a socket,
+// and makes the anti-amplification property checkable: a caller can assert that nothing
+// leaving is larger than what arrived.
+func (s *Server) Handle(from netip.AddrPort, datagram []byte) []Out {
+	frame, err := relayproto.Decode(datagram)
+	if err != nil {
+		// Silently. Anything on a public UDP port receives noise, and answering it is both
+		// pointless and a way to be used against someone else.
+		s.count(func(st *Stats) { st.DroppedUndecodable++ })
+		s.log.Debug("undecodable datagram", "from", from, "bytes", len(datagram), "error", err)
+		return nil
+	}
+
+	switch frame.Type {
+	case relayproto.TypeHello:
+		return s.hello(from, frame)
+	case relayproto.TypeSend:
+		return s.forward(from, frame)
+	case relayproto.TypePing:
+		return s.ping(from, frame)
+	default:
+		// Welcome, refused, recv and pong are what a relay emits, not what it accepts. A
+		// peer sending one is confused or probing; either way there is nothing to say.
+		s.log.Debug("unexpected frame type for a relay", "from", from, "type", frame.Type)
+		return nil
+	}
+}
+
+// hello authenticates an agent and records where it can be reached.
+func (s *Server) hello(from netip.AddrPort, frame relayproto.Frame) []Out {
+	// The size of what arrived, which bounds what may be sent back to a sender that has not
+	// proved anything.
+	arrived := relayproto.HeaderLen + len(frame.Payload)
+
+	key, network, err := s.auth.Authenticate(frame.Payload)
+	if err != nil {
+		s.count(func(st *Stats) { st.HelloRefused++ })
+		s.log.Info("refused a hello", "from", from, "error", err)
+		return s.refuse(from, arrived)
+	}
+
+	// The token names the key, so only its holder can move where that key is reachable.
+	if key != frame.Key {
+		s.count(func(st *Stats) { st.HelloRefused++ })
+		s.log.Info("hello key does not match its token", "from", from)
+		return s.refuse(from, arrived)
+	}
+
+	now := s.clk.Now()
+	s.mu.Lock()
+	previous, existed := s.byKey[key]
+	s.byKey[key] = &Session{Key: key, Network: network, Addr: from, LastSeen: now}
+	s.stats.HelloAccepted++
+	s.mu.Unlock()
+
+	if existed && previous.Addr != from {
+		// A NAT mapping changed, or the device moved network. Worth a line: it is the
+		// signal that a path is about to be renegotiated.
+		s.log.Info("a key moved", "from", previous.Addr, "to", from)
+	}
+
+	// The observed address is the whole reason an agent talks to a relay before it needs
+	// one: it is this device's server-reflexive candidate, and nothing else can tell it
+	// (ADR-0016). The control channel's TCP source address is not the same thing.
+	return []Out{{To: from, Frame: relayproto.Frame{
+		Type:    relayproto.TypeWelcome,
+		Key:     s.selfKey,
+		Payload: []byte(from.String()),
+	}}}
+}
+
+// refuse tells a sender its hello was rejected, if that can be done without amplifying.
+//
+// The reason is deliberately uninformative: a relay that explains why a token failed is an
+// oracle for guessing tokens. And if a refusal would be larger than the datagram that
+// prompted it, nothing is sent at all — a sender that hands over a one-byte token has not
+// earned a reply, and answering it would let an attacker bounce slightly larger packets off
+// this relay at a spoofed victim. A real token is much larger than "refused", so a genuine
+// agent with an expired token still learns what happened.
+func (s *Server) refuse(to netip.AddrPort, arrived int) []Out {
+	frame := relayproto.Frame{
+		Type:    relayproto.TypeRefused,
+		Key:     s.selfKey,
+		Payload: []byte("refused"),
+	}
+	if relayproto.HeaderLen+len(frame.Payload) > arrived {
+		s.log.Debug("dropping a refusal that would be larger than the hello", "to", to)
+		return nil
+	}
+	return []Out{{To: to, Frame: frame}}
+}
+
+// forward carries a packet to the peer it names.
+func (s *Server) forward(from netip.AddrPort, frame relayproto.Frame) []Out {
+	now := s.clk.Now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Who is sending. Established by the source address, not by anything in the frame: the
+	// frame names the destination, and a sender that has not said hello has proved nothing.
+	sender := s.senderAtLocked(from)
+	if sender == nil {
+		s.stats.DroppedNoSession++
+		return nil
+	}
+	sender.LastSeen = now
+
+	dest, ok := s.byKey[frame.Key]
+	if !ok {
+		// Silently, and deliberately: telling a sender that a key is unknown would make the
+		// relay a presence oracle for any key anyone cares to guess.
+		s.stats.DroppedNoPeer++
+		return nil
+	}
+	if dest.Network != sender.Network {
+		// The one policy a relay enforces. Not ACLs — those belong at the destination
+		// (ADR-0007) — but two customers must never be able to reach each other through
+		// shared infrastructure.
+		s.stats.DroppedOtherNet++
+		s.log.Warn("refused to forward across networks",
+			"from_network", sender.Network, "to_network", dest.Network)
+		return nil
+	}
+
+	s.stats.Forwarded++
+	// Rewritten to name the sender, because that is what tells the receiving agent which
+	// peer this came from and therefore which of its sockets to deliver it on. Forwarding
+	// without rewriting would send every packet back where it came from.
+	return []Out{{To: dest.Addr, Frame: relayproto.Frame{
+		Type:    relayproto.TypeRecv,
+		Key:     sender.Key,
+		Payload: frame.Payload,
+	}}}
+}
+
+// ping answers a keepalive, which is how an agent holds its NAT mapping open.
+func (s *Server) ping(from netip.AddrPort, frame relayproto.Frame) []Out {
+	now := s.clk.Now()
+
+	s.mu.Lock()
+	sender := s.senderAtLocked(from)
+	if sender == nil {
+		s.stats.DroppedNoSession++
+		s.mu.Unlock()
+		return nil
+	}
+	sender.LastSeen = now
+	s.mu.Unlock()
+
+	// The payload is echoed so the agent can measure a round trip, and echoing exactly what
+	// arrived means the reply can never be larger than the request.
+	return []Out{{To: from, Frame: relayproto.Frame{
+		Type:    relayproto.TypePong,
+		Key:     s.selfKey,
+		Payload: frame.Payload,
+	}}}
+}
+
+// senderAtLocked finds the live session reachable at an address.
+//
+// A session is only usable from the address its hello came from. A public key is public, so
+// if a data frame could move a session, anyone could redirect another device's traffic to
+// themselves by asserting its key — they could not decrypt it, but they could deny it and
+// watch it. Moving requires a fresh authenticated hello.
+func (s *Server) senderAtLocked(from netip.AddrPort) *Session {
+	for _, sess := range s.byKey {
+		if sess.Addr != from {
+			continue
+		}
+		if s.clk.Now().Sub(sess.LastSeen) > s.idle {
+			return nil
+		}
+		return sess
+	}
+	return nil
+}
+
+// Expire forgets sessions nothing has been heard from, and reports how many went.
+//
+// Called on a timer by the caller rather than on every datagram: a relay's hot path should
+// not walk every session it holds.
+func (s *Server) Expire() int {
+	cutoff := s.clk.Now().Add(-s.idle)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var gone int
+	for key, sess := range s.byKey {
+		if sess.LastSeen.Before(cutoff) {
+			delete(s.byKey, key)
+			gone++
+		}
+	}
+	s.stats.Expired += uint64(gone)
+	return gone
+}
+
+// Stats returns a snapshot of the counters.
+func (s *Server) Stats() Stats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := s.stats
+	out.Sessions = len(s.byKey)
+	return out
+}
+
+// Session reports what the relay knows about a key, for diagnostics.
+func (s *Server) Session(key relayproto.Key) (Session, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.byKey[key]
+	if !ok {
+		return Session{}, false
+	}
+	return *sess, true
+}
+
+func (s *Server) count(f func(*Stats)) {
+	s.mu.Lock()
+	f(&s.stats)
+	s.mu.Unlock()
+}
+
+// String renders stats for a log line.
+func (st Stats) String() string {
+	return fmt.Sprintf("sessions=%d forwarded=%d hello_ok=%d hello_refused=%d "+
+		"dropped(no_session=%d wrong_addr=%d no_peer=%d other_net=%d undecodable=%d) expired=%d",
+		st.Sessions, st.Forwarded, st.HelloAccepted, st.HelloRefused,
+		st.DroppedNoSession, st.DroppedWrongAddr, st.DroppedNoPeer,
+		st.DroppedOtherNet, st.DroppedUndecodable, st.Expired)
+}

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -1,0 +1,444 @@
+package relay
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/clock"
+	"github.com/meshpnet/meshp/internal/relayproto"
+)
+
+// fakeAuth grants tokens of the form "network:keybyte".
+type fakeAuth struct{ refuse bool }
+
+func (a fakeAuth) Authenticate(token []byte) (relayproto.Key, string, error) {
+	if a.refuse {
+		return relayproto.Key{}, "", errors.New("refused by test")
+	}
+	var network string
+	var b int
+	if _, err := fmt.Sscanf(string(token), "%s %d", &network, &b); err != nil {
+		return relayproto.Key{}, "", fmt.Errorf("malformed test token %q", token)
+	}
+	return key(byte(b)), network, nil
+}
+
+// token is padded to the length a signed token will actually be. A 7-byte fixture made the
+// amplification assertion fire on a hello no real agent would send, which is the sort of
+// unrealistic fixture that turns a good invariant into a nuisance.
+func token(network string, k byte) []byte {
+	return []byte(fmt.Sprintf("%s %d %s", network, k, strings.Repeat("s", 96)))
+}
+
+func key(b byte) relayproto.Key {
+	var out relayproto.Key
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
+
+func addr(s string) netip.AddrPort { return netip.MustParseAddrPort(s) }
+
+type fixture struct {
+	t   *testing.T
+	srv *Server
+	clk *clock.Fake
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	clk := clock.NewFake()
+	srv, err := New(Config{Auth: fakeAuth{}, SelfKey: key(0xFF), Clock: clk})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &fixture{t: t, srv: srv, clk: clk}
+}
+
+// send encodes a frame, hands it to the server, and returns the replies.
+func (f *fixture) send(from netip.AddrPort, frame relayproto.Frame) []Out {
+	f.t.Helper()
+	buf := make([]byte, relayproto.HeaderLen+relayproto.MaxPayload)
+	n, err := frame.Encode(buf)
+	if err != nil {
+		f.t.Fatalf("encoding %s: %v", frame.Type, err)
+	}
+	out := f.srv.Handle(from, buf[:n])
+
+	// The property that matters most for something on a public UDP port: a reply must never
+	// be larger than what prompted it, or the relay can be pointed at a third party and used
+	// to amplify traffic at them. Checked on every single exchange in these tests rather
+	// than once, because it is the kind of thing a later change breaks quietly.
+	for _, o := range out {
+		reply := make([]byte, relayproto.HeaderLen+relayproto.MaxPayload)
+		rn, err := o.Frame.Encode(reply)
+		if err != nil {
+			f.t.Fatalf("the server produced an unencodable frame: %v", err)
+		}
+		if rn > n {
+			f.t.Fatalf("amplification: a %d-byte %s produced a %d-byte %s reply",
+				n, frame.Type, rn, o.Frame.Type)
+		}
+	}
+	return out
+}
+
+// join gets a session established for a key at an address.
+func (f *fixture) join(network string, k byte, at string) {
+	f.t.Helper()
+	out := f.send(addr(at), relayproto.Frame{
+		Type: relayproto.TypeHello, Key: key(k), Payload: token(network, k),
+	})
+	if len(out) != 1 || out[0].Frame.Type != relayproto.TypeWelcome {
+		f.t.Fatalf("hello for %d was not welcomed: %+v", k, out)
+	}
+}
+
+func TestAHelloIsWelcomedWithTheAddressTheRelaySees(t *testing.T) {
+	f := newFixture(t)
+
+	out := f.send(addr("203.0.113.7:41234"), relayproto.Frame{
+		Type: relayproto.TypeHello, Key: key(1), Payload: token("acme", 1),
+	})
+	if len(out) != 1 {
+		t.Fatalf("%d replies, want 1", len(out))
+	}
+	if out[0].Frame.Type != relayproto.TypeWelcome {
+		t.Fatalf("replied with %s, want welcome", out[0].Frame.Type)
+	}
+
+	// The reflexive address, which is the thing an agent cannot learn any other way and the
+	// reason it talks to a relay before it needs one.
+	if got := string(out[0].Frame.Payload); got != "203.0.113.7:41234" {
+		t.Errorf("welcome carries %q, want the observed address", got)
+	}
+	if out[0].To != addr("203.0.113.7:41234") {
+		t.Errorf("replied to %s, want the sender", out[0].To)
+	}
+
+	if sess, ok := f.srv.Session(key(1)); !ok {
+		t.Error("no session was recorded")
+	} else if sess.Network != "acme" {
+		t.Errorf("session network is %q, want acme", sess.Network)
+	}
+}
+
+func TestABadTokenIsRefusedAndLeavesNoSession(t *testing.T) {
+	clk := clock.NewFake()
+	srv, err := New(Config{Auth: fakeAuth{refuse: true}, SelfKey: key(0xFF), Clock: clk})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &fixture{t: t, srv: srv, clk: clk}
+
+	out := f.send(addr("198.51.100.9:1234"), relayproto.Frame{
+		Type: relayproto.TypeHello, Key: key(1), Payload: token("acme", 1),
+	})
+	if len(out) != 1 || out[0].Frame.Type != relayproto.TypeRefused {
+		t.Fatalf("expected a refusal, got %+v", out)
+	}
+	if _, ok := srv.Session(key(1)); ok {
+		t.Error("a refused hello left a session behind")
+	}
+	// The refusal must not say what was wrong: a relay that explains itself is an oracle for
+	// guessing tokens.
+	if body := string(out[0].Frame.Payload); body != "refused" {
+		t.Errorf("refusal says %q, which tells an attacker more than it should", body)
+	}
+}
+
+// The token names the key. Without this check, anyone holding any valid token could claim
+// any key and have that peer's traffic delivered to them.
+func TestAHelloWhoseKeyDoesNotMatchItsTokenIsRefused(t *testing.T) {
+	f := newFixture(t)
+
+	out := f.send(addr("198.51.100.9:1234"), relayproto.Frame{
+		Type:    relayproto.TypeHello,
+		Key:     key(2),           // claiming key 2
+		Payload: token("acme", 1), // with a token for key 1
+	})
+	if len(out) != 1 || out[0].Frame.Type != relayproto.TypeRefused {
+		t.Fatalf("a mismatched hello was accepted: %+v", out)
+	}
+	if _, ok := f.srv.Session(key(2)); ok {
+		t.Error("a mismatched hello established a session")
+	}
+}
+
+func TestAPacketIsForwardedToItsPeerAndNamesItsSender(t *testing.T) {
+	f := newFixture(t)
+	f.join("acme", 1, "203.0.113.1:1111")
+	f.join("acme", 2, "203.0.113.2:2222")
+
+	out := f.send(addr("203.0.113.1:1111"), relayproto.Frame{
+		Type: relayproto.TypeSend, Key: key(2), Payload: []byte("a wireguard packet"),
+	})
+	if len(out) != 1 {
+		t.Fatalf("%d replies, want 1 forward", len(out))
+	}
+	if out[0].To != addr("203.0.113.2:2222") {
+		t.Errorf("forwarded to %s, want peer 2", out[0].To)
+	}
+	if out[0].Frame.Type != relayproto.TypeRecv {
+		t.Errorf("forwarded as %s, want recv", out[0].Frame.Type)
+	}
+	// The rewrite. Forwarding without it would return every packet to its sender, and the
+	// receiving agent would have no idea which peer it came from.
+	if out[0].Frame.Key != key(1) {
+		t.Error("the forwarded frame does not name the sender")
+	}
+	if string(out[0].Frame.Payload) != "a wireguard packet" {
+		t.Error("the payload was altered in transit")
+	}
+}
+
+// The one policy a relay enforces. ACLs belong at the destination (ADR-0007), but two
+// customers sharing infrastructure must never reach each other through it.
+func TestForwardingAcrossNetworksIsRefused(t *testing.T) {
+	f := newFixture(t)
+	f.join("acme", 1, "203.0.113.1:1111")
+	f.join("other-customer", 2, "203.0.113.2:2222")
+
+	out := f.send(addr("203.0.113.1:1111"), relayproto.Frame{
+		Type: relayproto.TypeSend, Key: key(2), Payload: []byte("packet"),
+	})
+	if len(out) != 0 {
+		t.Errorf("a packet crossed between networks: %+v", out)
+	}
+	if f.srv.Stats().DroppedOtherNet != 1 {
+		t.Error("the cross-network drop was not counted")
+	}
+}
+
+// A public key is public. If a data frame could move where a key is reachable, anyone could
+// have another device's traffic delivered to them by asserting its key — they could not
+// decrypt it, but they could deny it and observe it.
+func TestAKeyCannotBeHijackedByAnUnauthenticatedSender(t *testing.T) {
+	f := newFixture(t)
+	f.join("acme", 1, "203.0.113.1:1111")
+	f.join("acme", 2, "203.0.113.2:2222")
+
+	// An attacker asserts key 1 from its own address, without a hello.
+	out := f.send(addr("192.0.2.66:6666"), relayproto.Frame{
+		Type: relayproto.TypeSend, Key: key(2), Payload: []byte("packet"),
+	})
+	if len(out) != 0 {
+		t.Errorf("an unauthenticated sender was forwarded for: %+v", out)
+	}
+
+	// And peer 1's traffic still goes to peer 1's address, not the attacker's.
+	out = f.send(addr("203.0.113.2:2222"), relayproto.Frame{
+		Type: relayproto.TypeSend, Key: key(1), Payload: []byte("reply"),
+	})
+	if len(out) != 1 || out[0].To != addr("203.0.113.1:1111") {
+		t.Errorf("the session was redirected: %+v", out)
+	}
+}
+
+// Moving is legitimate — NAT mappings change — but it takes a fresh authenticated hello.
+func TestAKeyMovesOnANewHello(t *testing.T) {
+	f := newFixture(t)
+	f.join("acme", 1, "203.0.113.1:1111")
+	f.join("acme", 2, "203.0.113.2:2222")
+
+	f.join("acme", 2, "203.0.113.2:9999") // same key, new mapping
+
+	out := f.send(addr("203.0.113.1:1111"), relayproto.Frame{
+		Type: relayproto.TypeSend, Key: key(2), Payload: []byte("packet"),
+	})
+	if len(out) != 1 || out[0].To != addr("203.0.113.2:9999") {
+		t.Errorf("the packet did not follow the peer to its new address: %+v", out)
+	}
+}
+
+// Telling a sender that a key is unknown would make the relay a presence oracle for any key
+// anyone cares to guess. Public keys are public, so that is a real enumeration.
+func TestSendingToAnUnknownPeerSaysNothing(t *testing.T) {
+	f := newFixture(t)
+	f.join("acme", 1, "203.0.113.1:1111")
+
+	out := f.send(addr("203.0.113.1:1111"), relayproto.Frame{
+		Type: relayproto.TypeSend, Key: key(99), Payload: []byte("packet"),
+	})
+	if len(out) != 0 {
+		t.Errorf("the relay revealed something about an unknown key: %+v", out)
+	}
+	if f.srv.Stats().DroppedNoPeer != 1 {
+		t.Error("the drop was not counted")
+	}
+}
+
+func TestAPingIsAnsweredWithItsOwnPayload(t *testing.T) {
+	f := newFixture(t)
+	f.join("acme", 1, "203.0.113.1:1111")
+
+	out := f.send(addr("203.0.113.1:1111"), relayproto.Frame{
+		Type: relayproto.TypePing, Key: key(1), Payload: []byte("nonce"),
+	})
+	if len(out) != 1 || out[0].Frame.Type != relayproto.TypePong {
+		t.Fatalf("expected a pong: %+v", out)
+	}
+	if string(out[0].Frame.Payload) != "nonce" {
+		t.Error("the pong does not echo the ping, so a round trip cannot be measured")
+	}
+}
+
+func TestAPingFromNobodyIsIgnored(t *testing.T) {
+	f := newFixture(t)
+	out := f.send(addr("192.0.2.1:1"), relayproto.Frame{
+		Type: relayproto.TypePing, Key: key(1), Payload: []byte("x"),
+	})
+	if len(out) != 0 {
+		t.Errorf("an unauthenticated ping was answered, which is a reflector: %+v", out)
+	}
+}
+
+// Noise on a public port must produce nothing at all.
+func TestGarbageIsDroppedSilently(t *testing.T) {
+	f := newFixture(t)
+	for _, datagram := range [][]byte{
+		{},
+		{0},
+		make([]byte, 5),
+		make([]byte, 2000),
+		[]byte("GET / HTTP/1.1\r\nHost: x\r\n\r\n"),
+	} {
+		if out := f.srv.Handle(addr("192.0.2.9:9"), datagram); len(out) != 0 {
+			t.Errorf("%d bytes of garbage produced a reply: %+v", len(datagram), out)
+		}
+	}
+	if f.srv.Stats().DroppedUndecodable == 0 {
+		t.Error("undecodable datagrams were not counted")
+	}
+}
+
+// The frames a relay emits are not frames it accepts. A peer sending one is confused or
+// probing, and either way there is nothing to say.
+func TestTheRelayDoesNotAnswerItsOwnFrameTypes(t *testing.T) {
+	f := newFixture(t)
+	f.join("acme", 1, "203.0.113.1:1111")
+
+	for _, typ := range []relayproto.Type{
+		relayproto.TypeWelcome, relayproto.TypeRefused, relayproto.TypeRecv, relayproto.TypePong,
+	} {
+		payload := []byte("x")
+		out := f.send(addr("203.0.113.1:1111"), relayproto.Frame{Type: typ, Key: key(1), Payload: payload})
+		if len(out) != 0 {
+			t.Errorf("a %s was answered: %+v", typ, out)
+		}
+	}
+}
+
+func TestSessionsExpireWhenNothingIsHeard(t *testing.T) {
+	f := newFixture(t)
+	f.join("acme", 1, "203.0.113.1:1111")
+	f.join("acme", 2, "203.0.113.2:2222")
+
+	f.clk.Advance(DefaultIdle - time.Second)
+	// Peer 1 is still talking; peer 2 has gone quiet.
+	f.send(addr("203.0.113.1:1111"), relayproto.Frame{
+		Type: relayproto.TypePing, Key: key(1), Payload: []byte("x"),
+	})
+	f.clk.Advance(2 * time.Second)
+
+	if gone := f.srv.Expire(); gone != 1 {
+		t.Errorf("expired %d sessions, want 1", gone)
+	}
+	if _, ok := f.srv.Session(key(1)); !ok {
+		t.Error("the active session was expired")
+	}
+	if _, ok := f.srv.Session(key(2)); ok {
+		t.Error("the idle session survived")
+	}
+}
+
+// A session past its idle time is unusable even before Expire runs, or a relay that has not
+// swept recently would keep forwarding to an address nobody is listening at.
+func TestAStaleSessionCannotSendBeforeItIsSwept(t *testing.T) {
+	f := newFixture(t)
+	f.join("acme", 1, "203.0.113.1:1111")
+	f.join("acme", 2, "203.0.113.2:2222")
+
+	f.clk.Advance(DefaultIdle + time.Minute)
+
+	out := f.send(addr("203.0.113.1:1111"), relayproto.Frame{
+		Type: relayproto.TypeSend, Key: key(2), Payload: []byte("packet"),
+	})
+	if len(out) != 0 {
+		t.Errorf("a stale session forwarded: %+v", out)
+	}
+}
+
+func TestARelayWithoutAnAuthenticatorIsRefused(t *testing.T) {
+	if _, err := New(Config{SelfKey: key(1)}); err == nil {
+		t.Error("a relay was built with no authenticator, which is an open proxy")
+	}
+}
+
+// Forwarding a maximum-sized payload must work: the largest WireGuard packet a relayed
+// tunnel produces has to fit, or large packets are lost and only large ones — the symptom
+// that gets diagnosed as anything but the relay.
+func TestAMaximumSizedPacketIsForwarded(t *testing.T) {
+	f := newFixture(t)
+	f.join("acme", 1, "203.0.113.1:1111")
+	f.join("acme", 2, "203.0.113.2:2222")
+
+	payload := make([]byte, relayproto.MaxPayload)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	out := f.send(addr("203.0.113.1:1111"), relayproto.Frame{
+		Type: relayproto.TypeSend, Key: key(2), Payload: payload,
+	})
+	if len(out) != 1 {
+		t.Fatalf("a full-sized packet was not forwarded: %+v", out)
+	}
+	if len(out[0].Frame.Payload) != relayproto.MaxPayload {
+		t.Errorf("forwarded %d bytes, want %d", len(out[0].Frame.Payload), relayproto.MaxPayload)
+	}
+}
+
+// The amplification case in full. The rule is not "never reply" — it is "never reply with
+// more bytes than arrived", so a relay cannot be pointed at a spoofed source address and used
+// to bounce larger packets at someone. Asserted here across the smallest datagrams that
+// decode, where the margin is tightest.
+func TestARelayNeverRepliesWithMoreThanItReceived(t *testing.T) {
+	f := newFixture(t)
+
+	// A refusal is 33 bytes of header plus "refused", so anything under that gets nothing.
+	const refusalSize = relayproto.HeaderLen + len("refused")
+
+	for size := 1; size <= 32; size++ {
+		frame := relayproto.Frame{Type: relayproto.TypeHello, Key: key(1), Payload: make([]byte, size)}
+		buf := make([]byte, relayproto.HeaderLen+size)
+		n, err := frame.Encode(buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		out := f.srv.Handle(addr("192.0.2.50:5050"), buf[:n])
+		for _, o := range out {
+			reply := make([]byte, relayproto.HeaderLen+relayproto.MaxPayload)
+			rn, err := o.Frame.Encode(reply)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if rn > n {
+				t.Errorf("a %d-byte hello produced a %d-byte reply", n, rn)
+			}
+		}
+		if n < refusalSize && len(out) != 0 {
+			t.Errorf("a %d-byte hello, too small for even a refusal, got %d replies", n, len(out))
+		}
+	}
+
+	// Silent refusals are still counted, so an operator can see them happening.
+	if f.srv.Stats().HelloRefused == 0 {
+		t.Error("refusals are invisible in the counters")
+	}
+}


### PR DESCRIPTION
The decisions a relay makes, with the socket left outside. `Handle` takes a datagram and
returns what to send, so every rule is testable without a network and what remains is a read
loop and a write.

A relay is the one part of meshp that **anyone on the internet can send to without
authenticating**, so most of this is about refusal.

## What it refuses

**It never replies to an unauthenticated sender with more bytes than arrived** — enforced in
the code, not merely asserted in a test. A refusal larger than the hello that prompted it is
dropped, because otherwise the relay can be pointed at a spoofed source address and used to
bounce slightly larger packets at a victim. A real signed token is far larger than the word
`refused`, so a genuine agent with an expired token still learns what happened.

**It moves a key only on a fresh authenticated hello.** A public key is public, so if a data
frame could move a session, anyone could have another device's traffic delivered to them by
asserting its key — they couldn't decrypt it, but they could deny it and observe it. Moving is
still supported, since NAT mappings change; it just costs a hello.

**It refuses a hello whose key doesn't match its token.** Otherwise anyone holding any valid
token could claim any key.

**It says nothing about keys it doesn't know.** Answering would make it a presence oracle for
any public key anyone cares to guess.

**It enforces "same network" and nothing else.** ACLs belong at the destination (ADR-0007); a
relay that also enforced them would be a second implementation of the same policy, diverging
quietly.

## What it does

Forwards, **rewriting the frame to name the sender** — which is what tells the receiving agent
which peer a packet came from. Forwarding without rewriting returns every packet to where it
came from. `relayproto` has separate send/receive types to make that hard, and there's now a
test for it directly.

And it answers a hello with **the address it observed**, which is the device's
server-reflexive candidate. That's the thing an agent cannot learn any other way, and the
reason it talks to a relay before it needs one.

## Two things the tests taught while being written

The amplification assertion **fired on a hello no real agent would send**, because the fixture
token was 7 bytes. An unrealistic fixture turns a good invariant into a nuisance, so the
fixture now matches the length a signed token will actually be.

And the assertion itself **was wrong at first** — it demanded *no reply* rather than *no larger
reply*, which is stricter than the property that matters and would have forced a design that
gives legitimate agents no feedback.

## Invariants

- [x] No invariant is affected. (ADR-0007 is upheld by *not* implementing ACLs here.)

## Teeth

Removing the amplification guard fails `TestARelayNeverRepliesWithMoreThanItReceived`, which
sweeps every datagram size from 1 to 32 bytes — where the margin is tightest. 98.1% coverage,
gated at 90.

## Migrations

None.

## What follows

Token issuance and verification (the `Authenticator` is an interface here precisely so the
relay cannot mint what it verifies), then `cmd/meshp-relay` wiring this to a **multi-port**
UDP listener — because we now know from your own network that UDP 443 is blocked while 3478
passes, so one port is a single point of failure against a class of network that demonstrably
exists.