### PR TITLE
feat(relaytoken): the capability a relay checks, which it cannot mint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ CROSS_TARGETS := linux/amd64 linux/arm64 linux/arm \
 # are held lower rather than pretended into the top tier. Packages needing PostgreSQL
 # are checked separately: without a database their tests skip, and the figure would be
 # meaningless rather than merely low.
-COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan internal/relayproto internal/relay
+COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan internal/relayproto internal/relay internal/relaytoken
 COVER_FLOOR      := 90
 
 COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx internal/tunnel

--- a/internal/relaytoken/relaytoken.go
+++ b/internal/relaytoken/relaytoken.go
@@ -1,0 +1,143 @@
+// Package relaytoken issues and verifies the capability a relay checks before forwarding.
+//
+// The relay must be able to say no without being able to say yes on its own: it holds a
+// public key and nothing else, so a compromised relay cannot mint access to a network it was
+// never given (ADR-0016). The control plane signs; the relay verifies.
+//
+// The token is deliberately not a bearer credential for anything but relaying. It names one
+// WireGuard key and one network, and it expires. Stealing one buys the ability to have that
+// key's relayed packets delivered to you — which you still cannot decrypt — until it
+// expires, and nothing else.
+package relaytoken
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/relayproto"
+)
+
+// Version is the token layout this package writes.
+//
+// First byte on the wire, so a relay meeting a token from a newer control plane can say
+// which version it does not understand instead of failing to parse and blaming the
+// signature.
+const Version byte = 1
+
+// DefaultTTL is how long an issued token is good for.
+//
+// Short, because a token is trivially reissued over the control channel an agent already
+// holds, and the whole cost of a stolen one is bounded by this. Long enough that a relay
+// reconnect during a brief control-plane outage still works — losing the control plane must
+// not cost connectivity (Invariant 15).
+const DefaultTTL = 30 * time.Minute
+
+// Layout, all fixed width so parsing cannot disagree with writing:
+//
+//	 1  version
+//	32  WireGuard public key this token speaks for
+//	16  network id
+//	 8  expiry, unix seconds, big endian
+//	64  Ed25519 signature over everything above
+const (
+	versionLen   = 1
+	networkIDLen = 16
+	expiryLen    = 8
+
+	signedLen = versionLen + relayproto.KeyLen + networkIDLen + expiryLen
+	// Size is the encoded length of a token.
+	Size = signedLen + ed25519.SignatureSize
+)
+
+// Errors verification can produce. Distinguished because they mean different things to an
+// operator: an expired token is an agent that needs to ask for another, while a bad
+// signature is a relay configured with the wrong public key, or an attack.
+var (
+	// ErrMalformed means the token is not the right shape.
+	ErrMalformed = errors.New("relaytoken: malformed")
+	// ErrVersion means the token was written by a newer issuer.
+	ErrVersion = errors.New("relaytoken: unsupported version")
+	// ErrSignature means the signature does not verify against the given public key.
+	ErrSignature = errors.New("relaytoken: signature does not verify")
+	// ErrExpired means the token is past its expiry.
+	ErrExpired = errors.New("relaytoken: expired")
+)
+
+// Grant is what a valid token permits.
+type Grant struct {
+	Key       relayproto.Key
+	NetworkID [networkIDLen]byte
+	ExpiresAt time.Time
+}
+
+// Network renders the network id as a UUID string, which is what it is everywhere else.
+func (g Grant) Network() string {
+	b := g.NetworkID
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+// Issue signs a token granting a key the use of a relay on a network.
+func Issue(signer ed25519.PrivateKey, key relayproto.Key, networkID [networkIDLen]byte, expiresAt time.Time) ([]byte, error) {
+	if len(signer) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("relaytoken: signing key is %d bytes, want %d", len(signer), ed25519.PrivateKeySize)
+	}
+	if expiresAt.IsZero() {
+		return nil, errors.New("relaytoken: a token without an expiry is a permanent credential")
+	}
+
+	out := make([]byte, Size)
+	out[0] = Version
+	copy(out[versionLen:], key[:])
+	copy(out[versionLen+relayproto.KeyLen:], networkID[:])
+	binary.BigEndian.PutUint64(out[versionLen+relayproto.KeyLen+networkIDLen:], uint64(expiresAt.Unix()))
+	copy(out[signedLen:], ed25519.Sign(signer, out[:signedLen]))
+	return out, nil
+}
+
+// Verify checks a token and reports what it grants.
+//
+// The signature is checked before the expiry, deliberately. Reporting "expired" for a
+// forgery would tell an attacker their forgery parsed, and the cheaper check is the one that
+// leaks more.
+func Verify(public ed25519.PublicKey, token []byte, now time.Time) (Grant, error) {
+	if len(public) != ed25519.PublicKeySize {
+		return Grant{}, fmt.Errorf("relaytoken: public key is %d bytes, want %d", len(public), ed25519.PublicKeySize)
+	}
+	if len(token) != Size {
+		return Grant{}, fmt.Errorf("%w: %d bytes, want %d", ErrMalformed, len(token), Size)
+	}
+	if token[0] != Version {
+		return Grant{}, fmt.Errorf("%w: %d, this relay understands %d", ErrVersion, token[0], Version)
+	}
+	if !ed25519.Verify(public, token[:signedLen], token[signedLen:]) {
+		return Grant{}, ErrSignature
+	}
+
+	var grant Grant
+	copy(grant.Key[:], token[versionLen:versionLen+relayproto.KeyLen])
+	copy(grant.NetworkID[:], token[versionLen+relayproto.KeyLen:versionLen+relayproto.KeyLen+networkIDLen])
+	grant.ExpiresAt = time.Unix(
+		int64(binary.BigEndian.Uint64(token[versionLen+relayproto.KeyLen+networkIDLen:])), 0).UTC()
+
+	if now.After(grant.ExpiresAt) {
+		return Grant{}, fmt.Errorf("%w: at %s, now %s",
+			ErrExpired, grant.ExpiresAt.Format(time.RFC3339), now.UTC().Format(time.RFC3339))
+	}
+	return grant, nil
+}
+
+// Encode renders a token for a place that needs text, such as the control plane's JSON.
+func Encode(token []byte) string { return base64.StdEncoding.EncodeToString(token) }
+
+// Decode parses the text form.
+func Decode(s string) ([]byte, error) {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("%w: not base64: %w", ErrMalformed, err)
+	}
+	return b, nil
+}

--- a/internal/relaytoken/relaytoken_test.go
+++ b/internal/relaytoken/relaytoken_test.go
@@ -1,0 +1,257 @@
+package relaytoken
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/relayproto"
+)
+
+func pair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pub, priv
+}
+
+func key(b byte) relayproto.Key {
+	var k relayproto.Key
+	for i := range k {
+		k[i] = b
+	}
+	return k
+}
+
+func network(b byte) [networkIDLen]byte {
+	var n [networkIDLen]byte
+	for i := range n {
+		n[i] = b
+	}
+	return n
+}
+
+var now = time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+
+func TestATokenGrantsWhatItWasIssuedFor(t *testing.T) {
+	pub, priv := pair(t)
+	tok, err := Issue(priv, key(7), network(3), now.Add(DefaultTTL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tok) != Size {
+		t.Errorf("token is %d bytes, want %d", len(tok), Size)
+	}
+
+	grant, err := Verify(pub, tok, now)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if grant.Key != key(7) {
+		t.Error("the granted key is not the one issued")
+	}
+	if grant.NetworkID != network(3) {
+		t.Error("the granted network is not the one issued")
+	}
+	if !grant.ExpiresAt.Equal(now.Add(DefaultTTL)) {
+		t.Errorf("expiry is %s, want %s", grant.ExpiresAt, now.Add(DefaultTTL))
+	}
+	if got := grant.Network(); len(got) != 36 {
+		t.Errorf("network renders as %q, want a UUID", got)
+	}
+}
+
+// The whole point of signing rather than sharing a secret: a relay holds only the public key,
+// so a compromised relay cannot mint access to a network it was never given (ADR-0016).
+func TestAPublicKeyCannotIssue(t *testing.T) {
+	pub, _ := pair(t)
+	if _, err := Issue(ed25519.PrivateKey(pub), key(1), network(1), now.Add(time.Hour)); err == nil {
+		t.Error("a public key was accepted as a signing key")
+	}
+}
+
+func TestATokenFromAnotherIssuerIsRefused(t *testing.T) {
+	_, mine := pair(t)
+	theirs, _ := pair(t)
+
+	tok, err := Issue(mine, key(1), network(1), now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Verify(theirs, tok, now); !errors.Is(err, ErrSignature) {
+		t.Errorf("verified against the wrong public key with %v, want ErrSignature", err)
+	}
+}
+
+// Every single-bit change must be caught, or the signature is decoration. Sweeping every byte
+// of the signed region and the signature itself is cheap and complete.
+func TestEveryByteIsCoveredByTheSignature(t *testing.T) {
+	pub, priv := pair(t)
+	tok, err := Issue(priv, key(1), network(1), now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range tok {
+		tampered := make([]byte, len(tok))
+		copy(tampered, tok)
+		tampered[i] ^= 0x01
+
+		_, err := Verify(pub, tampered, now)
+		if err == nil {
+			t.Errorf("flipping a bit in byte %d was accepted", i)
+			continue
+		}
+		// A flip in the version byte is caught by the version check first, which is the
+		// better error for the operator anyway.
+		if i == 0 {
+			if !errors.Is(err, ErrVersion) && !errors.Is(err, ErrSignature) {
+				t.Errorf("byte %d gave %v, want a version or signature error", i, err)
+			}
+			continue
+		}
+		if !errors.Is(err, ErrSignature) {
+			t.Errorf("byte %d gave %v, want ErrSignature", i, err)
+		}
+	}
+}
+
+func TestAnExpiredTokenIsRefused(t *testing.T) {
+	pub, priv := pair(t)
+	tok, err := Issue(priv, key(1), network(1), now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Verify(pub, tok, now.Add(30*time.Second)); err != nil {
+		t.Errorf("a token inside its lifetime was refused: %v", err)
+	}
+	if _, err := Verify(pub, tok, now.Add(2*time.Minute)); !errors.Is(err, ErrExpired) {
+		t.Errorf("an expired token gave %v, want ErrExpired", err)
+	}
+	// Exactly at the expiry is still valid — the boundary has to be somewhere, and refusing
+	// on the same second a token was minted for would make short TTLs unusable.
+	if _, err := Verify(pub, tok, now.Add(time.Minute)); err != nil {
+		t.Errorf("a token exactly at its expiry was refused: %v", err)
+	}
+}
+
+// A forgery must not learn that it parsed. The signature is checked before the expiry so an
+// attacker cannot use "expired" as confirmation that everything else was right.
+func TestAForgeryIsNotToldItExpired(t *testing.T) {
+	pub, _ := pair(t)
+
+	forged := make([]byte, Size)
+	forged[0] = Version
+	// An expiry far in the past, so an implementation checking expiry first would say so.
+	for i := range forged[signedLen-expiryLen : signedLen] {
+		forged[signedLen-expiryLen+i] = 0
+	}
+
+	_, err := Verify(pub, forged, now)
+	if errors.Is(err, ErrExpired) {
+		t.Error("a forgery was told it expired, which confirms the rest of it parsed")
+	}
+	if !errors.Is(err, ErrSignature) {
+		t.Errorf("got %v, want ErrSignature", err)
+	}
+}
+
+func TestMalformedTokensAreRefused(t *testing.T) {
+	pub, priv := pair(t)
+	good, err := Issue(priv, key(1), network(1), now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := map[string][]byte{
+		"empty":        {},
+		"one byte":     {Version},
+		"a byte short": good[:len(good)-1],
+		"a byte long":  append(append([]byte{}, good...), 0),
+		"all zeroes":   make([]byte, Size),
+	}
+	for name, tok := range cases {
+		if _, err := Verify(pub, tok, now); err == nil {
+			t.Errorf("%s was accepted", name)
+		}
+	}
+}
+
+// A newer control plane must produce a clear complaint from an older relay, not a confusing
+// signature failure that sends someone hunting for a key mismatch.
+func TestAFutureVersionSaysSo(t *testing.T) {
+	pub, priv := pair(t)
+	tok, err := Issue(priv, key(1), network(1), now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok[0] = Version + 1
+
+	_, err = Verify(pub, tok, now)
+	if !errors.Is(err, ErrVersion) {
+		t.Errorf("a future version gave %v, want ErrVersion", err)
+	}
+}
+
+func TestATokenWithoutAnExpiryIsRefused(t *testing.T) {
+	_, priv := pair(t)
+	if _, err := Issue(priv, key(1), network(1), time.Time{}); err == nil {
+		t.Error("a token with no expiry was issued, which is a permanent credential")
+	}
+}
+
+func TestTheTextFormRoundTrips(t *testing.T) {
+	pub, priv := pair(t)
+	tok, err := Issue(priv, key(9), network(9), now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	back, err := Decode(Encode(tok))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Verify(pub, back, now); err != nil {
+		t.Errorf("a token did not survive the text form: %v", err)
+	}
+	if _, err := Decode("not base64 !!!"); !errors.Is(err, ErrMalformed) {
+		t.Error("garbage decoded")
+	}
+}
+
+// Verify faces whatever a relay is sent, so it must not panic on any input — and must never
+// accept anything that was not signed by the key it was given.
+func FuzzVerify(f *testing.F) {
+	pub, priv := pair(&testing.T{})
+	good, _ := Issue(priv, key(1), network(1), now.Add(time.Hour))
+
+	f.Add([]byte{})
+	f.Add(make([]byte, Size))
+	f.Add(good)
+	tampered := append([]byte{}, good...)
+	tampered[10] ^= 0xFF
+	f.Add(tampered)
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		grant, err := Verify(pub, data, now)
+		if err != nil {
+			return
+		}
+		// Anything accepted must be exactly a token this issuer would have produced, and
+		// re-issuing its contents must reproduce it byte for byte. A verifier that accepts
+		// something it could not have written is a forgery it did not notice.
+		again, issueErr := Issue(priv, grant.Key, grant.NetworkID, grant.ExpiresAt)
+		if issueErr != nil {
+			t.Fatalf("a verified grant could not be reissued: %v", issueErr)
+		}
+		if string(again) != string(data) {
+			t.Fatalf("Verify accepted a token this issuer would not produce:\n got %x\nwant %x",
+				data, again)
+		}
+	})
+}


### PR DESCRIPTION
The relay has to be able to say **no** without being able to say **yes**. It holds an Ed25519
public key and nothing else, so a compromised relay cannot grant access to a network it was
never given (ADR-0016) — the control plane signs, the relay verifies.

A shared HMAC secret would have been simpler and would have made every relay able to mint
credentials for every customer on it. That's the whole reason for the asymmetry.

## What a token is, and what stealing one gets you

One WireGuard key, one network, an expiry. Stealing one buys the ability to have that key's
relayed packets delivered to you — **which you still cannot decrypt** — until it expires.
Thirty minutes by default, because reissuing costs one message on a control channel the agent
already holds, so the exposure of a leak is bounded by a number we choose rather than by how
long until someone notices.

## Three decisions worth reviewing

**Fixed-width layout with a version byte first.** An older relay meeting a newer control plane
reports *which version* it doesn't understand, instead of failing to parse and blaming the
signature — which would send someone hunting for a key mismatch that isn't there.

**The signature is checked before the expiry.** Telling a forgery that it *expired* confirms
everything else about it parsed, which is a free oracle for anyone iterating on a forgery.
`TestAForgeryIsNotToldItExpired` pins the ordering, because it's exactly the sort of thing a
later refactor reorders for tidiness.

**Every byte is covered.** `TestEveryByteIsCoveredByTheSignature` flips one bit in each of the
121 bytes in turn and requires every one to be caught. A signature covering *most* of a token
is decoration.

## The fuzz target asserts more than absence of panics

Anything `Verify` accepts must **re-issue to exactly the bytes that arrived**. A verifier that
accepts something its own issuer could not have written has accepted a forgery without
noticing — and that's a property no amount of hand-written cases covers as well.

```
fuzz: elapsed: 40s, execs: 5903094 (134291/sec), new interesting: 5 (total: 9)
PASS
```

97% coverage, gated at 90.

## Invariants

- [x] An invariant is affected, and it still holds. Which, and how it is tested:

**15** (a control-plane outage does not interrupt established networking) shaped the TTL: it
has to be long enough that a relay reconnect during a brief outage still works, which is why
30 minutes rather than 30 seconds.

## Migrations

None.

## What follows

`cmd/meshp-relay` — wiring the core and this verifier to a **multi-port** UDP listener, since
your network demonstrated UDP 443 can be blocked while 3478 passes. Then token issuance in the
control plane, then the agent side.