### PR TITLE
feat(wgplan): a relayed peer, and why it cannot be inferred

### DIFF
--- a/internal/wgplan/wgplan.go
+++ b/internal/wgplan/wgplan.go
@@ -49,6 +49,17 @@ type Peer struct {
 	// path has been found rather than an error.
 	Endpoint string
 
+	// Relayed says this endpoint is a loopback socket the agent itself serves, forwarding to
+	// and from a relay (ADR-0016).
+	//
+	// Stated rather than inferred from the address. It would be tempting to test whether the
+	// endpoint is a loopback address, but that would leave the important part unsaid: a
+	// loopback endpoint requires a live socket behind it, and wgctrl cannot clear an
+	// endpoint — writing a peer with none leaves whatever was there. So a peer pointing at
+	// 127.0.0.1 must keep something serving that address until a different endpoint is
+	// written, and only the agent knows whether it intends to.
+	Relayed bool
+
 	// PresharedKey is optional per-pair symmetric material.
 	PresharedKey Key
 
@@ -298,6 +309,17 @@ func For(want Interface, observed Observed) (Plan, error) {
 			add(Op{Kind: SetPeer, Peer: desired})
 			continue
 		}
+		// Stopping relaying with nothing to replace the endpoint is the one change a single
+		// SetPeer cannot express: wgctrl treats an absent endpoint as "leave it", so the peer
+		// would keep pointing at a loopback socket about to stop existing. Removing and
+		// re-adding is the only way to clear one. It costs that peer's session, which is
+		// unavoidable and better than a silent black hole.
+		if isLoopback(current.Endpoint) && !desired.Relayed && desired.Endpoint == "" {
+			add(Op{Kind: RemovePeer, Peer: Peer{PublicKey: key}})
+			add(Op{Kind: SetPeer, Peer: desired})
+			continue
+		}
+
 		if write, peer := resolvePeer(current, desired); write {
 			add(Op{Kind: SetPeer, Peer: peer})
 		}
@@ -365,6 +387,18 @@ func (i Interface) Validate() error {
 		}
 		seen[peer.PublicKey] = struct{}{}
 
+		if peer.Relayed && peer.Endpoint == "" {
+			return fmt.Errorf("wgplan: interface %s peer %s is relayed with no endpoint; "+
+				"a relayed peer must point at the socket serving it", i.Name, peer.PublicKey)
+		}
+		if peer.Relayed && !isLoopback(peer.Endpoint) {
+			return fmt.Errorf("wgplan: interface %s peer %s is relayed but points at %s, "+
+				"which is not a socket this agent serves", i.Name, peer.PublicKey, peer.Endpoint)
+		}
+		if !peer.Relayed && isLoopback(peer.Endpoint) {
+			return fmt.Errorf("wgplan: interface %s peer %s points at %s without being marked "+
+				"relayed; nothing would keep that socket alive", i.Name, peer.PublicKey, peer.Endpoint)
+		}
 		if len(peer.AllowedIPs) == 0 {
 			// A peer with no allowed IPs can neither be sent to nor accepted from. It is
 			// not harmful, but it is never what anyone meant.
@@ -532,6 +566,18 @@ func resolvePeer(have, want Peer) (bool, Peer) {
 // keepObservedEndpoint reports whether the device's endpoint should be left as it is.
 func keepObservedEndpoint(have, want Peer) bool {
 	switch {
+	case want.Relayed:
+		// Ours by construction: the agent is serving that socket, so nothing the device
+		// reports is better information. Notably a loopback endpoint always looks alive —
+		// a local socket answers — so the evidence rule below would pin a relayed peer to
+		// the relay forever and no direct path could ever replace it.
+		return false
+
+	case isLoopback(have.Endpoint):
+		// The device points at a socket we no longer intend to serve. Whatever we do now,
+		// leaving it there is not an option: it is a black hole with a live-looking endpoint.
+		return false
+
 	case want.Endpoint == "":
 		// Nothing to offer. Whatever the device has — configured earlier, or learned from
 		// traffic — is more than we know, and this is every peer's state until endpoint
@@ -548,6 +594,21 @@ func keepObservedEndpoint(have, want Peer) bool {
 		// agent consumes candidate lists (ADR-0003).
 		return have.HasHandshake && have.HandshakeAge <= endpointGrace
 	}
+}
+
+// isLoopback reports whether an endpoint is one of ours.
+//
+// A loopback address can never be learned from the network — the kernel only has it because
+// something local wrote it — so it is never evidence about where a peer is.
+func isLoopback(endpoint string) bool {
+	if endpoint == "" {
+		return false
+	}
+	addr, err := netip.ParseAddrPort(endpoint)
+	if err != nil {
+		return false
+	}
+	return addr.Addr().IsLoopback()
 }
 
 // sameApartFromEndpoint compares everything the control plane decides outright.

--- a/internal/wgplan/wgplan_test.go
+++ b/internal/wgplan/wgplan_test.go
@@ -1009,3 +1009,175 @@ func TestAPeersAddressesAreCorrectedWithoutDisturbingAWorkingEndpoint(t *testing
 		t.Errorf("wrong allowed IPs were left in place:\n%s", plan)
 	}
 }
+
+// --- relayed peers -----------------------------------------------------------
+//
+// A relayed peer's endpoint is a loopback socket the agent serves, forwarding to and from a
+// relay (ADR-0016). That interacts with the endpoint-is-evidence rule in a way worth being
+// explicit about: a loopback socket always answers, so it always looks alive.
+
+func relayed(t *testing.T, port int) Peer {
+	t.Helper()
+	return Peer{
+		PublicKey:        "peer-bob",
+		AllowedIPs:       prefixes(t, "100.90.0.2/32"),
+		Endpoint:         fmt.Sprintf("127.0.0.1:%d", port),
+		Relayed:          true,
+		KeepaliveSeconds: 25,
+	}
+}
+
+// The rule that makes an upgrade possible at all. A loopback endpoint always looks alive, so
+// treating it as evidence would pin a relayed peer to the relay forever and no direct path
+// could ever replace it — the exact opposite of relay-first with opportunistic upgrade
+// (ADR-0002).
+func TestARelayedPeerIsNotPinnedByItsOwnLoopbackEndpoint(t *testing.T) {
+	iface := base(t)
+	iface.Peers = []Peer{relayed(t, 51000)}
+
+	obs := applied(iface)
+	// The kernel reports the loopback endpoint, handshaking happily, because our own socket
+	// answers every time.
+	obs.Peers[0].HasHandshake = true
+	obs.Peers[0].HandshakeAge = time.Second
+
+	// The server now offers a direct path.
+	want := base(t)
+	want.Peers = []Peer{{
+		PublicKey:        "peer-bob",
+		AllowedIPs:       prefixes(t, "100.90.0.2/32"),
+		Endpoint:         "203.0.113.2:51820",
+		KeepaliveSeconds: 25,
+	}}
+
+	plan, err := For(want, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var upgraded bool
+	for _, op := range plan.Ops {
+		if op.Kind == SetPeer && op.Peer.Endpoint == "203.0.113.2:51820" {
+			upgraded = true
+		}
+	}
+	if !upgraded {
+		t.Errorf("a relayed peer was never offered the direct path:\n%s", plan)
+	}
+}
+
+// And the other direction: what we intend beats what the device reports, because we are the
+// ones serving that socket.
+func TestARelayedEndpointIsWrittenOverWhateverTheDeviceHas(t *testing.T) {
+	iface := base(t)
+	iface.Peers = []Peer{relayed(t, 51000)}
+
+	obs := applied(iface)
+	// A direct path that was working a moment ago, and has now been judged unusable by
+	// whatever decided to relay this peer.
+	obs.Peers[0].Endpoint = "203.0.113.2:51820"
+	obs.Peers[0].Relayed = false
+	obs.Peers[0].HasHandshake = true
+	obs.Peers[0].HandshakeAge = time.Second
+
+	plan, err := For(iface, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wrote bool
+	for _, op := range plan.Ops {
+		if op.Kind == SetPeer && op.Peer.Endpoint == "127.0.0.1:51000" {
+			wrote = true
+		}
+	}
+	if !wrote {
+		t.Errorf("the relayed endpoint was not written:\n%s", plan)
+	}
+}
+
+// The case a single operation cannot express. wgctrl treats an absent endpoint as "leave it
+// alone", so a peer that stops being relayed with nothing to replace its endpoint would keep
+// pointing at a socket about to stop existing. Removing and re-adding is the only way to
+// clear one.
+func TestStoppingRelayingWithNoReplacementClearsTheEndpoint(t *testing.T) {
+	iface := base(t)
+	iface.Peers = []Peer{relayed(t, 51000)}
+	obs := applied(iface)
+
+	// No relay, and nowhere else to point either.
+	want := base(t)
+	want.Peers = []Peer{{
+		PublicKey:        "peer-bob",
+		AllowedIPs:       prefixes(t, "100.90.0.2/32"),
+		KeepaliveSeconds: 25,
+	}}
+
+	plan, err := For(want, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	removed, added := -1, -1
+	for i, op := range plan.Ops {
+		if op.Kind == RemovePeer && op.Peer.PublicKey == "peer-bob" {
+			removed = i
+		}
+		if op.Kind == SetPeer && op.Peer.PublicKey == "peer-bob" {
+			added = i
+		}
+	}
+	if removed < 0 || added < 0 {
+		t.Fatalf("the peer was not removed and re-added, so its endpoint still points at a\n"+
+			"socket nothing will serve:\n%s", plan)
+	}
+	if removed > added {
+		t.Errorf("re-added at %d before being removed at %d, which clears nothing", added, removed)
+	}
+	if plan.Ops[added].Peer.Endpoint != "" {
+		t.Errorf("re-added with endpoint %q, want none", plan.Ops[added].Peer.Endpoint)
+	}
+}
+
+// The states that must not be describable, because each is a peer pointing somewhere nothing
+// serves.
+func TestRelayedPeersMustBeCoherent(t *testing.T) {
+	cases := map[string]Peer{
+		"relayed with no endpoint": {
+			PublicKey: "peer-bob", AllowedIPs: nil, Relayed: true,
+		},
+		"relayed but pointing off-box": {
+			PublicKey: "peer-bob", Endpoint: "203.0.113.2:51820", Relayed: true,
+		},
+		"loopback without being relayed": {
+			PublicKey: "peer-bob", Endpoint: "127.0.0.1:51000", Relayed: false,
+		},
+	}
+	for name, peer := range cases {
+		t.Run(name, func(t *testing.T) {
+			iface := base(t)
+			peer.AllowedIPs = prefixes(t, "100.90.0.2/32")
+			iface.Peers = []Peer{peer}
+			if _, err := For(iface, Observed{}); err == nil {
+				t.Errorf("%s was accepted", name)
+			}
+		})
+	}
+}
+
+// A relayed peer that is still relayed to the same socket is not rewritten, or every reconcile
+// would reset the session of every relayed peer.
+func TestASteadyRelayedPeerIsLeftAlone(t *testing.T) {
+	iface := base(t)
+	iface.Peers = []Peer{relayed(t, 51000)}
+
+	obs := applied(iface)
+	obs.Peers[0].HasHandshake = true
+	obs.Peers[0].HandshakeAge = 5 * time.Second
+
+	plan, err := For(iface, obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !plan.Empty() {
+		t.Errorf("a steady relayed peer produced work:\n%s", plan)
+	}
+}


### PR DESCRIPTION
Groundwork for the agent using a relay: a peer whose endpoint is a loopback socket the agent
itself serves, forwarding to and from a relay (ADR-0016).

## I had this wrong, and the correction is the interesting part

I planned to derive "relayed" by testing whether the endpoint is a loopback address — no new
field, elegant. It's wrong, because of a constraint I hadn't noticed: **`wgctrl` cannot clear a
peer's endpoint.** Writing a peer without one leaves whatever was there.

So a peer pointing at `127.0.0.1:Px` *requires* something to keep serving that address until a
different endpoint is written — and only the agent knows whether it intends to. Sniffing the
address leaves that unsaid. The flag is explicit.

## Three rules, each load-bearing

**A relayed endpoint is ours, so what we intend beats what the device reports.** The
endpoint-is-evidence rule from #14 normally defers to the device — and here that would be
actively harmful: a loopback socket always answers, so a relayed peer *always* looks alive, so
it would be pinned to the relay forever and no direct path could ever replace it. The exact
opposite of relay-first with opportunistic upgrade (ADR-0002).

**A loopback endpoint the device holds is never evidence.** A loopback address cannot be
learned from the network; the kernel only has it because something local wrote it.

**Stopping relaying with nothing to replace the endpoint needs remove-then-re-add.** It's the
one change a single `SetPeer` cannot express, since an absent endpoint means "leave it". It
costs that peer's session — unavoidable, and better than a peer pointing at a socket nothing
serves, which is a black hole with a live-looking endpoint.

Validation refuses the incoherent states outright: relayed with no endpoint, relayed but
pointing off-box, loopback without being marked relayed.

## Teeth

| rule removed | test that fails |
|---|---|
| loopback-is-not-evidence | `TestARelayedPeerIsNotPinnedByItsOwnLoopbackEndpoint` |
| clear-the-endpoint case | `TestStoppingRelayingWithNoReplacementClearsTheEndpoint` |
| coherence validation | `TestRelayedPeersMustBeCoherent` |

94.7% coverage held. Data-plane tests against real interfaces still pass.

## Invariants

- [x] An invariant is affected, and it still holds. Which, and how it is tested:

**18** — `TestASteadyRelayedPeerIsLeftAlone`: a relayed peer still relayed to the same socket
produces no work, or every reconcile would reset every relayed peer's session.

## Migrations

None.

## What follows

The sockets themselves — one per relayed peer, with the forwarding loops — then wiring the
relay client and token request into meshpd. After that, the hotspot test.