### PR TITLE
feat(revoke): take a device out of a network, and mean it

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,15 @@ kernel WireGuard interfaces reconciled against what the control plane asked for
 attaches to it (ADR-0016, ADR-0017). Plus the parts nothing calls yet: IPAM, advertiser
 health and route-group selection.
 
+Devices can also be revoked: an administrator removes one and every other agent drops
+its key, which is what actually cuts it off — enforcement is at the peers, not at the
+device being removed, so a machine that is switched off or hostile is out just the same.
+
 What does not, and matters: **there is no policy enforcement** — every device in a
-network can reach every other, because the ACL engine is not wired up. **A device
-cannot be removed from a network**; nothing writes a revocation. **The control plane
-speaks plaintext HTTP.** Direct paths, DNS and internet egress are all unimplemented,
-and the data plane is Linux-only — elsewhere a device enrols, holds an address, and
-reports honestly that it has no tunnel.
+network can reach every other, because the ACL engine is not wired up. **The control
+plane speaks plaintext HTTP.** Direct paths, DNS and internet egress are all
+unimplemented, and the data plane is Linux-only — elsewhere a device enrols, holds an
+address, and reports honestly that it has no tunnel.
 
 It is public from the first commit because the design decisions are the
 interesting part and we would rather be argued with early.

--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -276,6 +276,7 @@ func (a *agent) ensureSession(m agentstate.Membership) {
 		OS:           runtime.GOOS,
 		Hostname:     hostname(),
 		Relay:        relayCredentials(relay),
+		Revoked:      &membershipRevoker{agent: a, membershipID: m.MembershipID},
 		Log:          log,
 	})
 	a.running[m.MembershipID] = &sessionHandle{
@@ -417,8 +418,13 @@ func (a *agent) Status(_ context.Context) (agentapi.Status, error) {
 			// Live, from the session rather than from disk. This is the reason to ask the
 			// daemon instead of reading the state file: the file cannot say whether the
 			// control plane is reachable right now.
-			ms.Connected = true
-			ms.ConnectedSince = handle.started
+			//
+			// From the client rather than from the handle. A handle exists for as long as
+			// the membership is supervised, which includes the whole time a revoked or
+			// misconfigured device is having every connection refused — reporting that as
+			// connected would make status agree with the device's own hopes rather than
+			// with the control plane.
+			ms.Connected, ms.ConnectedSince = handle.client.Connected()
 			ms.AppliedStateVersion = handle.client.AppliedVersion()
 			ms.LastError = handle.applier.lastError()
 			ms.TunnelUp, ms.TunnelKind = handle.applier.tunnelStatus()

--- a/cmd/meshpd/revoke.go
+++ b/cmd/meshpd/revoke.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/meshpnet/meshp/internal/agentstate"
+	"github.com/meshpnet/meshp/internal/logx"
+)
+
+// membershipRevoker acts on the control plane ending one membership.
+//
+// One per session, because a device may belong to several networks (ADR-0004) and one
+// revoking it says nothing about the others. Everything here is scoped to the membership
+// named at construction.
+type membershipRevoker struct {
+	agent        *agent
+	membershipID uuid.UUID
+}
+
+// Revoked implements sessionclient.Revoker.
+//
+// The interface comes down first (Invariant 20: what the agent installed, the agent
+// removes), then the local record goes. Both matter and for different reasons: an interface
+// left up would hold addresses and routes for a network this device is no longer part of,
+// and a membership left on disk would have meshpd trying to open a session that the control
+// plane refuses, forever, at every start.
+func (r *membershipRevoker) Revoked(reason string, wipeLocalState bool) {
+	r.agent.log.Warn("revoked from a network; tearing down",
+		"membership_id", r.membershipID,
+		"reason", logx.Safe(reason),
+		"wipe_local_state", wipeLocalState)
+	r.agent.revoke(r.membershipID, wipeLocalState)
+}
+
+// revoke removes every trace of one membership from this device.
+func (a *agent) revoke(membershipID uuid.UUID, wipeLocalState bool) {
+	a.mu.Lock()
+	handle, running := a.running[membershipID]
+	a.mu.Unlock()
+
+	// The interface before the session. Tearing down needs the reconciler, and cancelling
+	// the session first would race the goroutine that closes the relay link out from under
+	// it.
+	if running && handle.applier.reconciler != nil {
+		if err := handle.applier.reconciler.Teardown(); err != nil {
+			// Reported, not fatal. The membership is over regardless, and an interface that
+			// could not be removed is a mess to clean up rather than a reason to keep a
+			// device in a network it has been thrown out of.
+			a.log.Error("could not tear down the interface of a revoked membership",
+				"membership_id", membershipID, "error", err)
+		}
+	}
+	if running {
+		// Stops the session supervisor and the relay link together; the deferred close in
+		// ensureSession releases the relay's sockets.
+		handle.cancel()
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.state == nil {
+		return
+	}
+	if !a.state.RemoveMembership(membershipID) {
+		return
+	}
+	// Only once nothing is left. The identity names this device to every network it has
+	// joined (ADR-0006), so discarding it because one network revoked this device would
+	// quietly lock it out of the others.
+	if wipeLocalState && len(a.state.Memberships) == 0 {
+		a.state.ForgetIdentity()
+	}
+	if err := agentstate.Save(a.stateDir, a.state); err != nil {
+		a.log.Error("could not record a revocation locally",
+			"membership_id", membershipID, "error", err,
+			"hint", "meshpd will try to reopen this session until the file is written")
+	}
+}

--- a/internal/agentstate/state.go
+++ b/internal/agentstate/state.go
@@ -87,7 +87,15 @@ type Membership struct {
 }
 
 // Identity decodes the device identity.
+//
+// Absent is refused rather than decoded. Empty base64 decodes happily to an empty key, and
+// an empty key signs: the daemon would open sessions with a signature nothing can verify
+// and report the failure as an authentication problem at the control plane rather than as
+// the missing identity it is.
 func (s *State) Identity() (keys.Identity, error) {
+	if s.IdentityPrivateKey == "" || s.IdentityPublicKey == "" {
+		return keys.Identity{}, errors.New("agentstate: this device has no identity")
+	}
 	priv, err := base64.StdEncoding.DecodeString(s.IdentityPrivateKey)
 	if err != nil {
 		return keys.Identity{}, fmt.Errorf("agentstate: identity private key: %w", err)
@@ -124,6 +132,34 @@ func (s *State) AddMembership(m Membership) {
 		}
 	}
 	s.Memberships = append(s.Memberships, m)
+}
+
+// RemoveMembership forgets a membership, and reports whether there was one.
+//
+// The WireGuard key goes with it, which is right: keys are per membership and never shared
+// between them (Invariant 19), so discarding one network's key tells another network
+// nothing. The device identity is deliberately left alone — it is shared across every
+// membership (ADR-0006), and dropping it because one network revoked this device would
+// silently lock the device out of the others.
+func (s *State) RemoveMembership(membershipID uuid.UUID) bool {
+	for i := range s.Memberships {
+		if s.Memberships[i].MembershipID != membershipID {
+			continue
+		}
+		s.Memberships = append(s.Memberships[:i], s.Memberships[i+1:]...)
+		return true
+	}
+	return false
+}
+
+// ForgetIdentity discards the device's identity.
+//
+// Only meaningful once no memberships remain, which is the only time it is safe: the
+// identity names this device to every network it has joined (ADR-0006). Callers honouring
+// a wipe request must check that themselves — this does as it is told.
+func (s *State) ForgetIdentity() {
+	s.IdentityPublicKey = ""
+	s.IdentityPrivateKey = ""
 }
 
 // Path returns the state file's location inside dir.

--- a/internal/agentstate/state_test.go
+++ b/internal/agentstate/state_test.go
@@ -242,3 +242,64 @@ func TestIdentityRejectsCorruptKeys(t *testing.T) {
 		t.Error("Identity accepted unparseable keys")
 	}
 }
+
+// A revoked membership is forgotten, and only that one: a device may belong to several
+// networks (ADR-0004), and one revoking it says nothing about the others.
+func TestRemoveMembershipTakesOnlyTheOneNamed(t *testing.T) {
+	s := &State{}
+	keep, drop := uuid.New(), uuid.New()
+	s.AddMembership(Membership{MembershipID: keep, NetworkID: uuid.New(),
+		InterfaceName: "meshp0", WireGuardPrivateKey: "keep-key"})
+	s.AddMembership(Membership{MembershipID: drop, NetworkID: uuid.New(),
+		InterfaceName: "meshp1", WireGuardPrivateKey: "drop-key"})
+
+	if !s.RemoveMembership(drop) {
+		t.Fatal("removing a membership that exists reported nothing to do")
+	}
+	if len(s.Memberships) != 1 || s.Memberships[0].MembershipID != keep {
+		t.Fatalf("memberships = %+v, want only the kept one", s.Memberships)
+	}
+	// The key went with it. Keys are per membership and never shared (Invariant 19), so
+	// leaving one behind would keep material for a network this device is out of.
+	for _, m := range s.Memberships {
+		if m.WireGuardPrivateKey == "drop-key" {
+			t.Error("the revoked membership's key survived")
+		}
+	}
+
+	if s.RemoveMembership(drop) {
+		t.Error("removing the same membership twice reported that it did something")
+	}
+	if s.RemoveMembership(uuid.New()) {
+		t.Error("removing an unknown membership reported that it did something")
+	}
+}
+
+// The identity names this device to every network it has joined (ADR-0006), so it survives
+// one network revoking the device. Only an explicit wipe, once nothing is left, discards it.
+func TestRemoveMembershipKeepsTheIdentity(t *testing.T) {
+	s := &State{}
+	id, err := keys.NewIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetIdentity(id)
+	membershipID := uuid.New()
+	s.AddMembership(Membership{MembershipID: membershipID, NetworkID: uuid.New(), InterfaceName: "meshp0"})
+
+	s.RemoveMembership(membershipID)
+	if s.IdentityPublicKey == "" {
+		t.Fatal("removing a membership discarded the device's identity")
+	}
+	if _, err := s.Identity(); err != nil {
+		t.Fatalf("the identity is no longer usable: %v", err)
+	}
+
+	s.ForgetIdentity()
+	if s.IdentityPublicKey != "" || s.IdentityPrivateKey != "" {
+		t.Error("ForgetIdentity left key material behind")
+	}
+	if _, err := s.Identity(); err == nil {
+		t.Error("a forgotten identity still loads")
+	}
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -103,6 +103,9 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	mux.Handle("POST /api/v1/networks/{networkID}/enrollment-tokens", s.adminOnly(s.handleCreateToken))
 	mux.Handle("GET /api/v1/networks/{networkID}/enrollment-tokens", s.adminOnly(s.handleListTokens))
 	mux.Handle("DELETE /api/v1/networks/{networkID}/enrollment-tokens/{tokenID}", s.adminOnly(s.handleRevokeToken))
+
+	mux.Handle("GET /api/v1/networks/{networkID}/devices", s.adminOnly(s.handleListMemberships))
+	mux.Handle("DELETE /api/v1/networks/{networkID}/devices/{membershipID}", s.adminOnly(s.handleRevokeMembership))
 }
 
 // rateLimited wraps an unauthenticated handler.

--- a/internal/api/revoke.go
+++ b/internal/api/revoke.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/meshpnet/meshp/internal/httpx"
+	"github.com/meshpnet/meshp/internal/logx"
+	"github.com/meshpnet/meshp/internal/store"
+	dbgen "github.com/meshpnet/meshp/internal/store/gen"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// handleRevokeMembership takes a device out of a network.
+//
+// The order here is the whole design. The database commits first, so the network's desired
+// state no longer contains this peer; then the other agents are nudged, so they drop it;
+// only then is the device itself told, because telling it is a courtesy rather than the
+// mechanism. A device that is switched off, or hostile, or simply gone is out of the
+// network regardless — its peers stop accepting its key, and nothing it does changes that
+// (the same shape as ACLs enforced at the destination, ADR-0007).
+func (s *Server) handleRevokeMembership(w http.ResponseWriter, r *http.Request) {
+	networkID, ok := s.pathUUID(w, r, "networkID")
+	if !ok {
+		return
+	}
+	membershipID, ok := s.pathUUID(w, r, "membershipID")
+	if !ok {
+		return
+	}
+
+	var body struct {
+		Reason string `json:"reason"`
+		// Wipe asks the device to destroy its local keys as well as its interface. Off by
+		// default: it is unrecoverable, and an administrator removing a device from one
+		// network rarely means to erase its identity for every other.
+		Wipe bool `json:"wipe_local_state"`
+	}
+	if payload, err := io.ReadAll(io.LimitReader(r.Body, 1<<16)); err == nil && len(payload) > 0 {
+		if err := json.Unmarshal(payload, &body); err != nil {
+			httpx.Error(w, s.log, http.StatusBadRequest, "bad_request", "body must be JSON")
+			return
+		}
+	}
+
+	req := store.RevokeRequest{
+		NetworkID:    networkID,
+		MembershipID: membershipID,
+		Reason:       body.Reason,
+		ActorLabel:   "admin token",
+		SourceIP:     sourceAddr(r),
+	}
+	// Best effort: the organisation only labels the audit row, and failing to read it is
+	// not a reason to leave a device in a network someone has decided to remove it from.
+	if network, err := s.store.Queries().GetNetwork(r.Context(), networkID); err == nil {
+		req.OrganizationID = &network.OrganizationID
+	}
+
+	revoked, err := s.store.RevokeMembership(r.Context(), req)
+	if errors.Is(err, store.ErrNotAMember) {
+		httpx.Error(w, s.log, http.StatusNotFound, "not_found",
+			"no such device in that network, or it was already revoked")
+		return
+	}
+	if err != nil {
+		s.respondError(w, r, err)
+		return
+	}
+
+	s.log.Info("device revoked",
+		"network_id", networkID, "membership_id", revoked.MembershipID,
+		"device_id", revoked.DeviceID, "reason", logx.Safe(body.Reason))
+
+	// The peers first. They are what enforces this, so any delay here is the window in
+	// which a revoked device is still reachable.
+	s.tellNetwork(networkID)
+	s.tellRevoked(revoked, body.Reason, body.Wipe)
+
+	httpx.WriteJSON(w, s.log, http.StatusOK, map[string]any{
+		"status":               "revoked",
+		"membership_id":        revoked.MembershipID,
+		"device_id":            revoked.DeviceID,
+		"wireguard_public_key": revoked.WireGuardPublicKey,
+	})
+}
+
+// tellRevoked asks the device to tear itself down, if it happens to be listening.
+//
+// Courtesy, not enforcement: it saves the device from holding an interface that can no
+// longer carry anything, and it lets a person at the keyboard see why. A device that is
+// offline is equally revoked and will find out when it tries to reconnect.
+func (s *Server) tellRevoked(revoked store.Revoked, reason string, wipe bool) {
+	if s.session == nil {
+		return
+	}
+	sess, ok := s.session.Hub().Get(revoked.MembershipID)
+	if !ok {
+		return
+	}
+
+	sess.Farewell(&meshpv1.ServerMessage{Payload: &meshpv1.ServerMessage_Command{
+		Command: &meshpv1.Command{Payload: &meshpv1.Command_Revoke{Revoke: &meshpv1.Revoke{
+			Reason:         reason,
+			WipeLocalState: wipe,
+		}}},
+	}})
+}
+
+// handleListMemberships answers "who is in this network, and are they still allowed in".
+//
+// Revoked memberships are listed rather than hidden. An administrator checking that a
+// device really is out needs to see that it is out, and a device that silently vanished
+// from a list is indistinguishable from one that was never there.
+func (s *Server) handleListMemberships(w http.ResponseWriter, r *http.Request) {
+	networkID, ok := s.pathUUID(w, r, "networkID")
+	if !ok {
+		return
+	}
+	rows, err := s.store.Queries().ListMembershipsForNetwork(r.Context(), networkID)
+	if err != nil {
+		s.respondError(w, r, err)
+		return
+	}
+	if rows == nil {
+		rows = []dbgen.ListMembershipsForNetworkRow{}
+	}
+	httpx.WriteJSON(w, s.log, http.StatusOK, map[string]any{"devices": rows})
+}

--- a/internal/api/revoke_test.go
+++ b/internal/api/revoke_test.go
@@ -1,0 +1,225 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/meshpnet/meshp/internal/enrollclient"
+	"github.com/meshpnet/meshp/internal/store"
+	dbgen "github.com/meshpnet/meshp/internal/store/gen"
+)
+
+// enrol puts a device in the harness's network and returns what the control plane assigned.
+func (h *harness) enrol(name string) enrollclient.JoinResult {
+	h.t.Helper()
+	token := h.mintToken(1, time.Hour)
+	id, wg := newDevice(h.t)
+	res, err := enrollclient.New(h.server.URL, nil).Join(h.ctx, enrollclient.JoinRequest{
+		Token: token, Identity: id, WireGuard: wg,
+		Name: name, Hostname: name, OS: "linux", AgentVersion: "test",
+	})
+	if err != nil {
+		h.t.Fatalf("enrolling %s: %v", name, err)
+	}
+	return res
+}
+
+func (h *harness) revoke(networkID, membershipID uuid.UUID, body any) *http.Response {
+	h.t.Helper()
+	var payload []byte
+	if body != nil {
+		payload, _ = json.Marshal(body)
+	}
+	req, _ := http.NewRequest(http.MethodDelete,
+		h.server.URL+"/api/v1/networks/"+networkID.String()+"/devices/"+membershipID.String(),
+		bytes.NewReader(payload))
+	req.Header.Set("Authorization", "Bearer "+testAdminToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	return resp
+}
+
+// The point of the whole feature: a revoked device stops being a peer, so everyone else
+// is told to drop its key. That removal is the enforcement — nothing depends on reaching
+// the revoked device at all.
+func TestRevokingADeviceRemovesItAsAPeer(t *testing.T) {
+	h := newHarness(t)
+	alice := h.enrol("alice")
+	bob := h.enrol("bob")
+
+	resp := h.revoke(h.netID, bob.MembershipID, map[string]any{"reason": "sold"})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("revoke returned %d", resp.StatusCode)
+	}
+
+	var out struct {
+		Status             string `json:"status"`
+		WireGuardPublicKey string `json:"wireguard_public_key"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "revoked" || out.WireGuardPublicKey == "" {
+		t.Fatalf("response = %+v", out)
+	}
+
+	// Alice must no longer be told about Bob.
+	peers, err := h.store.Queries().ListPeersForMembership(h.ctx, dbgen.ListPeersForMembershipParams{NetworkID: h.netID, ID: alice.MembershipID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range peers {
+		if p.MembershipID == bob.MembershipID {
+			t.Fatal("a revoked device is still offered as a peer")
+		}
+	}
+
+	// And the removal is in the delta log by key, because by the time an agent asks, the
+	// row that held the key may be gone.
+	var kind, key string
+	if err := h.store.Pool().QueryRow(h.ctx,
+		`SELECT kind, peer_public_key FROM state_changes
+		 WHERE network_id = $1 AND kind = 'peer_remove' ORDER BY version DESC LIMIT 1`,
+		h.netID).Scan(&kind, &key); err != nil {
+		t.Fatalf("no removal was recorded: %v", err)
+	}
+	if key != out.WireGuardPublicKey {
+		t.Errorf("recorded removal of %q, want %q", key, out.WireGuardPublicKey)
+	}
+}
+
+// Revoking twice is not an error the second time so much as a different answer: there was
+// nothing to revoke. Reporting success would tell an administrator they had just removed a
+// device that somebody else removed an hour ago.
+func TestRevokingTwiceReportsNothingToDo(t *testing.T) {
+	h := newHarness(t)
+	bob := h.enrol("bob")
+
+	first := h.revoke(h.netID, bob.MembershipID, nil)
+	_ = first.Body.Close()
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("first revoke returned %d", first.StatusCode)
+	}
+
+	second := h.revoke(h.netID, bob.MembershipID, nil)
+	defer func() { _ = second.Body.Close() }()
+	if second.StatusCode != http.StatusNotFound {
+		t.Errorf("second revoke returned %d, want 404", second.StatusCode)
+	}
+}
+
+// Scoped by network as well as by id, so an administrator holding one network cannot reach
+// into another — and cannot use the endpoint to discover whether an id exists elsewhere.
+func TestRevokingFromTheWrongNetworkIsRefused(t *testing.T) {
+	h := newHarness(t)
+	bob := h.enrol("bob")
+
+	resp := h.revoke(uuid.New(), bob.MembershipID, nil)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("returned %d, want 404", resp.StatusCode)
+	}
+
+	// And it really did not happen.
+	rows, err := h.store.Queries().ListMembershipsForNetwork(h.ctx, h.netID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range rows {
+		if r.MembershipID == bob.MembershipID && r.State != "active" {
+			t.Fatalf("the membership is %s; a foreign network id revoked it", r.State)
+		}
+	}
+}
+
+// Cutting a device out of a network is the most consequential thing here, so it is
+// accounted for whether or not anyone was watching.
+func TestARevocationIsAudited(t *testing.T) {
+	h := newHarness(t)
+	bob := h.enrol("bob")
+
+	resp := h.revoke(h.netID, bob.MembershipID, map[string]any{"reason": "laptop stolen"})
+	_ = resp.Body.Close()
+
+	var action, metadata string
+	if err := h.store.Pool().QueryRow(h.ctx,
+		`SELECT action, metadata::text FROM audit_events
+		 WHERE network_id = $1 AND action = 'device.revoked' ORDER BY created_at DESC LIMIT 1`,
+		h.netID).Scan(&action, &metadata); err != nil {
+		t.Fatalf("no audit event: %v", err)
+	}
+	if !bytes.Contains([]byte(metadata), []byte("laptop stolen")) {
+		t.Errorf("the reason was not recorded: %s", metadata)
+	}
+}
+
+// An unauthenticated caller must not be able to empty a network.
+func TestRevokingNeedsAdmin(t *testing.T) {
+	h := newHarness(t)
+	bob := h.enrol("bob")
+
+	req, _ := http.NewRequest(http.MethodDelete,
+		h.server.URL+"/api/v1/networks/"+h.netID.String()+"/devices/"+bob.MembershipID.String(), nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("an unauthenticated revoke returned %d", resp.StatusCode)
+	}
+}
+
+// Revoked memberships stay listed. A device that silently vanished from the list is
+// indistinguishable from one that was never there, and an administrator checking that a
+// device is really out needs to see that it is out.
+func TestARevokedDeviceIsStillListed(t *testing.T) {
+	h := newHarness(t)
+	bob := h.enrol("bob")
+	resp := h.revoke(h.netID, bob.MembershipID, nil)
+	_ = resp.Body.Close()
+
+	rows, err := h.store.Queries().ListMembershipsForNetwork(h.ctx, h.netID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, r := range rows {
+		if r.MembershipID == bob.MembershipID {
+			found = true
+			if r.State != "revoked" || r.RevokedAt == nil {
+				t.Errorf("listed as state=%q revoked_at=%v", r.State, r.RevokedAt)
+			}
+		}
+	}
+	if !found {
+		t.Error("the revoked device disappeared from the list entirely")
+	}
+}
+
+// The store reports a missing membership as its own condition rather than a generic error,
+// because the caller answers 404 for it and 500 for everything else.
+func TestRevokingAnUnknownMembership(t *testing.T) {
+	h := newHarness(t)
+	_, err := h.store.RevokeMembership(h.ctx, store.RevokeRequest{
+		NetworkID:    h.netID,
+		MembershipID: uuid.New(),
+	})
+	if err == nil {
+		t.Fatal("revoking a membership that does not exist reported success")
+	}
+	if !isNotAMember(err) {
+		t.Errorf("error = %v, want store.ErrNotAMember", err)
+	}
+}
+
+func isNotAMember(err error) bool { return errors.Is(err, store.ErrNotAMember) }

--- a/internal/session/hub.go
+++ b/internal/session/hub.go
@@ -49,6 +49,15 @@ type Session struct {
 	send   chan *meshpv1.ServerMessage
 	notify chan struct{}
 
+	// farewell carries a last message that must reach the agent before the session ends.
+	//
+	// Separate from send because ending the session is part of delivering it, and the two
+	// cannot be expressed as "enqueue, then close": the writer selects on the queue and on
+	// closure together, so when both are ready Go picks between them at random and the
+	// message is dropped about half the time. One case that writes and then closes is the
+	// only version with a defined order.
+	farewell chan *meshpv1.ServerMessage
+
 	closeOnce sync.Once
 	closed    chan struct{}
 
@@ -67,6 +76,7 @@ func newSession(id string, membershipID, networkID, deviceID uuid.UUID, now time
 		ConnectedAt:  now,
 		send:         make(chan *meshpv1.ServerMessage, sendQueue),
 		notify:       make(chan struct{}, 1),
+		farewell:     make(chan *meshpv1.ServerMessage, 1),
 		closed:       make(chan struct{}),
 	}
 }
@@ -127,6 +137,19 @@ func (s *Session) enqueue(msg *meshpv1.ServerMessage) bool {
 		s.overrun.Store(true)
 		s.Close()
 		return false
+	}
+}
+
+// Farewell asks the session to deliver one last message and then end.
+//
+// Best effort by design. It is a courtesy to a device that happens to be connected —
+// revocation is enforced by the other agents dropping the key, not by reaching this one —
+// so a session already closing simply does not get it.
+func (s *Session) Farewell(msg *meshpv1.ServerMessage) {
+	select {
+	case <-s.closed:
+	case s.farewell <- msg:
+	default:
 	}
 }
 

--- a/internal/session/relaycreds.go
+++ b/internal/session/relaycreds.go
@@ -93,6 +93,19 @@ func (s *Server) relayTokenFor(ctx context.Context, sess *Session) ([]byte, time
 		return nil, time.Time{}, fmt.Errorf("loading membership: %w", err)
 	}
 
+	// Re-checked here rather than trusted from the handshake. A session outlives the
+	// request that opened it, so a device revoked mid-session would otherwise be handed a
+	// fresh half-hour capability on its way out — and the relay cannot know better,
+	// because a token it can verify is a token it must honour.
+	//
+	// It does not make an outstanding token expire. That is the reason revocation is
+	// enforced by the peers dropping the key rather than by cutting off the relay: the
+	// revoked device may still reach the relay until its token runs out, and there is
+	// no longer anybody on the far side willing to decrypt what it sends.
+	if membership.DeviceRevokedAt != nil || membership.MembershipState != "active" {
+		return nil, time.Time{}, errors.New("this membership is no longer active")
+	}
+
 	encoded, err := s.store.Queries().GetWireGuardKeyForMembership(ctx, sess.MembershipID)
 	if err != nil {
 		return nil, time.Time{}, fmt.Errorf("loading this membership's WireGuard key: %w", err)

--- a/internal/session/server.go
+++ b/internal/session/server.go
@@ -300,6 +300,18 @@ func (s *Server) run(ctx context.Context, conn *websocket.Conn, sess *Session) {
 				return
 			}
 
+		case msg := <-sess.farewell:
+			// Written and then closed, in that order, which is the reason this is its own
+			// case rather than an enqueue followed by a Close: those are two ready cases in
+			// one select, and the agent would be cut off before hearing why about half the
+			// time.
+			if err := writeServerMessage(ctx, conn, msg); err != nil {
+				s.log.Debug("could not deliver a farewell", "session", sess.ID, "error", err)
+			}
+			_ = conn.Close(websocket.StatusNormalClosure, "revoked")
+			sess.Close()
+			return
+
 		case <-sess.notify:
 			if err := s.pushState(ctx, conn, sess); err != nil {
 				s.log.Info("could not push state", "session", sess.ID, "error", err)

--- a/internal/sessionclient/client.go
+++ b/internal/sessionclient/client.go
@@ -49,6 +49,10 @@ const (
 	maxBackoff = 30 * time.Second
 )
 
+// ErrRevoked means the control plane ended this membership. Terminal: reconnecting would
+// be refused, and retrying forever would hide the reason behind a backoff loop.
+var ErrRevoked = errors.New("sessionclient: this device has been revoked from the network")
+
 // Applier converges the device toward a desired state.
 //
 // It is handed the complete desired state, not the delta that produced it. Folding deltas
@@ -87,6 +91,17 @@ type RelayCredentials interface {
 	TokenRefused(reason string)
 }
 
+// Revoker is told that this membership is over.
+//
+// The control plane says so as a courtesy, not as the mechanism: by the time this arrives
+// the other devices have already been told to drop this one's key, so the membership is
+// finished whether or not the message is received or acted on. What acting on it buys is
+// tidiness — an interface torn down rather than left up and carrying nothing — and a
+// person at the keyboard being told why.
+type Revoker interface {
+	Revoked(reason string, wipeLocalState bool)
+}
+
 // Options configures a Client.
 type Options struct {
 	ControlURL   string
@@ -102,6 +117,10 @@ type Options struct {
 	// with no data plane, and the client then never asks for one — a token nothing can use
 	// is a credential minted for no reason.
 	Relay RelayCredentials
+
+	// Revoked is told when the control plane ends this membership. Nil is fine: the
+	// membership is over either way.
+	Revoked Revoker
 
 	HTTPClient *http.Client
 	Log        *slog.Logger
@@ -124,6 +143,16 @@ type Client struct {
 	// only thing that licenses asking for a delta: a delta can be applied to it, and
 	// there is nothing else to apply one to.
 	state *peerset.Set
+
+	// establishedAt is when the control plane last welcomed this client, zero when there
+	// is no session right now.
+	//
+	// Tracked here because it is the only place that knows. The daemon supervises a
+	// session for as long as a membership exists, so "the supervisor is running" is true
+	// while every connection attempt is being refused — and status reporting that as
+	// connected is the exact failure this project keeps guarding against: a device that
+	// looks healthy and is not.
+	establishedAt time.Time
 }
 
 // New returns a Client.
@@ -142,6 +171,19 @@ func New(opts Options) *Client {
 	}
 	c.opts.ControlURL = validated
 	return c
+}
+
+// Connected reports whether a session is established right now, and since when.
+func (c *Client) Connected() (bool, time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return !c.establishedAt.IsZero(), c.establishedAt
+}
+
+func (c *Client) setEstablished(at time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.establishedAt = at
 }
 
 // AppliedVersion is the newest version this client has applied.
@@ -224,6 +266,13 @@ func (c *Client) Run(ctx context.Context, applier Applier) error {
 			return ctx.Err()
 		}
 
+		// Terminal. The membership is gone at the control plane, so every reconnection
+		// would be refused at the handshake — retrying would turn a clear answer into an
+		// endless backoff loop with the reason buried in the first line of it.
+		if errors.Is(err, ErrRevoked) {
+			return err
+		}
+
 		// A session that lasted a while was healthy, so the next failure should retry
 		// promptly rather than inheriting the backoff from an outage that is over.
 		if time.Since(start) > time.Minute {
@@ -286,7 +335,10 @@ func (c *Client) RunOnce(ctx context.Context, applier Applier) error {
 		return fmt.Errorf("sessionclient: dialling %s: %w", wsURL, err)
 	}
 	conn.SetReadLimit(maxMessageBytes)
-	defer func() { _ = conn.CloseNow() }()
+	defer func() {
+		_ = conn.CloseNow()
+		c.setEstablished(time.Time{})
+	}()
 
 	sessionCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -392,6 +444,10 @@ func (c *Client) RunOnce(ctx context.Context, applier Applier) error {
 
 		switch payload := msg.Payload.(type) {
 		case *meshpv1.ServerMessage_Hello:
+			// The server's hello is the first moment a session is genuinely established:
+			// the dial succeeded and the signature was accepted. A refused connection gets
+			// closed before this.
+			c.setEstablished(time.Now().UTC())
 			h := payload.Hello
 			c.log.Info("control channel established",
 				"session", h.GetSessionId(),
@@ -418,6 +474,19 @@ func (c *Client) RunOnce(ctx context.Context, applier Applier) error {
 			}
 
 		case *meshpv1.ServerMessage_Command:
+			if revoke := payload.Command.GetRevoke(); revoke != nil {
+				// The reason is written by an administrator and read by whoever finds the
+				// machine, so it crosses a trust boundary in both directions.
+				c.log.Warn("this device has been revoked from the network",
+					"reason", logx.Safe(revoke.GetReason()),
+					"wipe_local_state", revoke.GetWipeLocalState())
+				if c.opts.Revoked != nil {
+					c.opts.Revoked.Revoked(revoke.GetReason(), revoke.GetWipeLocalState())
+				}
+				// The server closes the connection after this. Returning rather than
+				// waiting for the read to fail keeps the reason as the reported cause.
+				return ErrRevoked
+			}
 			c.log.Info("received a command", "command", fmt.Sprintf("%T", payload.Command.Payload))
 
 		default:

--- a/internal/sessionclient/client_test.go
+++ b/internal/sessionclient/client_test.go
@@ -618,3 +618,241 @@ func TestJitterStaysWithinItsInterval(t *testing.T) {
 			len(spread))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Revocation
+
+type recordingRevoker struct {
+	mu     sync.Mutex
+	calls  int
+	reason string
+	wipe   bool
+}
+
+func (r *recordingRevoker) Revoked(reason string, wipe bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls++
+	r.reason, r.wipe = reason, wipe
+}
+
+func (r *recordingRevoker) seen() (int, string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls, r.reason, r.wipe
+}
+
+func revokeMessage(reason string, wipe bool) *meshpv1.ServerMessage {
+	return &meshpv1.ServerMessage{Payload: &meshpv1.ServerMessage_Command{
+		Command: &meshpv1.Command{Payload: &meshpv1.Command_Revoke{
+			Revoke: &meshpv1.Revoke{Reason: reason, WipeLocalState: wipe},
+		}},
+	}}
+}
+
+// startRevocable runs one session and returns the error RunOnce ended with.
+func startRevocable(t *testing.T, fc *fakeControl, rev Revoker) (*websocket.Conn, <-chan error) {
+	t.Helper()
+
+	identity, err := keys.NewIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := New(Options{
+		ControlURL:   fc.srv.URL,
+		Identity:     identity,
+		MembershipID: uuid.New(),
+		Revoked:      rev,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() { done <- client.RunOnce(ctx, &recordingApplier{}) }()
+
+	select {
+	case conn := <-fc.conn:
+		t.Cleanup(func() { _ = conn.CloseNow() })
+		return conn, done
+	case <-time.After(5 * time.Second):
+		t.Fatal("the agent never opened a session")
+		return nil, nil
+	}
+}
+
+// A revocation has to reach whatever tears the membership down, with the reason intact —
+// it is written by an administrator and read by whoever finds the machine.
+func TestARevocationReachesTheAgent(t *testing.T) {
+	fc := newFakeControl(t)
+	rev := &recordingRevoker{}
+	conn, done := startRevocable(t, fc, rev)
+
+	fc.send(conn, revokeMessage("laptop reported stolen", true))
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrRevoked) {
+			t.Fatalf("RunOnce returned %v, want ErrRevoked", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the session did not end on revocation")
+	}
+
+	calls, reason, wipe := rev.seen()
+	if calls != 1 {
+		t.Fatalf("the revoker was called %d times, want 1", calls)
+	}
+	if reason != "laptop reported stolen" {
+		t.Errorf("reason = %q", reason)
+	}
+	if !wipe {
+		t.Error("the wipe request was dropped")
+	}
+}
+
+// Terminal, not retryable. Every reconnection would be refused at the handshake, so a Run
+// that backed off and tried again would bury the reason under an endless loop.
+func TestRunStopsOnRevocationRatherThanReconnecting(t *testing.T) {
+	fc := newFakeControl(t)
+
+	attempts := make(chan struct{}, 8)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/session/challenge", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"challenge": base64.StdEncoding.EncodeToString([]byte("challenge")),
+		})
+	})
+	mux.HandleFunc("/api/v1/session", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		attempts <- struct{}{}
+		data, _ := proto.Marshal(revokeMessage("no longer employed", false))
+		_ = conn.Write(context.Background(), websocket.MessageBinary, data)
+		time.Sleep(200 * time.Millisecond)
+		_ = conn.CloseNow()
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	_ = fc
+
+	identity, err := keys.NewIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rev := &recordingRevoker{}
+	client := New(Options{
+		ControlURL: srv.URL, Identity: identity, MembershipID: uuid.New(), Revoked: rev,
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- client.Run(context.Background(), &recordingApplier{}) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrRevoked) {
+			t.Fatalf("Run returned %v, want ErrRevoked", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run kept reconnecting after a revocation")
+	}
+
+	if len(attempts) != 1 {
+		t.Errorf("opened %d sessions, want 1 — it reconnected after being revoked", len(attempts))
+	}
+}
+
+// An agent with nothing to tear down still has to stop. Nil is a normal configuration.
+func TestRevocationWithNoRevokerStillEndsTheSession(t *testing.T) {
+	fc := newFakeControl(t)
+	conn, done := startRevocable(t, fc, nil)
+
+	fc.send(conn, revokeMessage("", false))
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrRevoked) {
+			t.Fatalf("RunOnce returned %v, want ErrRevoked", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the session did not end")
+	}
+}
+
+// Other commands are not revocations and must not end anything. A newer control plane may
+// send commands this agent has never heard of (ADR-0008).
+func TestAnotherCommandDoesNotEndTheSession(t *testing.T) {
+	fc := newFakeControl(t)
+	rev := &recordingRevoker{}
+	conn, done := startRevocable(t, fc, rev)
+
+	fc.send(conn, &meshpv1.ServerMessage{Payload: &meshpv1.ServerMessage_Command{
+		Command: &meshpv1.Command{Payload: &meshpv1.Command_CollectDiagnostics{
+			CollectDiagnostics: &meshpv1.CollectDiagnostics{},
+		}},
+	}})
+
+	select {
+	case err := <-done:
+		t.Fatalf("an unrelated command ended the session: %v", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+	if calls, _, _ := rev.seen(); calls != 0 {
+		t.Errorf("the revoker fired on a command that was not a revocation")
+	}
+}
+
+// Status must report whether a session exists, not whether something is trying to make
+// one. A daemon supervises a membership for as long as it has one, so a device being
+// refused every connection would otherwise be reported as connected indefinitely.
+func TestConnectedReflectsAnEstablishedSessionOnly(t *testing.T) {
+	fc := newFakeControl(t)
+
+	identity, err := keys.NewIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := New(Options{
+		ControlURL: fc.srv.URL, Identity: identity, MembershipID: uuid.New(),
+	})
+
+	if up, _ := client.Connected(); up {
+		t.Fatal("reported connected before anything was dialled")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- client.RunOnce(ctx, &recordingApplier{}) }()
+
+	conn := <-fc.conn
+	t.Cleanup(func() { _ = conn.CloseNow() })
+
+	// Dialled, but not yet welcomed: the signature has not been accepted, so there is no
+	// session. This is the state a revoked device sits in.
+	if up, _ := client.Connected(); up {
+		t.Fatal("reported connected on a dial the server had not accepted")
+	}
+
+	fc.send(conn, &meshpv1.ServerMessage{Payload: &meshpv1.ServerMessage_Hello{
+		Hello: &meshpv1.ServerHello{SessionId: "s1", CurrentStateVersion: 1},
+	}})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if up, since := client.Connected(); up {
+			if since.IsZero() {
+				t.Error("connected with no time to say since when")
+			}
+			cancel()
+			<-done
+			if up, _ := client.Connected(); up {
+				t.Error("still reported connected after the session ended")
+			}
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	t.Fatal("never reported connected after being welcomed")
+}

--- a/internal/store/gen/devices.sql.go
+++ b/internal/store/gen/devices.sql.go
@@ -392,3 +392,107 @@ func (q *Queries) ListDeviceAddressPools(ctx context.Context, networkID uuid.UUI
 	}
 	return items, nil
 }
+
+const listMembershipsForNetwork = `-- name: ListMembershipsForNetwork :many
+SELECT
+    m.id            AS membership_id,
+    m.device_id,
+    d.name          AS device_name,
+    m.address_v4,
+    m.address_v6,
+    m.state,
+    m.joined_at,
+    m.revoked_at,
+    k.public_key    AS wireguard_public_key
+FROM device_network_memberships m
+JOIN devices d ON d.id = m.device_id
+LEFT JOIN wireguard_keys k ON k.membership_id = m.id AND k.state = 'current'
+WHERE m.network_id = $1
+ORDER BY m.joined_at
+`
+
+type ListMembershipsForNetworkRow struct {
+	MembershipID       uuid.UUID
+	DeviceID           uuid.UUID
+	DeviceName         string
+	AddressV4          *netip.Addr
+	AddressV6          *netip.Addr
+	State              string
+	JoinedAt           time.Time
+	RevokedAt          *time.Time
+	WireguardPublicKey *string
+}
+
+// Who is in a network, for an administrator deciding what to revoke.
+//
+// Revoked memberships are included rather than filtered out: an administrator checking
+// that a device really is out needs to see that it is out, and one that had silently
+// vanished would be indistinguishable from one that was never there.
+func (q *Queries) ListMembershipsForNetwork(ctx context.Context, networkID uuid.UUID) ([]ListMembershipsForNetworkRow, error) {
+	rows, err := q.db.Query(ctx, listMembershipsForNetwork, networkID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListMembershipsForNetworkRow
+	for rows.Next() {
+		var i ListMembershipsForNetworkRow
+		if err := rows.Scan(
+			&i.MembershipID,
+			&i.DeviceID,
+			&i.DeviceName,
+			&i.AddressV4,
+			&i.AddressV6,
+			&i.State,
+			&i.JoinedAt,
+			&i.RevokedAt,
+			&i.WireguardPublicKey,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const revokeMembership = `-- name: RevokeMembership :one
+UPDATE device_network_memberships m
+SET state = 'revoked', revoked_at = now()
+FROM wireguard_keys k
+WHERE m.id = $1
+  AND m.network_id = $2
+  AND m.state <> 'revoked'
+  AND k.membership_id = m.id
+  AND k.state = 'current'
+RETURNING m.id AS membership_id, m.device_id, k.public_key AS wireguard_public_key
+`
+
+type RevokeMembershipParams struct {
+	ID        uuid.UUID
+	NetworkID uuid.UUID
+}
+
+type RevokeMembershipRow struct {
+	MembershipID       uuid.UUID
+	DeviceID           uuid.UUID
+	WireguardPublicKey string
+}
+
+// Take a device out of a network, and say which key stopped being a peer.
+//
+// The key comes back because a removal is recorded by key rather than by membership: by
+// the time a delta is built this row may be long gone, and an agent that is never told to
+// drop a peer keeps a tunnel configured to a device that is no longer entitled to one.
+//
+// Scoped by network as well as by id so an administrator holding one network cannot revoke
+// a membership in another, and matched on state so revoking twice affects nothing — the
+// second call returns no row, which the caller reports rather than treating as success.
+func (q *Queries) RevokeMembership(ctx context.Context, arg RevokeMembershipParams) (RevokeMembershipRow, error) {
+	row := q.db.QueryRow(ctx, revokeMembership, arg.ID, arg.NetworkID)
+	var i RevokeMembershipRow
+	err := row.Scan(&i.MembershipID, &i.DeviceID, &i.WireguardPublicKey)
+	return i, err
+}

--- a/internal/store/revoke.go
+++ b/internal/store/revoke.go
@@ -1,0 +1,116 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/netip"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	dbgen "github.com/meshpnet/meshp/internal/store/gen"
+)
+
+// ErrNotAMember means there was nothing to revoke: no such membership in that network, or
+// it had already been revoked.
+//
+// One error for both, because they are the same answer to the only question an
+// administrator is asking — is this device out? — and telling them apart would let anyone
+// holding an admin token for one network probe for membership ids in another.
+var ErrNotAMember = errors.New("store: no such active membership in this network")
+
+// Revoked is what a revocation removed.
+type Revoked struct {
+	MembershipID uuid.UUID
+	DeviceID     uuid.UUID
+
+	// WireGuardPublicKey is what the other devices in the network must stop accepting. It
+	// is the whole enforcement mechanism: a revoked device keeps its key and its address,
+	// and what changes is that nobody else will talk to it.
+	WireGuardPublicKey string
+}
+
+// RevokeMembership takes a device out of a network.
+//
+// The revocation and the removal record go in one transaction. Split apart they fail
+// silently in both directions: a membership marked revoked with no logged removal leaves
+// every other agent holding a peer that the database says is gone, and a logged removal
+// with no revocation lets the device reconnect and be re-added on the next snapshot.
+//
+// What this does not do is reach the device. Revocation is enforced by the peers, not by
+// the revoked one — the same shape as ACLs being enforced at the destination (ADR-0007).
+// A device that is switched off, or that never reconnects, is out of the network the moment
+// everyone else applies the removal, and nothing it does can put it back.
+func (s *Store) RevokeMembership(ctx context.Context, req RevokeRequest) (Revoked, error) {
+	var out Revoked
+
+	err := s.InTx(ctx, func(q *dbgen.Queries) error {
+		row, err := q.RevokeMembership(ctx, dbgen.RevokeMembershipParams{
+			ID:        req.MembershipID,
+			NetworkID: req.NetworkID,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotAMember
+		}
+		if err != nil {
+			return fmt.Errorf("store: revoking membership: %w", err)
+		}
+
+		if _, err := BumpVersion(ctx, q, req.NetworkID, PeerRemoved(row.WireguardPublicKey)); err != nil {
+			return err
+		}
+
+		// In the same transaction as the act itself. Cutting a device out of a network is
+		// the most consequential thing an administrator can do here, and a revocation that
+		// committed while its audit record was rolled back would be one nobody can account
+		// for afterwards.
+		metadata, _ := json.Marshal(map[string]any{
+			"reason":               req.Reason,
+			"wireguard_public_key": row.WireguardPublicKey,
+		})
+		networkID := req.NetworkID
+		membershipID := row.MembershipID
+		if _, err := q.CreateAuditEvent(ctx, dbgen.CreateAuditEventParams{
+			OrganizationID: req.OrganizationID,
+			NetworkID:      &networkID,
+			ActorKind:      "api_token",
+			ActorLabel:     req.ActorLabel,
+			Action:         "device.revoked",
+			ResourceKind:   "membership",
+			ResourceID:     &membershipID,
+			SourceIp:       req.SourceIP,
+			Metadata:       metadata,
+		}); err != nil {
+			return fmt.Errorf("store: writing the revocation audit event: %w", err)
+		}
+
+		out = Revoked{
+			MembershipID:       row.MembershipID,
+			DeviceID:           row.DeviceID,
+			WireGuardPublicKey: row.WireguardPublicKey,
+		}
+		return nil
+	})
+	if err != nil {
+		return Revoked{}, err
+	}
+	return out, nil
+}
+
+// RevokeRequest is who is revoking what, and why.
+type RevokeRequest struct {
+	NetworkID    uuid.UUID
+	MembershipID uuid.UUID
+
+	// OrganizationID may be nil; the audit row tolerates it and a revocation is not worth
+	// refusing because the network's organisation could not be read.
+	OrganizationID *uuid.UUID
+
+	// Reason is recorded and also sent to the device, so it is written by an administrator
+	// and read by whoever finds the machine. Optional.
+	Reason     string
+	ActorLabel string
+	SourceIP   *netip.Addr
+}

--- a/queries/devices.sql
+++ b/queries/devices.sql
@@ -60,3 +60,45 @@ SELECT * FROM audit_events
 WHERE network_id = $1
 ORDER BY created_at DESC, id DESC
 LIMIT $2;
+
+-- name: RevokeMembership :one
+-- Take a device out of a network, and say which key stopped being a peer.
+--
+-- The key comes back because a removal is recorded by key rather than by membership: by
+-- the time a delta is built this row may be long gone, and an agent that is never told to
+-- drop a peer keeps a tunnel configured to a device that is no longer entitled to one.
+--
+-- Scoped by network as well as by id so an administrator holding one network cannot revoke
+-- a membership in another, and matched on state so revoking twice affects nothing — the
+-- second call returns no row, which the caller reports rather than treating as success.
+UPDATE device_network_memberships m
+SET state = 'revoked', revoked_at = now()
+FROM wireguard_keys k
+WHERE m.id = $1
+  AND m.network_id = $2
+  AND m.state <> 'revoked'
+  AND k.membership_id = m.id
+  AND k.state = 'current'
+RETURNING m.id AS membership_id, m.device_id, k.public_key AS wireguard_public_key;
+
+-- name: ListMembershipsForNetwork :many
+-- Who is in a network, for an administrator deciding what to revoke.
+--
+-- Revoked memberships are included rather than filtered out: an administrator checking
+-- that a device really is out needs to see that it is out, and one that had silently
+-- vanished would be indistinguishable from one that was never there.
+SELECT
+    m.id            AS membership_id,
+    m.device_id,
+    d.name          AS device_name,
+    m.address_v4,
+    m.address_v6,
+    m.state,
+    m.joined_at,
+    m.revoked_at,
+    k.public_key    AS wireguard_public_key
+FROM device_network_memberships m
+JOIN devices d ON d.id = m.device_id
+LEFT JOIN wireguard_keys k ON k.membership_id = m.id AND k.state = 'current'
+WHERE m.network_id = $1
+ORDER BY m.joined_at;

--- a/scripts/e2e-enrol.sh
+++ b/scripts/e2e-enrol.sh
@@ -411,6 +411,108 @@ if [ "$tunnel_possible" = "1" ]; then
   fi
   echo "  the kernel's traffic is leaving through the relay (${sent} packet(s))"
 
+  # ---------------------------------------------------------------------------
+  # Revocation
+  #
+  # Everything above describes a device that is in the network. This is the other half:
+  # taking one out has to actually remove it, and the removal is enforced here — on the
+  # peer — rather than on the device being revoked. That is why this is asserted against
+  # the first daemon while the second one is not even running.
+  echo "revoking the second device"
+
+  # Which membership is the peer? The second daemon's own state file says, which is also a
+  # check that the listing endpoint agrees with it.
+  PEER_MEMBERSHIP="$(sed -n 's/.*"membership_id": *"\([^"]*\)".*/\1/p' "$STATE_DIR2/state.json" | head -1)"
+  [ -n "$PEER_MEMBERSHIP" ] || fail "could not read the peer's membership id"
+
+  curl -fsS -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    "${BASE}/api/v1/networks/${NETWORK_ID}/devices" >"$WORK/devices.out" \
+    || fail "could not list the network's devices"
+  grep -q "$PEER_MEMBERSHIP" "$WORK/devices.out" \
+    || { cat "$WORK/devices.out" >&2; fail "the device listing does not contain the peer"; }
+
+  curl -fsS -X DELETE \
+    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    -H 'Content-Type: application/json' \
+    -d '{"reason":"e2e revocation"}' \
+    "${BASE}/api/v1/networks/${NETWORK_ID}/devices/${PEER_MEMBERSHIP}" >"$WORK/revoke.out" \
+    || { cat "$WORK/revoke.out" >&2; fail "the revoke request failed"; }
+  grep -q '"status":"revoked"' "$WORK/revoke.out" \
+    || { cat "$WORK/revoke.out" >&2; fail "revoke did not report success"; }
+
+  # The peer disappears from the interface. This is the whole enforcement mechanism: the
+  # revoked device keeps its key and its address, and what changes is that nobody will
+  # accept it any more.
+  gone=0
+  for _ in $(seq 1 25); do
+    if ! wg show meshp0 allowed-ips 2>/dev/null | grep -qE "100\.90\.${OCTET}\.2/32"; then
+      gone=1; break
+    fi
+    sleep 1
+  done
+  if [ "$gone" != "1" ]; then
+    echo "--- wg ---" >&2; wg show meshp0 >&2
+    echo "--- agent log ---" >&2; tail -20 "$AGENT_LOG" >&2
+    fail "a revoked device is still configured as a peer"
+  fi
+  echo "  the peer was dropped from the interface"
+
+  # And its route with it, or traffic for that address would still be handed to a tunnel
+  # that has nowhere to send it.
+  ip route show dev meshp0 | grep -q "100.90.${OCTET}.2" \
+    && { ip route show dev meshp0 >&2; fail "the route to the revoked device survived"; }
+  echo "  and its route withdrawn"
+
+  # The relayed socket that served it is released. Nothing had ever exercised this before
+  # revocation existed: a peer had no way to stop being relayed, so the retirement path in
+  # relaylink ran only in its own tests.
+  relayed_now="$(./bin/meshp status --socket "$SOCKET" \
+    | sed -n 's|.*peers     \([0-9]*\) relayed.*|\1|p')"
+  if [ -n "$relayed_now" ] && [ "$relayed_now" != "0" ]; then
+    ./bin/meshp status --socket "$SOCKET" >&2
+    fail "the revoked peer's relay socket was not released (${relayed_now} still served)"
+  fi
+  echo "  its relay socket was released"
+
+  # The revoked device cannot come back.
+  #
+  # Asserted by restarting its daemon rather than by poking the challenge endpoint. That
+  # endpoint deliberately does not check whether a membership exists — doing so would make
+  # it an enumeration oracle for membership ids — so it answers a revoked device just as it
+  # answers a made-up one. The signature check at connect time is what decides, and this is
+  # the only place to observe it.
+  ./bin/meshpd --reconcile-interval 2s --state-dir "$STATE_DIR2" --socket "$SOCKET2" \
+    --log-level debug >>"$WORK/meshpd2.log" 2>&1 &
+  AGENT2_PID=$!
+  for _ in $(seq 1 20); do
+    [ -S "$SOCKET2" ] && ./bin/meshp status --socket "$SOCKET2" >/dev/null 2>&1 && break
+    sleep 1
+  done
+
+  # The agent is told only that authentication failed. That is deliberate — the reason a
+  # membership is refused crosses a trust boundary towards a device that may no longer be
+  # trusted — so this matches the refusal rather than the cause. The cause is in the
+  # control plane's own log, asserted below, where an operator can see it.
+  refused=0
+  for _ in $(seq 1 20); do
+    if grep -q "authentication failed" "$WORK/meshpd2.log"; then refused=1; break; fi
+    sleep 1
+  done
+  if [ "$refused" != "1" ]; then
+    echo "--- revoked agent log ---" >&2; tail -20 "$WORK/meshpd2.log" >&2
+    fail "the revoked device was not refused a session"
+  fi
+
+  grep -qiE "revoked|membership is" "$CONTROL_LOG" \
+    || { tail -20 "$CONTROL_LOG" >&2; fail "the control plane did not record why it refused"; }
+  ./bin/meshp status --socket "$SOCKET2" | grep -qE 'session     connected' \
+    && { ./bin/meshp status --socket "$SOCKET2" >&2; fail "a revoked device holds a session"; }
+  echo "  and cannot open a new session"
+
+  kill "$AGENT2_PID" 2>/dev/null || true
+  wait "$AGENT2_PID" 2>/dev/null || true
+  AGENT2_PID=""
+
   # The listen port survives a restart, which is what keeps the endpoints peers hold valid
   # and any NAT mapping alive.
   #


### PR DESCRIPTION
A device could join a network and never leave it. `store.PeerRemoved` existed and was called by nothing; the `state_changes` log had a `peer_remove` kind that no code path could produce. For an MSP-facing product, "we cannot offboard a stolen laptop" is the gap that matters most.

## Enforcement is at the peers

The database commits first, so the network's desired state no longer contains that peer. Then the other agents are nudged and drop its key. **Only then** is the device itself told — and telling it is a courtesy, not the mechanism. A machine that is switched off, or hostile, or simply gone is out just the same. Same shape as ACLs enforced at the destination (ADR-0007).

The revocation, the removal record and the audit event share one transaction. Split apart they fail silently in both directions: a membership marked revoked with no logged removal leaves every other agent holding a peer the database says is gone; a logged removal with no revocation lets the device reconnect and get re-added on the next snapshot.

## The farewell needed its own path

Telling a connected device needed more than "enqueue, then close" — those are two ready cases in one `select`, so Go picks between them at random and the agent is cut off before hearing why about half the time. That is the trap the existing `enqueue` comment already warns about, so the session got a dedicated `farewell` channel whose writer case writes *then* closes.

## Three bugs found while testing, none in the feature as designed

- **The audit row used `actor_kind: "admin"`**, which the CHECK constraint rejects (`user`, `device`, `system`, `api_token`). Every revocation would have returned 500 in production. The API tests caught it on the first run.
- **`meshp status` reported a live session whenever the supervisor goroutine was alive**, not when a session existed — so a revoked device retrying a refused handshake showed as `connected`. `sessionclient` now records when it was actually welcomed. Found by the e2e; no unit test would have.
- **`agentstate.Identity` decoded an absent identity into an empty keypair** that would happily sign, turning "no identity" into "authentication failed at the control plane".

## One assertion of mine was wrong, not the code

I first asserted the session *challenge* endpoint must refuse a revoked membership. It shouldn't: checking membership there would make it an enumeration oracle for membership ids, which the handler's comment already explains. The signature check at connect time is the real boundary, so the e2e now restarts the revoked daemon and asserts it is refused at the handshake — and that the control plane logs *why* while the agent is told only "authentication failed", because that reason crosses a trust boundary toward a device that is no longer trusted.

## Also checked, and fine

After revoking the only peer, the agent receives a **snapshot** rather than a delta. That looked wrong; it is the `changes > len(peers)` rule working — a snapshot of an empty network is smaller than a delta describing one removal. With 50 peers, revoking one produces a delta.

## e2e

Extended to revoke the second device and assert, on a real kernel:

```
the peer was dropped from the interface
and its route withdrawn
its relay socket was released
and cannot open a new session
```

That third line is the first time `relaylink.Retain` has run in a real daemon — nothing could retire a relayed peer before this existed, so it had only ever run in its own tests.