### PR TITLE
fix(relay): report an IPv4 peer as IPv4

### DIFF
--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -208,10 +208,16 @@ func (s *Server) hello(via int, from netip.AddrPort, frame relayproto.Frame) []O
 	// The observed address is the whole reason an agent talks to a relay before it needs
 	// one: it is this device's server-reflexive candidate, and nothing else can tell it
 	// (ADR-0016). The control channel's TCP source address is not the same thing.
+	//
+	// Unmapped before it is reported. A relay listening on [::] sees an IPv4 peer as
+	// ::ffff:a.b.c.d, and that string does not equal the plain IPv4 address the agent knows
+	// itself by — so comparing a reflexive candidate against a host candidate would never
+	// match, and every device would be judged to be behind NAT. Found by deploying a relay
+	// and reading what it actually said.
 	return []Out{{Via: via, To: from, Frame: relayproto.Frame{
 		Type:    relayproto.TypeWelcome,
 		Key:     s.selfKey,
-		Payload: []byte(from.String()),
+		Payload: []byte(netip.AddrPortFrom(from.Addr().Unmap(), from.Port()).String()),
 	}}}
 }
 

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -527,3 +527,37 @@ func TestAPeerThatMovesSocketsIsFollowed(t *testing.T) {
 			out[0].To, out[0].Via)
 	}
 }
+
+// A relay listening on [::] sees an IPv4 peer as ::ffff:a.b.c.d. Reported in that form, the
+// reflexive candidate would never equal the plain IPv4 address the agent knows itself by — so
+// every device would look like it was behind NAT, and endpoint discovery would never conclude
+// a direct path was possible. Found by deploying a relay and reading what it said, not by any
+// test written beforehand.
+func TestAnIPv4PeerIsReportedAsIPv4(t *testing.T) {
+	f := newFixture(t)
+
+	out := f.send(addr("[::ffff:103.66.79.194]:49822"), relayproto.Frame{
+		Type: relayproto.TypeHello, Key: key(1), Payload: token("acme", 1),
+	})
+	if len(out) != 1 || out[0].Frame.Type != relayproto.TypeWelcome {
+		t.Fatalf("expected a welcome: %+v", out)
+	}
+	if got := string(out[0].Frame.Payload); got != "103.66.79.194:49822" {
+		t.Errorf("the relay reports %q, want the plain IPv4 form", got)
+	}
+}
+
+// A real IPv6 peer must still be reported as IPv6, brackets and all.
+func TestAnIPv6PeerIsReportedAsIPv6(t *testing.T) {
+	f := newFixture(t)
+
+	out := f.send(addr("[2400:6180:100:d0::5]:41234"), relayproto.Frame{
+		Type: relayproto.TypeHello, Key: key(1), Payload: token("acme", 1),
+	})
+	if len(out) != 1 {
+		t.Fatalf("expected a welcome: %+v", out)
+	}
+	if got := string(out[0].Frame.Payload); got != "[2400:6180:100:d0::5]:41234" {
+		t.Errorf("the relay reports %q, want the IPv6 form", got)
+	}
+}


### PR DESCRIPTION
Found by deploying the relay to a real host and reading what it actually said — not by any
test written beforehand:

```
client A welcomed; the relay sees this device at [::ffff:103.66.79.194]:49822
```

A relay listening on `[::]` is dual-stack, so an IPv4 peer arrives as `::ffff:a.b.c.d`, and
that's the form `netip.AddrPort.String()` produces.

**Why it matters more than it looks.** The address in a welcome is the device's
server-reflexive candidate, and the entire purpose of having it is to compare it against the
host candidates an agent reports — which are plain IPv4. The mapped form would never compare
equal, so **every device would be judged to be behind NAT**, a direct path would never be
attempted, and everything would silently relay forever. On every network. With no error
anywhere.

Unmapped before reporting. A genuine IPv6 peer is still reported as IPv6 — that's the other
half of the test, because "just strip the brackets" would break v6.

## Confirmed against the deployment, not only in a test

```
client A welcomed; the relay sees this device at 103.66.79.194:52809
client B welcomed; the relay sees this device at 103.66.79.194:54692
A -> relay -> B: 53 bytes in 21ms round trip
```

Two clients behind the same NAT, through a relay in Bangalore, over `relay1.meshp.net:3478`.

## Teeth

Reverting to `from.String()` fails `TestAnIPv4PeerIsReportedAsIPv4`. 98.1% coverage held.

## Invariants

- [x] No invariant is affected.

## Migrations

None.