### PR TITLE
feat(meshp-relay): a relay that listens, and does so on several ports

### DIFF
--- a/cmd/meshp-relay/main.go
+++ b/cmd/meshp-relay/main.go
@@ -1,41 +1,67 @@
-// Command meshp-relay forwards encrypted packets between peers that cannot
-// reach each other directly.
+// Command meshp-relay forwards encrypted packets between peers that cannot reach each other
+// directly.
 //
-// It is deliberately dumb. It authenticates that a sender is allowed to use it,
-// then forwards opaque bytes to a destination public key. It never holds a
-// WireGuard key for a user's tunnel and never needs to decrypt payloads
-// (Invariant 3) — which is what makes it safe for a customer to run their own
-// relay next to their users, and what keeps the blast radius of a compromised
+// It is deliberately dumb. It authenticates that a sender may use it, then forwards opaque
+// bytes to a destination public key. It never holds a WireGuard key for a user's tunnel and
+// never needs to decrypt a payload (Invariant 3) — which is what makes it safe for a customer
+// to run their own relay next to their users, and what keeps the blast radius of a compromised
 // relay small.
 //
-// meshp is relay-first: a new session starts on a relay and upgrades to a
-// direct path only if hole punching succeeds (ADR-0002). Connectivity therefore
-// never depends on NAT traversal working.
+// meshp is relay-first: a session starts on a relay and upgrades to a direct path only if one
+// can be found (ADR-0002), so connectivity never depends on NAT traversal succeeding.
+//
+// It listens on several UDP ports, because one is not enough. UDP 443 looks like the
+// friendliest choice and is the one most likely to be filtered, since it carries QUIC and
+// networks that want to inspect HTTP block it to force a fallback — measured on a real
+// network, where 443 was dropped and 3478 passed. So the default set leads with 3478 and the
+// agent is expected to try each in turn.
 package main
 
 import (
 	"context"
+	"crypto/ed25519"
+	"encoding/base64"
 	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
+	"sync"
 	"syscall"
 	"time"
 
+	"github.com/meshpnet/meshp/internal/clock"
 	"github.com/meshpnet/meshp/internal/httpx"
+	"github.com/meshpnet/meshp/internal/logx"
+	"github.com/meshpnet/meshp/internal/relay"
+	"github.com/meshpnet/meshp/internal/relayproto"
+	"github.com/meshpnet/meshp/internal/relaytoken"
 	"github.com/meshpnet/meshp/internal/version"
 )
+
+// defaultListen leads with 3478 deliberately. See the package comment.
+const defaultListen = ":3478,:443,:51820"
+
+// sweepInterval is how often sessions nothing has been heard from are forgotten. Frequent
+// enough that a relay's memory reflects who is connected, rare enough not to walk the table
+// on the hot path.
+const sweepInterval = 30 * time.Second
 
 func main() {
 	var (
 		showVersion = flag.Bool("version", false, "print build information and exit")
-		relayAddr   = flag.String("listen", envOr("MESHP_RELAY_LISTEN_ADDR", ":3478"), "UDP address for relayed traffic")
-		adminAddr   = flag.String("admin-listen", envOr("MESHP_RELAY_ADMIN_ADDR", ":9090"), "HTTP address for health and metrics")
-		controlURL  = flag.String("control-url", os.Getenv("MESHP_CONTROL_URL"), "control plane URL used to verify relay tokens")
-		logLevel    = flag.String("log-level", envOr("MESHP_LOG_LEVEL", "info"), "debug, info, warn or error")
+		listen      = flag.String("listen", envOr("MESHP_RELAY_LISTEN", defaultListen),
+			"comma-separated UDP addresses to listen on; the agent tries them in order")
+		adminAddr = flag.String("admin-listen", envOr("MESHP_RELAY_ADMIN_ADDR", "127.0.0.1:9090"),
+			"HTTP address for health and statistics; loopback by default because it is not authenticated")
+		issuerKey = flag.String("issuer-key", os.Getenv("MESHP_RELAY_ISSUER_KEY"),
+			"base64 Ed25519 public key of the control plane that issues relay tokens")
+		idle     = flag.Duration("idle", envDuration("MESHP_RELAY_IDLE", relay.DefaultIdle), "how long a session survives unheard from")
+		logLevel = flag.String("log-level", envOr("MESHP_LOG_LEVEL", "info"), "debug, info, warn or error")
 	)
 	flag.Parse()
 
@@ -45,19 +71,244 @@ func main() {
 	}
 
 	log := newLogger(*logLevel)
-	log.Info("meshp-relay starting", "relay_addr", *relayAddr, "admin_addr", *adminAddr, "control_url", *controlURL)
+
+	public, err := parseIssuerKey(*issuerKey)
+	if err != nil {
+		// Refusing to start is right: a relay with no issuer key could only either forward
+		// for anyone or for no one, and the first is an open proxy.
+		log.Error("cannot start without the control plane's public key",
+			"error", err,
+			"hint", "set MESHP_RELAY_ISSUER_KEY to the base64 Ed25519 public key the control plane signs relay tokens with")
+		os.Exit(2)
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	if err := run(ctx, log, *adminAddr); err != nil {
+	if err := run(ctx, log, config{
+		listen:    *listen,
+		adminAddr: *adminAddr,
+		issuer:    public,
+		idle:      *idle,
+	}); err != nil {
 		log.Error("meshp-relay exited with error", "error", err)
 		os.Exit(1)
 	}
 	log.Info("meshp-relay stopped cleanly")
 }
 
-func run(ctx context.Context, log *slog.Logger, adminAddr string) error {
+type config struct {
+	listen    string
+	adminAddr string
+	issuer    ed25519.PublicKey
+	idle      time.Duration
+}
+
+// issuerAuth verifies tokens against the control plane's public key.
+//
+// The relay can check a signature and cannot produce one, so a compromised relay cannot grant
+// access to a network it was never given (ADR-0016).
+type issuerAuth struct {
+	public ed25519.PublicKey
+	clk    clock.Clock
+}
+
+func (a issuerAuth) Authenticate(token []byte) (relayproto.Key, string, error) {
+	grant, err := relaytoken.Verify(a.public, token, a.clk.Now())
+	if err != nil {
+		return relayproto.Key{}, "", err
+	}
+	return grant.Key, grant.Network(), nil
+}
+
+func run(ctx context.Context, log *slog.Logger, cfg config) error {
+	selfKey, err := relayIdentity()
+	if err != nil {
+		return err
+	}
+
+	srv, err := relay.New(relay.Config{
+		Auth:    issuerAuth{public: cfg.issuer, clk: clock.System{}},
+		SelfKey: selfKey,
+		Idle:    cfg.idle,
+		Clock:   clock.System{},
+		Log:     log,
+	})
+	if err != nil {
+		return err
+	}
+
+	h, err := listenAll(cfg.listen)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		for _, c := range h.conns {
+			_ = c.Close()
+		}
+	}()
+	for i, c := range h.conns {
+		log.Info("listening for relayed traffic", "socket", i, "addr", c.LocalAddr().String())
+	}
+
+	wg := serve(ctx, log, srv, h)
+
+	admin := adminServer(cfg.adminAddr, log, srv)
+	errc := make(chan error, 1)
+	go func() {
+		if err := admin.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errc <- err
+			return
+		}
+		errc <- nil
+	}()
+	log.Info("admin endpoint listening", "addr", cfg.adminAddr)
+
+	select {
+	case err := <-errc:
+		return err
+	case <-ctx.Done():
+		log.Info("shutdown signal received")
+	}
+
+	// Closing the sockets is what unblocks the read loops; a context alone cannot interrupt
+	// a blocking ReadFromUDPAddrPort.
+	for _, c := range h.conns {
+		_ = c.Close()
+	}
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = admin.Shutdown(shutdownCtx)
+	wg.Wait()
+	log.Info("final statistics", "stats", srv.Stats().String())
+	return err
+}
+
+// serve starts a read loop per socket and the session sweeper, and returns something to wait
+// on. Separate from run so a test can drive a relay on ephemeral ports.
+func serve(ctx context.Context, log *slog.Logger, srv *relay.Server, h *host) *sync.WaitGroup {
+	var wg sync.WaitGroup
+	for i, c := range h.conns {
+		wg.Add(1)
+		go func(via int, conn *net.UDPConn) {
+			defer wg.Done()
+			forward(ctx, log, srv, h, via, conn)
+		}(i, c)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		sweep(ctx, log, srv)
+	}()
+	return &wg
+}
+
+// forward is the hot path: read a datagram, ask the server what to do, write the answers.
+//
+// One goroutine and one buffer per socket, so nothing is shared and nothing is allocated per
+// packet. Everything interesting is decided in internal/relay, which is why this is short
+// enough to read in one go.
+func forward(ctx context.Context, log *slog.Logger, srv *relay.Server, h *host, via int, conn *net.UDPConn) {
+	// Room for the largest frame, plus a little, so an oversized datagram is read and then
+	// rejected rather than silently truncated into something that looks valid.
+	in := make([]byte, relayproto.HeaderLen+relayproto.MaxPayload+64)
+	out := make([]byte, relayproto.HeaderLen+relayproto.MaxPayload)
+
+	for {
+		n, from, err := conn.ReadFromUDPAddrPort(in)
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
+				return
+			}
+			log.Warn("read failed", "socket", via, "error", logx.SafeError(err))
+			continue
+		}
+
+		for _, o := range srv.Handle(via, from, in[:n]) {
+			written, err := o.Frame.Encode(out)
+			if err != nil {
+				// A frame the server produced that will not encode is a bug here, not bad
+				// input, so it is worth an error rather than a dropped packet.
+				log.Error("could not encode a reply", "error", err, "type", o.Frame.Type.String())
+				continue
+			}
+			// Out of the socket the destination is talking to, which may not be this one.
+			if err := h.write(o, out[:written]); err != nil {
+				log.Debug("write failed", "to", o.To, "socket", o.Via, "error", logx.SafeError(err))
+			}
+		}
+	}
+}
+
+// host owns the listening sockets, so a reply can leave by the one its destination is using.
+//
+// The set is fixed once listening has started, so no lock is needed to read it — and a struct
+// rather than a package-level variable because two runs in one process (a test) must not share
+// sockets.
+type host struct {
+	conns []*net.UDPConn
+}
+
+func (h *host) write(o relay.Out, datagram []byte) error {
+	if o.Via < 0 || o.Via >= len(h.conns) {
+		return fmt.Errorf("relay: no socket %d", o.Via)
+	}
+	_, err := h.conns[o.Via].WriteToUDPAddrPort(datagram, o.To)
+	return err
+}
+
+func sweep(ctx context.Context, log *slog.Logger, srv *relay.Server) {
+	ticker := time.NewTicker(sweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if gone := srv.Expire(); gone > 0 {
+				log.Debug("forgot idle sessions", "count", gone)
+			}
+		}
+	}
+}
+
+// listenAll opens every address in a comma-separated list.
+//
+// All or nothing: a relay that came up on two of its three ports would advertise a port that
+// silently does not work, and the agent would spend its retries on it.
+func listenAll(spec string) (*host, error) {
+	var conns []*net.UDPConn
+	closeAll := func() {
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	}
+
+	for _, addr := range strings.Split(spec, ",") {
+		addr = strings.TrimSpace(addr)
+		if addr == "" {
+			continue
+		}
+		udpAddr, err := net.ResolveUDPAddr("udp", addr)
+		if err != nil {
+			closeAll()
+			return nil, fmt.Errorf("relay: %q is not a UDP address: %w", addr, err)
+		}
+		conn, err := net.ListenUDP("udp", udpAddr)
+		if err != nil {
+			closeAll()
+			return nil, fmt.Errorf("relay: listening on %s: %w", addr, err)
+		}
+		conns = append(conns, conn)
+	}
+	if len(conns) == 0 {
+		return nil, errors.New("relay: no addresses to listen on")
+	}
+
+	return &host{conns: conns}, nil
+}
+
+func adminServer(addr string, log *slog.Logger, srv *relay.Server) *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
 		httpx.WriteJSON(w, log, http.StatusOK, map[string]string{
@@ -65,32 +316,53 @@ func run(ctx context.Context, log *slog.Logger, adminAddr string) error {
 			"version": version.Version(),
 		})
 	})
+	// Every counter here is a question someone asks when a relay is not working: whether
+	// anyone connected, whether tokens are being refused, whether packets are being dropped
+	// and for which reason.
+	mux.HandleFunc("GET /stats", func(w http.ResponseWriter, _ *http.Request) {
+		st := srv.Stats()
+		httpx.WriteJSON(w, log, http.StatusOK, map[string]any{
+			"sessions":            st.Sessions,
+			"hello_accepted":      st.HelloAccepted,
+			"hello_refused":       st.HelloRefused,
+			"forwarded":           st.Forwarded,
+			"dropped_no_session":  st.DroppedNoSession,
+			"dropped_no_peer":     st.DroppedNoPeer,
+			"dropped_other_net":   st.DroppedOtherNet,
+			"dropped_undecodable": st.DroppedUndecodable,
+			"expired":             st.Expired,
+		})
+	})
+	return &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+}
 
-	srv := &http.Server{
-		Addr:              adminAddr,
-		Handler:           mux,
-		ReadHeaderTimeout: 10 * time.Second,
+// relayIdentity is the key this relay puts in the frames it originates.
+//
+// Generated per start rather than configured, because nothing verifies it yet: it exists so
+// that an agent talking to two relays can tell their replies apart, and so a log line can say
+// which relay answered.
+func relayIdentity() (relayproto.Key, error) {
+	var key relayproto.Key
+	pub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		return key, fmt.Errorf("relay: generating an identity: %w", err)
 	}
+	copy(key[:], pub)
+	return key, nil
+}
 
-	errc := make(chan error, 1)
-	go func() {
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errc <- err
-			return
-		}
-		errc <- nil
-	}()
-
-	log.Warn("packet forwarding not implemented yet; admin endpoint only")
-
-	select {
-	case err := <-errc:
-		return err
-	case <-ctx.Done():
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		return srv.Shutdown(shutdownCtx)
+func parseIssuerKey(s string) (ed25519.PublicKey, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, errors.New("no issuer key given")
 	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(s))
+	if err != nil {
+		return nil, fmt.Errorf("not base64: %w", err)
+	}
+	if len(raw) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("%d bytes, want %d", len(raw), ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(raw), nil
 }
 
 func newLogger(level string) *slog.Logger {
@@ -106,4 +378,17 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func envDuration(key string, fallback time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "meshp-relay: %s=%q is not a duration; using %s\n", key, v, fallback)
+		return fallback
+	}
+	return d
 }

--- a/cmd/meshp-relay/main_test.go
+++ b/cmd/meshp-relay/main_test.go
@@ -1,0 +1,367 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/clock"
+	"github.com/meshpnet/meshp/internal/relay"
+	"github.com/meshpnet/meshp/internal/relayproto"
+	"github.com/meshpnet/meshp/internal/relaytoken"
+)
+
+// These drive a real relay over real sockets. The unit tests in internal/relay decide what
+// should happen; this checks that the wiring between them and a UDP socket is right — in
+// particular that a reply leaves by the socket its destination is using, which no amount of
+// testing the core can establish.
+
+func testKey(b byte) relayproto.Key {
+	var k relayproto.Key
+	for i := range k {
+		k[i] = b
+	}
+	return k
+}
+
+var testNetwork = func() [16]byte {
+	var n [16]byte
+	copy(n[:], "acme------------")
+	return n
+}()
+
+type harness struct {
+	t      *testing.T
+	priv   ed25519.PrivateKey
+	ports  []string
+	server *relay.Server
+}
+
+// startRelay brings up a relay on two ephemeral ports and returns their addresses.
+//
+// Ephemeral rather than fixed, because a test that picks a port number is a test that fails
+// when something else on the machine happened to want it.
+func startRelay(t *testing.T) *harness {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv, err := relay.New(relay.Config{
+		Auth:    issuerAuth{public: pub, clk: clock.System{}},
+		SelfKey: testKey(0xFF),
+		Clock:   clock.System{},
+		Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h, err := listenAll("127.0.0.1:0,127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := serve(ctx, slog.New(slog.NewTextHandler(io.Discard, nil)), srv, h)
+	t.Cleanup(func() {
+		cancel()
+		for _, c := range h.conns {
+			_ = c.Close()
+		}
+		wg.Wait()
+	})
+
+	ports := make([]string, 0, len(h.conns))
+	for _, c := range h.conns {
+		ports = append(ports, c.LocalAddr().String())
+	}
+	return &harness{t: t, priv: priv, ports: ports, server: srv}
+}
+
+// client is one agent's socket.
+type client struct {
+	t    *testing.T
+	conn *net.UDPConn
+}
+
+func (h *harness) dial(port string) *client {
+	h.t.Helper()
+	raddr, err := net.ResolveUDPAddr("udp", port)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	conn, err := net.DialUDP("udp", nil, raddr)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	h.t.Cleanup(func() { _ = conn.Close() })
+	return &client{t: h.t, conn: conn}
+}
+
+func (c *client) send(frame relayproto.Frame) {
+	c.t.Helper()
+	buf := make([]byte, relayproto.HeaderLen+relayproto.MaxPayload)
+	n, err := frame.Encode(buf)
+	if err != nil {
+		c.t.Fatal(err)
+	}
+	if _, err := c.conn.Write(buf[:n]); err != nil {
+		c.t.Fatal(err)
+	}
+}
+
+// recv waits for one frame, or reports that nothing came.
+func (c *client) recv(within time.Duration) (relayproto.Frame, bool) {
+	c.t.Helper()
+	if err := c.conn.SetReadDeadline(time.Now().Add(within)); err != nil {
+		c.t.Fatal(err)
+	}
+	buf := make([]byte, 2048)
+	n, err := c.conn.Read(buf)
+	if err != nil {
+		return relayproto.Frame{}, false
+	}
+	frame, err := relayproto.Decode(buf[:n])
+	if err != nil {
+		c.t.Fatalf("the relay sent something undecodable: %v", err)
+	}
+	return frame, true
+}
+
+// hello authenticates a client and returns the address the relay observed.
+func (h *harness) hello(c *client, k byte) string {
+	h.t.Helper()
+	token, err := relaytoken.Issue(h.priv, testKey(k), testNetwork, time.Now().Add(time.Minute))
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	c.send(relayproto.Frame{Type: relayproto.TypeHello, Key: testKey(k), Payload: token})
+
+	frame, ok := c.recv(3 * time.Second)
+	if !ok {
+		h.t.Fatalf("no welcome for key %d", k)
+	}
+	if frame.Type != relayproto.TypeWelcome {
+		h.t.Fatalf("got %s, want welcome", frame.Type)
+	}
+	return string(frame.Payload)
+}
+
+// The reason a relay exists, over a real socket: a packet reaches a peer that is talking to a
+// different port. If replies left by the socket they arrived on, this would fail — and it
+// would pass whenever both peers happened to choose the same port, which is most of the time
+// by hand and rarely in the field.
+func TestAPacketReachesAPeerOnADifferentPort(t *testing.T) {
+	h := startRelay(t)
+	a := h.dial(h.ports[0])
+	b := h.dial(h.ports[1])
+
+	seenA := h.hello(a, 1)
+	seenB := h.hello(b, 2)
+	if seenA == "" || seenB == "" {
+		t.Fatal("the relay did not report the addresses it observed")
+	}
+	t.Logf("relay sees A at %s (port %s) and B at %s (port %s)", seenA, h.ports[0], seenB, h.ports[1])
+
+	payload := []byte("a wireguard packet, notionally")
+	a.send(relayproto.Frame{Type: relayproto.TypeSend, Key: testKey(2), Payload: payload})
+
+	frame, ok := b.recv(3 * time.Second)
+	if !ok {
+		t.Fatal("the packet never reached B; a reply left by the wrong socket")
+	}
+	if frame.Type != relayproto.TypeRecv {
+		t.Errorf("B got %s, want recv", frame.Type)
+	}
+	if frame.Key != testKey(1) {
+		t.Error("the forwarded frame does not name A, so B cannot tell who sent it")
+	}
+	if string(frame.Payload) != string(payload) {
+		t.Error("the payload changed in transit")
+	}
+
+	// And back the other way, which uses the other socket.
+	b.send(relayproto.Frame{Type: relayproto.TypeSend, Key: testKey(1), Payload: []byte("reply")})
+	if frame, ok := a.recv(3 * time.Second); !ok {
+		t.Error("the reverse direction did not arrive")
+	} else if string(frame.Payload) != "reply" {
+		t.Errorf("A got %q", frame.Payload)
+	}
+}
+
+// The address in a welcome is the reflexive candidate — what an agent cannot learn any other
+// way, and the reason it talks to a relay before it needs one.
+func TestTheWelcomeReportsTheAddressTheRelayActuallySees(t *testing.T) {
+	h := startRelay(t)
+	c := h.dial(h.ports[0])
+
+	seen := h.hello(c, 1)
+	local := c.conn.LocalAddr().String()
+	if seen != local {
+		t.Errorf("the relay reports %s, but this socket is %s", seen, local)
+	}
+}
+
+func TestATokenFromAnotherIssuerIsRefusedOverTheWire(t *testing.T) {
+	h := startRelay(t)
+	c := h.dial(h.ports[0])
+
+	_, other, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, err := relaytoken.Issue(other, testKey(3), testNetwork, time.Now().Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.send(relayproto.Frame{Type: relayproto.TypeHello, Key: testKey(3), Payload: token})
+
+	frame, ok := c.recv(3 * time.Second)
+	if !ok {
+		t.Fatal("no answer to a forged hello")
+	}
+	if frame.Type != relayproto.TypeRefused {
+		t.Errorf("got %s, want refused", frame.Type)
+	}
+	if h.server.Stats().HelloRefused == 0 {
+		t.Error("the refusal was not counted")
+	}
+}
+
+// An unauthenticated sender gets nothing at all, so the relay cannot be used as a reflector.
+func TestAnUnauthenticatedSenderGetsNothing(t *testing.T) {
+	h := startRelay(t)
+	known := h.dial(h.ports[0])
+	h.hello(known, 1)
+
+	stranger := h.dial(h.ports[0])
+	stranger.send(relayproto.Frame{Type: relayproto.TypeSend, Key: testKey(1), Payload: []byte("packet")})
+	if frame, ok := stranger.recv(time.Second); ok {
+		t.Errorf("the relay answered a stranger with %s", frame.Type)
+	}
+	// And the known peer was not sent anything either.
+	if frame, ok := known.recv(500 * time.Millisecond); ok {
+		t.Errorf("a stranger's packet was delivered as %s", frame.Type)
+	}
+}
+
+func TestAPingIsAnswered(t *testing.T) {
+	h := startRelay(t)
+	c := h.dial(h.ports[0])
+	h.hello(c, 1)
+
+	c.send(relayproto.Frame{Type: relayproto.TypePing, Key: testKey(1), Payload: []byte("nonce")})
+	frame, ok := c.recv(3 * time.Second)
+	if !ok {
+		t.Fatal("no pong")
+	}
+	if frame.Type != relayproto.TypePong || string(frame.Payload) != "nonce" {
+		t.Errorf("got %s %q, want a pong echoing the nonce", frame.Type, frame.Payload)
+	}
+}
+
+// A full-sized packet has to survive the socket as well as the encoder: if the read buffer
+// were a byte short, only large packets would be lost, which is the hardest failure to
+// attribute.
+func TestAFullSizedPacketSurvivesTheSocket(t *testing.T) {
+	h := startRelay(t)
+	a := h.dial(h.ports[0])
+	b := h.dial(h.ports[1])
+	h.hello(a, 1)
+	h.hello(b, 2)
+
+	payload := make([]byte, relayproto.MaxPayload)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+	a.send(relayproto.Frame{Type: relayproto.TypeSend, Key: testKey(2), Payload: payload})
+
+	frame, ok := b.recv(3 * time.Second)
+	if !ok {
+		t.Fatal("a full-sized packet did not arrive")
+	}
+	if len(frame.Payload) != relayproto.MaxPayload {
+		t.Fatalf("arrived with %d bytes, want %d", len(frame.Payload), relayproto.MaxPayload)
+	}
+	for i, b := range frame.Payload {
+		if b != byte(i%251) {
+			t.Fatalf("byte %d is %d, want %d", i, b, i%251)
+		}
+	}
+}
+
+// Garbage on a public port must not disturb anything.
+func TestGarbageDoesNotDisturbTheRelay(t *testing.T) {
+	h := startRelay(t)
+	a := h.dial(h.ports[0])
+	b := h.dial(h.ports[1])
+	h.hello(a, 1)
+	h.hello(b, 2)
+
+	noise := h.dial(h.ports[0])
+	for _, junk := range [][]byte{{}, {0}, make([]byte, 7), make([]byte, 3000), []byte("GET / HTTP/1.1\r\n\r\n")} {
+		if _, err := noise.conn.Write(junk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if frame, ok := noise.recv(500 * time.Millisecond); ok {
+		t.Errorf("garbage was answered with %s", frame.Type)
+	}
+
+	// The relay still works afterwards.
+	a.send(relayproto.Frame{Type: relayproto.TypeSend, Key: testKey(2), Payload: []byte("still here")})
+	if frame, ok := b.recv(3 * time.Second); !ok {
+		t.Error("the relay stopped forwarding after receiving garbage")
+	} else if string(frame.Payload) != "still here" {
+		t.Errorf("got %q", frame.Payload)
+	}
+}
+
+func TestAnIssuerKeyIsRequired(t *testing.T) {
+	if _, err := parseIssuerKey(""); err == nil {
+		t.Error("an empty issuer key was accepted, which would mean an open proxy")
+	}
+	if _, err := parseIssuerKey("not base64"); err == nil {
+		t.Error("a malformed issuer key was accepted")
+	}
+	if _, err := parseIssuerKey("c2hvcnQ="); err == nil {
+		t.Error("a short issuer key was accepted")
+	}
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseIssuerKey(relaytoken.Encode(pub)); err != nil {
+		t.Errorf("a valid key was refused: %v", err)
+	}
+}
+
+// All or nothing: a relay that came up on two of its three ports would advertise one that
+// silently does not work, and agents would spend their retries on it.
+func TestListeningIsAllOrNothing(t *testing.T) {
+	first, err := listenAll("127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	taken := first.conns[0].LocalAddr().String()
+	defer func() { _ = first.conns[0].Close() }()
+
+	// One good address and one already in use.
+	if _, err := listenAll("127.0.0.1:0," + taken); err == nil {
+		t.Error("listening succeeded although one address was unavailable")
+	}
+	if _, err := listenAll(""); err == nil {
+		t.Error("an empty listen list was accepted")
+	}
+	if _, err := listenAll("not an address"); err == nil {
+		t.Error("a malformed address was accepted")
+	}
+}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -51,15 +51,30 @@ type Authenticator interface {
 
 // Out is a datagram to send.
 type Out struct {
+	// Via is which of the relay's sockets to send from, as an index into whatever the
+	// caller is listening on.
+	//
+	// It matters because a relay listens on several ports — one is not enough, since
+	// networks exist that block UDP 443 while permitting 3478 — and a peer's NAT will only
+	// accept a reply whose source is the address it sent to. Forwarding a packet out of the
+	// wrong socket produces a relay that works only when both peers happened to choose the
+	// same port.
+	Via int
+
 	To    netip.AddrPort
 	Frame relayproto.Frame
 }
 
 // Session is a connected agent.
 type Session struct {
-	Key      relayproto.Key
-	Network  string
-	Addr     netip.AddrPort
+	Key     relayproto.Key
+	Network string
+	Addr    netip.AddrPort
+
+	// Via is the socket this agent said hello on, and therefore the only one it will accept
+	// replies from.
+	Via int
+
 	LastSeen time.Time
 }
 
@@ -132,7 +147,7 @@ func New(cfg Config) (*Server, error) {
 // Returning the replies rather than writing them keeps every rule testable without a socket,
 // and makes the anti-amplification property checkable: a caller can assert that nothing
 // leaving is larger than what arrived.
-func (s *Server) Handle(from netip.AddrPort, datagram []byte) []Out {
+func (s *Server) Handle(via int, from netip.AddrPort, datagram []byte) []Out {
 	frame, err := relayproto.Decode(datagram)
 	if err != nil {
 		// Silently. Anything on a public UDP port receives noise, and answering it is both
@@ -144,11 +159,11 @@ func (s *Server) Handle(from netip.AddrPort, datagram []byte) []Out {
 
 	switch frame.Type {
 	case relayproto.TypeHello:
-		return s.hello(from, frame)
+		return s.hello(via, from, frame)
 	case relayproto.TypeSend:
 		return s.forward(from, frame)
 	case relayproto.TypePing:
-		return s.ping(from, frame)
+		return s.ping(via, from, frame)
 	default:
 		// Welcome, refused, recv and pong are what a relay emits, not what it accepts. A
 		// peer sending one is confused or probing; either way there is nothing to say.
@@ -158,7 +173,7 @@ func (s *Server) Handle(from netip.AddrPort, datagram []byte) []Out {
 }
 
 // hello authenticates an agent and records where it can be reached.
-func (s *Server) hello(from netip.AddrPort, frame relayproto.Frame) []Out {
+func (s *Server) hello(via int, from netip.AddrPort, frame relayproto.Frame) []Out {
 	// The size of what arrived, which bounds what may be sent back to a sender that has not
 	// proved anything.
 	arrived := relayproto.HeaderLen + len(frame.Payload)
@@ -167,20 +182,20 @@ func (s *Server) hello(from netip.AddrPort, frame relayproto.Frame) []Out {
 	if err != nil {
 		s.count(func(st *Stats) { st.HelloRefused++ })
 		s.log.Info("refused a hello", "from", from, "error", err)
-		return s.refuse(from, arrived)
+		return s.refuse(via, from, arrived)
 	}
 
 	// The token names the key, so only its holder can move where that key is reachable.
 	if key != frame.Key {
 		s.count(func(st *Stats) { st.HelloRefused++ })
 		s.log.Info("hello key does not match its token", "from", from)
-		return s.refuse(from, arrived)
+		return s.refuse(via, from, arrived)
 	}
 
 	now := s.clk.Now()
 	s.mu.Lock()
 	previous, existed := s.byKey[key]
-	s.byKey[key] = &Session{Key: key, Network: network, Addr: from, LastSeen: now}
+	s.byKey[key] = &Session{Key: key, Network: network, Addr: from, Via: via, LastSeen: now}
 	s.stats.HelloAccepted++
 	s.mu.Unlock()
 
@@ -193,7 +208,7 @@ func (s *Server) hello(from netip.AddrPort, frame relayproto.Frame) []Out {
 	// The observed address is the whole reason an agent talks to a relay before it needs
 	// one: it is this device's server-reflexive candidate, and nothing else can tell it
 	// (ADR-0016). The control channel's TCP source address is not the same thing.
-	return []Out{{To: from, Frame: relayproto.Frame{
+	return []Out{{Via: via, To: from, Frame: relayproto.Frame{
 		Type:    relayproto.TypeWelcome,
 		Key:     s.selfKey,
 		Payload: []byte(from.String()),
@@ -208,7 +223,7 @@ func (s *Server) hello(from netip.AddrPort, frame relayproto.Frame) []Out {
 // earned a reply, and answering it would let an attacker bounce slightly larger packets off
 // this relay at a spoofed victim. A real token is much larger than "refused", so a genuine
 // agent with an expired token still learns what happened.
-func (s *Server) refuse(to netip.AddrPort, arrived int) []Out {
+func (s *Server) refuse(via int, to netip.AddrPort, arrived int) []Out {
 	frame := relayproto.Frame{
 		Type:    relayproto.TypeRefused,
 		Key:     s.selfKey,
@@ -218,7 +233,7 @@ func (s *Server) refuse(to netip.AddrPort, arrived int) []Out {
 		s.log.Debug("dropping a refusal that would be larger than the hello", "to", to)
 		return nil
 	}
-	return []Out{{To: to, Frame: frame}}
+	return []Out{{Via: via, To: to, Frame: frame}}
 }
 
 // forward carries a packet to the peer it names.
@@ -258,7 +273,10 @@ func (s *Server) forward(from netip.AddrPort, frame relayproto.Frame) []Out {
 	// Rewritten to name the sender, because that is what tells the receiving agent which
 	// peer this came from and therefore which of its sockets to deliver it on. Forwarding
 	// without rewriting would send every packet back where it came from.
-	return []Out{{To: dest.Addr, Frame: relayproto.Frame{
+	// Out of the socket the destination is talking to, not the one this arrived on. A peer's
+	// NAT only accepts a datagram whose source is the address it sent to, so sending from
+	// the wrong socket would work only when both peers happened to pick the same port.
+	return []Out{{Via: dest.Via, To: dest.Addr, Frame: relayproto.Frame{
 		Type:    relayproto.TypeRecv,
 		Key:     sender.Key,
 		Payload: frame.Payload,
@@ -266,7 +284,7 @@ func (s *Server) forward(from netip.AddrPort, frame relayproto.Frame) []Out {
 }
 
 // ping answers a keepalive, which is how an agent holds its NAT mapping open.
-func (s *Server) ping(from netip.AddrPort, frame relayproto.Frame) []Out {
+func (s *Server) ping(via int, from netip.AddrPort, frame relayproto.Frame) []Out {
 	now := s.clk.Now()
 
 	s.mu.Lock()
@@ -281,7 +299,7 @@ func (s *Server) ping(from netip.AddrPort, frame relayproto.Frame) []Out {
 
 	// The payload is echoed so the agent can measure a round trip, and echoing exactly what
 	// arrived means the reply can never be larger than the request.
-	return []Out{{To: from, Frame: relayproto.Frame{
+	return []Out{{Via: via, To: from, Frame: relayproto.Frame{
 		Type:    relayproto.TypePong,
 		Key:     s.selfKey,
 		Payload: frame.Payload,

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -48,6 +48,7 @@ type fixture struct {
 	t   *testing.T
 	srv *Server
 	clk *clock.Fake
+	via int // which listening socket the next send arrives on
 }
 
 func newFixture(t *testing.T) *fixture {
@@ -68,7 +69,7 @@ func (f *fixture) send(from netip.AddrPort, frame relayproto.Frame) []Out {
 	if err != nil {
 		f.t.Fatalf("encoding %s: %v", frame.Type, err)
 	}
-	out := f.srv.Handle(from, buf[:n])
+	out := f.srv.Handle(f.via, from, buf[:n])
 
 	// The property that matters most for something on a public UDP port: a reply must never
 	// be larger than what prompted it, or the relay can be pointed at a third party and used
@@ -88,8 +89,22 @@ func (f *fixture) send(from netip.AddrPort, frame relayproto.Frame) []Out {
 	return out
 }
 
-// join gets a session established for a key at an address.
+// joinVia gets a session established for a key at an address, on a given socket.
+func (f *fixture) joinVia(via int, network string, k byte, at string) {
+	f.t.Helper()
+	previous := f.via
+	f.via = via
+	defer func() { f.via = previous }()
+	f.joinHere(network, k, at)
+}
+
+// join gets a session established for a key at an address, on socket 0.
 func (f *fixture) join(network string, k byte, at string) {
+	f.t.Helper()
+	f.joinHere(network, k, at)
+}
+
+func (f *fixture) joinHere(network string, k byte, at string) {
 	f.t.Helper()
 	out := f.send(addr(at), relayproto.Frame{
 		Type: relayproto.TypeHello, Key: key(k), Payload: token(network, k),
@@ -308,7 +323,7 @@ func TestGarbageIsDroppedSilently(t *testing.T) {
 		make([]byte, 2000),
 		[]byte("GET / HTTP/1.1\r\nHost: x\r\n\r\n"),
 	} {
-		if out := f.srv.Handle(addr("192.0.2.9:9"), datagram); len(out) != 0 {
+		if out := f.srv.Handle(0, addr("192.0.2.9:9"), datagram); len(out) != 0 {
 			t.Errorf("%d bytes of garbage produced a reply: %+v", len(datagram), out)
 		}
 	}
@@ -421,7 +436,7 @@ func TestARelayNeverRepliesWithMoreThanItReceived(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		out := f.srv.Handle(addr("192.0.2.50:5050"), buf[:n])
+		out := f.srv.Handle(0, addr("192.0.2.50:5050"), buf[:n])
 		for _, o := range out {
 			reply := make([]byte, relayproto.HeaderLen+relayproto.MaxPayload)
 			rn, err := o.Frame.Encode(reply)
@@ -440,5 +455,75 @@ func TestARelayNeverRepliesWithMoreThanItReceived(t *testing.T) {
 	// Silent refusals are still counted, so an operator can see them happening.
 	if f.srv.Stats().HelloRefused == 0 {
 		t.Error("refusals are invisible in the counters")
+	}
+}
+
+// A relay listens on several ports, because networks exist that block UDP 443 while
+// permitting 3478 — verified against a real network, not hypothesised. Two peers may
+// therefore be talking to different sockets, and a forwarded packet has to leave by the one
+// its destination is using: a peer's NAT only accepts a datagram whose source is the address
+// it sent to. Getting this wrong yields a relay that works only when both peers happen to
+// choose the same port, which is most of the time in testing and not in the field.
+func TestAForwardedPacketLeavesByTheDestinationsSocket(t *testing.T) {
+	f := newFixture(t)
+	f.joinVia(0, "acme", 1, "203.0.113.1:1111") // peer 1 on socket 0, say udp/3478
+	f.joinVia(1, "acme", 2, "203.0.113.2:2222") // peer 2 on socket 1, say udp/443
+
+	// 1 -> 2 must leave by socket 1.
+	f.via = 0
+	out := f.send(addr("203.0.113.1:1111"), relayproto.Frame{
+		Type: relayproto.TypeSend, Key: key(2), Payload: []byte("packet"),
+	})
+	if len(out) != 1 {
+		t.Fatalf("expected one forward, got %+v", out)
+	}
+	if out[0].Via != 1 {
+		t.Errorf("forwarded via socket %d, want 1 — the socket peer 2 is talking to", out[0].Via)
+	}
+
+	// And 2 -> 1 must leave by socket 0.
+	f.via = 1
+	out = f.send(addr("203.0.113.2:2222"), relayproto.Frame{
+		Type: relayproto.TypeSend, Key: key(1), Payload: []byte("packet"),
+	})
+	if len(out) != 1 || out[0].Via != 0 {
+		t.Errorf("the reverse direction went via %+v, want socket 0", out)
+	}
+}
+
+// Replies to the sender go back out the way they came, for the same reason.
+func TestRepliesLeaveByTheSocketTheyArrivedOn(t *testing.T) {
+	f := newFixture(t)
+	f.joinVia(2, "acme", 1, "203.0.113.1:1111")
+
+	f.via = 2
+	out := f.send(addr("203.0.113.1:1111"), relayproto.Frame{
+		Type: relayproto.TypePing, Key: key(1), Payload: []byte("x"),
+	})
+	if len(out) != 1 || out[0].Via != 2 {
+		t.Errorf("a pong left by %+v, want socket 2", out)
+	}
+}
+
+// A peer that reconnects on a different port moves sockets as well as addresses — a NAT
+// rebinding, or an agent that fell back from 443 to 3478 because the first was blocked.
+func TestAPeerThatMovesSocketsIsFollowed(t *testing.T) {
+	f := newFixture(t)
+	f.joinVia(0, "acme", 1, "203.0.113.1:1111")
+	f.joinVia(0, "acme", 2, "203.0.113.2:2222")
+
+	// Peer 2 comes back on another port.
+	f.joinVia(1, "acme", 2, "203.0.113.2:3333")
+
+	f.via = 0
+	out := f.send(addr("203.0.113.1:1111"), relayproto.Frame{
+		Type: relayproto.TypeSend, Key: key(2), Payload: []byte("packet"),
+	})
+	if len(out) != 1 {
+		t.Fatalf("expected a forward, got %+v", out)
+	}
+	if out[0].Via != 1 || out[0].To != addr("203.0.113.2:3333") {
+		t.Errorf("forwarded to %s via socket %d, want 203.0.113.2:3333 via 1",
+			out[0].To, out[0].Via)
 	}
 }


### PR DESCRIPTION
The skeleton logged `packet forwarding not implemented yet` and served a health endpoint. It
now forwards.

## Writing the binary found a requirement the core didn't have

A relay listens on several ports, so **two peers may be talking to different sockets** — and a
forwarded packet has to leave by the socket its *destination* is using. A peer's NAT only
accepts a datagram whose source is the address it sent to.

Replying out of the socket a packet arrived on produces a relay that works exactly when both
peers happened to choose the same port: most of the time by hand, rarely in the field. Sessions
now record which socket they arrived on, and every reply names the socket to leave by.

This is the second time this milestone that writing the I/O layer corrected the pure layer
above it — the first was the kernel refusing a route on a down link.

## Several ports because of measurement, not taste

UDP 443 looks like the friendliest choice and is **the one most likely to be filtered**: it
carries QUIC, and networks that want to inspect HTTP block it to force a fallback. On the
network this was developed on, 443 is dropped and 3478 passes — checked against two independent
third parties to be sure it was the port and not the host.

So the default set leads with `3478`, then `443`, then `51820`, and binding is **all or
nothing**: a relay that came up on two of three ports would advertise one that silently doesn't
work, and agents would spend their retries on it.

## It refuses to start without an issuer key

```
level=ERROR msg="cannot start without the control plane's public key"
  hint="set MESHP_RELAY_ISSUER_KEY to the base64 Ed25519 public key..."
```

A relay with no issuer key can only forward for everyone or for no one. The first is an open
proxy, so exiting with a hint beats picking either.

## Tests drive real sockets

Because the socket routing is exactly what testing the core cannot establish:

```
relay sees A at 127.0.0.1:62219 (port 127.0.0.1:57962)
       and B at 127.0.0.1:61994 (port 127.0.0.1:62049)
--- PASS: TestAPacketReachesAPeerOnADifferentPort
```

Also over the wire: a full-sized payload survives the read buffer (a buffer one byte short
loses *only* large packets — the hardest failure to attribute), a token from another issuer is
refused, an unauthenticated sender gets nothing at all, and garbage neither answers nor
disturbs a working relay.

Ephemeral ports throughout, because a test that picks a port number fails when something else
on the machine wanted it.

## Teeth

Making forwarding always use socket 0 fails **four** tests — two in the core, two over real
sockets. `internal/relay` stays at 98.1%, and `cmd/meshp-relay` goes from no tests at all to
nine.

## Invariants

- [x] An invariant is affected, and it still holds. Which, and how it is tested:

**3** (a relay never needs to decrypt) — the relay handles opaque payloads only; nothing in it
parses a WireGuard packet, which is why forwarding needs the destination key outside the
payload.

## Migrations

None.

## What follows

Token issuance in the control plane, then the agent side — the loopback socket per peer, and
the trap already recorded: a loopback endpoint is *ours*, not roaming evidence, so it must not
be preserved by the endpoint rule from #14 or a relayed peer could never be upgraded to a
direct path.