### PR TITLE
feat(relayclient): the agent's side of the relay protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ CROSS_TARGETS := linux/amd64 linux/arm64 linux/arm \
 COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan internal/relayproto internal/relay internal/relaytoken
 COVER_FLOOR      := 90
 
-COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx internal/tunnel
+COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx internal/tunnel internal/relayclient
 COVER_FLOOR_IO      := 75
 
 COVER_FLOOR_DB_PKGS := internal/store internal/enroll internal/api internal/session

--- a/internal/relayclient/relayclient.go
+++ b/internal/relayclient/relayclient.go
@@ -1,0 +1,325 @@
+// Package relayclient is an agent's side of the relay protocol.
+//
+// It connects to a relay, learns the address the relay sees it at, and carries opaque packets
+// to and from other keys. It knows nothing about WireGuard: what it moves are bytes the agent
+// took off a socket, which is what keeps a relay unable to read anything (Invariant 3).
+//
+// A relay offers several ports and this tries them in order, because one port is not enough.
+// UDP 443 looks like the friendliest choice and is the one most likely to be filtered — it
+// carries QUIC, and networks that want to inspect HTTP block it to force a fallback. That is
+// measured rather than assumed: on the network this was developed on, 443 is dropped and 3478
+// passes.
+package relayclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+	"sync"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/logx"
+	"github.com/meshpnet/meshp/internal/relayproto"
+)
+
+// DefaultHelloTimeout is how long one endpoint gets to answer before the next is tried.
+//
+// Short, because the common failure is a filtered port that will never answer, and an agent
+// working through three of them should not take a minute to find the one that works.
+const DefaultHelloTimeout = 2 * time.Second
+
+// KeepaliveInterval is how often a ping holds the NAT mapping to the relay open.
+//
+// Twenty seconds, inside the shortest NAT UDP timeouts commonly seen. A mapping that lapses
+// does not break the tunnel visibly — it breaks it the next time the peer sends something,
+// which is much harder to attribute.
+const KeepaliveInterval = 20 * time.Second
+
+// Errors callers distinguish.
+var (
+	// ErrNoEndpoint means no advertised endpoint answered.
+	ErrNoEndpoint = errors.New("relayclient: no relay endpoint answered")
+	// ErrRefused means the relay rejected our token.
+	ErrRefused = errors.New("relayclient: the relay refused our token")
+	// ErrClosed means the client has been closed.
+	ErrClosed = errors.New("relayclient: closed")
+)
+
+// Client is one connection to one relay.
+type Client struct {
+	key   relayproto.Key
+	token []byte
+	log   *slog.Logger
+
+	// endpoint is the address that answered, kept so a log line and a reconnect can name it.
+	endpoint string
+
+	mu        sync.Mutex
+	conn      *net.UDPConn
+	reflexive netip.AddrPort
+	closed    bool
+
+	// out is the write buffer. Guarded by mu because a datagram must be encoded and sent
+	// without another goroutine interleaving into the same bytes.
+	out []byte
+}
+
+// Options configures a Dial.
+type Options struct {
+	// Endpoints are the relay's addresses, best first. Tried in order.
+	Endpoints []string
+
+	// Key is this device's WireGuard public key, which is what the relay knows it by.
+	Key relayproto.Key
+
+	// Token is the capability the control plane issued for this key and network.
+	Token []byte
+
+	HelloTimeout time.Duration
+	Log          *slog.Logger
+}
+
+// Dial connects to the first endpoint that answers, and returns a client that has already
+// been welcomed.
+//
+// Sequential rather than parallel: the endpoints are ordered by preference, and racing them
+// would mean deliberately opening sessions on relays we then abandon — which is work for the
+// relay and noise in its counters, to save a second on a path that is then used for hours.
+func Dial(ctx context.Context, opts Options) (*Client, error) {
+	if len(opts.Endpoints) == 0 {
+		return nil, errors.New("relayclient: no endpoints to try")
+	}
+	if len(opts.Token) == 0 {
+		return nil, errors.New("relayclient: no token; a relay will refuse an unauthenticated hello")
+	}
+	if opts.HelloTimeout <= 0 {
+		opts.HelloTimeout = DefaultHelloTimeout
+	}
+	if opts.Log == nil {
+		opts.Log = slog.New(slog.DiscardHandler)
+	}
+
+	var refused bool
+	for _, endpoint := range opts.Endpoints {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		c, err := dialOne(ctx, endpoint, opts)
+		if err == nil {
+			opts.Log.Info("relay connected",
+				"endpoint", endpoint, "reflexive", c.Reflexive().String())
+			return c, nil
+		}
+		if errors.Is(err, ErrRefused) {
+			// A refusal is about the token, not the path, so the next endpoint will refuse
+			// too. Recorded and the remaining endpoints still tried, because a relay that
+			// refuses could also be one that is misconfigured while a sibling is not.
+			refused = true
+		}
+		opts.Log.Debug("relay endpoint did not answer",
+			"endpoint", endpoint, "error", logx.SafeError(err))
+	}
+
+	if refused {
+		return nil, ErrRefused
+	}
+	return nil, fmt.Errorf("%w: tried %d", ErrNoEndpoint, len(opts.Endpoints))
+}
+
+func dialOne(ctx context.Context, endpoint string, opts Options) (*Client, error) {
+	raddr, err := net.ResolveUDPAddr("udp", endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("relayclient: %q: %w", endpoint, err)
+	}
+	conn, err := net.DialUDP("udp", nil, raddr)
+	if err != nil {
+		return nil, fmt.Errorf("relayclient: dialling %s: %w", endpoint, err)
+	}
+
+	c := &Client{
+		key:      opts.Key,
+		token:    opts.Token,
+		log:      opts.Log,
+		endpoint: endpoint,
+		conn:     conn,
+		out:      make([]byte, relayproto.HeaderLen+relayproto.MaxPayload),
+	}
+
+	if err := c.hello(ctx, opts.HelloTimeout); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
+// hello authenticates and records the address the relay reports seeing us at.
+func (c *Client) hello(ctx context.Context, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+
+	if err := c.send(relayproto.Frame{
+		Type: relayproto.TypeHello, Key: c.key, Payload: c.token,
+	}); err != nil {
+		return err
+	}
+
+	if err := c.conn.SetReadDeadline(deadline); err != nil {
+		return err
+	}
+	in := make([]byte, relayproto.HeaderLen+relayproto.MaxPayload)
+	for {
+		n, err := c.conn.Read(in)
+		if err != nil {
+			return fmt.Errorf("relayclient: %s did not answer: %w", c.endpoint, err)
+		}
+		frame, err := relayproto.Decode(in[:n])
+		if err != nil {
+			// Noise, or a relay speaking a protocol we do not. Keep waiting until the
+			// deadline rather than giving up on the endpoint for one bad datagram.
+			continue
+		}
+
+		switch frame.Type {
+		case relayproto.TypeWelcome:
+			// The address the relay sees is this device's server-reflexive candidate — the
+			// thing nothing else can tell it, and the reason to talk to a relay before
+			// needing one (ADR-0016).
+			seen, err := netip.ParseAddrPort(string(frame.Payload))
+			if err != nil {
+				return fmt.Errorf("relayclient: %s welcomed us with an unparseable address %q: %w",
+					c.endpoint, logx.Safe(string(frame.Payload)), err)
+			}
+			c.mu.Lock()
+			c.reflexive = seen
+			c.mu.Unlock()
+			return nil
+
+		case relayproto.TypeRefused:
+			return fmt.Errorf("%w: %s", ErrRefused, c.endpoint)
+
+		default:
+			// Something else arriving before the welcome is not fatal.
+			continue
+		}
+	}
+}
+
+// Reflexive is the address the relay reports seeing this device at.
+func (c *Client) Reflexive() netip.AddrPort {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.reflexive
+}
+
+// Endpoint is the relay address that answered.
+func (c *Client) Endpoint() string { return c.endpoint }
+
+// Send carries a packet to a peer through the relay.
+func (c *Client) Send(peer relayproto.Key, payload []byte) error {
+	if len(payload) > relayproto.MaxPayload {
+		// Refused rather than truncated: a truncated WireGuard packet fails authentication
+		// at the far end, so the symptom would be a peer that handshakes and goes quiet.
+		return fmt.Errorf("relayclient: %d bytes is more than a relayed packet may carry (%d)",
+			len(payload), relayproto.MaxPayload)
+	}
+	return c.send(relayproto.Frame{Type: relayproto.TypeSend, Key: peer, Payload: payload})
+}
+
+// Ping asks the relay to answer, which holds the NAT mapping open and measures the path.
+func (c *Client) Ping(nonce []byte) error {
+	return c.send(relayproto.Frame{Type: relayproto.TypePing, Key: c.key, Payload: nonce})
+}
+
+func (c *Client) send(frame relayproto.Frame) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return ErrClosed
+	}
+	n, err := frame.Encode(c.out)
+	if err != nil {
+		return err
+	}
+	if _, err := c.conn.Write(c.out[:n]); err != nil {
+		return fmt.Errorf("relayclient: sending to %s: %w", c.endpoint, err)
+	}
+	return nil
+}
+
+// Receive waits for one relayed packet and reports which peer it came from.
+//
+// The payload is copied into buf rather than aliasing an internal buffer, because the caller
+// hands it to a kernel socket and a shared buffer would be overwritten by the next read.
+//
+// A pong is consumed here rather than returned: it exists to keep a mapping open, and a
+// caller waiting for peer traffic should not have to know that.
+func (c *Client) Receive(buf []byte) (relayproto.Key, int, error) {
+	in := make([]byte, relayproto.HeaderLen+relayproto.MaxPayload)
+	for {
+		c.mu.Lock()
+		closed, conn := c.closed, c.conn
+		c.mu.Unlock()
+		if closed {
+			return relayproto.Key{}, 0, ErrClosed
+		}
+
+		n, err := conn.Read(in)
+		if err != nil {
+			return relayproto.Key{}, 0, err
+		}
+		frame, err := relayproto.Decode(in[:n])
+		if err != nil {
+			continue // noise on a public port
+		}
+
+		switch frame.Type {
+		case relayproto.TypeRecv:
+			if len(frame.Payload) > len(buf) {
+				return relayproto.Key{}, 0, fmt.Errorf(
+					"relayclient: a %d-byte packet does not fit a %d-byte buffer",
+					len(frame.Payload), len(buf))
+			}
+			return frame.Key, copy(buf, frame.Payload), nil
+
+		case relayproto.TypePong, relayproto.TypeWelcome:
+			continue
+
+		case relayproto.TypeRefused:
+			// The relay has stopped accepting us — most likely the token expired. The caller
+			// has to get another and reconnect, so this is worth reporting rather than
+			// looping on.
+			return relayproto.Key{}, 0, ErrRefused
+
+		default:
+			continue
+		}
+	}
+}
+
+// SetReadDeadline bounds a Receive.
+func (c *Client) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return ErrClosed
+	}
+	return c.conn.SetReadDeadline(t)
+}
+
+// Close releases the socket. Safe to call twice, because the agent closes on shutdown and on
+// every error path and should not have to remember which came first.
+func (c *Client) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	return c.conn.Close()
+}

--- a/internal/relayclient/relayclient_test.go
+++ b/internal/relayclient/relayclient_test.go
@@ -1,0 +1,452 @@
+package relayclient
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/clock"
+	"github.com/meshpnet/meshp/internal/relay"
+	"github.com/meshpnet/meshp/internal/relayproto"
+	"github.com/meshpnet/meshp/internal/relaytoken"
+)
+
+// These run against a real relay over real sockets. A fake relay would only prove the client
+// agrees with my idea of the protocol; the point is that it agrees with the relay.
+
+func key(b byte) relayproto.Key {
+	var k relayproto.Key
+	for i := range k {
+		k[i] = b
+	}
+	return k
+}
+
+var network = func() [16]byte {
+	var n [16]byte
+	copy(n[:], "acme------------")
+	return n
+}()
+
+type fixture struct {
+	t         *testing.T
+	priv      ed25519.PrivateKey
+	endpoints []string
+	server    *relay.Server
+}
+
+// start runs a relay on the given number of ephemeral ports and returns their addresses.
+func start(t *testing.T, ports int) *fixture {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	srv, err := relay.New(relay.Config{
+		Auth:    tokenAuth{public: pub},
+		SelfKey: key(0xFF),
+		Clock:   clock.System{},
+		Log:     discard,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var conns []*net.UDPConn
+	var endpoints []string
+	for range ports {
+		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		conns = append(conns, conn)
+		endpoints = append(endpoints, conn.LocalAddr().String())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{}, len(conns))
+	for i, conn := range conns {
+		go func(via int, conn *net.UDPConn) {
+			defer func() { done <- struct{}{} }()
+			in := make([]byte, 4096)
+			out := make([]byte, relayproto.HeaderLen+relayproto.MaxPayload)
+			for {
+				n, from, err := conn.ReadFromUDPAddrPort(in)
+				if err != nil {
+					return
+				}
+				for _, o := range srv.Handle(via, from, in[:n]) {
+					written, err := o.Frame.Encode(out)
+					if err != nil {
+						continue
+					}
+					_, _ = conns[o.Via].WriteToUDPAddrPort(out[:written], o.To)
+				}
+			}
+		}(i, conn)
+	}
+	t.Cleanup(func() {
+		cancel()
+		for _, c := range conns {
+			_ = c.Close()
+		}
+		for range conns {
+			<-done
+		}
+	})
+	_ = ctx
+
+	return &fixture{t: t, priv: priv, endpoints: endpoints, server: srv}
+}
+
+type tokenAuth struct{ public ed25519.PublicKey }
+
+func (a tokenAuth) Authenticate(token []byte) (relayproto.Key, string, error) {
+	grant, err := relaytoken.Verify(a.public, token, time.Now())
+	if err != nil {
+		return relayproto.Key{}, "", err
+	}
+	return grant.Key, grant.Network(), nil
+}
+
+func (f *fixture) token(k byte) []byte {
+	f.t.Helper()
+	tok, err := relaytoken.Issue(f.priv, key(k), network, time.Now().Add(time.Minute))
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	return tok
+}
+
+func (f *fixture) dial(k byte, endpoints []string) *Client {
+	f.t.Helper()
+	c, err := Dial(context.Background(), Options{
+		Endpoints: endpoints,
+		Key:       key(k),
+		Token:     f.token(k),
+	})
+	if err != nil {
+		f.t.Fatalf("Dial: %v", err)
+	}
+	f.t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func TestAClientIsWelcomedAndLearnsItsOwnAddress(t *testing.T) {
+	f := start(t, 1)
+	c := f.dial(1, f.endpoints)
+
+	if c.Endpoint() != f.endpoints[0] {
+		t.Errorf("connected to %s, want %s", c.Endpoint(), f.endpoints[0])
+	}
+	// The reflexive address: what the relay sees, which over loopback is this socket itself.
+	if !c.Reflexive().IsValid() {
+		t.Error("no reflexive address was learned, which is the reason to talk to a relay at all")
+	}
+	if c.Reflexive().Port() == 0 {
+		t.Error("the reflexive address has no port")
+	}
+}
+
+func TestAPacketReachesAnotherClient(t *testing.T) {
+	f := start(t, 1)
+	a := f.dial(1, f.endpoints)
+	b := f.dial(2, f.endpoints)
+
+	payload := []byte("a wireguard packet, notionally")
+	if err := a.Send(key(2), payload); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := b.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 2048)
+	from, n, err := b.Receive(buf)
+	if err != nil {
+		t.Fatalf("B received nothing: %v", err)
+	}
+	if from != key(1) {
+		t.Error("the packet does not name A, so B cannot tell which peer sent it")
+	}
+	if string(buf[:n]) != string(payload) {
+		t.Errorf("payload is %q, want %q", buf[:n], payload)
+	}
+}
+
+// The reason a relay offers several ports: a filtered one must not stop an agent connecting.
+// Here the first two endpoints are dead, standing in for a network that drops UDP 443.
+func TestABlockedPortIsSkipped(t *testing.T) {
+	f := start(t, 1)
+
+	// Two addresses nothing is listening on. Discard-prefix documentation addresses would
+	// hang; unbound loopback ports refuse or drop quickly.
+	dead1 := freeLoopbackAddr(t)
+	dead2 := freeLoopbackAddr(t)
+
+	c, err := Dial(context.Background(), Options{
+		Endpoints:    []string{dead1, dead2, f.endpoints[0]},
+		Key:          key(1),
+		Token:        f.token(1),
+		HelloTimeout: 300 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Dial did not fall through to the working endpoint: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	if c.Endpoint() != f.endpoints[0] {
+		t.Errorf("connected to %s, want the working endpoint %s", c.Endpoint(), f.endpoints[0])
+	}
+}
+
+func TestNoEndpointAnsweringIsReportedAsSuch(t *testing.T) {
+	f := start(t, 1)
+
+	_, err := Dial(context.Background(), Options{
+		Endpoints:    []string{freeLoopbackAddr(t), freeLoopbackAddr(t)},
+		Key:          key(1),
+		Token:        f.token(1),
+		HelloTimeout: 200 * time.Millisecond,
+	})
+	if !errors.Is(err, ErrNoEndpoint) {
+		t.Errorf("got %v, want ErrNoEndpoint", err)
+	}
+}
+
+// A refused token is a different problem from an unreachable relay, and an agent has to tell
+// them apart: one means get a new token, the other means try another path.
+func TestARefusedTokenIsDistinctFromAnUnreachableRelay(t *testing.T) {
+	f := start(t, 1)
+
+	_, other, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	forged, err := relaytoken.Issue(other, key(1), network, time.Now().Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Dial(context.Background(), Options{
+		Endpoints:    f.endpoints,
+		Key:          key(1),
+		Token:        forged,
+		HelloTimeout: time.Second,
+	})
+	if !errors.Is(err, ErrRefused) {
+		t.Errorf("got %v, want ErrRefused", err)
+	}
+	if errors.Is(err, ErrNoEndpoint) {
+		t.Error("a refusal was reported as an unreachable relay, which would send an agent retrying forever")
+	}
+}
+
+func TestDiallingWithoutATokenIsRefusedLocally(t *testing.T) {
+	f := start(t, 1)
+	if _, err := Dial(context.Background(), Options{Endpoints: f.endpoints, Key: key(1)}); err == nil {
+		t.Error("dialling with no token was attempted; a relay would only refuse it")
+	}
+	if _, err := Dial(context.Background(), Options{Key: key(1), Token: []byte("x")}); err == nil {
+		t.Error("dialling with no endpoints was attempted")
+	}
+}
+
+// A ping keeps the NAT mapping open. Its pong must not surface as peer traffic, or a caller
+// waiting for a packet would be woken by every keepalive.
+func TestAPongDoesNotLookLikePeerTraffic(t *testing.T) {
+	f := start(t, 1)
+	a := f.dial(1, f.endpoints)
+	b := f.dial(2, f.endpoints)
+
+	if err := a.Ping([]byte("nonce")); err != nil {
+		t.Fatal(err)
+	}
+	// B sends a real packet after A's ping; A must see the packet, not the pong.
+	if err := b.Send(key(1), []byte("real")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := a.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 2048)
+	from, n, err := a.Receive(buf)
+	if err != nil {
+		t.Fatalf("A received nothing: %v", err)
+	}
+	if from != key(2) || string(buf[:n]) != "real" {
+		t.Errorf("A received %q from %x, want \"real\" from B", buf[:n], from[:2])
+	}
+}
+
+// Two peers on different relay ports, which is the case the relay's socket routing exists for
+// and the one an agent will hit whenever a network filters one of the ports.
+func TestPeersOnDifferentPortsCanTalk(t *testing.T) {
+	f := start(t, 2)
+	a := f.dial(1, []string{f.endpoints[0]})
+	b := f.dial(2, []string{f.endpoints[1]})
+
+	if err := a.Send(key(2), []byte("across ports")); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 2048)
+	from, n, err := b.Receive(buf)
+	if err != nil {
+		t.Fatalf("nothing crossed between relay ports: %v", err)
+	}
+	if from != key(1) || string(buf[:n]) != "across ports" {
+		t.Errorf("got %q from %x", buf[:n], from[:2])
+	}
+}
+
+// An oversized packet is refused rather than truncated: a truncated WireGuard packet fails
+// authentication far from here, so the symptom would be a peer that handshakes and goes quiet.
+func TestAnOversizedPacketIsRefusedRatherThanTruncated(t *testing.T) {
+	f := start(t, 1)
+	a := f.dial(1, f.endpoints)
+
+	if err := a.Send(key(2), make([]byte, relayproto.MaxPayload+1)); err == nil {
+		t.Error("an oversized packet was accepted")
+	}
+	if err := a.Send(key(2), make([]byte, relayproto.MaxPayload)); err != nil {
+		t.Errorf("a packet of exactly the maximum was refused: %v", err)
+	}
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	f := start(t, 1)
+	c := f.dial(1, f.endpoints)
+
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Close(); err != nil {
+		t.Errorf("closing twice returned %v; an agent closes on every error path", err)
+	}
+	if err := c.Send(key(2), []byte("x")); !errors.Is(err, ErrClosed) {
+		t.Errorf("sending after close gave %v, want ErrClosed", err)
+	}
+	buf := make([]byte, 16)
+	if _, _, err := c.Receive(buf); !errors.Is(err, ErrClosed) {
+		t.Errorf("receiving after close gave %v, want ErrClosed", err)
+	}
+}
+
+// freeLoopbackAddr returns a loopback address with nothing listening on it.
+func freeLoopbackAddr(t *testing.T) string {
+	t.Helper()
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := conn.LocalAddr().String()
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return addr
+}
+
+// The case that matters, and the one an unbound loopback port does not reproduce: a filtered
+// endpoint that swallows the datagram and never answers.
+//
+// An unbound port replies with ICMP port-unreachable, so falling through takes no time and
+// exercises the error path rather than the timeout. A firewall drops silently — which is what
+// UDP 443 does on the network this was developed on — so the client has to give up on a
+// deadline and move on. Without a black hole in the test, "tries the next endpoint" is only
+// half tested.
+func TestASilentlyFilteredPortIsSkippedOnTimeout(t *testing.T) {
+	f := start(t, 1)
+
+	// Bound, so nothing rejects, and never read from, so nothing answers.
+	blackHole, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = blackHole.Close() }()
+
+	const timeout = 400 * time.Millisecond
+	started := time.Now()
+	c, err := Dial(context.Background(), Options{
+		Endpoints:    []string{blackHole.LocalAddr().String(), f.endpoints[0]},
+		Key:          key(1),
+		Token:        f.token(1),
+		HelloTimeout: timeout,
+	})
+	if err != nil {
+		t.Fatalf("Dial gave up instead of trying the next endpoint: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	if c.Endpoint() != f.endpoints[0] {
+		t.Errorf("connected to %s, want the working endpoint", c.Endpoint())
+	}
+	// It really waited, so this went through the timeout rather than an error.
+	if elapsed := time.Since(started); elapsed < timeout {
+		t.Errorf("fell through in %s, less than the %s timeout — the black hole answered something",
+			elapsed, timeout)
+	}
+}
+
+// And when every endpoint is a black hole, the failure is reported as nothing answering rather
+// than hanging forever.
+func TestAllEndpointsFilteredFailsWithinTheTimeouts(t *testing.T) {
+	f := start(t, 1)
+
+	var holes []string
+	for range 3 {
+		h, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = h.Close() }()
+		holes = append(holes, h.LocalAddr().String())
+	}
+
+	const timeout = 200 * time.Millisecond
+	started := time.Now()
+	_, err := Dial(context.Background(), Options{
+		Endpoints: holes, Key: key(1), Token: f.token(1), HelloTimeout: timeout,
+	})
+	if !errors.Is(err, ErrNoEndpoint) {
+		t.Errorf("got %v, want ErrNoEndpoint", err)
+	}
+	// Bounded: three endpoints, not an unbounded wait.
+	if elapsed := time.Since(started); elapsed > 3*timeout+time.Second {
+		t.Errorf("took %s for three endpoints at %s each", elapsed, timeout)
+	}
+}
+
+// A cancelled context stops the attempt, so a daemon shutting down does not sit through every
+// endpoint's timeout.
+func TestACancelledContextStopsDialling(t *testing.T) {
+	f := start(t, 1)
+
+	hole, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = hole.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := Dial(ctx, Options{
+		Endpoints: []string{hole.LocalAddr().String(), f.endpoints[0]},
+		Key:       key(1), Token: f.token(1), HelloTimeout: 5 * time.Second,
+	}); !errors.Is(err, context.Canceled) {
+		t.Errorf("got %v, want context.Canceled", err)
+	}
+}


### PR DESCRIPTION
Connects to a relay, learns the address the relay sees it at, and carries opaque packets to and
from other keys. It knows nothing about WireGuard — what it moves are bytes the agent took off a
socket, which is what keeps a relay unable to read anything (Invariant 3).

## My first version of the fall-through test was wrong, in an instructive way

Endpoints are tried in order because one port is not enough. I tested that with unbound
loopback ports and it passed in **0.00s** — which is the tell. An unbound port answers with ICMP
port-unreachable, so the read fails immediately and only the *error* path is exercised.

**A firewall drops silently.** That's what UDP 443 does on the network this was developed on, and
it means the client must give up on a deadline instead. The test now uses a bound socket that
never answers, and asserts the fall-through *really waited*:

```go
if elapsed := time.Since(started); elapsed < timeout {
    t.Errorf("fell through in %s, less than the %s timeout — the black hole answered something", ...)
}
```

Without that, "tries the next endpoint" was half tested — and the untested half is the one that
happens in the field.

## Three other decisions worth reviewing

**A refused token is distinct from an unreachable relay.** An agent must do different things
about them: one means get another token, the other means try another path. Conflating them would
have an agent retrying forever against a relay that will never accept it.

**A pong is consumed, not returned.** It exists to hold a NAT mapping open; a caller waiting for
peer traffic shouldn't be woken by every keepalive.

**An oversized packet is refused rather than truncated.** A truncated WireGuard packet fails
authentication at the far end, so the symptom would be a peer that handshakes and then goes
quiet, with nothing pointing here.

## Tested against the real relay, not a fake

A fake would only prove the client agrees with my idea of the protocol; the point is that it
agrees with the relay. So the tests run `relay.Server` over real sockets — including **two peers
on different relay ports**, which is the case the relay's socket routing exists for and the one
an agent hits whenever a network filters a port.

Also covered: a cancelled context stops dialling rather than sitting through every endpoint's
timeout, and all-endpoints-filtered fails within a bounded time instead of hanging.

85% coverage, gated at 75 as socket code.

## Invariants

- [x] An invariant is affected, and it still holds. Which, and how it is tested:

**3** (a relay never needs to decrypt) — this client hands the relay opaque bytes and nothing
here parses a WireGuard packet.

## Migrations

None.

## Not in scope, and one open design question

The agent doesn't use this yet. Two things remain before two devices can talk:

**The loopback plumbing** — a socket per relayed peer, with the peer's endpoint set to
`127.0.0.1:Px` and inbound packets written *from* that socket so the kernel sees the endpoint it
has configured.

**Token delivery, which needs a decision.** `RelayConfig` exists in the protocol (relays with
ids, regions, endpoints, keys) and `Peer.relay_id` names which to use — but there is **no token
field anywhere**. Tokens live 30 minutes and sessions live longer, so embedding one in desired
state would mean pushing a new state version per device every half hour, which couples a
device-specific credential to a network-wide version counter. My inclination is a small
request/response on the control channel — the agent asks when its token is near expiry, since it
is the only party that knows. That is additive to the protocol and I'd rather propose it as an
ADR than decide it quietly.