### PR TITLE
feat(acl): the policy language, and compiling it to a device's filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ CROSS_TARGETS := linux/amd64 linux/arm64 linux/arm \
 # are held lower rather than pretended into the top tier. Packages needing PostgreSQL
 # are checked separately: without a database their tests skip, and the figure would be
 # meaningless rather than merely low.
-COVER_FLOOR_PKGS := internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan internal/relayproto internal/relay internal/relaytoken
+COVER_FLOOR_PKGS := internal/acl internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan internal/relayproto internal/relay internal/relaytoken
 COVER_FLOOR      := 90
 
 COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx internal/tunnel internal/relayclient internal/relayforward internal/relaylink internal/sessionclient

--- a/internal/acl/acl_test.go
+++ b/internal/acl/acl_test.go
@@ -1,0 +1,482 @@
+package acl
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"net/netip"
+	"slices"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+func device(key string, addr string, tags ...string) Device {
+	return Device{
+		Key:       key,
+		Addresses: []netip.Prefix{netip.MustParsePrefix(addr)},
+		Tags:      tags,
+	}
+}
+
+func doc(rules ...Rule) Document {
+	return Document{Version: Version, Rules: rules}
+}
+
+// allowed reports whether any rule in the list permits src to reach dst.
+func allowed(rules []*meshpv1.PacketFilter_Rule, src, dst string) bool {
+	for _, r := range rules {
+		if slices.Contains(r.GetSrcPrefixes(), src) && slices.Contains(r.GetDstPrefixes(), dst) {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// The document
+
+func TestParseRejectsWhatItCannotCompileFaithfully(t *testing.T) {
+	for _, tc := range []struct{ name, json, wants string }{
+		{"a future version", `{"version":2,"rules":[]}`, "version"},
+		{"no version at all", `{"rules":[]}`, "version"},
+		{
+			// The reason unknown fields are refused: this compiles to a rule permitting
+			// every protocol, which is the opposite of what was written and invisible in a
+			// diff.
+			"a misspelled key",
+			`{"version":1,"rules":[{"src":["*"],"dst":["*"],"protocols":"tcp"}]}`,
+			"protocols",
+		},
+		{"a rule with no source", `{"version":1,"rules":[{"dst":["*"]}]}`, "source"},
+		{"a rule with no destination", `{"version":1,"rules":[{"src":["*"]}]}`, "destination"},
+		{"an unknown protocol", `{"version":1,"rules":[{"src":["*"],"dst":["*"],"protocol":"sctp"}]}`, "sctp"},
+		{
+			// Honouring the protocol and dropping the ports would hand someone a working
+			// rule that is not the one they wrote.
+			"ports on a protocol without ports",
+			`{"version":1,"rules":[{"src":["*"],"dst":["*"],"protocol":"icmp","ports":["22"]}]}`,
+			"ports",
+		},
+		{"a port that is not a number", `{"version":1,"rules":[{"src":["*"],"dst":["*"],"protocol":"tcp","ports":["ssh"]}]}`, "number"},
+		{"a port out of range", `{"version":1,"rules":[{"src":["*"],"dst":["*"],"protocol":"tcp","ports":["70000"]}]}`, "65535"},
+		{"a backwards range", `{"version":1,"rules":[{"src":["*"],"dst":["*"],"protocol":"tcp","ports":["100-20"]}]}`, "ends before"},
+		{"an empty selector", `{"version":1,"rules":[{"src":[""],"dst":["*"]}]}`, "empty"},
+		{"a tag naming nothing", `{"version":1,"rules":[{"src":["tag:"],"dst":["*"]}]}`, "tag"},
+		{"a selector that is nothing recognisable", `{"version":1,"rules":[{"src":["engineering"],"dst":["*"]}]}`, "not"},
+		{"a malformed prefix", `{"version":1,"rules":[{"src":["100.90.0.0/33"],"dst":["*"]}]}`, "not"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.json))
+			if err == nil {
+				t.Fatalf("accepted %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wants) {
+				t.Errorf("error %q does not mention %q", err, tc.wants)
+			}
+		})
+	}
+}
+
+func TestParseAcceptsAPolicySomeoneWouldWrite(t *testing.T) {
+	parsed, err := Parse([]byte(`{
+	  "version": 1,
+	  "comment": "hq",
+	  "rules": [
+	    {"src": ["tag:laptop"], "dst": ["tag:server"], "protocol": "tcp", "ports": ["22", "8000-8100"],
+	     "comment": "engineers reach the build servers"},
+	    {"src": ["*"], "dst": ["100.64.0.0/10"], "protocol": "any"}
+	  ]
+	}`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(parsed.Rules) != 2 {
+		t.Fatalf("%d rules, want 2", len(parsed.Rules))
+	}
+	if parsed.Comment != "hq" {
+		t.Errorf("the author's comment was lost")
+	}
+	ranges, err := parsed.Rules[0].PortRanges()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ranges) != 2 || ranges[0].String() != "22" || ranges[1].String() != "8000-8100" {
+		t.Errorf("ports = %v", ranges)
+	}
+}
+
+// A prefix written with host bits set means the range, not the host. Reading it the other
+// way would make a rule about 256 addresses behave like a rule about one.
+func TestAPrefixIsMasked(t *testing.T) {
+	s := Selector("100.90.0.5/24")
+	prefix, ok := s.Prefix()
+	if !ok {
+		t.Fatal("not read as a prefix")
+	}
+	if prefix.String() != "100.90.0.0/24" {
+		t.Errorf("prefix = %s, want 100.90.0.0/24", prefix)
+	}
+}
+
+func TestABareAddressIsASingleHost(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"100.90.0.5", "100.90.0.5/32"},
+		{"fd7c::1", "fd7c::1/128"},
+	} {
+		prefix, ok := Selector(tc.in).Prefix()
+		if !ok || prefix.String() != tc.want {
+			t.Errorf("%q read as %v (ok=%v), want %s", tc.in, prefix, ok, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Compiling
+
+// The ordinary case, and the one the whole feature exists for.
+func TestOnlyWhatARulePermitsIsAllowed(t *testing.T) {
+	server := device("server", "100.90.0.1/32", "server")
+	laptop := device("laptop", "100.90.0.2/32", "laptop")
+	printer := device("printer", "100.90.0.3/32", "printer")
+
+	policy := doc(Rule{
+		Src: []Selector{"tag:laptop"}, Dst: []Selector{"tag:server"},
+		Protocol: "tcp", Ports: []string{"22"},
+	})
+
+	filter, err := Compile(policy, server, []Device{laptop, printer, server})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filter.GetDefaultDeny() {
+		t.Fatal("a compiled filter does not default to deny; everything would be permitted")
+	}
+	if !allowed(filter.GetInbound(), "100.90.0.2/32", "100.90.0.1/32") {
+		t.Error("the laptop cannot reach the server it was granted")
+	}
+	if allowed(filter.GetInbound(), "100.90.0.3/32", "100.90.0.1/32") {
+		t.Error("the printer reaches the server with no rule permitting it")
+	}
+	if got := filter.GetInbound()[0].GetPorts(); !slices.Equal(got, []string{"22"}) {
+		t.Errorf("ports = %v, want [22]", got)
+	}
+	if got := filter.GetInbound()[0].GetProtocol(); got != ProtoTCP {
+		t.Errorf("protocol = %q", got)
+	}
+}
+
+// The printer is in the network and no rule mentions it, so it receives a filter that
+// permits nothing rather than one that permits everything. An empty allow set and an absent
+// filter must not be the same thing.
+func TestADeviceNoRuleMentionsGetsAnEmptyAllowSet(t *testing.T) {
+	server := device("server", "100.90.0.1/32", "server")
+	laptop := device("laptop", "100.90.0.2/32", "laptop")
+	printer := device("printer", "100.90.0.3/32", "printer")
+
+	policy := doc(Rule{Src: []Selector{"tag:laptop"}, Dst: []Selector{"tag:server"}})
+
+	filter, err := Compile(policy, printer, []Device{laptop, printer, server})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.GetInbound()) != 0 || len(filter.GetOutbound()) != 0 {
+		t.Fatalf("an unmentioned device got rules: %+v", filter)
+	}
+	if !filter.GetDefaultDeny() {
+		t.Fatal("an unmentioned device got a filter that permits everything")
+	}
+}
+
+// Inbound is the authoritative check and outbound only mirrors it, so a device that is a
+// source gets the outbound half and a device that is a destination gets the inbound half.
+func TestBothDirectionsAreCompiled(t *testing.T) {
+	server := device("server", "100.90.0.1/32", "server")
+	laptop := device("laptop", "100.90.0.2/32", "laptop")
+	peers := []Device{laptop, server}
+	policy := doc(Rule{Src: []Selector{"tag:laptop"}, Dst: []Selector{"tag:server"}})
+
+	fromLaptop, err := Compile(policy, laptop, peers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fromLaptop.GetOutbound()) == 0 {
+		t.Error("the sender got no outbound rule, so a denied connection would hang rather than fail")
+	}
+	if len(fromLaptop.GetInbound()) != 0 {
+		t.Error("the sender got an inbound rule it was never granted")
+	}
+
+	atServer, err := Compile(policy, server, peers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(atServer.GetInbound()) == 0 {
+		t.Error("the destination got no inbound rule, and inbound is the security boundary")
+	}
+}
+
+// A rule written about a prefix has to survive the prefix containing no meshp device: that
+// is exactly the case where a gateway is carrying the subnet.
+func TestALiteralPrefixSurvivesHavingNoDevicesInIt(t *testing.T) {
+	gateway := device("gateway", "100.90.0.1/32", "gateway")
+	laptop := device("laptop", "100.90.0.2/32", "laptop")
+
+	policy := doc(Rule{Src: []Selector{"tag:laptop"}, Dst: []Selector{"192.168.1.0/24"}})
+	filter, err := Compile(policy, laptop, []Device{laptop, gateway})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !allowed(filter.GetOutbound(), "100.90.0.2/32", "192.168.1.0/24") {
+		t.Fatalf("the office subnet was dropped from the rule: %+v", filter.GetOutbound())
+	}
+}
+
+// permits reports whether a rule set actually allows an address to reach another, matching
+// by prefix containment the way the kernel will.
+//
+// Distinct from allowed, which compares the rendered strings. A rule naming 100.90.0.0/24
+// permits 100.90.0.2 without ever mentioning it, so a test that only compared strings would
+// call that a denial — and would push the compiler towards expanding prefixes into host
+// addresses, which is longer, more brittle, and drops every address in the range that is
+// not a device.
+func permits(rules []*meshpv1.PacketFilter_Rule, src, dst netip.Addr) bool {
+	covers := func(prefixes []string, addr netip.Addr) bool {
+		for _, s := range prefixes {
+			p, err := netip.ParsePrefix(s)
+			if err == nil && p.Contains(addr) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, r := range rules {
+		if covers(r.GetSrcPrefixes(), src) && covers(r.GetDstPrefixes(), dst) {
+			return true
+		}
+	}
+	return false
+}
+
+// A device inside a prefix a rule names is covered by it. Otherwise a policy's meaning
+// would depend on whether an address happened to belong to a device.
+func TestAPrefixCoversTheDevicesInsideIt(t *testing.T) {
+	server := device("server", "100.90.0.1/32", "server")
+	laptop := device("laptop", "100.90.0.2/32", "laptop")
+
+	policy := doc(Rule{Src: []Selector{"100.90.0.0/24"}, Dst: []Selector{"tag:server"}})
+	filter, err := Compile(policy, server, []Device{laptop, server})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !permits(filter.GetInbound(), netip.MustParseAddr("100.90.0.2"), netip.MustParseAddr("100.90.0.1")) {
+		t.Errorf("a device inside a permitted prefix was not permitted: %+v", filter.GetInbound())
+	}
+
+	// The prefix is carried through as written rather than expanded into the devices
+	// inside it, which is what keeps a rule about a subnet covering the addresses in it
+	// that are not devices.
+	if !allowed(filter.GetInbound(), "100.90.0.0/24", "100.90.0.1/32") {
+		t.Errorf("the prefix was expanded away: %+v", filter.GetInbound())
+	}
+}
+
+// A device outside every named prefix stays outside.
+func TestAPrefixDoesNotCoverWhatIsOutsideIt(t *testing.T) {
+	server := device("server", "100.90.0.1/32", "server")
+	stranger := device("stranger", "100.91.0.9/32")
+
+	policy := doc(Rule{Src: []Selector{"100.90.0.0/24"}, Dst: []Selector{"tag:server"}})
+	filter, err := Compile(policy, server, []Device{stranger, server})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if permits(filter.GetInbound(), netip.MustParseAddr("100.91.0.9"), netip.MustParseAddr("100.90.0.1")) {
+		t.Error("a device outside the permitted prefix was permitted")
+	}
+}
+
+func TestADeviceWithNoAddressesIsRefused(t *testing.T) {
+	_, err := Compile(doc(), Device{Key: "nobody"}, nil)
+	if err == nil {
+		t.Fatal("compiled a filter for a device with nowhere to send anything")
+	}
+}
+
+func TestAnInvalidDocumentIsRefusedAtCompileToo(t *testing.T) {
+	// Not only at Parse: a document can reach the compiler from storage, where it was
+	// written by an older build with a different idea of what is valid.
+	bad := Document{Version: 99}
+	if _, err := Compile(bad, device("a", "100.90.0.1/32"), nil); err == nil {
+		t.Fatal("compiled a document this build does not understand")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+
+func randomDevices(rng *rand.Rand, n int) []Device {
+	tags := []string{"laptop", "server", "printer", "gateway"}
+	out := make([]Device, 0, n)
+	for i := range n {
+		var carried []string
+		for _, tag := range tags {
+			if rng.IntN(3) == 0 {
+				carried = append(carried, tag)
+			}
+		}
+		out = append(out, device(fmt.Sprintf("key-%d", i),
+			fmt.Sprintf("100.90.%d.%d/32", i/250, i%250+1), carried...))
+	}
+	return out
+}
+
+func randomRule(rng *rand.Rand) Rule {
+	pick := func() Selector {
+		switch rng.IntN(4) {
+		case 0:
+			return Everything
+		case 1:
+			return Selector("tag:laptop")
+		case 2:
+			return Selector("tag:server")
+		default:
+			return Selector("100.90.0.0/16")
+		}
+	}
+	r := Rule{Src: []Selector{pick()}, Dst: []Selector{pick()}}
+	switch rng.IntN(3) {
+	case 0:
+		r.Protocol = ProtoTCP
+		r.Ports = []string{"22"}
+	case 1:
+		r.Protocol = ProtoUDP
+	}
+	return r
+}
+
+// Everything downstream diffs a compiled filter to decide whether a device's policy
+// changed. An unstable ordering would make every recomputation look like a change and be
+// pushed to every agent in the network, forever.
+func TestPropertyCompilingTwiceGivesTheSameFilter(t *testing.T) {
+	rng := rand.New(rand.NewPCG(1, 2))
+
+	for range 300 {
+		devices := randomDevices(rng, 1+rng.IntN(12))
+		rules := make([]Rule, 0, 4)
+		for range rng.IntN(4) {
+			rules = append(rules, randomRule(rng))
+		}
+		policy := doc(rules...)
+		self := devices[rng.IntN(len(devices))]
+
+		first, err := Compile(policy, self, devices)
+		if err != nil {
+			t.Fatal(err)
+		}
+		second, err := Compile(policy, self, devices)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !proto.Equal(first, second) {
+			t.Fatalf("two compilations differ:\n%v\n%v", first, second)
+		}
+
+		// And the peer order it was given must not matter either: the control plane's
+		// listing order is not something a policy should depend on.
+		shuffled := append([]Device(nil), devices...)
+		rng.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+		third, err := Compile(policy, self, shuffled)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !proto.Equal(first, third) {
+			t.Fatalf("the peer order changed the filter:\n%v\n%v", first, third)
+		}
+	}
+}
+
+// The language allows only. Adding a rule can therefore never take access away, and that is
+// the property that makes a policy reviewable: a diff that only adds rules cannot break
+// anything that worked.
+func TestPropertyAddingARuleNeverRemovesAccess(t *testing.T) {
+	rng := rand.New(rand.NewPCG(3, 4))
+
+	for range 300 {
+		devices := randomDevices(rng, 2+rng.IntN(8))
+		self := devices[rng.IntN(len(devices))]
+
+		var rules []Rule
+		for range 1 + rng.IntN(3) {
+			rules = append(rules, randomRule(rng))
+		}
+		before, err := Compile(doc(rules...), self, devices)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		after, err := Compile(doc(append(rules, randomRule(rng))...), self, devices)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Every pair permitted before must still be permitted.
+		for _, rule := range before.GetInbound() {
+			for _, src := range rule.GetSrcPrefixes() {
+				for _, dst := range rule.GetDstPrefixes() {
+					if !allowedWithProtocol(after.GetInbound(), src, dst, rule.GetProtocol(), rule.GetPorts()) {
+						t.Fatalf("adding a rule removed inbound access %s -> %s (%s %v)",
+							src, dst, rule.GetProtocol(), rule.GetPorts())
+					}
+				}
+			}
+		}
+	}
+}
+
+// allowedWithProtocol is allowed, but also requiring the same protocol and ports, so the
+// monotonicity property cannot be satisfied by a rule that permits something narrower.
+func allowedWithProtocol(rules []*meshpv1.PacketFilter_Rule, src, dst, protocol string, ports []string) bool {
+	for _, r := range rules {
+		if !slices.Contains(r.GetSrcPrefixes(), src) || !slices.Contains(r.GetDstPrefixes(), dst) {
+			continue
+		}
+		if r.GetProtocol() != protocol {
+			continue
+		}
+		if !slices.Equal(r.GetPorts(), ports) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// A filter always denies by default, whatever the policy says. There is no document that
+// compiles to "permit anything not mentioned" — that is the property the whole language
+// rests on, and it must not be reachable by any combination of rules.
+func TestPropertyEveryFilterDefaultsToDeny(t *testing.T) {
+	rng := rand.New(rand.NewPCG(5, 6))
+
+	for range 300 {
+		devices := randomDevices(rng, 1+rng.IntN(10))
+		var rules []Rule
+		for range rng.IntN(5) {
+			rules = append(rules, randomRule(rng))
+		}
+		filter, err := Compile(doc(rules...), devices[rng.IntN(len(devices))], devices)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !filter.GetDefaultDeny() {
+			t.Fatal("a policy compiled to a filter that permits the unmentioned")
+		}
+		for _, r := range append(filter.GetInbound(), filter.GetOutbound()...) {
+			if !r.GetAllow() {
+				t.Fatal("a compiled rule denies; the language has no way to express that")
+			}
+		}
+	}
+}

--- a/internal/acl/compile.go
+++ b/internal/acl/compile.go
@@ -1,0 +1,204 @@
+package acl
+
+import (
+	"fmt"
+	"net/netip"
+	"sort"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// Device is what the compiler needs to know about one member of a network.
+type Device struct {
+	// Key is the WireGuard public key, which is what identifies a device to everything
+	// downstream and what makes two Devices comparable.
+	Key string
+
+	// Addresses are this device's own addresses, as single-host prefixes.
+	Addresses []netip.Prefix
+
+	// Tags are what selectors match on. Authoritative here because this comes from the
+	// control plane's own record, and nowhere else — a device does not get to say what it
+	// is tagged with.
+	Tags []string
+}
+
+// hasTag reports whether this device carries a tag.
+func (d Device) hasTag(tag string) bool {
+	for _, t := range d.Tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// matches reports whether a selector picks this device.
+//
+// Literal prefixes match a device when they contain one of its addresses, so a rule written
+// about 100.90.0.0/24 covers the devices inside it. That is what someone writing a prefix
+// means, and the alternative — prefixes matching only non-device destinations — would make
+// a policy's behaviour depend on whether an address happens to belong to a device.
+func (d Device) matches(s Selector) bool {
+	if s.IsEverything() {
+		return true
+	}
+	if tag, ok := s.Tag(); ok {
+		return d.hasTag(tag)
+	}
+	if prefix, ok := s.Prefix(); ok {
+		for _, addr := range d.Addresses {
+			if prefix.Overlaps(addr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Compile turns a policy into the filter one device should enforce.
+//
+// Two directions, and they are not equal in standing. The inbound rules are the
+// authoritative check: traffic is permitted or dropped where it arrives, so a compromised
+// or modified sender cannot talk its way past the receiver's policy (ADR-0007). The
+// outbound rules describe the same permissions from the sending side and exist to fail
+// fast — a connection refused locally is a far better error than one that vanishes — but
+// they are never the boundary.
+//
+// What a filter governs is mesh traffic and nothing else. It is enforced on the WireGuard
+// interface, so a policy cannot cut a device off from its control plane, from a relay, or
+// from its own addresses — those never traverse the tunnel. That bound is worth knowing
+// deliberately: it means the worst a mistaken policy can do is isolate devices from each
+// other, and an operator always has a way back in to fix it.
+func Compile(doc Document, self Device, peers []Device) (*meshpv1.PacketFilter, error) {
+	if err := doc.Validate(); err != nil {
+		return nil, err
+	}
+
+	filter := &meshpv1.PacketFilter{
+		// The whole point. Anything no rule permits is dropped, which is what makes the
+		// language allow-only and order-independent.
+		DefaultDeny: true,
+	}
+
+	selfPrefixes := sortedPrefixes(self.Addresses)
+	if len(selfPrefixes) == 0 {
+		return nil, fmt.Errorf("acl: cannot compile a filter for a device with no addresses")
+	}
+
+	for i, rule := range doc.Rules {
+		ports, err := rule.PortRanges()
+		if err != nil {
+			return nil, fmt.Errorf("acl: rule %d: %w", i, err)
+		}
+		proto := rule.CanonicalProtocol()
+
+		// Inbound: this device is a destination, so whoever the rule allows may reach it.
+		if matchesAny(self, rule.Dst) {
+			if sources := resolve(rule.Src, peers); len(sources) > 0 {
+				filter.Inbound = append(filter.Inbound, &meshpv1.PacketFilter_Rule{
+					SrcPrefixes: sources,
+					DstPrefixes: selfPrefixes,
+					Protocol:    proto,
+					Ports:       renderPorts(ports),
+					Allow:       true,
+				})
+			}
+		}
+
+		// Outbound: this device is a source, so it may reach whoever the rule allows.
+		if matchesAny(self, rule.Src) {
+			if destinations := resolve(rule.Dst, peers); len(destinations) > 0 {
+				filter.Outbound = append(filter.Outbound, &meshpv1.PacketFilter_Rule{
+					SrcPrefixes: selfPrefixes,
+					DstPrefixes: destinations,
+					Protocol:    proto,
+					Ports:       renderPorts(ports),
+					Allow:       true,
+				})
+			}
+		}
+	}
+
+	return filter, nil
+}
+
+// matchesAny reports whether any selector picks this device.
+func matchesAny(d Device, selectors []Selector) bool {
+	for _, s := range selectors {
+		if d.matches(s) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolve turns selectors into the concrete prefixes they name.
+//
+// Devices contribute their addresses; literal prefixes contribute themselves, whether or
+// not any device sits inside them — a rule about an office subnet has to survive the subnet
+// being empty of meshp devices, because that is exactly when a gateway is carrying it.
+func resolve(selectors []Selector, peers []Device) []string {
+	seen := make(map[netip.Prefix]struct{})
+
+	for _, s := range selectors {
+		if prefix, ok := s.Prefix(); ok {
+			seen[prefix] = struct{}{}
+			continue
+		}
+		for _, peer := range peers {
+			if !peer.matches(s) {
+				continue
+			}
+			for _, addr := range peer.Addresses {
+				seen[addr] = struct{}{}
+			}
+		}
+	}
+
+	out := make([]netip.Prefix, 0, len(seen))
+	for prefix := range seen {
+		out = append(out, prefix)
+	}
+	return sortedPrefixes(out)
+}
+
+// sortedPrefixes renders prefixes in a stable order.
+//
+// Stability is not cosmetic. Everything downstream diffs this to decide whether a device's
+// policy changed, and a set rendered in Go's map order would differ between two compilations
+// of the same policy — so every state recomputation would look like a policy change and be
+// pushed to every agent in the network.
+func sortedPrefixes(prefixes []netip.Prefix) []string {
+	sorted := append([]netip.Prefix(nil), prefixes...)
+	sort.Slice(sorted, func(i, j int) bool {
+		a, b := sorted[i], sorted[j]
+		if a.Addr() != b.Addr() {
+			return a.Addr().Less(b.Addr())
+		}
+		return a.Bits() < b.Bits()
+	})
+
+	out := make([]string, 0, len(sorted))
+	var last string
+	for _, p := range sorted {
+		s := p.String()
+		if s == last {
+			continue
+		}
+		out = append(out, s)
+		last = s
+	}
+	return out
+}
+
+func renderPorts(ranges []PortRange) []string {
+	if len(ranges) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(ranges))
+	for _, r := range ranges {
+		out = append(out, r.String())
+	}
+	return out
+}

--- a/internal/acl/document.go
+++ b/internal/acl/document.go
@@ -1,0 +1,301 @@
+// Package acl is the policy language and its compiler.
+//
+// One versioned JSON document per network describes who may reach what. The control plane
+// compiles it into a per-device PacketFilter and the agent enforces that inbound, at the
+// destination, as the authoritative check (ADR-0007). Nothing here talks to a database or a
+// kernel: a policy is a value, compiling it is a pure function, and both can be wrong in
+// ways that no amount of integration testing would find reliably.
+//
+// Two decisions shape the language.
+//
+// **Rules only allow.** There is no deny rule, and the default is to deny. Order therefore
+// never matters, nothing shadows anything, and "why can this device reach that one" always
+// has exactly one answer: some rule permits it. A language with both allow and deny needs a
+// precedence story, and every precedence story produces policies whose author is surprised
+// by them — which for a security control is the whole problem.
+//
+// **Tags are resolved here, not on the device.** A compiled filter names concrete prefixes,
+// because a device evaluating its own tags would be deciding its own access, and a device
+// is exactly the thing whose word cannot be taken for that. It is why Peer.tags is marked
+// as context and never authoritative.
+package acl
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/netip"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Version is the only document version this build understands.
+//
+// Refused rather than assumed when it does not match: a control plane reading a policy it
+// only partly understands would compile a filter that is not the policy anyone wrote, and
+// the failure would be silent and in the direction of granting access.
+const Version = 1
+
+// Document is a network's policy.
+type Document struct {
+	Version int    `json:"version"`
+	Rules   []Rule `json:"rules"`
+
+	// Comment carries the author's own note. Kept so a policy round-trips through storage
+	// and review unchanged; never interpreted.
+	Comment string `json:"comment,omitempty"`
+}
+
+// Rule permits traffic from anything matching Src to anything matching Dst.
+type Rule struct {
+	Src []Selector `json:"src"`
+	Dst []Selector `json:"dst"`
+
+	// Protocol is "tcp", "udp", "icmp" or "any". Empty means "any".
+	Protocol string `json:"protocol,omitempty"`
+
+	// Ports are single ports or inclusive ranges: "22", "8000-8100". Empty means every
+	// port. Meaningful only for tcp and udp — a policy naming ports for icmp is a mistake
+	// about what the rule does, so it is refused rather than quietly ignored.
+	Ports []string `json:"ports,omitempty"`
+
+	Comment string `json:"comment,omitempty"`
+}
+
+// Selector picks devices or addresses.
+//
+// Three forms, deliberately few:
+//
+//   - every device in the network
+//     tag:<name>    every device carrying that tag
+//     <cidr>        a literal prefix, for anything that is not a device
+//
+// A bare address is accepted and read as a single host, because "100.90.0.5" meaning
+// "100.90.0.5/32" is what everyone means and refusing it teaches nothing.
+type Selector string
+
+const (
+	// Everything selects every device in the network.
+	Everything Selector = "*"
+
+	tagPrefix = "tag:"
+)
+
+// IsEverything reports whether this selector matches every device.
+func (s Selector) IsEverything() bool { return s == Everything }
+
+// Tag returns the tag this selector names, if it names one.
+func (s Selector) Tag() (string, bool) {
+	rest, ok := strings.CutPrefix(string(s), tagPrefix)
+	return rest, ok
+}
+
+// Prefix returns the literal prefix this selector names, if it names one.
+func (s Selector) Prefix() (netip.Prefix, bool) {
+	if s.IsEverything() {
+		return netip.Prefix{}, false
+	}
+	if _, isTag := s.Tag(); isTag {
+		return netip.Prefix{}, false
+	}
+	return parsePrefix(string(s))
+}
+
+// parsePrefix reads a CIDR or a bare address, which is read as a single host.
+func parsePrefix(s string) (netip.Prefix, bool) {
+	if strings.Contains(s, "/") {
+		prefix, err := netip.ParsePrefix(s)
+		if err != nil {
+			return netip.Prefix{}, false
+		}
+		// Masked, so 100.90.0.5/24 does not silently become a rule about one host that is
+		// written like a rule about 256 of them.
+		return prefix.Masked(), true
+	}
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return netip.Prefix{}, false
+	}
+	addr = addr.Unmap()
+	return netip.PrefixFrom(addr, addr.BitLen()), true
+}
+
+// Protocols the language understands.
+const (
+	ProtoAny  = "any"
+	ProtoTCP  = "tcp"
+	ProtoUDP  = "udp"
+	ProtoICMP = "icmp"
+)
+
+// PortRange is an inclusive range of ports. A single port is a range of one.
+type PortRange struct {
+	From, To uint16
+}
+
+func (p PortRange) String() string {
+	if p.From == p.To {
+		return strconv.Itoa(int(p.From))
+	}
+	return strconv.Itoa(int(p.From)) + "-" + strconv.Itoa(int(p.To))
+}
+
+// Parse reads a policy document and validates it.
+//
+// Unknown fields are refused. A policy is written by a person and applied to a security
+// boundary, so a misspelled key must not be read as an absent one: "protocols": "tcp" would
+// otherwise compile to a rule permitting every protocol, which is the opposite of what was
+// written and impossible to see in a diff.
+func Parse(data []byte) (Document, error) {
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec.DisallowUnknownFields()
+
+	var doc Document
+	if err := dec.Decode(&doc); err != nil {
+		return Document{}, fmt.Errorf("acl: reading the policy: %w", err)
+	}
+	if err := doc.Validate(); err != nil {
+		return Document{}, err
+	}
+	return doc, nil
+}
+
+// Validate reports whether a document is one this build can compile faithfully.
+func (d Document) Validate() error {
+	if d.Version != Version {
+		return fmt.Errorf("acl: this policy is version %d; this build understands version %d",
+			d.Version, Version)
+	}
+	for i, rule := range d.Rules {
+		if err := rule.validate(); err != nil {
+			return fmt.Errorf("acl: rule %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func (r Rule) validate() error {
+	if len(r.Src) == 0 {
+		return fmt.Errorf("names no source; a rule that permits nothing is more likely a mistake than an intention")
+	}
+	if len(r.Dst) == 0 {
+		return fmt.Errorf("names no destination")
+	}
+	for _, s := range append(append([]Selector{}, r.Src...), r.Dst...) {
+		if err := s.validate(); err != nil {
+			return err
+		}
+	}
+
+	proto, err := r.protocol()
+	if err != nil {
+		return err
+	}
+	if len(r.Ports) > 0 && proto != ProtoTCP && proto != ProtoUDP {
+		// Refused rather than ignored. A rule reading "icmp ports 22" means its author
+		// believed something false, and honouring the protocol while dropping the ports
+		// would give them a working rule that is not the one they wrote.
+		return fmt.Errorf("names ports with protocol %q; only tcp and udp have ports", proto)
+	}
+	if _, err := r.PortRanges(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s Selector) validate() error {
+	if s == "" {
+		return fmt.Errorf("has an empty selector")
+	}
+	if s.IsEverything() {
+		return nil
+	}
+	if tag, ok := s.Tag(); ok {
+		if tag == "" {
+			return fmt.Errorf("has a %q selector naming no tag", tagPrefix)
+		}
+		return nil
+	}
+	if _, ok := s.Prefix(); ok {
+		return nil
+	}
+	return fmt.Errorf("selector %q is not %q, %q or an address", string(s), Everything, tagPrefix+"<name>")
+}
+
+// protocol returns the rule's protocol in canonical form.
+func (r Rule) protocol() (string, error) {
+	switch strings.ToLower(strings.TrimSpace(r.Protocol)) {
+	case "", ProtoAny:
+		return ProtoAny, nil
+	case ProtoTCP:
+		return ProtoTCP, nil
+	case ProtoUDP:
+		return ProtoUDP, nil
+	case ProtoICMP:
+		return ProtoICMP, nil
+	default:
+		return "", fmt.Errorf("protocol %q is not one of any, tcp, udp, icmp", r.Protocol)
+	}
+}
+
+// CanonicalProtocol returns the protocol in the form the compiler uses, defaulting to any.
+//
+// Only meaningful on a validated rule; an unparseable protocol reads as any here and is
+// refused by Validate, which is the only place that decides whether a policy is usable.
+func (r Rule) CanonicalProtocol() string {
+	proto, err := r.protocol()
+	if err != nil {
+		return ProtoAny
+	}
+	return proto
+}
+
+// PortRanges parses the rule's ports.
+//
+// An empty list means every port, which is different from a list that failed to parse —
+// so a malformed port is an error rather than an empty result that would silently widen
+// the rule to everything.
+func (r Rule) PortRanges() ([]PortRange, error) {
+	out := make([]PortRange, 0, len(r.Ports))
+	for _, spec := range r.Ports {
+		spec = strings.TrimSpace(spec)
+		from, to, isRange := strings.Cut(spec, "-")
+		lo, err := parsePort(from)
+		if err != nil {
+			return nil, fmt.Errorf("port %q: %w", spec, err)
+		}
+		hi := lo
+		if isRange {
+			hi, err = parsePort(to)
+			if err != nil {
+				return nil, fmt.Errorf("port %q: %w", spec, err)
+			}
+		}
+		if hi < lo {
+			return nil, fmt.Errorf("port range %q ends before it begins", spec)
+		}
+		out = append(out, PortRange{From: lo, To: hi})
+	}
+
+	// Sorted so two compilations of the same policy produce identical output. Everything
+	// downstream diffs this, and an unstable ordering would make every recomputation look
+	// like a policy change to every agent.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].From != out[j].From {
+			return out[i].From < out[j].From
+		}
+		return out[i].To < out[j].To
+	})
+	return out, nil
+}
+
+func parsePort(s string) (uint16, error) {
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return 0, fmt.Errorf("is not a number")
+	}
+	if n < 1 || n > 65535 {
+		return 0, fmt.Errorf("is outside 1-65535")
+	}
+	return uint16(n), nil
+}


### PR DESCRIPTION
The first slice of ACLs, and deliberately the one with no I/O in it: a policy is a value and compiling it is a pure function, so both can be got wrong in ways integration tests find only by luck.

**Nothing enforces anything yet.** This is the language and the compiler. The remaining slices are listed at the bottom.

## The language allows only

There is no deny rule, and the default is deny. So rule order never matters, nothing shadows anything, and "why can this device reach that one" always has exactly one answer: some rule permits it.

A language with both allow and deny needs a precedence story, and every precedence story produces policies whose author is surprised by them — which for a security control is the whole problem. It also buys a property worth having: **a diff that only adds rules cannot take access away**, which is what makes a policy reviewable. That's property-tested rather than claimed.

```json
{
  "version": 1,
  "rules": [
    {"src": ["tag:laptop"], "dst": ["tag:server"], "protocol": "tcp", "ports": ["22", "8000-8100"]},
    {"src": ["*"], "dst": ["192.168.1.0/24"]}
  ]
}
```

Three selectors, deliberately few: `*`, `tag:<name>`, and a literal CIDR.

## Tags resolve here, never on the device

A compiled filter names concrete prefixes. A device evaluating its own tags would be deciding its own access, and a device is exactly the thing whose word can't be taken for that — which is why `Peer.tags` has always carried the comment "context only; never authoritative".

## Determinism is correctness, not tidiness

Everything downstream diffs a compiled filter to decide whether a device's policy changed. A set rendered in Go's map order would differ between two compilations of the same policy, so **every state recomputation would look like a policy change and be pushed to every agent in the network, forever**. Compiling twice — and compiling with the peers in a different order — must give byte-identical output. Both are property-tested.

## Unknown fields are refused

`"protocols": "tcp"` is a realistic typo that would otherwise parse as a rule permitting *every* protocol: the opposite of what was written, and invisible in review. Same reasoning refuses ports on a protocol that has none (`icmp` + `ports: ["22"]`) rather than honouring the protocol and silently dropping the ports.

## One test of mine was wrong

I first asserted that a prefix selector expands into the devices inside it. It shouldn't: nftables matches by prefix, so `100.90.0.0/24` already permits the device at `.2`, and expanding would be longer, more brittle, and would drop every address in the range that *isn't* a device — exactly the case where a gateway is carrying a subnet. The test now checks the effective permission by prefix containment, plus that the prefix survives as written.

## Scope bound worth knowing

A filter governs mesh traffic only — it's enforced on the WireGuard interface, so no policy can cut a device off from its control plane, its relay, or its own addresses. The worst a mistaken policy can do is isolate devices from each other, and an operator always has a way back in.

## What's next

1. Storage and an admin API for the document (`acl_policies` already exists in the schema, with a one-active-per-network constraint)
2. Delivery through `StateDelta.filter`, and ACL-aware peer scoping (ADR-0008)
3. nftables on Linux; agents reporting `packet_filter: false` are refused a policy that needs port-level enforcement rather than silently degrading
4. `meshp acl test`

96.4% coverage; five mutations checked, all caught.