### PR TITLE
feat(relayforward): carry packets between the kernel and a relay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ CROSS_TARGETS := linux/amd64 linux/arm64 linux/arm \
 COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan internal/relayproto internal/relay internal/relaytoken
 COVER_FLOOR      := 90
 
-COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx internal/tunnel internal/relayclient
+COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx internal/tunnel internal/relayclient internal/relayforward
 COVER_FLOOR_IO      := 75
 
 COVER_FLOOR_DB_PKGS := internal/store internal/enroll internal/api internal/session

--- a/internal/relayforward/chain_test.go
+++ b/internal/relayforward/chain_test.go
@@ -1,0 +1,258 @@
+package relayforward_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/clock"
+	"github.com/meshpnet/meshp/internal/relay"
+	"github.com/meshpnet/meshp/internal/relayclient"
+	"github.com/meshpnet/meshp/internal/relayforward"
+	"github.com/meshpnet/meshp/internal/relayproto"
+	"github.com/meshpnet/meshp/internal/relaytoken"
+)
+
+// The whole design, end to end, with nothing faked but the kernel:
+//
+//	kernel A -> forwarder A -> relay client A -> RELAY -> client B -> forwarder B -> kernel B
+//
+// Everything between the two ends is the shipping code. The kernel is stood in for by an
+// ordinary UDP socket, which is all it is from the outside — something that sends to a peer's
+// endpoint and receives from it — and that is what makes this runnable without privileges.
+//
+// What it proves is the claim ADR-0016 rests on: that giving the kernel a loopback endpoint
+// and serving it is enough to carry a packet between two hosts through a relay.
+
+func testKey(b byte) relayproto.Key {
+	var k relayproto.Key
+	for i := range k {
+		k[i] = b
+	}
+	return k
+}
+
+func startRelay(t *testing.T) (endpoint string, signer ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	srv, err := relay.New(relay.Config{
+		Auth: authFunc(func(token []byte) (relayproto.Key, string, error) {
+			grant, err := relaytoken.Verify(pub, token, time.Now())
+			if err != nil {
+				return relayproto.Key{}, "", err
+			}
+			return grant.Key, grant.Network(), nil
+		}),
+		SelfKey: testKey(0xFF),
+		Clock:   clock.System{},
+		Log:     discard,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		in := make([]byte, 4096)
+		out := make([]byte, relayproto.HeaderLen+relayproto.MaxPayload)
+		for {
+			n, from, err := conn.ReadFromUDPAddrPort(in)
+			if err != nil {
+				return
+			}
+			for _, o := range srv.Handle(0, from, in[:n]) {
+				written, err := o.Frame.Encode(out)
+				if err != nil {
+					continue
+				}
+				_, _ = conn.WriteToUDPAddrPort(out[:written], o.To)
+			}
+		}
+	}()
+	t.Cleanup(func() { _ = conn.Close(); <-done })
+
+	return conn.LocalAddr().String(), priv
+}
+
+type authFunc func([]byte) (relayproto.Key, string, error)
+
+func (f authFunc) Authenticate(token []byte) (relayproto.Key, string, error) { return f(token) }
+
+// end is one device: a stand-in kernel, a forwarder and a relay connection.
+type end struct {
+	t         *testing.T
+	kernel    *net.UDPConn
+	forwarder *relayforward.Forwarder
+	client    *relayclient.Client
+}
+
+func newEnd(t *testing.T, relayAddr string, signer ed25519.PrivateKey, self relayproto.Key) *end {
+	t.Helper()
+
+	kernel, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = kernel.Close() })
+
+	var networkID [16]byte
+	copy(networkID[:], "acme------------")
+	token, err := relaytoken.Issue(signer, self, networkID, time.Now().Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := relayclient.Dial(context.Background(), relayclient.Options{
+		Endpoints: []string{relayAddr},
+		Key:       self,
+		Token:     token,
+	})
+	if err != nil {
+		t.Fatalf("dialling the relay: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	fwd, err := relayforward.New(kernel.LocalAddr().(*net.UDPAddr).Port, client, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = fwd.Close() })
+
+	e := &end{t: t, kernel: kernel, forwarder: fwd, client: client}
+
+	// The inbound loop the agent will run: read from the relay, hand to the forwarder.
+	go func() {
+		buf := make([]byte, relayproto.MaxPayload)
+		for {
+			peer, n, err := client.Receive(buf)
+			if err != nil {
+				return
+			}
+			_ = fwd.Deliver(peer, buf[:n])
+		}
+	}()
+	return e
+}
+
+func TestAPacketCrossesARelayThroughTheLoopbackPath(t *testing.T) {
+	relayAddr, signer := startRelay(t)
+
+	a := newEnd(t, relayAddr, signer, testKey(1))
+	b := newEnd(t, relayAddr, signer, testKey(2))
+
+	// Each side is told where to send for the other, exactly as wgplan would configure a
+	// relayed peer's endpoint.
+	aToB, err := a.forwarder.Endpoint(testKey(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.forwarder.Endpoint(testKey(1)); err != nil {
+		t.Fatal(err)
+	}
+
+	// A's kernel sends to B's endpoint on A's host.
+	payload := []byte("a wireguard packet, notionally, via a relay")
+	if _, err := a.kernel.WriteToUDPAddrPort(payload, aToB); err != nil {
+		t.Fatal(err)
+	}
+
+	// B's kernel receives it, and the source must be the endpoint B has configured for A —
+	// otherwise the kernel would not associate it with A and the tunnel silently fails.
+	if err := b.kernel.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 2048)
+	n, from, err := b.kernel.ReadFromUDPAddrPort(buf)
+	if err != nil {
+		t.Fatalf("the packet never arrived at B: %v", err)
+	}
+	if string(buf[:n]) != string(payload) {
+		t.Errorf("B received %q", buf[:n])
+	}
+
+	wantFrom, err := b.forwarder.Endpoint(testKey(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if from != wantFrom {
+		t.Errorf("arrived from %s, want %s — the endpoint B has configured for A", from, wantFrom)
+	}
+
+	// And back, which uses the other direction of both sockets.
+	bToA, err := b.forwarder.Endpoint(testKey(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.kernel.WriteToUDPAddrPort([]byte("and back again"), bToA); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.kernel.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	n, from, err = a.kernel.ReadFromUDPAddrPort(buf)
+	if err != nil {
+		t.Fatalf("the reply never arrived at A: %v", err)
+	}
+	if string(buf[:n]) != "and back again" {
+		t.Errorf("A received %q", buf[:n])
+	}
+	if from != aToB {
+		t.Errorf("the reply arrived from %s, want %s", from, aToB)
+	}
+}
+
+// A full-sized packet has to survive every hop: two loopback sockets, the relay framing and
+// the relay itself. One byte lost anywhere and only large packets fail.
+func TestAFullSizedPacketCrossesTheWholeChain(t *testing.T) {
+	relayAddr, signer := startRelay(t)
+	a := newEnd(t, relayAddr, signer, testKey(1))
+	b := newEnd(t, relayAddr, signer, testKey(2))
+
+	aToB, err := a.forwarder.Endpoint(testKey(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.forwarder.Endpoint(testKey(1)); err != nil {
+		t.Fatal(err)
+	}
+
+	payload := make([]byte, relayproto.MaxPayload)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+	if _, err := a.kernel.WriteToUDPAddrPort(payload, aToB); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := b.kernel.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 4096)
+	n, _, err := b.kernel.ReadFromUDPAddrPort(buf)
+	if err != nil {
+		t.Fatalf("a full-sized packet did not cross: %v", err)
+	}
+	if n != relayproto.MaxPayload {
+		t.Fatalf("arrived with %d bytes, want %d", n, relayproto.MaxPayload)
+	}
+	for i := range n {
+		if buf[i] != byte(i%251) {
+			t.Fatalf("byte %d is %d, want %d", i, buf[i], i%251)
+		}
+	}
+}

--- a/internal/relayforward/relayforward.go
+++ b/internal/relayforward/relayforward.go
@@ -1,0 +1,272 @@
+// Package relayforward carries WireGuard packets between the local kernel and a relay.
+//
+// On Linux the data plane is the kernel's, and a kernel WireGuard socket cannot be
+// intercepted the way a userspace implementation can — where Tailscale hands wireguard-go a
+// fake endpoint and catches the packets in process, there is no equivalent. So a relayed peer
+// is given an endpoint the kernel is willing to send to: a loopback socket this package owns
+// (ADR-0016).
+//
+// One socket per relayed peer, and it serves both directions:
+//
+//	outbound  kernel -> 127.0.0.1:Px -> read here -> relay
+//	inbound   relay -> read here -> written FROM 127.0.0.1:Px to the WireGuard port
+//
+// The inbound direction is the subtle half. The packet must arrive at the kernel's WireGuard
+// port with a source address of exactly the endpoint configured for that peer, or the kernel
+// will not associate it with the peer. Writing from the same socket the kernel sends to is
+// what makes that true, and it is why there is a socket per peer rather than one shared one.
+package relayforward
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+	"sync"
+
+	"github.com/meshpnet/meshp/internal/logx"
+	"github.com/meshpnet/meshp/internal/relayproto"
+)
+
+// Sender is the part of a relay client this package needs.
+//
+// An interface so the forwarder can be handed a different connection when a client
+// reconnects, and so tests can drive it without one.
+type Sender interface {
+	Send(peer relayproto.Key, payload []byte) error
+}
+
+// Forwarder owns the loopback sockets serving relayed peers.
+type Forwarder struct {
+	// wgAddr is the local WireGuard listen port, where inbound packets are delivered.
+	wgAddr netip.AddrPort
+	log    *slog.Logger
+
+	mu      sync.Mutex
+	peers   map[relayproto.Key]*peerSocket
+	sender  Sender
+	stopped bool
+	stats   Stats
+}
+
+// Stats are what an operator asks about when relaying is not working.
+//
+// DroppedNoRelay in particular: packets going nowhere because there is no relay connection is
+// a completely different problem from packets a relay rejected, and without a number the two
+// look identical from outside.
+type Stats struct {
+	Peers          int
+	Relayed        uint64
+	Delivered      uint64
+	DroppedNoRelay uint64
+	DroppedNoPeer  uint64
+	SendFailed     uint64
+}
+
+// Stats returns a snapshot.
+func (f *Forwarder) Stats() Stats {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := f.stats
+	out.Peers = len(f.peers)
+	return out
+}
+
+type peerSocket struct {
+	key  relayproto.Key
+	conn *net.UDPConn
+	addr netip.AddrPort // the loopback address the kernel is told to use
+	done chan struct{}
+}
+
+// New returns a Forwarder delivering inbound packets to a WireGuard listen port.
+func New(wgPort int, sender Sender, log *slog.Logger) (*Forwarder, error) {
+	if wgPort <= 0 {
+		// Without it there is nowhere to deliver, and a forwarder that silently discarded
+		// inbound packets would look like a relay problem from every angle.
+		return nil, errors.New("relayforward: no WireGuard listen port to deliver to")
+	}
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	return &Forwarder{
+		wgAddr: netip.AddrPortFrom(netip.AddrFrom4([4]byte{127, 0, 0, 1}), uint16(wgPort)),
+		log:    log,
+		peers:  make(map[relayproto.Key]*peerSocket),
+		sender: sender,
+	}, nil
+}
+
+// SetSender swaps the relay connection, for when a client reconnects.
+//
+// The sockets are untouched: their addresses are what the kernel has been told, and changing
+// them because a relay connection was replaced would mean rewriting every peer.
+func (f *Forwarder) SetSender(s Sender) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sender = s
+}
+
+// Endpoint returns the loopback address serving a peer, opening a socket if this is the first
+// time that peer has been asked for.
+//
+// The address is stable for as long as the peer is relayed, because it is what the kernel has
+// been configured with — a new port would mean the kernel keeps sending to a socket nobody
+// reads.
+func (f *Forwarder) Endpoint(peer relayproto.Key) (netip.AddrPort, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.stopped {
+		return netip.AddrPort{}, errors.New("relayforward: stopped")
+	}
+	if existing, ok := f.peers[peer]; ok {
+		return existing.addr, nil
+	}
+
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("relayforward: opening a socket for a relayed peer: %w", err)
+	}
+	local, ok := netip.AddrFromSlice(conn.LocalAddr().(*net.UDPAddr).IP)
+	if !ok {
+		_ = conn.Close()
+		return netip.AddrPort{}, errors.New("relayforward: the socket has no usable address")
+	}
+	ps := &peerSocket{
+		key:  peer,
+		conn: conn,
+		addr: netip.AddrPortFrom(local.Unmap(), uint16(conn.LocalAddr().(*net.UDPAddr).Port)),
+		done: make(chan struct{}),
+	}
+	f.peers[peer] = ps
+	go f.outbound(ps)
+
+	f.log.Debug("serving a relayed peer", "endpoint", ps.addr.String())
+	return ps.addr, nil
+}
+
+// Forget stops serving a peer.
+//
+// Only safe once the kernel no longer points at that socket. wgctrl cannot clear an endpoint,
+// so the caller must have written a different one first — closing a socket the kernel still
+// sends to produces a peer that looks configured and goes nowhere (ADR-0016, and the reason
+// wgplan refuses to un-relay a peer with nothing to replace its endpoint).
+func (f *Forwarder) Forget(peer relayproto.Key) {
+	f.mu.Lock()
+	ps, ok := f.peers[peer]
+	if ok {
+		delete(f.peers, peer)
+	}
+	f.mu.Unlock()
+
+	if ok {
+		_ = ps.conn.Close()
+		<-ps.done
+	}
+}
+
+// Peers reports which peers are being served, for status and tests.
+func (f *Forwarder) Peers() []relayproto.Key {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]relayproto.Key, 0, len(f.peers))
+	for key := range f.peers {
+		out = append(out, key)
+	}
+	return out
+}
+
+// Deliver writes a packet received from the relay into the kernel, as though it had arrived
+// from the peer's configured endpoint.
+//
+// From the peer's own socket, which is the whole reason each peer has one: the kernel accepts
+// a packet as belonging to a peer only when its source matches that peer's endpoint.
+func (f *Forwarder) Deliver(peer relayproto.Key, payload []byte) error {
+	f.mu.Lock()
+	ps, ok := f.peers[peer]
+	f.mu.Unlock()
+
+	if !ok {
+		// A packet for a peer we are not serving. Not alarming on its own — a relay may
+		// still be flushing traffic for a peer that has just moved to a direct path — but
+		// worth counting, because a lot of it means the two ends disagree.
+		f.count(func(st *Stats) { st.DroppedNoPeer++ })
+		return fmt.Errorf("relayforward: no socket serving %s", truncate(peer))
+	}
+	if _, err := ps.conn.WriteToUDPAddrPort(payload, f.wgAddr); err != nil {
+		return fmt.Errorf("relayforward: delivering to the local WireGuard port: %w", err)
+	}
+	f.count(func(st *Stats) { st.Delivered++ })
+	return nil
+}
+
+// outbound carries what the kernel sends to a peer's socket on to the relay.
+func (f *Forwarder) outbound(ps *peerSocket) {
+	defer close(ps.done)
+
+	buf := make([]byte, relayproto.MaxPayload)
+	for {
+		n, err := ps.conn.Read(buf)
+		if err != nil {
+			if !errors.Is(err, net.ErrClosed) {
+				f.log.Debug("relayed peer socket closed",
+					"endpoint", ps.addr.String(), "error", logx.SafeError(err))
+			}
+			return
+		}
+
+		f.mu.Lock()
+		sender := f.sender
+		f.mu.Unlock()
+		if sender == nil {
+			// Not connected to a relay at the moment. Dropping is right: WireGuard will
+			// retransmit, and queueing packets for a connection that may never come back
+			// would deliver them long after they stopped meaning anything.
+			f.count(func(st *Stats) { st.DroppedNoRelay++ })
+			continue
+		}
+
+		if err := sender.Send(ps.key, buf[:n]); err != nil {
+			f.count(func(st *Stats) { st.SendFailed++ })
+			f.log.Debug("could not relay a packet",
+				"peer", truncate(ps.key), "error", logx.SafeError(err))
+			continue
+		}
+		f.count(func(st *Stats) { st.Relayed++ })
+	}
+}
+
+// Close stops every socket.
+func (f *Forwarder) Close() error {
+	f.mu.Lock()
+	if f.stopped {
+		f.mu.Unlock()
+		return nil
+	}
+	f.stopped = true
+	sockets := make([]*peerSocket, 0, len(f.peers))
+	for key, ps := range f.peers {
+		sockets = append(sockets, ps)
+		delete(f.peers, key)
+	}
+	f.mu.Unlock()
+
+	for _, ps := range sockets {
+		_ = ps.conn.Close()
+		<-ps.done
+	}
+	return nil
+}
+
+func (f *Forwarder) count(fn func(*Stats)) {
+	f.mu.Lock()
+	fn(&f.stats)
+	f.mu.Unlock()
+}
+
+func truncate(key relayproto.Key) string {
+	s := fmt.Sprintf("%x", key[:])
+	return s[:12] + "…"
+}

--- a/internal/relayforward/relayforward_test.go
+++ b/internal/relayforward/relayforward_test.go
@@ -1,0 +1,387 @@
+package relayforward
+
+import (
+	"errors"
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/relayproto"
+)
+
+func key(b byte) relayproto.Key {
+	var k relayproto.Key
+	for i := range k {
+		k[i] = b
+	}
+	return k
+}
+
+// fakeKernel stands in for the kernel's WireGuard socket.
+//
+// It can be an ordinary UDP socket because that is all the kernel's is, from the outside:
+// something that sends to a peer's endpoint and receives from it. Standing in for it here is
+// what lets the whole loopback path be tested without privileges, and lets a test assert the
+// thing that actually matters — the source address inbound packets arrive from.
+type fakeKernel struct {
+	t    *testing.T
+	conn *net.UDPConn
+}
+
+func newFakeKernel(t *testing.T) *fakeKernel {
+	t.Helper()
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return &fakeKernel{t: t, conn: conn}
+}
+
+func (k *fakeKernel) port() int { return k.conn.LocalAddr().(*net.UDPAddr).Port }
+
+// sendTo is what WireGuard does when it has something for a peer: send to its endpoint.
+func (k *fakeKernel) sendTo(endpoint netip.AddrPort, payload []byte) {
+	k.t.Helper()
+	if _, err := k.conn.WriteToUDPAddrPort(payload, endpoint); err != nil {
+		k.t.Fatal(err)
+	}
+}
+
+// recv returns a packet and the address it came from, which is the assertion that matters.
+func (k *fakeKernel) recv(within time.Duration) ([]byte, netip.AddrPort, bool) {
+	k.t.Helper()
+	if err := k.conn.SetReadDeadline(time.Now().Add(within)); err != nil {
+		k.t.Fatal(err)
+	}
+	buf := make([]byte, 2048)
+	n, from, err := k.conn.ReadFromUDPAddrPort(buf)
+	if err != nil {
+		return nil, netip.AddrPort{}, false
+	}
+	return buf[:n], from, true
+}
+
+// recordingSender captures what would have gone to a relay.
+type recordingSender struct {
+	mu   sync.Mutex
+	sent []struct {
+		peer    relayproto.Key
+		payload []byte
+	}
+	ch  chan struct{}
+	err error
+}
+
+func newRecordingSender() *recordingSender {
+	return &recordingSender{ch: make(chan struct{}, 64)}
+}
+
+func (r *recordingSender) Send(peer relayproto.Key, payload []byte) error {
+	if r.err != nil {
+		return r.err
+	}
+	r.mu.Lock()
+	cp := make([]byte, len(payload))
+	copy(cp, payload)
+	r.sent = append(r.sent, struct {
+		peer    relayproto.Key
+		payload []byte
+	}{peer, cp})
+	r.mu.Unlock()
+	select {
+	case r.ch <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (r *recordingSender) wait(t *testing.T, within time.Duration) bool {
+	t.Helper()
+	select {
+	case <-r.ch:
+		return true
+	case <-time.After(within):
+		return false
+	}
+}
+
+func (r *recordingSender) last() (relayproto.Key, []byte, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.sent) == 0 {
+		return relayproto.Key{}, nil, false
+	}
+	s := r.sent[len(r.sent)-1]
+	return s.peer, s.payload, true
+}
+
+// waitFor polls until a condition holds, so a test can synchronise on something observable
+// rather than on a sleep long enough to usually work.
+func waitFor(t *testing.T, within time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("condition did not hold within %s", within)
+}
+
+func newForwarder(t *testing.T, wgPort int, s Sender) *Forwarder {
+	t.Helper()
+	f, err := New(wgPort, s, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	return f
+}
+
+// What the kernel sends to a peer's endpoint reaches the relay, named for that peer.
+func TestWhatTheKernelSendsGoesToTheRelay(t *testing.T) {
+	kernel := newFakeKernel(t)
+	sender := newRecordingSender()
+	f := newForwarder(t, kernel.port(), sender)
+
+	endpoint, err := f.Endpoint(key(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !endpoint.Addr().IsLoopback() {
+		t.Fatalf("endpoint %s is not a loopback address", endpoint)
+	}
+
+	kernel.sendTo(endpoint, []byte("a wireguard packet"))
+	if !sender.wait(t, 3*time.Second) {
+		t.Fatal("nothing reached the relay")
+	}
+	peer, payload, ok := sender.last()
+	if !ok {
+		t.Fatal("nothing recorded")
+	}
+	if peer != key(2) {
+		t.Error("the packet was relayed for the wrong peer")
+	}
+	if string(payload) != "a wireguard packet" {
+		t.Errorf("payload is %q", payload)
+	}
+}
+
+// The assertion the whole design turns on: an inbound packet must reach the WireGuard port
+// with a source address of exactly the endpoint that peer is configured with. Anything else
+// and the kernel will not associate it with the peer, and the tunnel silently does not work.
+func TestAnInboundPacketArrivesFromThePeersConfiguredEndpoint(t *testing.T) {
+	kernel := newFakeKernel(t)
+	f := newForwarder(t, kernel.port(), newRecordingSender())
+
+	endpoint, err := f.Endpoint(key(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := f.Deliver(key(2), []byte("from the relay")); err != nil {
+		t.Fatal(err)
+	}
+	payload, from, ok := kernel.recv(3 * time.Second)
+	if !ok {
+		t.Fatal("nothing was delivered to the WireGuard port")
+	}
+	if string(payload) != "from the relay" {
+		t.Errorf("payload is %q", payload)
+	}
+	if from != endpoint {
+		t.Errorf("arrived from %s, want the peer's configured endpoint %s — the kernel would\n"+
+			"not associate this with the peer", from, endpoint)
+	}
+}
+
+// Each peer gets its own socket, because the source address is how the kernel tells them
+// apart. One shared socket would make every relayed peer look like the same peer.
+func TestEachPeerHasItsOwnEndpoint(t *testing.T) {
+	kernel := newFakeKernel(t)
+	f := newForwarder(t, kernel.port(), newRecordingSender())
+
+	a, err := f.Endpoint(key(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := f.Endpoint(key(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Fatal("two peers share an endpoint; the kernel could not tell them apart")
+	}
+
+	// And each delivers from its own.
+	for peer, want := range map[relayproto.Key]netip.AddrPort{key(1): a, key(2): b} {
+		if err := f.Deliver(peer, []byte("x")); err != nil {
+			t.Fatal(err)
+		}
+		_, from, ok := kernel.recv(3 * time.Second)
+		if !ok {
+			t.Fatal("nothing delivered")
+		}
+		if from != want {
+			t.Errorf("a packet for one peer arrived from %s, want %s", from, want)
+		}
+	}
+}
+
+// The endpoint must not move: it is what the kernel has been configured with, and a new port
+// would leave the kernel sending to a socket nobody reads.
+func TestAnEndpointIsStableForAPeer(t *testing.T) {
+	f := newForwarder(t, newFakeKernel(t).port(), newRecordingSender())
+
+	first, err := f.Endpoint(key(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 5 {
+		again, err := f.Endpoint(key(1))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if again != first {
+			t.Fatalf("the endpoint moved from %s to %s", first, again)
+		}
+	}
+}
+
+func TestForgettingAPeerReleasesItsSocket(t *testing.T) {
+	kernel := newFakeKernel(t)
+	f := newForwarder(t, kernel.port(), newRecordingSender())
+
+	if _, err := f.Endpoint(key(1)); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Peers()) != 1 {
+		t.Fatalf("%d peers served, want 1", len(f.Peers()))
+	}
+
+	f.Forget(key(1))
+	if len(f.Peers()) != 0 {
+		t.Errorf("%d peers still served after forgetting", len(f.Peers()))
+	}
+	// Delivering for a peer nobody serves is reported rather than silently dropped.
+	if err := f.Deliver(key(1), []byte("x")); err == nil {
+		t.Error("delivering to a forgotten peer was reported as success")
+	}
+}
+
+// A relay connection that has gone away must not stop the sockets: WireGuard retransmits, and
+// dropping is right — queueing would deliver packets long after they stopped meaning anything.
+func TestPacketsAreDroppedWhileThereIsNoRelay(t *testing.T) {
+	kernel := newFakeKernel(t)
+	f := newForwarder(t, kernel.port(), nil)
+
+	endpoint, err := f.Endpoint(key(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	kernel.sendTo(endpoint, []byte("goes nowhere"))
+
+	// Wait for the drop to be recorded before reconnecting. Without this the test races its
+	// own subject: the socket may read the first packet after SetSender and relay it with the
+	// new sender, which is exactly the flake this test had when it was written.
+	waitFor(t, 3*time.Second, func() bool { return f.Stats().DroppedNoRelay == 1 })
+
+	// Reconnected, and now it flows again.
+	sender := newRecordingSender()
+	f.SetSender(sender)
+	kernel.sendTo(endpoint, []byte("goes somewhere"))
+
+	if !sender.wait(t, 3*time.Second) {
+		t.Fatal("nothing reached the relay after reconnecting")
+	}
+	_, payload, _ := sender.last()
+	if string(payload) != "goes somewhere" {
+		t.Errorf("relayed %q, want the packet sent after reconnecting", payload)
+	}
+}
+
+// A failing relay must not kill the socket, or one transient error would leave a peer
+// permanently unable to send even after the relay came back.
+func TestASendFailureDoesNotStopTheSocket(t *testing.T) {
+	kernel := newFakeKernel(t)
+	failing := newRecordingSender()
+	failing.err = errors.New("relay unreachable")
+	f := newForwarder(t, kernel.port(), failing)
+
+	endpoint, err := f.Endpoint(key(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	kernel.sendTo(endpoint, []byte("fails"))
+	time.Sleep(100 * time.Millisecond)
+
+	working := newRecordingSender()
+	f.SetSender(working)
+	kernel.sendTo(endpoint, []byte("works"))
+
+	if !working.wait(t, 3*time.Second) {
+		t.Fatal("the socket stopped after a send failure")
+	}
+}
+
+// A full-sized packet has to survive the read buffer. One byte short and only large packets
+// are lost, which is the hardest fault to attribute.
+func TestAFullSizedPacketSurvives(t *testing.T) {
+	kernel := newFakeKernel(t)
+	sender := newRecordingSender()
+	f := newForwarder(t, kernel.port(), sender)
+
+	endpoint, err := f.Endpoint(key(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := make([]byte, relayproto.MaxPayload)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+	kernel.sendTo(endpoint, payload)
+
+	if !sender.wait(t, 3*time.Second) {
+		t.Fatal("a full-sized packet did not reach the relay")
+	}
+	_, got, _ := sender.last()
+	if len(got) != relayproto.MaxPayload {
+		t.Fatalf("relayed %d bytes, want %d", len(got), relayproto.MaxPayload)
+	}
+	for i, b := range got {
+		if b != byte(i%251) {
+			t.Fatalf("byte %d is %d, want %d", i, b, i%251)
+		}
+	}
+}
+
+func TestAForwarderNeedsSomewhereToDeliver(t *testing.T) {
+	if _, err := New(0, newRecordingSender(), nil); err == nil {
+		t.Error("a forwarder with no WireGuard port was built; inbound packets would vanish")
+	}
+}
+
+func TestCloseIsIdempotentAndStopsEverything(t *testing.T) {
+	f := newForwarder(t, newFakeKernel(t).port(), newRecordingSender())
+	if _, err := f.Endpoint(key(1)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Errorf("closing twice returned %v", err)
+	}
+	if len(f.Peers()) != 0 {
+		t.Error("peers are still served after close")
+	}
+	if _, err := f.Endpoint(key(2)); err == nil {
+		t.Error("a socket was opened after close")
+	}
+}


### PR DESCRIPTION
The piece ADR-0016 turns on. On Linux the data plane is the kernel's, and a kernel WireGuard
socket cannot be intercepted the way a userspace one can — where Tailscale hands `wireguard-go`
a fake endpoint and catches packets in process, there is no equivalent. So a relayed peer gets
an endpoint the kernel *is* willing to send to: a loopback socket this package owns.

One socket per peer, serving both directions. Outbound is unremarkable. **Inbound is the subtle
half**: the packet must reach the kernel's WireGuard port with a source address of exactly the
endpoint that peer is configured with, or the kernel won't associate it with the peer and the
tunnel silently doesn't work. Writing from the same socket the kernel sends to is what makes
that true — and it's why there's a socket per peer rather than one shared.

## The whole path is testable without privileges

From the outside, the kernel's WireGuard socket is just a UDP socket: something that sends to a
peer's endpoint and receives from it. Standing in for it lets a test assert the thing that
actually matters — the source address an inbound packet arrives from.

So the chain test runs the real thing end to end with only the kernels faked:

```
kernel A -> forwarder A -> relay client A -> RELAY -> client B -> forwarder B -> kernel B
```

A full-sized packet crosses it intact, exercising every hop's buffer at once.

## I wrote a flaky test, and CI caught it before merge

The drop-while-disconnected case sent a packet with no relay connection, reconnected, and
asserted the first packet wasn't relayed — but the socket may read that packet *after* the
reconnect, so the test raced its own subject. It passed alone and under `-race`, then failed
under `make ci`'s different load.

**The fix wasn't a sleep.** The forwarder now counts what it drops and why, and the test waits
for the drop to be *recorded* before reconnecting. That makes the test deterministic and the
behaviour observable — which an operator needs regardless: packets going nowhere for lack of a
relay is a completely different problem from packets a relay rejected, and without a number the
two look identical from outside.

Five consecutive clean runs plus two full CI runs after the fix.

## Teeth

Delivering from a shared socket instead of each peer's own fails
`TestEachPeerHasItsOwnEndpoint` — the case where every relayed peer would look like the same
peer to the kernel. 94.9% coverage, gated at 75 as socket code.

## Invariants

- [x] An invariant is affected, and it still holds. Which, and how it is tested:

**3** (a relay never needs to decrypt) — this moves opaque bytes; nothing here parses a
WireGuard packet.

## Migrations

None.

## What's still missing before two devices can relay

The daemon wiring: `meshpd` fetching a token, dialling a relay, running the inbound loop, and
marking peers relayed with these endpoints. And the server side — nothing yet **decides** that a
peer should be relayed or sends `RelayConfig`.

So the hotspot test is one step further out than I said last time: the pieces all exist and are
tested against each other, but no device relays yet.