### PR TITLE
feat(session): agents ask for relay credentials (ADR-0017)

### DIFF
--- a/cmd/meshp-control/main.go
+++ b/cmd/meshp-control/main.go
@@ -11,13 +11,18 @@ package main
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -26,6 +31,7 @@ import (
 	"github.com/meshpnet/meshp/internal/clock"
 	"github.com/meshpnet/meshp/internal/enroll"
 	"github.com/meshpnet/meshp/internal/httpx"
+	"github.com/meshpnet/meshp/internal/relaytoken"
 	"github.com/meshpnet/meshp/internal/session"
 	"github.com/meshpnet/meshp/internal/store"
 	"github.com/meshpnet/meshp/internal/version"
@@ -43,6 +49,15 @@ func main() {
 			"do not apply migrations at startup; readiness still requires the schema to be current")
 		logLevel = flag.String("log-level", envOr("MESHP_LOG_LEVEL", "info"), "debug, info, warn or error")
 
+		// The Ed25519 key this deployment signs relay tokens with. Relays are configured
+		// with the public half and can therefore verify without being able to issue
+		// (ADR-0016). Absent means relaying is not offered: devices still enrol and
+		// converge, and an agent asking for a token is told so.
+		relayKey = flag.String("relay-signing-key", os.Getenv("MESHP_RELAY_SIGNING_KEY"),
+			"base64 Ed25519 seed or private key for signing relay tokens; empty disables relaying")
+		generateRelayKey = flag.Bool("generate-relay-key", false,
+			"print a new relay signing keypair and exit")
+
 		// How far back deltas can be built. An agent offline longer than this is sent a
 		// snapshot when it returns, which is correct but expensive — so this is the
 		// trade-off between the size of the change log and how cheap a reconnection is
@@ -54,6 +69,16 @@ func main() {
 
 	if *showVersion {
 		fmt.Println(version.String("meshp-control"))
+		return
+	}
+
+	if *generateRelayKey {
+		// Here rather than in a README, because the alternative is an openssl incantation
+		// that people copy from a search result and get subtly wrong.
+		if err := printRelayKeypair(os.Stdout); err != nil {
+			fmt.Fprintln(os.Stderr, "meshp-control:", err)
+			os.Exit(1)
+		}
 		return
 	}
 
@@ -84,13 +109,20 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	signer, err := parseRelaySigningKey(*relayKey)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "meshp-control: relay signing key: %v\n", err)
+		os.Exit(2)
+	}
+
 	cfg := runConfig{
-		addr:           *listenAddr,
-		databaseURL:    *databaseURL,
-		secretKey:      []byte(*secretKey),
-		adminToken:     *adminToken,
-		skipMigrate:    *skipMigrate,
-		deltaRetention: *deltaRetention,
+		relaySigningKey: signer,
+		addr:            *listenAddr,
+		databaseURL:     *databaseURL,
+		secretKey:       []byte(*secretKey),
+		adminToken:      *adminToken,
+		skipMigrate:     *skipMigrate,
+		deltaRetention:  *deltaRetention,
 	}
 	if err := run(ctx, log, cfg); err != nil {
 		log.Error("meshp-control exited with error", "error", err)
@@ -100,12 +132,13 @@ func main() {
 }
 
 type runConfig struct {
-	addr           string
-	databaseURL    string
-	secretKey      []byte
-	adminToken     string
-	skipMigrate    bool
-	deltaRetention time.Duration
+	relaySigningKey ed25519.PrivateKey
+	addr            string
+	databaseURL     string
+	secretKey       []byte
+	adminToken      string
+	skipMigrate     bool
+	deltaRetention  time.Duration
 }
 
 func run(ctx context.Context, log *slog.Logger, cfg runConfig) error {
@@ -156,8 +189,24 @@ func run(ctx context.Context, log *slog.Logger, cfg runConfig) error {
 			log.Error("could not derive the enrolment challenge key", "error", err)
 			return
 		}
+		issuer, err := session.NewRelayIssuer(cfg.relaySigningKey, relaytoken.DefaultTTL)
+		if err != nil {
+			log.Error("could not prepare the relay issuer", "error", err)
+			return
+		}
+		if issuer == nil {
+			log.Warn("relaying is disabled: no signing key configured",
+				"hint", "meshp-control --generate-relay-key prints a pair; give the private half here and the public half to each relay")
+		} else {
+			// Logged so an operator can see what to configure a relay with, and can check a
+			// relay's configuration matches without reading a secret anywhere.
+			log.Info("relay tokens will be signed by this deployment",
+				"public_key", base64.StdEncoding.EncodeToString(issuer.PublicKey()))
+		}
+
 		sessionServer, err := session.NewServer(st, session.NewHub(), session.Config{
 			MasterSecret: cfg.secretKey,
+			RelayIssuer:  issuer,
 			Clock:        clock.System{},
 			Log:          log,
 		})
@@ -365,6 +414,50 @@ func pruneDeltaLog(ctx context.Context, log *slog.Logger, st *store.Store, reten
 				"networks", res.Networks, "rows", res.Rows, "retention", retention)
 		}
 	}
+}
+
+// parseRelaySigningKey accepts either a 32-byte seed or a full 64-byte private key.
+//
+// Both, because `--generate-relay-key` prints a seed and someone will inevitably paste the
+// longer form from somewhere else; refusing one of them would be a papercut with no benefit.
+func parseRelaySigningKey(s string) (ed25519.PrivateKey, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("not base64: %w", err)
+	}
+	switch len(raw) {
+	case ed25519.SeedSize:
+		return ed25519.NewKeyFromSeed(raw), nil
+	case ed25519.PrivateKeySize:
+		return ed25519.PrivateKey(raw), nil
+	default:
+		return nil, fmt.Errorf("%d bytes, want a %d-byte seed or a %d-byte private key",
+			len(raw), ed25519.SeedSize, ed25519.PrivateKeySize)
+	}
+}
+
+// printRelayKeypair writes a fresh pair, labelled so the halves cannot be confused.
+func printRelayKeypair(w io.Writer) error {
+	seed := make([]byte, ed25519.SeedSize)
+	if _, err := rand.Read(seed); err != nil {
+		return fmt.Errorf("reading randomness: %w", err)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+
+	// One write, one error to check. Writing a keypair half-way and reporting success would
+	// hand someone a secret with no matching public key.
+	_, err := fmt.Fprintf(w,
+		"# Keep this secret. Give it to meshp-control only.\n"+
+			"MESHP_RELAY_SIGNING_KEY=%s\n\n"+
+			"# Not secret. Give this to every relay.\n"+
+			"MESHP_RELAY_ISSUER_KEY=%s\n",
+		base64.StdEncoding.EncodeToString(seed),
+		base64.StdEncoding.EncodeToString(priv.Public().(ed25519.PublicKey)))
+	return err
 }
 
 func envOr(key, fallback string) string {

--- a/docs/adr/0017-relay-credentials-over-the-control-channel.md
+++ b/docs/adr/0017-relay-credentials-over-the-control-channel.md
@@ -1,0 +1,88 @@
+# ADR-0017: An agent asks for its relay credential; the server does not push it
+
+- **Status:** accepted
+- **Date:** 2026-08-13
+
+## Context
+
+A relay verifies a short-lived signed capability naming one WireGuard key and one
+network (ADR-0016). Something has to get that capability to the agent.
+
+Two things about it decide the answer. It is **device-specific** — a token for one
+key is useless to another. And it is **short-lived** — thirty minutes, chosen so
+that the whole cost of a leak is bounded by a number we pick rather than by how
+long until someone notices.
+
+Desired state is neither of those things. It is network-scoped and versioned: a
+delta describes a network at a version, and every agent in that network converges
+on it. Putting a per-device credential inside it would mean bumping a network's
+state version for one device's token, every half hour, for every device — turning a
+counter that exists to describe the network into a clock. The delta machinery would
+work; the meaning would be wrong.
+
+Where relay *endpoints* belong is a different question with a different answer,
+already settled by the protocol: `StateDelta` carries `RelayConfig`. Which relays
+exist, their addresses and their keys are network-wide facts that change rarely, and
+versioning them is exactly right.
+
+## Decision
+
+Relay endpoints arrive in desired state, as the protocol already provides for.
+
+The token arrives by request: the agent sends `RelayTokenRequest` on the control
+channel it already holds, and the server answers with `RelayToken`. Two additive
+messages.
+
+The agent asks because **it is the only party that knows when it needs one**. It
+knows when its token expires, whether it is currently relaying, and whether a relay
+has just refused it. A server pushing on a timer would have to model all of that
+from a distance and would push to devices that are not relaying at all.
+
+The token is not relay-specific. It names a key and a network and is signed by the
+deployment, so any relay holding that public key accepts it. A token per relay would
+multiply the requests and buy nothing: the relay is not the thing being
+authenticated, the device is.
+
+The request carries no fields. The session already establishes which membership is
+asking, and adding a device identifier to a message sent over an authenticated
+session would create a second, weaker way to say who you are.
+
+## Consequences
+
+An agent with no control channel cannot obtain a *new* relay credential. Its
+existing one keeps working until it expires, so a control-plane outage costs
+connectivity only if it outlasts the token — which is why thirty minutes rather than
+thirty seconds, and it is the reason Invariant 15 constrains the TTL rather than
+security alone. An outage longer than the TTL degrades relayed paths while direct
+paths continue, and that is a real weakening of Invariant 15 that ADR-0016 already
+introduced by putting the agent in the data path.
+
+The server must hold a signing key, which is new: until now the control plane held a
+symmetric secret for enrolment challenges and sessions, and nothing it produced was
+verified by a third party. A deployment now has an identity that relays trust, which
+means key rotation becomes something we will have to design — a relay configured with
+the old public key rejects every token from a rotated control plane, and the failure
+looks like every device losing relaying at once.
+
+Requests are cheap but unbounded: a misbehaving agent could ask continuously. The
+server should rate-limit and, better, refuse to issue a second token while the first
+is still comfortably valid — returning the one it already issued rather than minting
+another, so a loop costs nothing and the number of live credentials per device stays
+at one.
+
+## Alternatives considered
+
+**An HTTP endpoint on the control plane.** Simpler to reason about in isolation and
+trivially testable with curl. Rejected because the agent already holds an
+authenticated, live session that exists precisely to carry this kind of exchange, and
+a second path means a second authentication story, a second thing to rate-limit, and
+a second thing that has to work through whatever proxy an operator puts in front.
+
+**Pushing the token in desired state.** Rejected above: it would make a network's
+version counter advance for per-device credential rotation. It also delivers to every
+device whether or not it relays.
+
+**A long-lived or permanent token.** Removes the refresh problem entirely. Rejected
+because the credential's whole security argument is that it expires: a stolen token
+lets someone receive a key's relayed packets — which they still cannot decrypt — and
+the only thing bounding that is the clock.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,6 +25,7 @@ deliberate act with a written reason rather than a drift nobody noticed.
 | [0014](0014-hand-written-migration-runner.md) | A hand-written migration runner that checksums what it applied |
 | [0015](0015-data-plane-kernel-first.md) | Kernel WireGuard where it exists, userspace where it does not, and say which |
 | [0016](0016-relay-transport.md) | One relay port, multiplexed, with the agent carrying relayed packets |
+| [0017](0017-relay-credentials-over-the-control-channel.md) | An agent asks for its relay credential; the server does not push it |
 
 ## Format
 

--- a/internal/session/hub.go
+++ b/internal/session/hub.go
@@ -33,6 +33,13 @@ const sendQueue = 16
 
 // Session is one connected membership.
 type Session struct {
+	// relayMu guards the relay credential, which the read loop writes and nothing else
+	// touches today — but a session is reachable from the hub, so the guarantee should not
+	// depend on that staying true.
+	relayMu  sync.Mutex
+	relayTok []byte
+	relayExp time.Time
+
 	ID           string
 	MembershipID uuid.UUID
 	NetworkID    uuid.UUID
@@ -68,6 +75,26 @@ func newSession(id string, membershipID, networkID, deviceID uuid.UUID, now time
 func (s *Session) AppliedVersion() int64 { return s.applied.Load() }
 
 func (s *Session) setApplied(v int64) { s.applied.Store(v) }
+
+// relayToken returns the credential this session was last issued, if it holds one.
+//
+// Kept on the session rather than in the database: it is derivable from the signing key at any
+// time, it expires within the hour, and storing a credential that need not be stored is a
+// liability with no benefit.
+func (s *Session) relayToken() ([]byte, time.Time, bool) {
+	s.relayMu.Lock()
+	defer s.relayMu.Unlock()
+	if len(s.relayTok) == 0 {
+		return nil, time.Time{}, false
+	}
+	return s.relayTok, s.relayExp, true
+}
+
+func (s *Session) setRelayToken(token []byte, expires time.Time) {
+	s.relayMu.Lock()
+	defer s.relayMu.Unlock()
+	s.relayTok, s.relayExp = token, expires
+}
 
 // Closed reports the channel that closes when the session ends.
 func (s *Session) Closed() <-chan struct{} { return s.closed }

--- a/internal/session/relaycreds.go
+++ b/internal/session/relaycreds.go
@@ -1,0 +1,136 @@
+package session
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/meshpnet/meshp/internal/keys"
+	"github.com/meshpnet/meshp/internal/relayproto"
+	"github.com/meshpnet/meshp/internal/relaytoken"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// reissueWithin is how close to expiry a token must be before a new one is minted.
+//
+// Asking again while the current token is comfortably valid gets the same token back rather
+// than a new one. That bounds a misbehaving agent to one live credential instead of as many
+// as it cares to request, and makes a retry loop cost nothing (ADR-0017).
+const reissueWithin = 5 * time.Minute
+
+// RelayIssuer mints the capability a relay checks.
+//
+// Held by the control plane and nowhere else: the relay verifies a signature and cannot
+// produce one, which is what stops a compromised relay granting access to a network it was
+// never given (ADR-0016).
+type RelayIssuer struct {
+	signer ed25519.PrivateKey
+	ttl    time.Duration
+}
+
+// NewRelayIssuer returns an issuer, or nothing if the deployment has no signing key.
+//
+// A control plane with no key cannot issue, and says so when asked rather than failing to
+// start: relaying is one feature, and a deployment that has not configured it should still
+// enrol devices and carry state.
+func NewRelayIssuer(signer ed25519.PrivateKey, ttl time.Duration) (*RelayIssuer, error) {
+	if len(signer) == 0 {
+		return nil, nil
+	}
+	if len(signer) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("session: relay signing key is %d bytes, want %d",
+			len(signer), ed25519.PrivateKeySize)
+	}
+	if ttl <= 0 {
+		ttl = relaytoken.DefaultTTL
+	}
+	return &RelayIssuer{signer: signer, ttl: ttl}, nil
+}
+
+// PublicKey is what a relay must be configured with.
+func (r *RelayIssuer) PublicKey() ed25519.PublicKey {
+	if r == nil {
+		return nil
+	}
+	return r.signer.Public().(ed25519.PublicKey)
+}
+
+// handleRelayTokenRequest answers an agent asking for a relay credential.
+//
+// The membership comes from the session rather than from the request, so an agent can only
+// ever be issued a token for the key it authenticated as.
+func (s *Server) handleRelayTokenRequest(ctx context.Context, sess *Session) {
+	token, expires, err := s.relayTokenFor(ctx, sess)
+
+	msg := &meshpv1.RelayToken{}
+	if err != nil {
+		// The reason reaches the agent so a person reading its log can see why relaying is
+		// not working, but it is a short phrase rather than an internal error: this crosses
+		// a trust boundary in the direction of a device.
+		msg.Error = "relaying is not available"
+		s.log.Warn("could not issue a relay token",
+			"membership_id", sess.MembershipID, "error", err)
+	} else {
+		msg.Token = token
+		msg.ExpiresAtUnix = expires.Unix()
+	}
+
+	sess.enqueue(&meshpv1.ServerMessage{Payload: &meshpv1.ServerMessage_RelayToken{RelayToken: msg}})
+}
+
+// relayTokenFor mints, or returns the one already in force.
+func (s *Server) relayTokenFor(ctx context.Context, sess *Session) ([]byte, time.Time, error) {
+	if s.relay == nil {
+		return nil, time.Time{}, errors.New("this deployment has no relay signing key configured")
+	}
+
+	membership, err := s.store.Queries().GetMembershipForSession(ctx, sess.MembershipID)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("loading membership: %w", err)
+	}
+
+	encoded, err := s.store.Queries().GetWireGuardKeyForMembership(ctx, sess.MembershipID)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("loading this membership's WireGuard key: %w", err)
+	}
+	key, err := relayKeyOf(encoded)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	now := s.clk.Now()
+	// Reuse while there is comfortable life left, so a retry loop costs one signature rather
+	// than one per attempt, and a device holds one credential rather than a collection.
+	if existing, expires, ok := sess.relayToken(); ok && expires.Sub(now) > reissueWithin {
+		return existing, expires, nil
+	}
+
+	expires := now.Add(s.relay.ttl)
+	token, err := relaytoken.Issue(s.relay.signer, key, networkIDBytes(membership.NetworkID), expires)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("issuing: %w", err)
+	}
+	sess.setRelayToken(token, expires)
+	return token, expires, nil
+}
+
+// relayKeyOf turns the stored base64 WireGuard key into the raw form a token names.
+func relayKeyOf(encoded string) (relayproto.Key, error) {
+	var key relayproto.Key
+	parsed, err := keys.ParseWireGuardKey(encoded)
+	if err != nil {
+		return key, fmt.Errorf("this membership's WireGuard key is unusable: %w", err)
+	}
+	copy(key[:], parsed[:])
+	return key, nil
+}
+
+func networkIDBytes(id uuid.UUID) [16]byte {
+	var out [16]byte
+	copy(out[:], id[:])
+	return out
+}

--- a/internal/session/relaycreds_test.go
+++ b/internal/session/relaycreds_test.go
@@ -1,0 +1,181 @@
+package session
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/meshpnet/meshp/internal/relayproto"
+	"github.com/meshpnet/meshp/internal/relaytoken"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// withRelayIssuer gives the fixture's server a signing key, as a deployment that has
+// configured relaying would have.
+func (f *fixture) withRelayIssuer(t *testing.T) ed25519.PublicKey {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	issuer, err := NewRelayIssuer(priv, relaytoken.DefaultTTL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.srv.relay = issuer
+	return pub
+}
+
+// askForToken drives the handler as the read loop would and returns what the agent receives.
+func (f *fixture) askForToken(t *testing.T, membershipID uuid.UUID) *meshpv1.RelayToken {
+	t.Helper()
+	sess := newSession("test", membershipID, f.netID, uuid.New(), f.clk.Now())
+	f.srv.handleRelayTokenRequest(f.ctx, sess)
+
+	select {
+	case msg := <-sess.send:
+		token := msg.GetRelayToken()
+		if token == nil {
+			t.Fatalf("the server sent %T, want a relay token", msg.Payload)
+		}
+		return token
+	default:
+		t.Fatal("the server sent nothing at all, which an agent would wait on forever")
+		return nil
+	}
+}
+
+func TestARelayTokenNamesTheDevicesOwnKeyAndNetwork(t *testing.T) {
+	f := newFixture(t)
+	pub := f.withRelayIssuer(t)
+	alice := f.enrolDevice("alice")
+
+	msg := f.askForToken(t, alice.membershipID)
+	if msg.GetError() != "" {
+		t.Fatalf("refused: %s", msg.GetError())
+	}
+
+	grant, err := relaytoken.Verify(pub, msg.GetToken(), f.clk.Now())
+	if err != nil {
+		t.Fatalf("the issued token does not verify against the deployment's key: %v", err)
+	}
+
+	// The key comes from the session's membership, never from the request, so a device can
+	// only be issued a token for the key it authenticated as.
+	stored, err := f.store.Queries().GetWireGuardKeyForMembership(f.ctx, alice.membershipID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := relayKeyOf(stored)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grant.Key != want {
+		t.Error("the token names a key other than this membership's")
+	}
+	if grant.Network() != f.netID.String() {
+		t.Errorf("the token names network %s, want %s", grant.Network(), f.netID)
+	}
+	if msg.GetExpiresAtUnix() != grant.ExpiresAt.Unix() {
+		t.Error("the reported expiry disagrees with the token's own")
+	}
+}
+
+// Asking again while the current token is comfortably valid returns the same one. Otherwise a
+// retry loop costs a signature per attempt and a device accumulates live credentials.
+func TestAskingAgainReturnsTheSameTokenWhileItIsValid(t *testing.T) {
+	f := newFixture(t)
+	f.withRelayIssuer(t)
+	alice := f.enrolDevice("alice")
+
+	sess := newSession("s", alice.membershipID, f.netID, uuid.New(), f.clk.Now())
+	first, expires, err := f.srv.relayTokenFor(f.ctx, sess)
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, expiresAgain, err := f.srv.relayTokenFor(f.ctx, sess)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(again) || !expires.Equal(expiresAgain) {
+		t.Error("a second request minted a new token although the first was still good")
+	}
+
+	// Close to expiry it is replaced, or an agent would be handed something about to die.
+	f.clk.Advance(relaytoken.DefaultTTL - time.Minute)
+	fresh, _, err := f.srv.relayTokenFor(f.ctx, sess)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(fresh) == string(first) {
+		t.Error("a token near expiry was handed out again rather than replaced")
+	}
+}
+
+// A deployment that has not configured relaying still enrols devices and carries state. An
+// agent asking is told, rather than met with silence it would retry against forever.
+func TestADeploymentWithoutARelayKeySaysSo(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+
+	msg := f.askForToken(t, alice.membershipID)
+	if msg.GetError() == "" {
+		t.Error("a deployment with no signing key issued a token")
+	}
+	if len(msg.GetToken()) != 0 {
+		t.Error("a refusal carried a token anyway")
+	}
+}
+
+// An agent whose membership has vanished must be refused rather than crash the read loop.
+func TestAnUnknownMembershipIsRefused(t *testing.T) {
+	f := newFixture(t)
+	f.withRelayIssuer(t)
+
+	msg := f.askForToken(t, uuid.New())
+	if msg.GetError() == "" {
+		t.Error("a token was issued for a membership that does not exist")
+	}
+}
+
+func TestAnIssuerRefusesAMalformedSigningKey(t *testing.T) {
+	if _, err := NewRelayIssuer(ed25519.PrivateKey("short"), time.Minute); err == nil {
+		t.Error("a malformed signing key was accepted")
+	}
+	issuer, err := NewRelayIssuer(nil, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if issuer != nil {
+		t.Error("no signing key should mean no issuer")
+	}
+	if issuer.PublicKey() != nil {
+		t.Error("a nil issuer reported a public key")
+	}
+}
+
+// The relay is configured with exactly what PublicKey returns, so it had better be the half
+// that verifies this issuer's tokens.
+func TestTheReportedPublicKeyIsTheOneThatVerifies(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	issuer, err := NewRelayIssuer(priv, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var key relayproto.Key
+	key[0] = 1
+	tok, err := relaytoken.Issue(priv, key, [16]byte{}, time.Now().Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := relaytoken.Verify(issuer.PublicKey(), tok, time.Now()); err != nil {
+		t.Errorf("the reported public key does not verify this issuer's tokens: %v", err)
+	}
+}

--- a/internal/session/server.go
+++ b/internal/session/server.go
@@ -52,6 +52,11 @@ type Config struct {
 	// MasterSecret derives the session challenge key.
 	MasterSecret []byte
 
+	// RelayIssuer mints relay credentials when asked. Nil where a deployment has not
+	// configured relaying: enrolment and state still work, and an agent asking for a token
+	// is told relaying is unavailable rather than met with silence (ADR-0017).
+	RelayIssuer *RelayIssuer
+
 	Clock clock.Clock
 	Log   *slog.Logger
 }
@@ -62,6 +67,7 @@ type Server struct {
 	hub        *Hub
 	builder    *StateBuilder
 	challenger *challenge.Challenger
+	relay      *RelayIssuer
 	clk        clock.Clock
 	log        *slog.Logger
 }
@@ -83,6 +89,7 @@ func NewServer(st *store.Store, hub *Hub, cfg Config) (*Server, error) {
 		hub:        hub,
 		builder:    NewStateBuilder(st),
 		challenger: challenger,
+		relay:      cfg.RelayIssuer,
 		clk:        cfg.Clock,
 		log:        cfg.Log,
 	}, nil
@@ -327,6 +334,9 @@ func (s *Server) readLoop(ctx context.Context, conn *websocket.Conn, sess *Sessi
 		switch payload := msg.Payload.(type) {
 		case *meshpv1.ClientMessage_StateAck:
 			s.handleAck(ctx, sess, payload.StateAck)
+
+		case *meshpv1.ClientMessage_RelayTokenRequest:
+			s.handleRelayTokenRequest(ctx, sess)
 
 		case *meshpv1.ClientMessage_Heartbeat:
 			s.handleHeartbeat(ctx, sess, payload.Heartbeat)

--- a/internal/store/gen/sessions.sql.go
+++ b/internal/store/gen/sessions.sql.go
@@ -77,6 +77,24 @@ func (q *Queries) GetMembershipForSession(ctx context.Context, id uuid.UUID) (Ge
 	return i, err
 }
 
+const getWireGuardKeyForMembership = `-- name: GetWireGuardKeyForMembership :one
+SELECT public_key
+FROM wireguard_keys
+WHERE membership_id = $1
+`
+
+// The current WireGuard public key a membership presents.
+//
+// Separate from GetMembershipForSession because almost nothing needs it: the key identifies
+// this device to its peers and to a relay, and loading it on every state build would be work
+// for one caller.
+func (q *Queries) GetWireGuardKeyForMembership(ctx context.Context, membershipID uuid.UUID) (string, error) {
+	row := q.db.QueryRow(ctx, getWireGuardKeyForMembership, membershipID)
+	var public_key string
+	err := row.Scan(&public_key)
+	return public_key, err
+}
+
 const listPeersForMembership = `-- name: ListPeersForMembership :many
 SELECT
     m.id            AS membership_id,

--- a/proto/gen/meshp/v1/control.pb.go
+++ b/proto/gen/meshp/v1/control.pb.go
@@ -79,7 +79,7 @@ func (x RouteGroupAssignment_Mode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use RouteGroupAssignment_Mode.Descriptor instead.
 func (RouteGroupAssignment_Mode) EnumDescriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{12, 0}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{14, 0}
 }
 
 type RouteCandidate_Health int32
@@ -137,7 +137,7 @@ func (x RouteCandidate_Health) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use RouteCandidate_Health.Descriptor instead.
 func (RouteCandidate_Health) EnumDescriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{13, 0}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{15, 0}
 }
 
 type IceCandidate_Kind int32
@@ -192,7 +192,7 @@ func (x IceCandidate_Kind) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use IceCandidate_Kind.Descriptor instead.
 func (IceCandidate_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{19, 0}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{21, 0}
 }
 
 type PathReport_PeerPath_Kind int32
@@ -244,7 +244,7 @@ func (x PathReport_PeerPath_Kind) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use PathReport_PeerPath_Kind.Descriptor instead.
 func (PathReport_PeerPath_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{21, 0, 0}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{23, 0, 0}
 }
 
 type ClientMessage struct {
@@ -257,6 +257,7 @@ type ClientMessage struct {
 	//	*ClientMessage_PathReport
 	//	*ClientMessage_ReachabilityReport
 	//	*ClientMessage_Heartbeat
+	//	*ClientMessage_RelayTokenRequest
 	Payload       isClientMessage_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -353,6 +354,15 @@ func (x *ClientMessage) GetHeartbeat() *Heartbeat {
 	return nil
 }
 
+func (x *ClientMessage) GetRelayTokenRequest() *RelayTokenRequest {
+	if x != nil {
+		if x, ok := x.Payload.(*ClientMessage_RelayTokenRequest); ok {
+			return x.RelayTokenRequest
+		}
+	}
+	return nil
+}
+
 type isClientMessage_Payload interface {
 	isClientMessage_Payload()
 }
@@ -381,6 +391,10 @@ type ClientMessage_Heartbeat struct {
 	Heartbeat *Heartbeat `protobuf:"bytes,6,opt,name=heartbeat,proto3,oneof"`
 }
 
+type ClientMessage_RelayTokenRequest struct {
+	RelayTokenRequest *RelayTokenRequest `protobuf:"bytes,7,opt,name=relay_token_request,json=relayTokenRequest,proto3,oneof"`
+}
+
 func (*ClientMessage_Hello) isClientMessage_Payload() {}
 
 func (*ClientMessage_StateAck) isClientMessage_Payload() {}
@@ -393,6 +407,8 @@ func (*ClientMessage_ReachabilityReport) isClientMessage_Payload() {}
 
 func (*ClientMessage_Heartbeat) isClientMessage_Payload() {}
 
+func (*ClientMessage_RelayTokenRequest) isClientMessage_Payload() {}
+
 type ServerMessage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Payload:
@@ -402,6 +418,7 @@ type ServerMessage struct {
 	//	*ServerMessage_Signal
 	//	*ServerMessage_Command
 	//	*ServerMessage_HeartbeatAck
+	//	*ServerMessage_RelayToken
 	Payload       isServerMessage_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -489,6 +506,15 @@ func (x *ServerMessage) GetHeartbeatAck() *HeartbeatAck {
 	return nil
 }
 
+func (x *ServerMessage) GetRelayToken() *RelayToken {
+	if x != nil {
+		if x, ok := x.Payload.(*ServerMessage_RelayToken); ok {
+			return x.RelayToken
+		}
+	}
+	return nil
+}
+
 type isServerMessage_Payload interface {
 	isServerMessage_Payload()
 }
@@ -513,6 +539,10 @@ type ServerMessage_HeartbeatAck struct {
 	HeartbeatAck *HeartbeatAck `protobuf:"bytes,5,opt,name=heartbeat_ack,json=heartbeatAck,proto3,oneof"`
 }
 
+type ServerMessage_RelayToken struct {
+	RelayToken *RelayToken `protobuf:"bytes,6,opt,name=relay_token,json=relayToken,proto3,oneof"`
+}
+
 func (*ServerMessage_Hello) isServerMessage_Payload() {}
 
 func (*ServerMessage_StateDelta) isServerMessage_Payload() {}
@@ -522,6 +552,8 @@ func (*ServerMessage_Signal) isServerMessage_Payload() {}
 func (*ServerMessage_Command) isServerMessage_Payload() {}
 
 func (*ServerMessage_HeartbeatAck) isServerMessage_Payload() {}
+
+func (*ServerMessage_RelayToken) isServerMessage_Payload() {}
 
 type ClientHello struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1309,6 +1341,107 @@ func (x *PacketFilter) GetDefaultDeny() bool {
 	return false
 }
 
+// The agent asks for a relay credential rather than the server pushing one (ADR-0017): the
+// agent is the only party that knows when its token is near expiry, whether it is relaying at
+// all, and whether a relay has just refused it.
+type RelayTokenRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RelayTokenRequest) Reset() {
+	*x = RelayTokenRequest{}
+	mi := &file_meshp_v1_control_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RelayTokenRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RelayTokenRequest) ProtoMessage() {}
+
+func (x *RelayTokenRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_meshp_v1_control_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RelayTokenRequest.ProtoReflect.Descriptor instead.
+func (*RelayTokenRequest) Descriptor() ([]byte, []int) {
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{11}
+}
+
+type RelayToken struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Token         []byte                 `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`                                         // opaque to the agent; the relay verifies it
+	ExpiresAtUnix int64                  `protobuf:"varint,2,opt,name=expires_at_unix,json=expiresAtUnix,proto3" json:"expires_at_unix,omitempty"` // so the agent knows when to ask again
+	// Set when the server declines. The agent should stop asking until something changes;
+	// retrying a refusal in a loop is how a control plane gets a self-inflicted load problem.
+	Error         string `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RelayToken) Reset() {
+	*x = RelayToken{}
+	mi := &file_meshp_v1_control_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RelayToken) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RelayToken) ProtoMessage() {}
+
+func (x *RelayToken) ProtoReflect() protoreflect.Message {
+	mi := &file_meshp_v1_control_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RelayToken.ProtoReflect.Descriptor instead.
+func (*RelayToken) Descriptor() ([]byte, []int) {
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *RelayToken) GetToken() []byte {
+	if x != nil {
+		return x.Token
+	}
+	return nil
+}
+
+func (x *RelayToken) GetExpiresAtUnix() int64 {
+	if x != nil {
+		return x.ExpiresAtUnix
+	}
+	return 0
+}
+
+func (x *RelayToken) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
 type RelayConfig struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	Relays           []*RelayConfig_Relay   `protobuf:"bytes,1,rep,name=relays,proto3" json:"relays,omitempty"`
@@ -1319,7 +1452,7 @@ type RelayConfig struct {
 
 func (x *RelayConfig) Reset() {
 	*x = RelayConfig{}
-	mi := &file_meshp_v1_control_proto_msgTypes[11]
+	mi := &file_meshp_v1_control_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1331,7 +1464,7 @@ func (x *RelayConfig) String() string {
 func (*RelayConfig) ProtoMessage() {}
 
 func (x *RelayConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[11]
+	mi := &file_meshp_v1_control_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1344,7 +1477,7 @@ func (x *RelayConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RelayConfig.ProtoReflect.Descriptor instead.
 func (*RelayConfig) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{11}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *RelayConfig) GetRelays() []*RelayConfig_Relay {
@@ -1382,7 +1515,7 @@ type RouteGroupAssignment struct {
 
 func (x *RouteGroupAssignment) Reset() {
 	*x = RouteGroupAssignment{}
-	mi := &file_meshp_v1_control_proto_msgTypes[12]
+	mi := &file_meshp_v1_control_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1394,7 +1527,7 @@ func (x *RouteGroupAssignment) String() string {
 func (*RouteGroupAssignment) ProtoMessage() {}
 
 func (x *RouteGroupAssignment) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[12]
+	mi := &file_meshp_v1_control_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1407,7 +1540,7 @@ func (x *RouteGroupAssignment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteGroupAssignment.ProtoReflect.Descriptor instead.
 func (*RouteGroupAssignment) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{12}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *RouteGroupAssignment) GetRouteGroupId() string {
@@ -1477,7 +1610,7 @@ type RouteCandidate struct {
 
 func (x *RouteCandidate) Reset() {
 	*x = RouteCandidate{}
-	mi := &file_meshp_v1_control_proto_msgTypes[13]
+	mi := &file_meshp_v1_control_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1489,7 +1622,7 @@ func (x *RouteCandidate) String() string {
 func (*RouteCandidate) ProtoMessage() {}
 
 func (x *RouteCandidate) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[13]
+	mi := &file_meshp_v1_control_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1502,7 +1635,7 @@ func (x *RouteCandidate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteCandidate.ProtoReflect.Descriptor instead.
 func (*RouteCandidate) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{13}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *RouteCandidate) GetAdvertiserId() string {
@@ -1578,7 +1711,7 @@ type LocalFailoverPolicy struct {
 
 func (x *LocalFailoverPolicy) Reset() {
 	*x = LocalFailoverPolicy{}
-	mi := &file_meshp_v1_control_proto_msgTypes[14]
+	mi := &file_meshp_v1_control_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1590,7 +1723,7 @@ func (x *LocalFailoverPolicy) String() string {
 func (*LocalFailoverPolicy) ProtoMessage() {}
 
 func (x *LocalFailoverPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[14]
+	mi := &file_meshp_v1_control_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1603,7 +1736,7 @@ func (x *LocalFailoverPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LocalFailoverPolicy.ProtoReflect.Descriptor instead.
 func (*LocalFailoverPolicy) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{14}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *LocalFailoverPolicy) GetEnabled() bool {
@@ -1673,7 +1806,7 @@ type SignalEnvelope struct {
 
 func (x *SignalEnvelope) Reset() {
 	*x = SignalEnvelope{}
-	mi := &file_meshp_v1_control_proto_msgTypes[15]
+	mi := &file_meshp_v1_control_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1685,7 +1818,7 @@ func (x *SignalEnvelope) String() string {
 func (*SignalEnvelope) ProtoMessage() {}
 
 func (x *SignalEnvelope) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[15]
+	mi := &file_meshp_v1_control_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1698,7 +1831,7 @@ func (x *SignalEnvelope) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignalEnvelope.ProtoReflect.Descriptor instead.
 func (*SignalEnvelope) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{15}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *SignalEnvelope) GetFromMembershipId() string {
@@ -1805,7 +1938,7 @@ type IceOffer struct {
 
 func (x *IceOffer) Reset() {
 	*x = IceOffer{}
-	mi := &file_meshp_v1_control_proto_msgTypes[16]
+	mi := &file_meshp_v1_control_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1817,7 +1950,7 @@ func (x *IceOffer) String() string {
 func (*IceOffer) ProtoMessage() {}
 
 func (x *IceOffer) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[16]
+	mi := &file_meshp_v1_control_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1830,7 +1963,7 @@ func (x *IceOffer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IceOffer.ProtoReflect.Descriptor instead.
 func (*IceOffer) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{16}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *IceOffer) GetCandidates() []*IceCandidate {
@@ -1874,7 +2007,7 @@ type IceAnswer struct {
 
 func (x *IceAnswer) Reset() {
 	*x = IceAnswer{}
-	mi := &file_meshp_v1_control_proto_msgTypes[17]
+	mi := &file_meshp_v1_control_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1886,7 +2019,7 @@ func (x *IceAnswer) String() string {
 func (*IceAnswer) ProtoMessage() {}
 
 func (x *IceAnswer) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[17]
+	mi := &file_meshp_v1_control_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1899,7 +2032,7 @@ func (x *IceAnswer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IceAnswer.ProtoReflect.Descriptor instead.
 func (*IceAnswer) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{17}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *IceAnswer) GetCandidates() []*IceCandidate {
@@ -1946,7 +2079,7 @@ type IceCandidates struct {
 
 func (x *IceCandidates) Reset() {
 	*x = IceCandidates{}
-	mi := &file_meshp_v1_control_proto_msgTypes[18]
+	mi := &file_meshp_v1_control_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1958,7 +2091,7 @@ func (x *IceCandidates) String() string {
 func (*IceCandidates) ProtoMessage() {}
 
 func (x *IceCandidates) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[18]
+	mi := &file_meshp_v1_control_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1971,7 +2104,7 @@ func (x *IceCandidates) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IceCandidates.ProtoReflect.Descriptor instead.
 func (*IceCandidates) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{18}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *IceCandidates) GetCandidates() []*IceCandidate {
@@ -1994,7 +2127,7 @@ type IceCandidate struct {
 
 func (x *IceCandidate) Reset() {
 	*x = IceCandidate{}
-	mi := &file_meshp_v1_control_proto_msgTypes[19]
+	mi := &file_meshp_v1_control_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2006,7 +2139,7 @@ func (x *IceCandidate) String() string {
 func (*IceCandidate) ProtoMessage() {}
 
 func (x *IceCandidate) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[19]
+	mi := &file_meshp_v1_control_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2019,7 +2152,7 @@ func (x *IceCandidate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IceCandidate.ProtoReflect.Descriptor instead.
 func (*IceCandidate) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{19}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *IceCandidate) GetKind() IceCandidate_Kind {
@@ -2066,7 +2199,7 @@ type PathGiveUp struct {
 
 func (x *PathGiveUp) Reset() {
 	*x = PathGiveUp{}
-	mi := &file_meshp_v1_control_proto_msgTypes[20]
+	mi := &file_meshp_v1_control_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2078,7 +2211,7 @@ func (x *PathGiveUp) String() string {
 func (*PathGiveUp) ProtoMessage() {}
 
 func (x *PathGiveUp) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[20]
+	mi := &file_meshp_v1_control_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2091,7 +2224,7 @@ func (x *PathGiveUp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PathGiveUp.ProtoReflect.Descriptor instead.
 func (*PathGiveUp) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{20}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *PathGiveUp) GetReason() string {
@@ -2111,7 +2244,7 @@ type PathReport struct {
 
 func (x *PathReport) Reset() {
 	*x = PathReport{}
-	mi := &file_meshp_v1_control_proto_msgTypes[21]
+	mi := &file_meshp_v1_control_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2123,7 +2256,7 @@ func (x *PathReport) String() string {
 func (*PathReport) ProtoMessage() {}
 
 func (x *PathReport) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[21]
+	mi := &file_meshp_v1_control_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2136,7 +2269,7 @@ func (x *PathReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PathReport.ProtoReflect.Descriptor instead.
 func (*PathReport) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{21}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *PathReport) GetPaths() []*PathReport_PeerPath {
@@ -2171,7 +2304,7 @@ type ReachabilityReport struct {
 
 func (x *ReachabilityReport) Reset() {
 	*x = ReachabilityReport{}
-	mi := &file_meshp_v1_control_proto_msgTypes[22]
+	mi := &file_meshp_v1_control_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2183,7 +2316,7 @@ func (x *ReachabilityReport) String() string {
 func (*ReachabilityReport) ProtoMessage() {}
 
 func (x *ReachabilityReport) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[22]
+	mi := &file_meshp_v1_control_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2196,7 +2329,7 @@ func (x *ReachabilityReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReachabilityReport.ProtoReflect.Descriptor instead.
 func (*ReachabilityReport) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{22}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ReachabilityReport) GetRouteGroupId() string {
@@ -2265,7 +2398,7 @@ type Heartbeat struct {
 
 func (x *Heartbeat) Reset() {
 	*x = Heartbeat{}
-	mi := &file_meshp_v1_control_proto_msgTypes[23]
+	mi := &file_meshp_v1_control_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2277,7 +2410,7 @@ func (x *Heartbeat) String() string {
 func (*Heartbeat) ProtoMessage() {}
 
 func (x *Heartbeat) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[23]
+	mi := &file_meshp_v1_control_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2290,7 +2423,7 @@ func (x *Heartbeat) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Heartbeat.ProtoReflect.Descriptor instead.
 func (*Heartbeat) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{23}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *Heartbeat) GetAppliedStateVersion() uint64 {
@@ -2319,7 +2452,7 @@ type HeartbeatAck struct {
 
 func (x *HeartbeatAck) Reset() {
 	*x = HeartbeatAck{}
-	mi := &file_meshp_v1_control_proto_msgTypes[24]
+	mi := &file_meshp_v1_control_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2331,7 +2464,7 @@ func (x *HeartbeatAck) String() string {
 func (*HeartbeatAck) ProtoMessage() {}
 
 func (x *HeartbeatAck) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[24]
+	mi := &file_meshp_v1_control_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2344,7 +2477,7 @@ func (x *HeartbeatAck) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatAck.ProtoReflect.Descriptor instead.
 func (*HeartbeatAck) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{24}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *HeartbeatAck) GetCurrentStateVersion() uint64 {
@@ -2382,7 +2515,7 @@ type Command struct {
 
 func (x *Command) Reset() {
 	*x = Command{}
-	mi := &file_meshp_v1_control_proto_msgTypes[25]
+	mi := &file_meshp_v1_control_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2394,7 +2527,7 @@ func (x *Command) String() string {
 func (*Command) ProtoMessage() {}
 
 func (x *Command) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[25]
+	mi := &file_meshp_v1_control_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2407,7 +2540,7 @@ func (x *Command) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Command.ProtoReflect.Descriptor instead.
 func (*Command) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{25}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *Command) GetPayload() isCommand_Payload {
@@ -2478,7 +2611,7 @@ type Revoke struct {
 
 func (x *Revoke) Reset() {
 	*x = Revoke{}
-	mi := &file_meshp_v1_control_proto_msgTypes[26]
+	mi := &file_meshp_v1_control_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2490,7 +2623,7 @@ func (x *Revoke) String() string {
 func (*Revoke) ProtoMessage() {}
 
 func (x *Revoke) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[26]
+	mi := &file_meshp_v1_control_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2503,7 +2636,7 @@ func (x *Revoke) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Revoke.ProtoReflect.Descriptor instead.
 func (*Revoke) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{26}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *Revoke) GetReason() string {
@@ -2530,7 +2663,7 @@ type Reconnect struct {
 
 func (x *Reconnect) Reset() {
 	*x = Reconnect{}
-	mi := &file_meshp_v1_control_proto_msgTypes[27]
+	mi := &file_meshp_v1_control_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2542,7 +2675,7 @@ func (x *Reconnect) String() string {
 func (*Reconnect) ProtoMessage() {}
 
 func (x *Reconnect) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[27]
+	mi := &file_meshp_v1_control_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2555,7 +2688,7 @@ func (x *Reconnect) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Reconnect.ProtoReflect.Descriptor instead.
 func (*Reconnect) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{27}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *Reconnect) GetReason() string {
@@ -2583,7 +2716,7 @@ type CollectDiagnostics struct {
 
 func (x *CollectDiagnostics) Reset() {
 	*x = CollectDiagnostics{}
-	mi := &file_meshp_v1_control_proto_msgTypes[28]
+	mi := &file_meshp_v1_control_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2595,7 +2728,7 @@ func (x *CollectDiagnostics) String() string {
 func (*CollectDiagnostics) ProtoMessage() {}
 
 func (x *CollectDiagnostics) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[28]
+	mi := &file_meshp_v1_control_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2608,7 +2741,7 @@ func (x *CollectDiagnostics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CollectDiagnostics.ProtoReflect.Descriptor instead.
 func (*CollectDiagnostics) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{28}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *CollectDiagnostics) GetUploadUrl() string {
@@ -2637,7 +2770,7 @@ type DnsConfig_Route struct {
 
 func (x *DnsConfig_Route) Reset() {
 	*x = DnsConfig_Route{}
-	mi := &file_meshp_v1_control_proto_msgTypes[29]
+	mi := &file_meshp_v1_control_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2649,7 +2782,7 @@ func (x *DnsConfig_Route) String() string {
 func (*DnsConfig_Route) ProtoMessage() {}
 
 func (x *DnsConfig_Route) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[29]
+	mi := &file_meshp_v1_control_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2692,7 +2825,7 @@ type PacketFilter_Rule struct {
 
 func (x *PacketFilter_Rule) Reset() {
 	*x = PacketFilter_Rule{}
-	mi := &file_meshp_v1_control_proto_msgTypes[30]
+	mi := &file_meshp_v1_control_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2704,7 +2837,7 @@ func (x *PacketFilter_Rule) String() string {
 func (*PacketFilter_Rule) ProtoMessage() {}
 
 func (x *PacketFilter_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[30]
+	mi := &file_meshp_v1_control_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2767,7 +2900,7 @@ type RelayConfig_Relay struct {
 
 func (x *RelayConfig_Relay) Reset() {
 	*x = RelayConfig_Relay{}
-	mi := &file_meshp_v1_control_proto_msgTypes[31]
+	mi := &file_meshp_v1_control_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2779,7 +2912,7 @@ func (x *RelayConfig_Relay) String() string {
 func (*RelayConfig_Relay) ProtoMessage() {}
 
 func (x *RelayConfig_Relay) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[31]
+	mi := &file_meshp_v1_control_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2792,7 +2925,7 @@ func (x *RelayConfig_Relay) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RelayConfig_Relay.ProtoReflect.Descriptor instead.
 func (*RelayConfig_Relay) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{11, 0}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{13, 0}
 }
 
 func (x *RelayConfig_Relay) GetId() string {
@@ -2838,7 +2971,7 @@ type PathReport_PeerPath struct {
 
 func (x *PathReport_PeerPath) Reset() {
 	*x = PathReport_PeerPath{}
-	mi := &file_meshp_v1_control_proto_msgTypes[32]
+	mi := &file_meshp_v1_control_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2850,7 +2983,7 @@ func (x *PathReport_PeerPath) String() string {
 func (*PathReport_PeerPath) ProtoMessage() {}
 
 func (x *PathReport_PeerPath) ProtoReflect() protoreflect.Message {
-	mi := &file_meshp_v1_control_proto_msgTypes[32]
+	mi := &file_meshp_v1_control_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2863,7 +2996,7 @@ func (x *PathReport_PeerPath) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PathReport_PeerPath.ProtoReflect.Descriptor instead.
 func (*PathReport_PeerPath) Descriptor() ([]byte, []int) {
-	return file_meshp_v1_control_proto_rawDescGZIP(), []int{21, 0}
+	return file_meshp_v1_control_proto_rawDescGZIP(), []int{23, 0}
 }
 
 func (x *PathReport_PeerPath) GetPeerPublicKey() string {
@@ -2919,7 +3052,7 @@ var File_meshp_v1_control_proto protoreflect.FileDescriptor
 
 const file_meshp_v1_control_proto_rawDesc = "" +
 	"\n" +
-	"\x16meshp/v1/control.proto\x12\bmeshp.v1\"\xef\x02\n" +
+	"\x16meshp/v1/control.proto\x12\bmeshp.v1\"\xbe\x03\n" +
 	"\rClientMessage\x12-\n" +
 	"\x05hello\x18\x01 \x01(\v2\x15.meshp.v1.ClientHelloH\x00R\x05hello\x121\n" +
 	"\tstate_ack\x18\x02 \x01(\v2\x12.meshp.v1.StateAckH\x00R\bstateAck\x122\n" +
@@ -2927,15 +3060,18 @@ const file_meshp_v1_control_proto_rawDesc = "" +
 	"\vpath_report\x18\x04 \x01(\v2\x14.meshp.v1.PathReportH\x00R\n" +
 	"pathReport\x12O\n" +
 	"\x13reachability_report\x18\x05 \x01(\v2\x1c.meshp.v1.ReachabilityReportH\x00R\x12reachabilityReport\x123\n" +
-	"\theartbeat\x18\x06 \x01(\v2\x13.meshp.v1.HeartbeatH\x00R\theartbeatB\t\n" +
-	"\apayload\"\xa4\x02\n" +
+	"\theartbeat\x18\x06 \x01(\v2\x13.meshp.v1.HeartbeatH\x00R\theartbeat\x12M\n" +
+	"\x13relay_token_request\x18\a \x01(\v2\x1b.meshp.v1.RelayTokenRequestH\x00R\x11relayTokenRequestB\t\n" +
+	"\apayload\"\xdd\x02\n" +
 	"\rServerMessage\x12-\n" +
 	"\x05hello\x18\x01 \x01(\v2\x15.meshp.v1.ServerHelloH\x00R\x05hello\x127\n" +
 	"\vstate_delta\x18\x02 \x01(\v2\x14.meshp.v1.StateDeltaH\x00R\n" +
 	"stateDelta\x122\n" +
 	"\x06signal\x18\x03 \x01(\v2\x18.meshp.v1.SignalEnvelopeH\x00R\x06signal\x12-\n" +
 	"\acommand\x18\x04 \x01(\v2\x11.meshp.v1.CommandH\x00R\acommand\x12=\n" +
-	"\rheartbeat_ack\x18\x05 \x01(\v2\x16.meshp.v1.HeartbeatAckH\x00R\fheartbeatAckB\t\n" +
+	"\rheartbeat_ack\x18\x05 \x01(\v2\x16.meshp.v1.HeartbeatAckH\x00R\fheartbeatAck\x127\n" +
+	"\vrelay_token\x18\x06 \x01(\v2\x14.meshp.v1.RelayTokenH\x00R\n" +
+	"relayTokenB\t\n" +
 	"\apayload\"\x96\x03\n" +
 	"\vClientHello\x12.\n" +
 	"\x13identity_public_key\x18\x01 \x01(\fR\x11identityPublicKey\x12/\n" +
@@ -3020,7 +3156,13 @@ const file_meshp_v1_control_proto_rawDesc = "" +
 	"\fdst_prefixes\x18\x02 \x03(\tR\vdstPrefixes\x12\x1a\n" +
 	"\bprotocol\x18\x03 \x01(\tR\bprotocol\x12\x14\n" +
 	"\x05ports\x18\x04 \x03(\tR\x05ports\x12\x14\n" +
-	"\x05allow\x18\x05 \x01(\bR\x05allow\"\xde\x01\n" +
+	"\x05allow\x18\x05 \x01(\bR\x05allow\"\x13\n" +
+	"\x11RelayTokenRequest\"`\n" +
+	"\n" +
+	"RelayToken\x12\x14\n" +
+	"\x05token\x18\x01 \x01(\fR\x05token\x12&\n" +
+	"\x0fexpires_at_unix\x18\x02 \x01(\x03R\rexpiresAtUnix\x12\x14\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"\xde\x01\n" +
 	"\vRelayConfig\x123\n" +
 	"\x06relays\x18\x01 \x03(\v2\x1b.meshp.v1.RelayConfig.RelayR\x06relays\x12,\n" +
 	"\x12preferred_relay_id\x18\x02 \x01(\tR\x10preferredRelayId\x1al\n" +
@@ -3178,7 +3320,7 @@ func file_meshp_v1_control_proto_rawDescGZIP() []byte {
 }
 
 var file_meshp_v1_control_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_meshp_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_meshp_v1_control_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_meshp_v1_control_proto_goTypes = []any{
 	(RouteGroupAssignment_Mode)(0), // 0: meshp.v1.RouteGroupAssignment.Mode
 	(RouteCandidate_Health)(0),     // 1: meshp.v1.RouteCandidate.Health
@@ -3195,74 +3337,78 @@ var file_meshp_v1_control_proto_goTypes = []any{
 	(*TunnelConfig)(nil),           // 12: meshp.v1.TunnelConfig
 	(*DnsConfig)(nil),              // 13: meshp.v1.DnsConfig
 	(*PacketFilter)(nil),           // 14: meshp.v1.PacketFilter
-	(*RelayConfig)(nil),            // 15: meshp.v1.RelayConfig
-	(*RouteGroupAssignment)(nil),   // 16: meshp.v1.RouteGroupAssignment
-	(*RouteCandidate)(nil),         // 17: meshp.v1.RouteCandidate
-	(*LocalFailoverPolicy)(nil),    // 18: meshp.v1.LocalFailoverPolicy
-	(*SignalEnvelope)(nil),         // 19: meshp.v1.SignalEnvelope
-	(*IceOffer)(nil),               // 20: meshp.v1.IceOffer
-	(*IceAnswer)(nil),              // 21: meshp.v1.IceAnswer
-	(*IceCandidates)(nil),          // 22: meshp.v1.IceCandidates
-	(*IceCandidate)(nil),           // 23: meshp.v1.IceCandidate
-	(*PathGiveUp)(nil),             // 24: meshp.v1.PathGiveUp
-	(*PathReport)(nil),             // 25: meshp.v1.PathReport
-	(*ReachabilityReport)(nil),     // 26: meshp.v1.ReachabilityReport
-	(*Heartbeat)(nil),              // 27: meshp.v1.Heartbeat
-	(*HeartbeatAck)(nil),           // 28: meshp.v1.HeartbeatAck
-	(*Command)(nil),                // 29: meshp.v1.Command
-	(*Revoke)(nil),                 // 30: meshp.v1.Revoke
-	(*Reconnect)(nil),              // 31: meshp.v1.Reconnect
-	(*CollectDiagnostics)(nil),     // 32: meshp.v1.CollectDiagnostics
-	(*DnsConfig_Route)(nil),        // 33: meshp.v1.DnsConfig.Route
-	(*PacketFilter_Rule)(nil),      // 34: meshp.v1.PacketFilter.Rule
-	(*RelayConfig_Relay)(nil),      // 35: meshp.v1.RelayConfig.Relay
-	(*PathReport_PeerPath)(nil),    // 36: meshp.v1.PathReport.PeerPath
+	(*RelayTokenRequest)(nil),      // 15: meshp.v1.RelayTokenRequest
+	(*RelayToken)(nil),             // 16: meshp.v1.RelayToken
+	(*RelayConfig)(nil),            // 17: meshp.v1.RelayConfig
+	(*RouteGroupAssignment)(nil),   // 18: meshp.v1.RouteGroupAssignment
+	(*RouteCandidate)(nil),         // 19: meshp.v1.RouteCandidate
+	(*LocalFailoverPolicy)(nil),    // 20: meshp.v1.LocalFailoverPolicy
+	(*SignalEnvelope)(nil),         // 21: meshp.v1.SignalEnvelope
+	(*IceOffer)(nil),               // 22: meshp.v1.IceOffer
+	(*IceAnswer)(nil),              // 23: meshp.v1.IceAnswer
+	(*IceCandidates)(nil),          // 24: meshp.v1.IceCandidates
+	(*IceCandidate)(nil),           // 25: meshp.v1.IceCandidate
+	(*PathGiveUp)(nil),             // 26: meshp.v1.PathGiveUp
+	(*PathReport)(nil),             // 27: meshp.v1.PathReport
+	(*ReachabilityReport)(nil),     // 28: meshp.v1.ReachabilityReport
+	(*Heartbeat)(nil),              // 29: meshp.v1.Heartbeat
+	(*HeartbeatAck)(nil),           // 30: meshp.v1.HeartbeatAck
+	(*Command)(nil),                // 31: meshp.v1.Command
+	(*Revoke)(nil),                 // 32: meshp.v1.Revoke
+	(*Reconnect)(nil),              // 33: meshp.v1.Reconnect
+	(*CollectDiagnostics)(nil),     // 34: meshp.v1.CollectDiagnostics
+	(*DnsConfig_Route)(nil),        // 35: meshp.v1.DnsConfig.Route
+	(*PacketFilter_Rule)(nil),      // 36: meshp.v1.PacketFilter.Rule
+	(*RelayConfig_Relay)(nil),      // 37: meshp.v1.RelayConfig.Relay
+	(*PathReport_PeerPath)(nil),    // 38: meshp.v1.PathReport.PeerPath
 }
 var file_meshp_v1_control_proto_depIdxs = []int32{
 	6,  // 0: meshp.v1.ClientMessage.hello:type_name -> meshp.v1.ClientHello
 	10, // 1: meshp.v1.ClientMessage.state_ack:type_name -> meshp.v1.StateAck
-	19, // 2: meshp.v1.ClientMessage.signal:type_name -> meshp.v1.SignalEnvelope
-	25, // 3: meshp.v1.ClientMessage.path_report:type_name -> meshp.v1.PathReport
-	26, // 4: meshp.v1.ClientMessage.reachability_report:type_name -> meshp.v1.ReachabilityReport
-	27, // 5: meshp.v1.ClientMessage.heartbeat:type_name -> meshp.v1.Heartbeat
-	8,  // 6: meshp.v1.ServerMessage.hello:type_name -> meshp.v1.ServerHello
-	9,  // 7: meshp.v1.ServerMessage.state_delta:type_name -> meshp.v1.StateDelta
-	19, // 8: meshp.v1.ServerMessage.signal:type_name -> meshp.v1.SignalEnvelope
-	29, // 9: meshp.v1.ServerMessage.command:type_name -> meshp.v1.Command
-	28, // 10: meshp.v1.ServerMessage.heartbeat_ack:type_name -> meshp.v1.HeartbeatAck
-	7,  // 11: meshp.v1.ClientHello.capabilities:type_name -> meshp.v1.AgentCapabilities
-	11, // 12: meshp.v1.StateDelta.upsert_peers:type_name -> meshp.v1.Peer
-	13, // 13: meshp.v1.StateDelta.dns:type_name -> meshp.v1.DnsConfig
-	14, // 14: meshp.v1.StateDelta.filter:type_name -> meshp.v1.PacketFilter
-	16, // 15: meshp.v1.StateDelta.route_groups:type_name -> meshp.v1.RouteGroupAssignment
-	15, // 16: meshp.v1.StateDelta.relays:type_name -> meshp.v1.RelayConfig
-	12, // 17: meshp.v1.StateDelta.tunnel:type_name -> meshp.v1.TunnelConfig
-	33, // 18: meshp.v1.DnsConfig.routes:type_name -> meshp.v1.DnsConfig.Route
-	34, // 19: meshp.v1.PacketFilter.inbound:type_name -> meshp.v1.PacketFilter.Rule
-	34, // 20: meshp.v1.PacketFilter.outbound:type_name -> meshp.v1.PacketFilter.Rule
-	35, // 21: meshp.v1.RelayConfig.relays:type_name -> meshp.v1.RelayConfig.Relay
-	0,  // 22: meshp.v1.RouteGroupAssignment.mode:type_name -> meshp.v1.RouteGroupAssignment.Mode
-	17, // 23: meshp.v1.RouteGroupAssignment.candidates:type_name -> meshp.v1.RouteCandidate
-	18, // 24: meshp.v1.RouteGroupAssignment.local_failover:type_name -> meshp.v1.LocalFailoverPolicy
-	1,  // 25: meshp.v1.RouteCandidate.server_health:type_name -> meshp.v1.RouteCandidate.Health
-	20, // 26: meshp.v1.SignalEnvelope.offer:type_name -> meshp.v1.IceOffer
-	21, // 27: meshp.v1.SignalEnvelope.answer:type_name -> meshp.v1.IceAnswer
-	22, // 28: meshp.v1.SignalEnvelope.candidates:type_name -> meshp.v1.IceCandidates
-	24, // 29: meshp.v1.SignalEnvelope.give_up:type_name -> meshp.v1.PathGiveUp
-	23, // 30: meshp.v1.IceOffer.candidates:type_name -> meshp.v1.IceCandidate
-	23, // 31: meshp.v1.IceAnswer.candidates:type_name -> meshp.v1.IceCandidate
-	23, // 32: meshp.v1.IceCandidates.candidates:type_name -> meshp.v1.IceCandidate
-	2,  // 33: meshp.v1.IceCandidate.kind:type_name -> meshp.v1.IceCandidate.Kind
-	36, // 34: meshp.v1.PathReport.paths:type_name -> meshp.v1.PathReport.PeerPath
-	30, // 35: meshp.v1.Command.revoke:type_name -> meshp.v1.Revoke
-	31, // 36: meshp.v1.Command.reconnect:type_name -> meshp.v1.Reconnect
-	32, // 37: meshp.v1.Command.collect_diagnostics:type_name -> meshp.v1.CollectDiagnostics
-	3,  // 38: meshp.v1.PathReport.PeerPath.kind:type_name -> meshp.v1.PathReport.PeerPath.Kind
-	39, // [39:39] is the sub-list for method output_type
-	39, // [39:39] is the sub-list for method input_type
-	39, // [39:39] is the sub-list for extension type_name
-	39, // [39:39] is the sub-list for extension extendee
-	0,  // [0:39] is the sub-list for field type_name
+	21, // 2: meshp.v1.ClientMessage.signal:type_name -> meshp.v1.SignalEnvelope
+	27, // 3: meshp.v1.ClientMessage.path_report:type_name -> meshp.v1.PathReport
+	28, // 4: meshp.v1.ClientMessage.reachability_report:type_name -> meshp.v1.ReachabilityReport
+	29, // 5: meshp.v1.ClientMessage.heartbeat:type_name -> meshp.v1.Heartbeat
+	15, // 6: meshp.v1.ClientMessage.relay_token_request:type_name -> meshp.v1.RelayTokenRequest
+	8,  // 7: meshp.v1.ServerMessage.hello:type_name -> meshp.v1.ServerHello
+	9,  // 8: meshp.v1.ServerMessage.state_delta:type_name -> meshp.v1.StateDelta
+	21, // 9: meshp.v1.ServerMessage.signal:type_name -> meshp.v1.SignalEnvelope
+	31, // 10: meshp.v1.ServerMessage.command:type_name -> meshp.v1.Command
+	30, // 11: meshp.v1.ServerMessage.heartbeat_ack:type_name -> meshp.v1.HeartbeatAck
+	16, // 12: meshp.v1.ServerMessage.relay_token:type_name -> meshp.v1.RelayToken
+	7,  // 13: meshp.v1.ClientHello.capabilities:type_name -> meshp.v1.AgentCapabilities
+	11, // 14: meshp.v1.StateDelta.upsert_peers:type_name -> meshp.v1.Peer
+	13, // 15: meshp.v1.StateDelta.dns:type_name -> meshp.v1.DnsConfig
+	14, // 16: meshp.v1.StateDelta.filter:type_name -> meshp.v1.PacketFilter
+	18, // 17: meshp.v1.StateDelta.route_groups:type_name -> meshp.v1.RouteGroupAssignment
+	17, // 18: meshp.v1.StateDelta.relays:type_name -> meshp.v1.RelayConfig
+	12, // 19: meshp.v1.StateDelta.tunnel:type_name -> meshp.v1.TunnelConfig
+	35, // 20: meshp.v1.DnsConfig.routes:type_name -> meshp.v1.DnsConfig.Route
+	36, // 21: meshp.v1.PacketFilter.inbound:type_name -> meshp.v1.PacketFilter.Rule
+	36, // 22: meshp.v1.PacketFilter.outbound:type_name -> meshp.v1.PacketFilter.Rule
+	37, // 23: meshp.v1.RelayConfig.relays:type_name -> meshp.v1.RelayConfig.Relay
+	0,  // 24: meshp.v1.RouteGroupAssignment.mode:type_name -> meshp.v1.RouteGroupAssignment.Mode
+	19, // 25: meshp.v1.RouteGroupAssignment.candidates:type_name -> meshp.v1.RouteCandidate
+	20, // 26: meshp.v1.RouteGroupAssignment.local_failover:type_name -> meshp.v1.LocalFailoverPolicy
+	1,  // 27: meshp.v1.RouteCandidate.server_health:type_name -> meshp.v1.RouteCandidate.Health
+	22, // 28: meshp.v1.SignalEnvelope.offer:type_name -> meshp.v1.IceOffer
+	23, // 29: meshp.v1.SignalEnvelope.answer:type_name -> meshp.v1.IceAnswer
+	24, // 30: meshp.v1.SignalEnvelope.candidates:type_name -> meshp.v1.IceCandidates
+	26, // 31: meshp.v1.SignalEnvelope.give_up:type_name -> meshp.v1.PathGiveUp
+	25, // 32: meshp.v1.IceOffer.candidates:type_name -> meshp.v1.IceCandidate
+	25, // 33: meshp.v1.IceAnswer.candidates:type_name -> meshp.v1.IceCandidate
+	25, // 34: meshp.v1.IceCandidates.candidates:type_name -> meshp.v1.IceCandidate
+	2,  // 35: meshp.v1.IceCandidate.kind:type_name -> meshp.v1.IceCandidate.Kind
+	38, // 36: meshp.v1.PathReport.paths:type_name -> meshp.v1.PathReport.PeerPath
+	32, // 37: meshp.v1.Command.revoke:type_name -> meshp.v1.Revoke
+	33, // 38: meshp.v1.Command.reconnect:type_name -> meshp.v1.Reconnect
+	34, // 39: meshp.v1.Command.collect_diagnostics:type_name -> meshp.v1.CollectDiagnostics
+	3,  // 40: meshp.v1.PathReport.PeerPath.kind:type_name -> meshp.v1.PathReport.PeerPath.Kind
+	41, // [41:41] is the sub-list for method output_type
+	41, // [41:41] is the sub-list for method input_type
+	41, // [41:41] is the sub-list for extension type_name
+	41, // [41:41] is the sub-list for extension extendee
+	0,  // [0:41] is the sub-list for field type_name
 }
 
 func init() { file_meshp_v1_control_proto_init() }
@@ -3277,6 +3423,7 @@ func file_meshp_v1_control_proto_init() {
 		(*ClientMessage_PathReport)(nil),
 		(*ClientMessage_ReachabilityReport)(nil),
 		(*ClientMessage_Heartbeat)(nil),
+		(*ClientMessage_RelayTokenRequest)(nil),
 	}
 	file_meshp_v1_control_proto_msgTypes[1].OneofWrappers = []any{
 		(*ServerMessage_Hello)(nil),
@@ -3284,14 +3431,15 @@ func file_meshp_v1_control_proto_init() {
 		(*ServerMessage_Signal)(nil),
 		(*ServerMessage_Command)(nil),
 		(*ServerMessage_HeartbeatAck)(nil),
+		(*ServerMessage_RelayToken)(nil),
 	}
-	file_meshp_v1_control_proto_msgTypes[15].OneofWrappers = []any{
+	file_meshp_v1_control_proto_msgTypes[17].OneofWrappers = []any{
 		(*SignalEnvelope_Offer)(nil),
 		(*SignalEnvelope_Answer)(nil),
 		(*SignalEnvelope_Candidates)(nil),
 		(*SignalEnvelope_GiveUp)(nil),
 	}
-	file_meshp_v1_control_proto_msgTypes[25].OneofWrappers = []any{
+	file_meshp_v1_control_proto_msgTypes[27].OneofWrappers = []any{
 		(*Command_Revoke)(nil),
 		(*Command_Reconnect)(nil),
 		(*Command_CollectDiagnostics)(nil),
@@ -3302,7 +3450,7 @@ func file_meshp_v1_control_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_meshp_v1_control_proto_rawDesc), len(file_meshp_v1_control_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   33,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/meshp/v1/control.proto
+++ b/proto/meshp/v1/control.proto
@@ -31,6 +31,7 @@ message ClientMessage {
     PathReport path_report = 4;
     ReachabilityReport reachability_report = 5;
     Heartbeat heartbeat = 6;
+    RelayTokenRequest relay_token_request = 7;
   }
 }
 
@@ -41,6 +42,7 @@ message ServerMessage {
     SignalEnvelope signal = 3;
     Command command = 4;
     HeartbeatAck heartbeat_ack = 5;
+    RelayToken relay_token = 6;
   }
 }
 
@@ -196,6 +198,23 @@ message PacketFilter {
   repeated Rule inbound = 1;
   repeated Rule outbound = 2;
   bool default_deny = 3;
+}
+
+// The agent asks for a relay credential rather than the server pushing one (ADR-0017): the
+// agent is the only party that knows when its token is near expiry, whether it is relaying at
+// all, and whether a relay has just refused it.
+message RelayTokenRequest {
+  // Deliberately empty. The session already establishes which membership is asking, and
+  // adding a device identifier here would create a second, weaker way to say who you are.
+}
+
+message RelayToken {
+  bytes token = 1;             // opaque to the agent; the relay verifies it
+  int64 expires_at_unix = 2;   // so the agent knows when to ask again
+
+  // Set when the server declines. The agent should stop asking until something changes;
+  // retrying a refusal in a loop is how a control plane gets a self-inflicted load problem.
+  string error = 3;
 }
 
 message RelayConfig {

--- a/queries/sessions.sql
+++ b/queries/sessions.sql
@@ -81,3 +81,13 @@ WHERE membership_id = $1;
 UPDATE device_network_memberships
 SET last_seen_at = sqlc.arg(now)
 WHERE id = $1;
+
+-- name: GetWireGuardKeyForMembership :one
+-- The current WireGuard public key a membership presents.
+--
+-- Separate from GetMembershipForSession because almost nothing needs it: the key identifies
+-- this device to its peers and to a relay, and loading it on every state build would be work
+-- for one caller.
+SELECT public_key
+FROM wireguard_keys
+WHERE membership_id = $1;


### PR DESCRIPTION
A relay verifies a short-lived signed capability naming one key and one network. Something has
to get it to the agent, and two facts about it decide how: it is **device-specific**, and it
lives **thirty minutes**.

Desired state is neither. It is network-scoped and versioned — so putting a per-device
credential in it would bump a network's state version for one device's token every half hour,
for every device, turning a counter that describes the network into a clock. The delta
machinery would work; the meaning would be wrong.

So the agent asks, on the control channel it already holds. Two additive messages.

**The agent asks because it is the only party that knows when it needs one**: its expiry,
whether it is relaying at all, whether a relay has just refused it. A server pushing on a timer
would model all of that from a distance and push to devices that never relay.

## The protocol was already right, and better than my first sketch

`StateDelta` carries `RelayConfig`. Which relays exist and where is a network-wide fact that
changes rarely and deserves versioning. I had planned to bundle that into the token response,
which would have duplicated it — the up-front protocol design anticipated this correctly and I
deleted my version.

## Details worth reviewing

**The request carries no fields.** The session establishes which membership is asking; a device
identifier in the message would be a second, weaker way to say who you are. The key is read
from the membership, so an agent can only ever be issued a token for the key it authenticated
as — there's a test that the token names exactly that key and network.

**Asking again returns the same token** while it's comfortably valid. A retry loop then costs
one signature rather than one per attempt, and a device holds one credential rather than a
collection. Near expiry it is replaced, so nobody is handed something about to die.

**A deployment with no signing key still works.** Devices enrol and converge; an agent asking
is told relaying is unavailable rather than met with silence it would retry against forever.
The reason it receives is a short phrase, not an internal error — that message crosses a trust
boundary in the direction of a device.

## Operator experience

```
$ meshp-control --generate-relay-key
# Keep this secret. Give it to meshp-control only.
MESHP_RELAY_SIGNING_KEY=eRiMsyldwc6VOlCAfUpdpwOSefYkkdRKIUUQ1cPoHw4=

# Not secret. Give this to every relay.
MESHP_RELAY_ISSUER_KEY=cMo8K3kKeJozUfP7WCotXVYqWZEGZYlES/BxvBZYtxY=
```

Labelled halves, because the alternative is an `openssl` incantation people copy from a search
result and get subtly wrong. The public half is logged at startup so an operator can check a
relay's config matches without reading a secret anywhere.

## Invariants

- [x] An invariant is affected, and it still holds. Which, and how it is tested:

**15** constrains the TTL rather than security alone: an agent with no control channel cannot
obtain a *new* credential, so an outage longer than the token's life degrades relayed paths
while direct paths continue. Thirty minutes rather than thirty seconds for that reason, and
ADR-0017 records it as a real consequence rather than burying it.

## Migrations

None. One new query for a membership's own WireGuard key, kept separate from
`GetMembershipForSession` because almost nothing needs it.

## What follows

The loopback plumbing, and then the hotspot test. Also recorded in ADR-0017 as a thing we will
have to design: **rotating the signing key**. A relay configured with the old public half
rejects every token from a rotated control plane, and the failure looks like every device
losing relaying at once.