### PR TITLE
feat(session): tell agents which relay to use, and lower the MTU for it

### DIFF
--- a/cmd/meshp-control/main.go
+++ b/cmd/meshp-control/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/meshpnet/meshp/internal/store"
 	"github.com/meshpnet/meshp/internal/version"
 	"github.com/meshpnet/meshp/migrations"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
 )
 
 func main() {
@@ -57,6 +58,12 @@ func main() {
 			"base64 Ed25519 seed or private key for signing relay tokens; empty disables relaying")
 		generateRelayKey = flag.Bool("generate-relay-key", false,
 			"print a new relay signing keypair and exit")
+
+		// Where this deployment's relays are, as id=host:port[,host:port];id=... Several
+		// addresses per relay because one port is not enough: the agent tries them in order,
+		// so the port most likely to get through belongs first.
+		relays = flag.String("relays", os.Getenv("MESHP_RELAYS"),
+			"relays to offer agents, as id=host:port[,host:port][;id=...]")
 
 		// How far back deltas can be built. An agent offline longer than this is sent a
 		// snapshot when it returns, which is correct but expensive — so this is the
@@ -115,7 +122,14 @@ func main() {
 		os.Exit(2)
 	}
 
+	relayConfig, err := session.ParseRelays(*relays)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "meshp-control: %v\n", err)
+		os.Exit(2)
+	}
+
 	cfg := runConfig{
+		relays:          relayConfig,
 		relaySigningKey: signer,
 		addr:            *listenAddr,
 		databaseURL:     *databaseURL,
@@ -132,6 +146,7 @@ func main() {
 }
 
 type runConfig struct {
+	relays          *meshpv1.RelayConfig
 	relaySigningKey ed25519.PrivateKey
 	addr            string
 	databaseURL     string
@@ -194,6 +209,15 @@ func run(ctx context.Context, log *slog.Logger, cfg runConfig) error {
 			log.Error("could not prepare the relay issuer", "error", err)
 			return
 		}
+		for _, relay := range cfg.relays.GetRelays() {
+			log.Info("offering a relay to agents",
+				"id", relay.GetId(), "endpoints", strings.Join(relay.GetEndpoints(), ","))
+		}
+		if cfg.relays == nil {
+			log.Warn("no relays configured: peers will know about each other and be unable to reach each other",
+				"hint", "set MESHP_RELAYS to id=host:port")
+		}
+
 		if issuer == nil {
 			log.Warn("relaying is disabled: no signing key configured",
 				"hint", "meshp-control --generate-relay-key prints a pair; give the private half here and the public half to each relay")
@@ -207,6 +231,7 @@ func run(ctx context.Context, log *slog.Logger, cfg runConfig) error {
 		sessionServer, err := session.NewServer(st, session.NewHub(), session.Config{
 			MasterSecret: cfg.secretKey,
 			RelayIssuer:  issuer,
+			Relays:       cfg.relays,
 			Clock:        clock.System{},
 			Log:          log,
 		})

--- a/internal/session/relaycreds_test.go
+++ b/internal/session/relaycreds_test.go
@@ -179,3 +179,127 @@ func TestTheReportedPublicKeyIsTheOneThatVerifies(t *testing.T) {
 		t.Errorf("the reported public key does not verify this issuer's tokens: %v", err)
 	}
 }
+
+// --- relay assignment --------------------------------------------------------
+
+// Every peer is relayed, because nothing discovers where a peer is yet. That is what
+// relay-first means (ADR-0002) rather than a limitation: connectivity does not wait on NAT
+// traversal succeeding.
+func TestPeersNameTheRelayAndTheStateCarriesIt(t *testing.T) {
+	f := newFixture(t)
+	relays, err := ParseRelays("relay1=relay1.example:3478,relay1.example:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.srv.builder = f.srv.builder.WithRelays(relays)
+
+	alice := f.enrolDevice("alice")
+	f.enrolDevice("bob")
+
+	state, err := f.srv.builder.For(f.ctx, alice.membershipID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(state.GetUpsertPeers()) != 1 {
+		t.Fatalf("%d peers, want 1", len(state.GetUpsertPeers()))
+	}
+	if got := state.GetUpsertPeers()[0].GetRelayId(); got != "relay1" {
+		t.Errorf("the peer names relay %q, want relay1", got)
+	}
+	// The agent needs to be told where that relay is, or it has a name and nothing to do
+	// with it.
+	if len(state.GetRelays().GetRelays()) != 1 {
+		t.Fatalf("the state carries %d relays", len(state.GetRelays().GetRelays()))
+	}
+	if len(state.GetRelays().GetRelays()[0].GetEndpoints()) != 2 {
+		t.Error("the relay's addresses were not passed through")
+	}
+}
+
+// A relayed packet carries the relay's header outside the WireGuard packet, so it needs a
+// smaller tunnel. WireGuard's MTU is per interface, so one relayed peer lowers it for all.
+func TestTheMTUAllowsForTheRelayHeader(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+
+	// With no relay configured, the conventional direct-path figure.
+	direct, err := f.srv.builder.For(f.ctx, alice.membershipID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if direct.GetTunnel().GetMtu() != 1420 {
+		t.Errorf("MTU without a relay is %d, want 1420", direct.GetTunnel().GetMtu())
+	}
+
+	relays, err := ParseRelays("relay1=relay1.example:3478")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.srv.builder = f.srv.builder.WithRelays(relays)
+
+	relayed, err := f.srv.builder.For(f.ctx, alice.membershipID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := relayed.GetTunnel().GetMtu(); got != uint32(relayproto.RelayedTunnelMTU) {
+		t.Errorf("MTU with a relay is %d, want %d — a relayed packet would fragment",
+			got, relayproto.RelayedTunnelMTU)
+	}
+	if relayed.GetTunnel().GetMtu() >= direct.GetTunnel().GetMtu() {
+		t.Error("relaying did not lower the MTU")
+	}
+}
+
+// A deployment with no relay says so by omission: peers carry neither an endpoint nor a relay,
+// and an agent knows about them without being able to reach them. Honest, and what the system
+// did before relays existed.
+func TestWithoutRelaysPeersCarryNeitherEndpointNorRelay(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+	f.enrolDevice("bob")
+
+	state, err := f.srv.builder.For(f.ctx, alice.membershipID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	peer := state.GetUpsertPeers()[0]
+	if peer.GetRelayId() != "" {
+		t.Errorf("a peer names relay %q in a deployment with none", peer.GetRelayId())
+	}
+	if len(peer.GetEndpoints()) != 0 {
+		t.Error("a peer carries an endpoint, which nothing discovers yet")
+	}
+	if state.GetRelays() != nil {
+		t.Error("relay configuration was sent by a deployment with no relays")
+	}
+}
+
+// Deltas carry the relay configuration too, not only snapshots: an agent that missed the
+// snapshot would have peers naming a relay it knows nothing about.
+func TestADeltaAlsoCarriesTheRelayConfiguration(t *testing.T) {
+	f := newFixture(t)
+	relays, err := ParseRelays("relay1=relay1.example:3478")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.srv.builder = f.srv.builder.WithRelays(relays)
+
+	alice := f.enrolDevice("alice")
+	before := f.headVersion()
+	f.enrolDevice("bob")
+
+	delta, err := f.srv.builder.For(f.ctx, alice.membershipID, before)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delta.GetFromVersion() == 0 {
+		t.Fatal("expected a delta, got a snapshot")
+	}
+	if delta.GetRelays() == nil {
+		t.Error("the delta carries no relay configuration")
+	}
+	if delta.GetUpsertPeers()[0].GetRelayId() != "relay1" {
+		t.Error("the peer in the delta does not name the relay")
+	}
+}

--- a/internal/session/relays.go
+++ b/internal/session/relays.go
@@ -1,0 +1,99 @@
+package session
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// ParseRelays reads a deployment's relay list.
+//
+// The form is `id=host:port[,host:port...]`, several relays separated by semicolons:
+//
+//	relay1=relay1.meshp.net:3478,relay1.meshp.net:443
+//
+// Several addresses per relay because one port is not enough: UDP 443 looks like the
+// friendliest choice and is the one most likely to be filtered, since it carries QUIC and
+// networks that inspect HTTP block it. The order is the order an agent tries them in, so put
+// the port most likely to work first.
+//
+// Configuration rather than a database table for now. A table is right eventually — relays
+// will have regions and health — but a deployment with one relay should not need a migration
+// to name it.
+func ParseRelays(spec string) (*meshpv1.RelayConfig, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return nil, nil
+	}
+
+	cfg := &meshpv1.RelayConfig{}
+	for _, entry := range strings.Split(spec, ";") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		id, addresses, ok := strings.Cut(entry, "=")
+		if !ok {
+			return nil, fmt.Errorf("session: relay %q has no id; expected id=host:port", entry)
+		}
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return nil, fmt.Errorf("session: relay %q has an empty id", entry)
+		}
+
+		relay := &meshpv1.RelayConfig_Relay{Id: id}
+		for _, addr := range strings.Split(addresses, ",") {
+			addr = strings.TrimSpace(addr)
+			if addr == "" {
+				continue
+			}
+			// Validated here rather than at the agent, because a typo in a deployment's
+			// configuration should be an error where it is written, not a device somewhere
+			// failing to connect to a relay that never existed.
+			if err := validRelayAddress(addr); err != nil {
+				return nil, fmt.Errorf("session: relay %s: %w", id, err)
+			}
+			relay.Endpoints = append(relay.Endpoints, addr)
+		}
+		if len(relay.Endpoints) == 0 {
+			return nil, fmt.Errorf("session: relay %s has no addresses", id)
+		}
+		cfg.Relays = append(cfg.Relays, relay)
+	}
+
+	if len(cfg.Relays) == 0 {
+		return nil, nil
+	}
+	cfg.PreferredRelayId = cfg.Relays[0].GetId()
+	return cfg, nil
+}
+
+// validRelayAddress accepts host:port, where the host may be a name or an address.
+//
+// A name is normal — relays are reached by DNS so they can move — so this cannot simply parse
+// an AddrPort.
+func validRelayAddress(addr string) error {
+	host, port, ok := strings.Cut(addr, ":")
+	if !ok {
+		return fmt.Errorf("%q has no port; a relay is reached at host:port", addr)
+	}
+	if host == "" {
+		return fmt.Errorf("%q has no host", addr)
+	}
+	if _, err := netip.ParseAddrPort(addr); err == nil {
+		return nil // a literal address, already checked
+	}
+	// Not a literal, so the host is a name and only the port can be checked here.
+	if port == "" {
+		return fmt.Errorf("%q has an empty port", addr)
+	}
+	for _, r := range port {
+		if r < '0' || r > '9' {
+			return fmt.Errorf("%q does not end in a port number", addr)
+		}
+	}
+	return nil
+}

--- a/internal/session/relays_test.go
+++ b/internal/session/relays_test.go
@@ -1,0 +1,90 @@
+package session
+
+import "testing"
+
+func TestParsingADeploymentsRelays(t *testing.T) {
+	cfg, err := ParseRelays("relay1=relay1.meshp.net:3478,relay1.meshp.net:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.GetRelays()) != 1 {
+		t.Fatalf("%d relays, want 1", len(cfg.GetRelays()))
+	}
+	relay := cfg.GetRelays()[0]
+	if relay.GetId() != "relay1" {
+		t.Errorf("id is %q", relay.GetId())
+	}
+	// Order matters: it is the order an agent tries, so the port most likely to work leads.
+	want := []string{"relay1.meshp.net:3478", "relay1.meshp.net:443"}
+	if len(relay.GetEndpoints()) != len(want) {
+		t.Fatalf("%d endpoints, want %d", len(relay.GetEndpoints()), len(want))
+	}
+	for i, w := range want {
+		if relay.GetEndpoints()[i] != w {
+			t.Errorf("endpoint %d is %q, want %q", i, relay.GetEndpoints()[i], w)
+		}
+	}
+	if cfg.GetPreferredRelayId() != "relay1" {
+		t.Errorf("preferred relay is %q", cfg.GetPreferredRelayId())
+	}
+}
+
+func TestSeveralRelays(t *testing.T) {
+	cfg, err := ParseRelays("blr=a.meshp.net:3478; fra=b.meshp.net:3478,b.meshp.net:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.GetRelays()) != 2 {
+		t.Fatalf("%d relays, want 2", len(cfg.GetRelays()))
+	}
+	if cfg.GetRelays()[1].GetId() != "fra" {
+		t.Errorf("second relay is %q", cfg.GetRelays()[1].GetId())
+	}
+}
+
+func TestNoRelaysConfiguredIsNotAnError(t *testing.T) {
+	for _, spec := range []string{"", "   "} {
+		cfg, err := ParseRelays(spec)
+		if err != nil {
+			t.Errorf("%q gave %v", spec, err)
+		}
+		if cfg != nil {
+			t.Errorf("%q produced a config", spec)
+		}
+	}
+}
+
+// A typo belongs where it was written, not as a device somewhere failing to reach a relay
+// that never existed.
+func TestMalformedRelaysAreRefusedAtConfiguration(t *testing.T) {
+	for _, spec := range []string{
+		"relay1.meshp.net:3478",        // no id
+		"=relay1.meshp.net:3478",       // empty id
+		"relay1=",                      // no addresses
+		"relay1=relay1.meshp.net",      // no port
+		"relay1=relay1.meshp.net:",     // empty port
+		"relay1=relay1.meshp.net:http", // not a number
+		"relay1=:3478",                 // no host
+	} {
+		if _, err := ParseRelays(spec); err == nil {
+			t.Errorf("%q was accepted", spec)
+		}
+	}
+}
+
+// A literal address is as valid as a name, since a small deployment may not have DNS for it.
+func TestLiteralAddressesAreAccepted(t *testing.T) {
+	for _, spec := range []string{
+		"relay1=203.0.113.9:3478",
+		"relay1=[2001:db8::9]:3478",
+	} {
+		cfg, err := ParseRelays(spec)
+		if err != nil {
+			t.Errorf("%q gave %v", spec, err)
+			continue
+		}
+		if len(cfg.GetRelays()[0].GetEndpoints()) != 1 {
+			t.Errorf("%q produced %d endpoints", spec, len(cfg.GetRelays()[0].GetEndpoints()))
+		}
+	}
+}

--- a/internal/session/server.go
+++ b/internal/session/server.go
@@ -52,6 +52,9 @@ type Config struct {
 	// MasterSecret derives the session challenge key.
 	MasterSecret []byte
 
+	// Relays is what this deployment offers, sent to agents as part of desired state.
+	Relays *meshpv1.RelayConfig
+
 	// RelayIssuer mints relay credentials when asked. Nil where a deployment has not
 	// configured relaying: enrolment and state still work, and an agent asking for a token
 	// is told relaying is unavailable rather than met with silence (ADR-0017).
@@ -87,7 +90,7 @@ func NewServer(st *store.Store, hub *Hub, cfg Config) (*Server, error) {
 	return &Server{
 		store:      st,
 		hub:        hub,
-		builder:    NewStateBuilder(st),
+		builder:    NewStateBuilder(st).WithRelays(cfg.Relays),
 		challenger: challenger,
 		relay:      cfg.RelayIssuer,
 		clk:        cfg.Clock,

--- a/internal/session/state.go
+++ b/internal/session/state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/meshpnet/meshp/internal/relayproto"
 	"github.com/meshpnet/meshp/internal/store"
 	dbgen "github.com/meshpnet/meshp/internal/store/gen"
 	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
@@ -24,10 +25,21 @@ const keepaliveSeconds = 25
 // StateBuilder turns what the database says into what an agent should do.
 type StateBuilder struct {
 	store *store.Store
+
+	// relays is what this deployment offers, sent to every agent as part of desired state.
+	// Nil where relaying is not configured, in which case peers carry neither an endpoint
+	// nor a relay and know about each other without being able to reach each other.
+	relays *meshpv1.RelayConfig
 }
 
 // NewStateBuilder returns a builder reading from st.
 func NewStateBuilder(st *store.Store) *StateBuilder { return &StateBuilder{store: st} }
+
+// WithRelays returns a builder that tells agents about these relays.
+func (b *StateBuilder) WithRelays(relays *meshpv1.RelayConfig) *StateBuilder {
+	b.relays = relays
+	return b
+}
 
 // For returns the state to send an agent that has applied fromVersion.
 //
@@ -125,10 +137,11 @@ func (b *StateBuilder) snapshotFromPeers(membership dbgen.GetMembershipForSessio
 		FromVersion: 0,
 		ToVersion:   uint64(membership.StateVersion),
 		UpsertPeers: make([]*meshpv1.Peer, 0, len(peers)),
-		Tunnel:      tunnelConfig(),
+		Tunnel:      b.tunnelConfig(),
+		Relays:      b.relays,
 	}
 	for _, p := range peers {
-		delta.UpsertPeers = append(delta.UpsertPeers, peerFrom(
+		delta.UpsertPeers = append(delta.UpsertPeers, b.peerFrom(
 			p.WireguardPublicKey, p.DeviceName, p.Tags, p.AddressV4, p.AddressV6))
 	}
 	return delta
@@ -173,6 +186,11 @@ func (b *StateBuilder) delta(ctx context.Context, membership dbgen.GetMembership
 	delta := &meshpv1.StateDelta{
 		FromVersion: fromVersion,
 		ToVersion:   head,
+		// Sent with every delta, not only snapshots. It is small, it changes rarely, and an
+		// agent that missed the snapshot carrying it would have peers naming a relay it
+		// knows nothing about.
+		Relays: b.relays,
+		Tunnel: b.tunnelConfig(),
 	}
 
 	for id := range upserts {
@@ -189,7 +207,7 @@ func (b *StateBuilder) delta(ctx context.Context, membership dbgen.GetMembership
 		// A key that is being removed and re-added in the same delta is a rotation. The
 		// upsert is the newer fact, so it must not also be removed.
 		delete(removes, peer.WireguardPublicKey)
-		delta.UpsertPeers = append(delta.UpsertPeers, peerFrom(
+		delta.UpsertPeers = append(delta.UpsertPeers, b.peerFrom(
 			peer.WireguardPublicKey, peer.DeviceName, peer.Tags, peer.AddressV4, peer.AddressV6))
 	}
 
@@ -206,25 +224,53 @@ func (b *StateBuilder) delta(ctx context.Context, membership dbgen.GetMembership
 	return delta, nil
 }
 
-func peerFrom(publicKey, deviceName string, tags []string, v4, v6 *netip.Addr) *meshpv1.Peer {
-	return &meshpv1.Peer{
+func (b *StateBuilder) peerFrom(publicKey, deviceName string, tags []string, v4, v6 *netip.Addr) *meshpv1.Peer {
+	peer := &meshpv1.Peer{
 		PublicKey:                  publicKey,
 		AllowedIps:                 allowedIPs(v4, v6),
 		PersistentKeepaliveSeconds: keepaliveSeconds,
 		DeviceName:                 deviceName,
 		Tags:                       tags,
-		// No endpoints and no relay yet: neither exists, so an agent receiving this knows
-		// about its peers and has no way to reach them. That is the honest state of the
-		// system and the next milestone.
+		// No endpoints. Nothing discovers where a peer is yet, so every peer is reached
+		// through a relay — which is what relay-first means (ADR-0002) rather than a
+		// limitation to apologise for. Endpoints arrive with discovery, and a peer that has
+		// one will prefer it.
 	}
+	if relay := b.preferredRelay(); relay != nil {
+		peer.RelayId = relay.GetId()
+	}
+	return peer
 }
 
-func tunnelConfig() *meshpv1.TunnelConfig {
+// preferredRelay is the relay this deployment offers, or nothing.
+func (b *StateBuilder) preferredRelay() *meshpv1.RelayConfig_Relay {
+	if b.relays == nil || len(b.relays.GetRelays()) == 0 {
+		return nil
+	}
+	// One relay today. When there are several, this is where region and load belong — and
+	// the agent is told all of them regardless, so it can fall back without asking.
+	return b.relays.GetRelays()[0]
+}
+
+func (b *StateBuilder) tunnelConfig() *meshpv1.TunnelConfig {
+	// 1420 leaves room for WireGuard's overhead inside a 1500-byte path.
+	mtu := uint32(1420)
+
+	// A relayed packet carries the relay's header outside the WireGuard packet, so it needs
+	// a smaller tunnel. WireGuard's MTU is per interface rather than per peer, so one
+	// relayed peer lowers it for all of them — and since every peer is relayed until
+	// discovery exists, that is every interface today.
+	//
+	// Chosen over switching the MTU as peers move between relayed and direct: a changing
+	// MTU makes the failure intermittent, and the failure mode is loss of large packets
+	// only, which is the hardest thing to attribute. A stable conservative number costs a
+	// little throughput on direct paths and nothing else.
+	if b.preferredRelay() != nil {
+		mtu = uint32(relayproto.RelayedTunnelMTU)
+	}
+
 	return &meshpv1.TunnelConfig{
-		// 1420 leaves room for WireGuard's overhead inside a 1500-byte path. A starting
-		// point, not a measurement: the agent probes and reports what it finds, and a wrong
-		// MTU is the usual cause of "connected but some sites hang".
-		Mtu: 1420,
+		Mtu: mtu,
 		// No default route is claimed yet, so there is nothing to fail closed around. This
 		// turns on with route groups (ADR-0011).
 		FailClosed: false,


### PR DESCRIPTION
The control plane now decides that peers are relayed and says where the relays are. Peers carry
a relay id; desired state carries the relay list the protocol already had a field for.

## Every peer is relayed, and that is not a placeholder

Nothing discovers where a peer is yet, and relay-first means connectivity does not wait on NAT
traversal succeeding (ADR-0002). So relaying everything is the honest rule until discovery
exists — and it is the rule that makes the feature testable end to end. Peers that later carry
an endpoint will prefer it.

The relay list rides **every delta**, not only snapshots: it is small, it changes rarely, and an
agent that missed the snapshot carrying it would hold peers naming a relay it knows nothing
about.

## The MTU decision, made rather than deferred

A relayed packet carries the relay header outside the WireGuard packet, so it needs a smaller
tunnel — **1387 rather than 1420**, with the arithmetic written out in `relayproto`. WireGuard's
MTU is per *interface*, not per peer, so one relayed peer lowers it for all of them; and since
every peer is relayed today, that is every interface.

The alternative was switching the MTU as peers move between relayed and direct. Faster on direct
paths, and it makes the failure **intermittent** — and the failure mode here is loss of large
packets only, already the hardest thing to attribute. Making it come and go would cost more than
the throughput it buys. A stable conservative number until path probing exists (`PathReport` is
in the protocol, unimplemented).

## Configuration refuses typos where they are written

```
$ MESHP_RELAYS="relay1=relay1.meshp.net" meshp-control
meshp-control: session: relay relay1: "relay1.meshp.net" has no port; a relay is reached at host:port
```

Several addresses per relay, because one port is not enough — and the order is the order an
agent tries them in, so the port most likely to get through belongs first. A typo belongs where
it was written, not as a device somewhere failing to reach a relay that never existed.

## Invariants

- [x] An invariant is affected, and it still holds. Which, and how it is tested:

**18** — the state builder's output is still a pure function of the database and configuration,
so a converged agent stays converged; the existing delta and property tests cover it.

## Migrations

None. Relays are configuration rather than a table — a table is right eventually, when they have
regions and health, but a deployment with one relay should not need a migration to name it.

## What is left before a device actually relays

Only the `meshpd` wiring: request a token (the server side of that merged in #23), dial the
relay with `relayclient`, build a `relayforward.Forwarder`, and set each relayed peer's endpoint
to a forwarder socket with `Relayed: true`. Every component exists and is tested; nothing calls
them yet.

That next PR is the one that ends with asking for the hotspot.