### PR TITLE
feat(acl): enforce policy with nftables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ CROSS_TARGETS := linux/amd64 linux/arm64 linux/arm \
 COVER_FLOOR_PKGS := internal/acl internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan internal/relayproto internal/relay internal/relaytoken
 COVER_FLOOR      := 90
 
-COVER_FLOOR_IO_PKGS := internal/agentapi internal/agentstate internal/httpx internal/tunnel internal/relayclient internal/relayforward internal/relaylink internal/sessionclient
+COVER_FLOOR_IO_PKGS := internal/nftables internal/agentapi internal/agentstate internal/httpx internal/tunnel internal/relayclient internal/relayforward internal/relaylink internal/sessionclient
 COVER_FLOOR_IO      := 75
 
 COVER_FLOOR_DB_PKGS := internal/store internal/enroll internal/api internal/session
@@ -267,11 +267,16 @@ dataplane: ## Run the data-plane tests against real interfaces, in a privileged 
 	@# Privileged and Linux, because there is no way to create a WireGuard interface
 	@# without both. On a Linux host with root, `sudo -E go test ./internal/wglink/` does
 	@# the same thing without Docker.
+	@#
+	@# nftables is here for the same reason: rendering a ruleset can be tested anywhere, but
+	@# whether the kernel accepts it cannot, and a ruleset that does not load is a policy
+	@# that silently is not enforced.
 	docker run --rm --privileged \
 	  -v "$(CURDIR)":/src -w /src \
 	  -v "$$(go env GOMODCACHE)":/go/pkg/mod \
 	  golang:$(GO_IMAGE_VERSION)-alpine sh -c \
-	  'apk add --no-cache iproute2 wireguard-tools >/dev/null && go test ./internal/wglink/ -count=1 -v'
+	  'apk add --no-cache iproute2 wireguard-tools nftables >/dev/null && \
+	   go test ./internal/wglink/ ./internal/nftables/ -count=1 -v'
 
 .PHONY: migrate-check
 migrate-check: ## Apply, roll back and re-apply every migration against MESHP_TEST_DATABASE_URL

--- a/README.md
+++ b/README.md
@@ -30,11 +30,15 @@ Devices can also be revoked: an administrator removes one and every other agent 
 its key, which is what actually cuts it off — enforcement is at the peers, not at the
 device being removed, so a machine that is switched off or hostile is out just the same.
 
-What does not, and matters: **there is no policy enforcement** — every device in a
-network can reach every other, because the ACL engine is not wired up. **The control
-plane speaks plaintext HTTP.** Direct paths, DNS and internet egress are all
-unimplemented, and the data plane is Linux-only — elsewhere a device enrols, holds an
-address, and reports honestly that it has no tunnel.
+Policy works on Linux: an ACL document published to a network compiles per device and
+is enforced by nftables at the destination (ADR-0007). A network with no policy is
+unfiltered, and a host that cannot enforce says so rather than accepting a policy and
+ignoring it.
+
+What does not, and matters: **the control plane speaks plaintext HTTP.** Direct paths,
+DNS and internet egress are all unimplemented, and the data plane is Linux-only —
+elsewhere a device enrols, holds an address, and reports honestly that it has no
+tunnel and cannot filter.
 
 It is public from the first commit because the design decisions are the
 interesting part and we would rather be argued with early.

--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -17,6 +17,7 @@ import (
 	"github.com/meshpnet/meshp/internal/controlurl"
 	"github.com/meshpnet/meshp/internal/enrollclient"
 	"github.com/meshpnet/meshp/internal/keys"
+	"github.com/meshpnet/meshp/internal/nftables"
 	"github.com/meshpnet/meshp/internal/peerset"
 	"github.com/meshpnet/meshp/internal/relaylink"
 	"github.com/meshpnet/meshp/internal/sessionclient"
@@ -53,6 +54,12 @@ type agent struct {
 	linkOnce sync.Once
 	link     wglink.Link
 	linkErr  error
+
+	// filter enforces network policy, opened once and shared. Nil where this host cannot
+	// filter, which the agent reports honestly rather than accepting a policy it will not
+	// apply (ADR-0007).
+	filterOnce sync.Once
+	filter     *nftables.Filter
 
 	ctx context.Context
 }
@@ -95,7 +102,36 @@ func (a *agent) reconcilerFor(m agentstate.Membership, relay tunnel.Relay, log *
 		AddressV4:     m.AddressV4,
 		AddressV6:     m.AddressV6,
 		ListenPort:    m.ListenPort,
-	}, relay, log)
+	}, relay, a.filterOrNil(), log)
+}
+
+// ensureFilter opens the host's packet filter, once.
+//
+// Probed rather than assumed: a container can have nft installed and no permission to use
+// it, and finding that out at apply time would look like a policy fault rather than a
+// missing capability.
+func (a *agent) ensureFilter() *nftables.Filter {
+	a.filterOnce.Do(func() {
+		a.filter = nftables.New(a.ctx)
+		if a.filter == nil {
+			a.log.Warn("this host cannot enforce a packet filter",
+				"os", runtime.GOOS,
+				"note", "networks with a policy will report this device as unconverged")
+		}
+	})
+	return a.filter
+}
+
+// filterOrNil converts a possibly-absent filter into the interface.
+//
+// Explicit for the same reason relayOrNil is: a nil *nftables.Filter assigned straight to
+// an interface is a non-nil interface holding a nil pointer, so every downstream nil check
+// would pass and the reconciler would believe it can enforce.
+func (a *agent) filterOrNil() tunnel.Filter {
+	if f := a.ensureFilter(); f != nil {
+		return f
+	}
+	return nil
 }
 
 // relayFor returns this membership's relay attachment, or nil when there is no data plane
@@ -276,6 +312,7 @@ func (a *agent) ensureSession(m agentstate.Membership) {
 		OS:           runtime.GOOS,
 		Hostname:     hostname(),
 		Relay:        relayCredentials(relay),
+		CanFilter:    a.ensureFilter() != nil,
 		Revoked:      &membershipRevoker{agent: a, membershipID: m.MembershipID},
 		Log:          log,
 	})

--- a/internal/nftables/apply_linux.go
+++ b/internal/nftables/apply_linux.go
@@ -1,0 +1,71 @@
+//go:build linux
+
+package nftables
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/logx"
+)
+
+// applyTimeout bounds one nft invocation.
+//
+// Loading a table is milliseconds of work. A bound exists because this runs on the
+// reconcile path: nft blocking forever — on a contended netlink socket, or because
+// something else holds the ruleset — would stop the agent converging on anything else.
+const applyTimeout = 10 * time.Second
+
+// Available reports whether this host can enforce a packet filter.
+//
+// The answer decides what the agent claims in its capabilities, and the control plane
+// refuses to place a device that cannot enforce into a network whose policy needs
+// port-level rules rather than silently degrading (ADR-0007). So this must be honest:
+// finding the binary is not enough, since a container can have nft and no permission to
+// use it, which fails later and looks like a policy fault. It asks nft to list the
+// ruleset, which needs the same access that loading one does.
+func Available(ctx context.Context) bool {
+	path, err := exec.LookPath("nft")
+	if err != nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(ctx, applyTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, path, "list", "ruleset").Run() == nil
+}
+
+// Apply loads a rendered ruleset.
+//
+// One nft invocation reading one script, which is what makes the replacement atomic: nft
+// applies a whole file as a single netlink transaction, so either the new policy is in
+// force or the old one still is. Feeding it rule by rule would leave a window in which
+// half a policy applies, and that window is exactly when traffic is permitted that the new
+// policy denies.
+func Apply(ctx context.Context, script string) error {
+	path, err := exec.LookPath("nft")
+	if err != nil {
+		return fmt.Errorf("%w: nft is not installed, so this host cannot enforce a policy", ErrUnsupported)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, applyTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, path, "-f", "-")
+	cmd.Stdin = strings.NewReader(script)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("nftables: nft did not finish within %s", applyTimeout)
+		}
+		// nft names the offending line, which is the only thing that makes a rendering
+		// mistake diagnosable. Passed through rather than summarised, but through logx
+		// because it quotes back the script it was given.
+		return fmt.Errorf("nftables: loading the ruleset: %w: %s",
+			err, logx.Safe(strings.TrimSpace(string(output))))
+	}
+	return nil
+}

--- a/internal/nftables/apply_linux_test.go
+++ b/internal/nftables/apply_linux_test.go
@@ -1,0 +1,188 @@
+//go:build linux
+
+package nftables
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// sampleFilter is a policy with both families and a port range, so a load exercises more
+// of the rendering than a single rule would.
+func sampleFilter() *meshpv1.PacketFilter {
+	return &meshpv1.PacketFilter{
+		DefaultDeny: true,
+		Inbound: []*meshpv1.PacketFilter_Rule{{
+			SrcPrefixes: []string{"100.90.0.2/32", "fd7c::2/128"},
+			DstPrefixes: []string{"100.90.0.1/32", "fd7c::1/128"},
+			Protocol:    "tcp", Ports: []string{"22", "8000-8100"}, Allow: true,
+		}},
+		Outbound: []*meshpv1.PacketFilter_Rule{{
+			SrcPrefixes: []string{"100.90.0.1/32"},
+			DstPrefixes: []string{"100.90.0.2/32"},
+			Protocol:    "any", Allow: true,
+		}},
+	}
+}
+
+// These run against a real kernel and a real nft. A rendering mistake — a missing keyword,
+// a malformed set, an expression nft parses differently from how I read the manual — is
+// invisible to every test that only inspects the string, and shows up on a customer's host
+// as a policy that silently does not load.
+
+func requireNFT(t *testing.T) {
+	t.Helper()
+	if !Available(context.Background()) {
+		t.Skip("nft is unavailable or unusable here; run this in the privileged container")
+	}
+	t.Cleanup(func() {
+		// Never leave meshp's table behind on a host that ran the tests.
+		script, err := Render("meshp0", nil)
+		if err == nil {
+			_ = Apply(context.Background(), script)
+		}
+	})
+}
+
+func listTable(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("nft", "list", "table", "inet", TableName).CombinedOutput()
+	if err != nil {
+		t.Fatalf("listing the table: %v: %s", err, out)
+	}
+	return string(out)
+}
+
+// The one thing string tests cannot answer: does the kernel accept this.
+func TestARenderedRulesetLoads(t *testing.T) {
+	requireNFT(t)
+	ctx := context.Background()
+
+	script, err := Render("meshp0", sampleFilter())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(ctx, script); err != nil {
+		t.Fatalf("the kernel refused a ruleset this package rendered: %v", err)
+	}
+
+	listed := listTable(t)
+	for _, want := range []string{
+		`iifname != "meshp0" accept`,
+		"ct state established,related accept",
+		"100.90.0.2",
+		"tcp dport",
+		"counter",
+		"drop",
+	} {
+		if !strings.Contains(listed, want) {
+			t.Errorf("the loaded table does not contain %q:\n%s", want, listed)
+		}
+	}
+}
+
+// Loading twice must be safe, because the reconciler does exactly that whenever a policy
+// changes. A ruleset that appended to the last would accumulate rules from policies nobody
+// is enforcing any more.
+func TestLoadingReplacesRatherThanAccumulates(t *testing.T) {
+	requireNFT(t)
+	ctx := context.Background()
+
+	script, err := Render("meshp0", sampleFilter())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Apply(ctx, script); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// Compared against itself after one load rather than counted, because a rule's addresses
+	// legitimately appear in more than one chain — an absolute count would be asserting the
+	// shape of the fixture rather than that loading replaces.
+	once := listTable(t)
+
+	for range 3 {
+		if err := Apply(ctx, script); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+	}
+	if got := listTable(t); got != once {
+		t.Errorf("loading the same ruleset again changed the table:\nafter one:\n%s\nafter four:\n%s",
+			once, got)
+	}
+}
+
+// A withdrawn policy has to leave nothing behind, or it goes on denying traffic the network
+// no longer denies.
+func TestANilFilterRemovesTheTableFromTheKernel(t *testing.T) {
+	requireNFT(t)
+	ctx := context.Background()
+
+	loaded, err := Render("meshp0", sampleFilter())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(ctx, loaded); err != nil {
+		t.Fatal(err)
+	}
+
+	empty, err := Render("meshp0", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(ctx, empty); err != nil {
+		t.Fatalf("removing the table: %v", err)
+	}
+
+	if out, err := exec.Command("nft", "list", "table", "inet", TableName).CombinedOutput(); err == nil {
+		t.Fatalf("meshp's table survived a withdrawn policy:\n%s", out)
+	}
+}
+
+// Removing a table that was never there is the first thing a fresh host does, so it must
+// not be an error.
+func TestRemovingATableThatIsNotThere(t *testing.T) {
+	requireNFT(t)
+	script, err := Render("meshp0", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if err := Apply(context.Background(), script); err != nil {
+			t.Fatalf("removing an absent table: %v", err)
+		}
+	}
+}
+
+// An empty policy is a table that drops all mesh traffic, and the kernel has to accept that
+// as readily as one full of rules.
+func TestAnEmptyPolicyLoads(t *testing.T) {
+	requireNFT(t)
+	script, err := Render("meshp0", &meshpv1.PacketFilter{DefaultDeny: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(context.Background(), script); err != nil {
+		t.Fatalf("the kernel refused an empty policy: %v", err)
+	}
+	if !strings.Contains(listTable(t), "drop") {
+		t.Error("an empty policy loaded without a drop")
+	}
+}
+
+// A script the kernel refuses must be reported with what nft said, or a rendering mistake
+// is undiagnosable.
+func TestAMalformedScriptIsReportedWithItsReason(t *testing.T) {
+	requireNFT(t)
+	err := Apply(context.Background(), "add rule inet meshp nosuchchain accept\n")
+	if err == nil {
+		t.Fatal("nft accepted a script naming a chain that does not exist")
+	}
+	if !strings.Contains(err.Error(), "meshp") {
+		t.Errorf("the error does not carry nft's complaint: %v", err)
+	}
+}

--- a/internal/nftables/apply_other.go
+++ b/internal/nftables/apply_other.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package nftables
+
+import "context"
+
+// Available is false everywhere but Linux.
+//
+// Reported rather than assumed, because it decides what the agent claims it can do and the
+// control plane acts on that claim. Windows enforces through WFP and macOS through the
+// network extension's packet-filter path (ADR-0007); neither is implemented, and saying so
+// is what stops a device being placed in a network whose policy it cannot honour.
+func Available(context.Context) bool { return false }
+
+// Apply is unsupported off Linux.
+func Apply(context.Context, string) error { return ErrUnsupported }

--- a/internal/nftables/filter.go
+++ b/internal/nftables/filter.go
@@ -1,0 +1,31 @@
+package nftables
+
+import (
+	"context"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// Filter enforces packet filters through nftables. It satisfies tunnel.Filter.
+type Filter struct{}
+
+// New returns a Filter, or nothing when this host cannot enforce one.
+//
+// Nil rather than an error, and checked once at construction rather than on every apply:
+// the answer decides what the agent claims in its capabilities, and a capability that
+// flapped between reconciles would be worse than one that is simply false.
+func New(ctx context.Context) *Filter {
+	if !Available(ctx) {
+		return nil
+	}
+	return &Filter{}
+}
+
+// Apply renders and loads a filter, or removes the ruleset when there is none.
+func (f *Filter) Apply(ctx context.Context, iface string, filter *meshpv1.PacketFilter) error {
+	script, err := Render(iface, filter)
+	if err != nil {
+		return err
+	}
+	return Apply(ctx, script)
+}

--- a/internal/nftables/nftables.go
+++ b/internal/nftables/nftables.go
@@ -1,0 +1,10 @@
+package nftables
+
+import "errors"
+
+// ErrUnsupported means this host cannot enforce a packet filter.
+//
+// A condition to report, not a failure to retry: a device that cannot filter is still a
+// device, and the honest answer is to say so in its capabilities and let the control plane
+// decide whether to place it in a network whose policy requires enforcement (ADR-0007).
+var ErrUnsupported = errors.New("nftables: this platform cannot enforce a packet filter")

--- a/internal/nftables/render.go
+++ b/internal/nftables/render.go
@@ -1,0 +1,275 @@
+// Package nftables turns a compiled PacketFilter into a ruleset the Linux kernel enforces.
+//
+// It is the destination-side half of ADR-0007: the control plane decides who may reach
+// what, and this is where that decision stops packets. Split the way wgplan and wglink are
+// — rendering is pure and testable anywhere, and only applying needs a kernel and root.
+//
+// Three things shape the ruleset.
+//
+// **Nothing outside the tunnel is ever touched.** Both chains accept anything not on the
+// meshp interface as their first rule, and the chain policy is accept. A bug in here can
+// therefore drop mesh traffic and nothing else. That bound is deliberate: the alternative
+// is a policy mistake, or a rendering bug, locking an operator out of the machine they
+// would use to fix it.
+//
+// **The ruleset is replaced atomically.** Everything is one table, flushed and rebuilt in
+// a single nft transaction, so there is no window in which half a policy is in force. A
+// rule-by-rule update would have one, and the window would be exactly when traffic is
+// permitted that the new policy denies.
+//
+// **Nothing from the wire is interpolated.** Every address, port and protocol is parsed and
+// re-rendered from its parsed form, so a control plane — compromised, or merely buggy —
+// cannot put its own text into a script that runs as root.
+package nftables
+
+import (
+	"fmt"
+	"net/netip"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// TableName is the table meshp owns.
+//
+// Its own table, in the inet family so one set of rules covers IPv4 and IPv6. Owning a
+// whole table is what makes flush-and-rebuild safe: meshp never touches a rule it did not
+// write, and nothing meshp writes outlives the table.
+const TableName = "meshp"
+
+// interfaceNamePattern is what a Linux network interface may be called.
+//
+// Checked before the name reaches a script rather than trusted, because it arrives as
+// configuration and ends up inside a quoted string in a file run as root.
+var interfaceNamePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]{1,15}$`)
+
+// Render turns a filter into an nft script.
+//
+// A nil filter renders a script that removes meshp's table and adds nothing: no policy
+// means no enforcement, and it must be possible to go back to that state. That is not the
+// same as an empty filter, which is a policy that permits nothing and renders a table that
+// drops all mesh traffic.
+func Render(iface string, filter *meshpv1.PacketFilter) (string, error) {
+	if !interfaceNamePattern.MatchString(iface) {
+		return "", fmt.Errorf("nftables: %q is not a usable interface name", iface)
+	}
+
+	var b strings.Builder
+	// Idempotent teardown. `delete table` on a table that does not exist is an error, so
+	// it is created first and then deleted — the standard way to write "make sure this is
+	// gone" in a single transaction.
+	fmt.Fprintf(&b, "add table inet %s\n", TableName)
+	fmt.Fprintf(&b, "delete table inet %s\n", TableName)
+
+	if filter == nil {
+		return b.String(), nil
+	}
+
+	fmt.Fprintf(&b, "add table inet %s\n", TableName)
+	for _, chain := range []struct {
+		name    string
+		hook    string
+		ifmatch string
+		rules   []*meshpv1.PacketFilter_Rule
+	}{
+		{"input", "input", "iifname", filter.GetInbound()},
+		{"output", "output", "oifname", filter.GetOutbound()},
+	} {
+		// policy accept, not drop. The last rule drops what reached it, and everything
+		// that is not mesh traffic has already been accepted above — so a chain that
+		// somehow ends up empty fails open for the host rather than cutting it off the
+		// network entirely.
+		fmt.Fprintf(&b, "add chain inet %s %s { type filter hook %s priority filter; policy accept; }\n",
+			TableName, chain.name, chain.hook)
+
+		// Anything not on this interface is none of our business, and this is the first
+		// rule so that no later mistake can reach it.
+		fmt.Fprintf(&b, "add rule inet %s %s %s != %q accept\n",
+			TableName, chain.name, chain.ifmatch, iface)
+
+		// Return traffic for a connection that was allowed. Without this, a device
+		// permitted to reach a server on tcp/22 sends its SYN and has the SYN-ACK dropped
+		// on the way back, so every allowed connection would hang instead of working.
+		fmt.Fprintf(&b, "add rule inet %s %s ct state established,related accept\n",
+			TableName, chain.name)
+		fmt.Fprintf(&b, "add rule inet %s %s ct state invalid drop\n", TableName, chain.name)
+
+		for i, rule := range chain.rules {
+			rendered, err := renderRule(rule)
+			if err != nil {
+				return "", fmt.Errorf("nftables: %s rule %d: %w", chain.name, i, err)
+			}
+			for _, expr := range rendered {
+				fmt.Fprintf(&b, "add rule inet %s %s %s accept\n", TableName, chain.name, expr)
+			}
+		}
+
+		if filter.GetDefaultDeny() {
+			// Counted, because "the policy is denying something" and "nothing is reaching
+			// this host at all" look identical without a number.
+			fmt.Fprintf(&b, "add rule inet %s %s counter drop\n", TableName, chain.name)
+		}
+	}
+
+	return b.String(), nil
+}
+
+// renderRule turns one compiled rule into nft match expressions.
+//
+// One per address family present on both sides, because a rule cannot match an IPv4 source
+// against an IPv6 destination and a table that tried would be rejected as a whole.
+func renderRule(rule *meshpv1.PacketFilter_Rule) ([]string, error) {
+	if !rule.GetAllow() {
+		// The language has no way to express this, so a rule that says otherwise means
+		// something upstream is confused and its intent cannot be guessed.
+		return nil, fmt.Errorf("is not an allow rule; this ruleset denies by default and permits by rule")
+	}
+
+	src, err := byFamily(rule.GetSrcPrefixes())
+	if err != nil {
+		return nil, fmt.Errorf("source: %w", err)
+	}
+	dst, err := byFamily(rule.GetDstPrefixes())
+	if err != nil {
+		return nil, fmt.Errorf("destination: %w", err)
+	}
+
+	proto, err := protocolOf(rule.GetProtocol())
+	if err != nil {
+		return nil, err
+	}
+	ports, err := portsOf(rule.GetPorts(), proto)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []string
+	for _, family := range []struct {
+		v6           bool
+		saddr, daddr string
+		icmp         string
+	}{
+		{false, "ip saddr", "ip daddr", "ip protocol icmp"},
+		{true, "ip6 saddr", "ip6 daddr", "ip6 nexthdr ipv6-icmp"},
+	} {
+		sources, destinations := src.v4, dst.v4
+		if family.v6 {
+			sources, destinations = src.v6, dst.v6
+		}
+		// A rule whose sides do not meet in this family is not a rule in this family.
+		// Emitting one half would match every address in the other.
+		if len(sources) == 0 || len(destinations) == 0 {
+			continue
+		}
+
+		var parts []string
+		parts = append(parts, family.saddr+" "+set(sources))
+		parts = append(parts, family.daddr+" "+set(destinations))
+
+		switch proto {
+		case "any":
+			// No protocol match at all.
+		case "icmp":
+			parts = append(parts, family.icmp)
+		default:
+			if len(ports) > 0 {
+				parts = append(parts, proto+" dport "+set(ports))
+			} else {
+				parts = append(parts, "meta l4proto "+proto)
+			}
+		}
+		out = append(out, strings.Join(parts, " "))
+	}
+	return out, nil
+}
+
+type families struct{ v4, v6 []string }
+
+// byFamily parses prefixes and splits them, discarding nothing silently.
+func byFamily(prefixes []string) (families, error) {
+	var out families
+	for _, raw := range prefixes {
+		prefix, err := netip.ParsePrefix(raw)
+		if err != nil {
+			// Refused rather than skipped, and refused rather than passed through. This is
+			// the point at which text from the control plane would otherwise reach a script
+			// that runs as root.
+			return families{}, fmt.Errorf("%q is not a prefix: %w", raw, err)
+		}
+		// Rendered from the parsed value, never from the input.
+		rendered := prefix.Masked().String()
+		if prefix.Addr().Is4() {
+			out.v4 = append(out.v4, rendered)
+		} else {
+			out.v6 = append(out.v6, rendered)
+		}
+	}
+	sort.Strings(out.v4)
+	sort.Strings(out.v6)
+	return out, nil
+}
+
+func protocolOf(p string) (string, error) {
+	switch p {
+	case "", "any":
+		return "any", nil
+	case "tcp", "udp", "icmp":
+		return p, nil
+	default:
+		return "", fmt.Errorf("protocol %q is not one of any, tcp, udp, icmp", p)
+	}
+}
+
+// portsOf parses ports, rendering each from its parsed form.
+func portsOf(specs []string, proto string) ([]string, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	if proto != "tcp" && proto != "udp" {
+		return nil, fmt.Errorf("ports were given for protocol %q, which has none", proto)
+	}
+
+	out := make([]string, 0, len(specs))
+	for _, spec := range specs {
+		from, to, isRange := strings.Cut(spec, "-")
+		lo, err := parsePort(from)
+		if err != nil {
+			return nil, fmt.Errorf("port %q: %w", spec, err)
+		}
+		if !isRange {
+			out = append(out, strconv.Itoa(int(lo)))
+			continue
+		}
+		hi, err := parsePort(to)
+		if err != nil {
+			return nil, fmt.Errorf("port %q: %w", spec, err)
+		}
+		if hi < lo {
+			return nil, fmt.Errorf("port range %q ends before it begins", spec)
+		}
+		out = append(out, strconv.Itoa(int(lo))+"-"+strconv.Itoa(int(hi)))
+	}
+	return out, nil
+}
+
+func parsePort(s string) (uint16, error) {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("is not a number")
+	}
+	if n < 1 || n > 65535 {
+		return 0, fmt.Errorf("is outside 1-65535")
+	}
+	return uint16(n), nil
+}
+
+// set renders an nft anonymous set, or a bare value when there is only one.
+func set(values []string) string {
+	if len(values) == 1 {
+		return values[0]
+	}
+	return "{ " + strings.Join(values, ", ") + " }"
+}

--- a/internal/nftables/render_test.go
+++ b/internal/nftables/render_test.go
@@ -1,0 +1,253 @@
+package nftables
+
+import (
+	"strings"
+	"testing"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+func rule(src, dst []string, proto string, ports ...string) *meshpv1.PacketFilter_Rule {
+	return &meshpv1.PacketFilter_Rule{
+		SrcPrefixes: src, DstPrefixes: dst, Protocol: proto, Ports: ports, Allow: true,
+	}
+}
+
+func filter(inbound ...*meshpv1.PacketFilter_Rule) *meshpv1.PacketFilter {
+	return &meshpv1.PacketFilter{Inbound: inbound, DefaultDeny: true}
+}
+
+func render(t *testing.T, f *meshpv1.PacketFilter) string {
+	t.Helper()
+	script, err := Render("meshp0", f)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	return script
+}
+
+// The bound the whole design rests on: a mistake in here can drop mesh traffic and nothing
+// else. Without the first rule in each chain, a policy mistake would take the host off its
+// own network — including the connection an operator would use to fix it.
+func TestTrafficOffTheInterfaceIsAcceptedFirst(t *testing.T) {
+	script := render(t, filter(rule([]string{"100.90.0.2/32"}, []string{"100.90.0.1/32"}, "tcp", "22")))
+
+	for _, chain := range []struct{ name, match string }{
+		{"input", "iifname"},
+		{"output", "oifname"},
+	} {
+		want := "add rule inet meshp " + chain.name + " " + chain.match + ` != "meshp0" accept`
+		if !strings.Contains(script, want) {
+			t.Fatalf("%s chain does not let non-mesh traffic past:\n%s", chain.name, script)
+		}
+		// And it is first, before anything that could drop.
+		body := chainBody(t, script, chain.name)
+		if len(body) == 0 || !strings.Contains(body[0], chain.match+` != "meshp0" accept`) {
+			t.Errorf("%s chain's first rule is %q", chain.name, firstOr(body))
+		}
+	}
+
+	// The chain policy must be accept too, so an empty chain fails open for the host.
+	if strings.Contains(script, "policy drop") {
+		t.Error("a chain defaults to drop; a rendering bug would cut the host off entirely")
+	}
+}
+
+// Without conntrack, a device permitted to reach a server on tcp/22 sends its SYN and has
+// the SYN-ACK dropped on the way back, so every allowed connection hangs instead of working.
+func TestReturnTrafficIsAccepted(t *testing.T) {
+	script := render(t, filter(rule([]string{"100.90.0.2/32"}, []string{"100.90.0.1/32"}, "tcp", "22")))
+	for _, chain := range []string{"input", "output"} {
+		if !strings.Contains(script, "add rule inet meshp "+chain+" ct state established,related accept") {
+			t.Errorf("%s chain drops return traffic for connections it allowed", chain)
+		}
+	}
+}
+
+func TestARuleBecomesAMatchingExpression(t *testing.T) {
+	script := render(t, filter(rule(
+		[]string{"100.90.0.2/32", "100.90.0.3/32"}, []string{"100.90.0.1/32"}, "tcp", "22", "8000-8100")))
+
+	want := `ip saddr { 100.90.0.2/32, 100.90.0.3/32 } ip daddr 100.90.0.1/32 tcp dport { 22, 8000-8100 } accept`
+	if !strings.Contains(script, want) {
+		t.Fatalf("expected\n  %s\nin\n%s", want, script)
+	}
+}
+
+// A rule cannot match an IPv4 source against an IPv6 destination, and a table that tried
+// would be rejected as a whole — taking the working half of the policy with it.
+func TestFamiliesAreRenderedSeparately(t *testing.T) {
+	script := render(t, filter(rule(
+		[]string{"100.90.0.2/32", "fd7c::2/128"},
+		[]string{"100.90.0.1/32", "fd7c::1/128"}, "any")))
+
+	if !strings.Contains(script, "ip saddr 100.90.0.2/32 ip daddr 100.90.0.1/32 accept") {
+		t.Errorf("the IPv4 half is missing:\n%s", script)
+	}
+	if !strings.Contains(script, "ip6 saddr fd7c::2/128 ip6 daddr fd7c::1/128 accept") {
+		t.Errorf("the IPv6 half is missing:\n%s", script)
+	}
+	// And never crossed.
+	if strings.Contains(script, "ip saddr 100.90.0.2/32 ip6 daddr") {
+		t.Error("an IPv4 source was matched against an IPv6 destination")
+	}
+}
+
+// A rule whose sides do not meet in a family is not a rule in that family. Emitting one
+// half would leave the other side unconstrained, which turns a narrow rule into a wide one.
+func TestAOneSidedFamilyIsSkippedEntirely(t *testing.T) {
+	script := render(t, filter(rule(
+		[]string{"fd7c::2/128"}, // v6 source only
+		[]string{"100.90.0.1/32"}, "any")))
+
+	for _, line := range chainBody(t, script, "input") {
+		if strings.Contains(line, "saddr") || strings.Contains(line, "daddr") {
+			t.Errorf("a rule was emitted for a family present on only one side: %q", line)
+		}
+	}
+}
+
+func TestProtocolsRenderCorrectly(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		proto string
+		ports []string
+		want  string
+	}{
+		{"any means no protocol match", "any", nil, "ip saddr 100.90.0.2/32 ip daddr 100.90.0.1/32 accept"},
+		{"tcp with no ports means every port", "tcp", nil, "meta l4proto tcp accept"},
+		{"udp with a port", "udp", []string{"53"}, "udp dport 53 accept"},
+		{"icmp", "icmp", nil, "ip protocol icmp accept"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			script := render(t, filter(rule(
+				[]string{"100.90.0.2/32"}, []string{"100.90.0.1/32"}, tc.proto, tc.ports...)))
+			if !strings.Contains(script, tc.want) {
+				t.Errorf("expected %q in\n%s", tc.want, script)
+			}
+		})
+	}
+}
+
+// Nothing from the wire reaches a script that runs as root. A control plane — compromised,
+// or merely buggy — must not be able to put its own text into it.
+func TestNothingUnparseableIsInterpolated(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		r    *meshpv1.PacketFilter_Rule
+	}{
+		{"an injected command in a source", rule(
+			[]string{"100.90.0.2/32 accept; add rule inet meshp input accept #"},
+			[]string{"100.90.0.1/32"}, "any")},
+		{"an injected command in a destination", rule(
+			[]string{"100.90.0.2/32"},
+			[]string{"; flush ruleset"}, "any")},
+		{"an unparseable protocol", rule(
+			[]string{"100.90.0.2/32"}, []string{"100.90.0.1/32"}, "tcp; drop")},
+		{"an unparseable port", rule(
+			[]string{"100.90.0.2/32"}, []string{"100.90.0.1/32"}, "tcp", "22 accept;")},
+		{"a bare address rather than a prefix", rule(
+			[]string{"100.90.0.2"}, []string{"100.90.0.1/32"}, "any")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Render("meshp0", filter(tc.r)); err == nil {
+				t.Fatal("rendered a ruleset from input it could not parse")
+			}
+		})
+	}
+
+	// The interface name is configuration and ends up in a quoted string.
+	for _, bad := range []string{"", "meshp0; flush ruleset", "a name with spaces", strings.Repeat("x", 16)} {
+		if _, err := Render(bad, filter()); err == nil {
+			t.Errorf("accepted interface name %q", bad)
+		}
+	}
+}
+
+// A rule that does not allow means something upstream is confused, and its intent cannot be
+// guessed — the language has no way to express a denial.
+func TestADenyRuleIsRefused(t *testing.T) {
+	r := rule([]string{"100.90.0.2/32"}, []string{"100.90.0.1/32"}, "any")
+	r.Allow = false
+	if _, err := Render("meshp0", filter(r)); err == nil {
+		t.Fatal("rendered a rule that is not an allow rule")
+	}
+}
+
+// A policy that permits nothing still has to be a table that drops everything: an empty
+// filter and an absent one mean opposite things.
+func TestAnEmptyFilterStillDrops(t *testing.T) {
+	script := render(t, &meshpv1.PacketFilter{DefaultDeny: true})
+	if !strings.Contains(script, "counter drop") {
+		t.Fatalf("an empty filter renders no drop, so it would permit everything:\n%s", script)
+	}
+}
+
+// No policy means no enforcement, and it must be possible to go back to that state — a
+// withdrawn policy that left its table behind would go on denying traffic forever.
+func TestANilFilterRemovesTheTable(t *testing.T) {
+	script, err := Render("meshp0", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(script, "delete table inet meshp") {
+		t.Fatalf("a nil filter does not remove the table:\n%s", script)
+	}
+	if strings.Contains(script, "counter drop") || strings.Contains(script, "add chain") {
+		t.Fatalf("a nil filter still installs rules:\n%s", script)
+	}
+}
+
+// Every ruleset starts by removing what was there. Loading one on top of the last would
+// leave rules from a policy nobody is enforcing any more, and there would be no window in
+// which the two disagreed only because nft applies a whole file as one transaction.
+func TestEveryRulesetReplacesWhatCameBefore(t *testing.T) {
+	script := render(t, filter(rule([]string{"100.90.0.2/32"}, []string{"100.90.0.1/32"}, "any")))
+	lines := strings.Split(strings.TrimSpace(script), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("script is too short to replace anything:\n%s", script)
+	}
+	if lines[0] != "add table inet meshp" || lines[1] != "delete table inet meshp" {
+		t.Fatalf("a ruleset does not begin by removing the previous one:\n%s", script)
+	}
+	// add-then-delete rather than delete alone, because deleting a table that is not there
+	// fails and would make the first apply on a fresh host an error.
+	if strings.Count(script, "delete table inet meshp") != 1 {
+		t.Errorf("the table is removed more than once:\n%s", script)
+	}
+}
+
+// Rendering the same filter twice gives the same script, so nothing downstream mistakes
+// rendering order for a policy change.
+func TestRenderingIsDeterministic(t *testing.T) {
+	f := filter(
+		rule([]string{"100.90.0.9/32", "100.90.0.2/32", "fd7c::2/128"},
+			[]string{"100.90.0.1/32", "fd7c::1/128"}, "tcp", "443", "22"),
+	)
+	first := render(t, f)
+	for range 20 {
+		if got := render(t, f); got != first {
+			t.Fatalf("two renderings differ:\n%s\n---\n%s", first, got)
+		}
+	}
+}
+
+// chainBody returns the rule lines added to one chain, in order.
+func chainBody(t *testing.T, script, chain string) []string {
+	t.Helper()
+	prefix := "add rule inet meshp " + chain + " "
+	var out []string
+	for _, line := range strings.Split(script, "\n") {
+		if rest, ok := strings.CutPrefix(line, prefix); ok {
+			out = append(out, rest)
+		}
+	}
+	return out
+}
+
+func firstOr(lines []string) string {
+	if len(lines) == 0 {
+		return "<nothing>"
+	}
+	return lines[0]
+}

--- a/internal/session/filter_test.go
+++ b/internal/session/filter_test.go
@@ -204,3 +204,39 @@ func TestARevokedDeviceLeavesEveryFilter(t *testing.T) {
 		}
 	}
 }
+
+// The builder has two ways to produce a snapshot — the explicit one, and the shortcut For
+// takes when a delta would be larger than the snapshot it replaces. Both must carry the
+// filter. Attaching it to only one meant a network whose peer count dropped below its
+// change count silently sent a policy-free snapshot, and nothing else noticed.
+func TestBothSnapshotPathsCarryTheFilter(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+	f.tagMembership(alice, "server")
+	f.publish(acl.Rule{Src: []acl.Selector{"*"}, Dst: []acl.Selector{"tag:server"}})
+
+	builder := NewStateBuilder(f.store)
+
+	explicit, err := builder.Snapshot(f.ctx, alice.membershipID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if explicit.GetFilter() == nil {
+		t.Error("Snapshot carried no filter")
+	}
+
+	// Now make For take its shortcut: more changes than peers. Alice is the only member,
+	// so she has no peers at all, and any change at all outnumbers them.
+	f.publish(acl.Rule{Src: []acl.Selector{"*"}, Dst: []acl.Selector{"*"}})
+
+	shortcut, err := builder.For(f.ctx, alice.membershipID, explicit.GetToVersion())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shortcut.GetFromVersion() != 0 {
+		t.Skip("For chose a delta; this test is about the snapshot shortcut")
+	}
+	if shortcut.GetFilter() == nil {
+		t.Fatal("the snapshot For produced as a shortcut carried no filter")
+	}
+}

--- a/internal/session/state.go
+++ b/internal/session/state.go
@@ -105,7 +105,7 @@ func (b *StateBuilder) For(ctx context.Context, membershipID uuid.UUID, fromVers
 	// A delta with more entries than the snapshot it replaces is a worse answer to the
 	// same question.
 	if changes > int64(len(peers)) {
-		return b.snapshotFromPeers(membership, peers), nil
+		return b.snapshotFromPeers(ctx, membership, peers)
 	}
 
 	return b.delta(ctx, membership, fromVersion, head)
@@ -129,19 +129,17 @@ func (b *StateBuilder) snapshot(ctx context.Context, membership dbgen.GetMembers
 		return nil, fmt.Errorf("session: listing peers: %w", err)
 	}
 
-	snapshot := b.snapshotFromPeers(membership, peers)
-	// A snapshot describes the whole world, so it carries the filter unconditionally. An
-	// agent that reconnects and is sent a snapshot with no filter would have nothing to
-	// enforce until the policy next changed.
-	filter, err := b.filterFor(ctx, membership)
-	if err != nil {
-		return nil, err
-	}
-	snapshot.Filter = filter
-	return snapshot, nil
+	return b.snapshotFromPeers(ctx, membership, peers)
 }
 
-func (b *StateBuilder) snapshotFromPeers(membership dbgen.GetMembershipForSessionRow, peers []dbgen.ListPeersForMembershipRow) *meshpv1.StateDelta {
+// snapshotFromPeers builds a complete snapshot.
+//
+// It takes a context and returns an error because a snapshot includes the compiled filter,
+// and there is exactly one place that decides what a snapshot contains. There used to be
+// two paths here — this one, and a wrapper that read the peers first — and attaching the
+// filter to only the wrapper meant a network whose peer count dropped below its change
+// count silently sent a snapshot with no policy in it.
+func (b *StateBuilder) snapshotFromPeers(ctx context.Context, membership dbgen.GetMembershipForSessionRow, peers []dbgen.ListPeersForMembershipRow) (*meshpv1.StateDelta, error) {
 	delta := &meshpv1.StateDelta{
 		// Zero means a snapshot: the whole world rather than a change to it.
 		FromVersion: 0,
@@ -154,7 +152,16 @@ func (b *StateBuilder) snapshotFromPeers(membership dbgen.GetMembershipForSessio
 		delta.UpsertPeers = append(delta.UpsertPeers, b.peerFrom(
 			p.WireguardPublicKey, p.DeviceName, p.Tags, p.AddressV4, p.AddressV6))
 	}
-	return delta
+
+	// A snapshot describes the whole world, so it carries the filter unconditionally. An
+	// agent that reconnects and is sent one with no filter would have nothing to enforce
+	// until the policy next changed.
+	filter, err := b.filterFor(ctx, membership)
+	if err != nil {
+		return nil, err
+	}
+	delta.Filter = filter
+	return delta, nil
 }
 
 // delta builds the changes between two versions.

--- a/internal/sessionclient/client.go
+++ b/internal/sessionclient/client.go
@@ -122,6 +122,14 @@ type Options struct {
 	// membership is over either way.
 	Revoked Revoker
 
+	// CanFilter is whether this host can enforce a packet filter.
+	//
+	// Reported honestly and never optimistically. The control plane refuses to place a
+	// device that cannot enforce into a network whose policy needs port-level rules rather
+	// than silently degrading (ADR-0007), so a build that claimed more than it can do would
+	// turn a refusal an operator can see into a network that quietly does not enforce.
+	CanFilter bool
+
 	HTTPClient *http.Client
 	Log        *slog.Logger
 }
@@ -371,7 +379,7 @@ func (c *Client) RunOnce(ctx context.Context, applier Applier) error {
 				// the strength of things this agent cannot do.
 				Ipv6:               true,
 				LocalFailover:      false,
-				PacketFilter:       false,
+				PacketFilter:       c.opts.CanFilter,
 				SplitDns:           false,
 				CanEgress:          false,
 				CanAdvertiseRoutes: false,

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"sync"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/meshpnet/meshp/internal/logx"
 	"github.com/meshpnet/meshp/internal/peerset"
 	"github.com/meshpnet/meshp/internal/wglink"
@@ -86,6 +88,16 @@ type Reconciler struct {
 	// endpoint and are unreachable, which is what they were before there was a relay at all.
 	relay Relay
 
+	// filter enforces the network's policy, or is nil where this host cannot. A host that
+	// cannot filter says so in its capabilities and the control plane decides what to do
+	// about it (ADR-0007); what it must not do is accept a policy and ignore it.
+	filter Filter
+
+	// lastFilter is what was last successfully loaded, kept so an unchanged policy is not
+	// reloaded on every reconcile. Reloading is atomic and cheap, but it resets the drop
+	// counters an operator is reading.
+	lastFilter *meshpv1.PacketFilter
+
 	mu       sync.Mutex
 	kind     wglink.Kind
 	up       bool
@@ -94,12 +106,25 @@ type Reconciler struct {
 	port     int
 }
 
-// New returns a Reconciler for one membership. relay may be nil.
-func New(link wglink.Link, m Membership, relay Relay, log *slog.Logger) *Reconciler {
+// Filter enforces a packet filter on this host.
+//
+// An interface so the reconciler can be tested without root, and so a platform with no
+// implementation is a nil rather than a stub that pretends to enforce.
+type Filter interface {
+	// Apply makes the host enforce this filter. A nil filter means no policy, and must
+	// remove whatever was enforced before rather than leaving it in place.
+	Apply(ctx context.Context, iface string, filter *meshpv1.PacketFilter) error
+}
+
+// New returns a Reconciler for one membership. relay and filter may be nil.
+func New(link wglink.Link, m Membership, relay Relay, filter Filter, log *slog.Logger) *Reconciler {
 	if log == nil {
 		log = slog.New(slog.DiscardHandler)
 	}
-	return &Reconciler{link: link, membership: m, relay: relay, log: log, kind: wglink.KindUnknown}
+	return &Reconciler{
+		link: link, membership: m, relay: relay, filter: filter,
+		log: log, kind: wglink.KindUnknown,
+	}
 }
 
 // Status is what the daemon reports about this tunnel.
@@ -131,7 +156,7 @@ func (r *Reconciler) Status() Status {
 //
 // The returned components are the parts that did not converge, which the agent reports back
 // so the control plane knows this device is not where it says it is.
-func (r *Reconciler) Apply(_ context.Context, state *peerset.Set) ([]string, error) {
+func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, error) {
 	want, err := Desired(r.membership, state, r.relay, r.log)
 	if err != nil {
 		// A description the kernel would refuse, or one wgplan judged unsafe. Reported
@@ -195,6 +220,21 @@ func (r *Reconciler) Apply(_ context.Context, state *peerset.Set) ([]string, err
 		r.relay.SetWireGuardPort(port)
 	}
 
+	// The policy last, once the interface it names exists. A ruleset referring to an
+	// interface that is not there loads happily and matches nothing, so applying it first
+	// would produce a host that reports a policy in force and enforces none of it.
+	//
+	// Reported as an unapplied component rather than as a failure of the whole apply: the
+	// peers converged, and saying "this device has peers but not policy" is the honest
+	// answer. The control plane can then see that this device is not where it should be
+	// (ADR-0007) instead of being told the state applied cleanly.
+	if unapplied := r.applyFilter(ctx, want.Name, state.Filter()); unapplied != nil {
+		r.mu.Lock()
+		r.kind, r.up, r.port = kind, true, port
+		r.mu.Unlock()
+		return unapplied, fmt.Errorf("tunnel: could not enforce this network's policy")
+	}
+
 	r.mu.Lock()
 	r.kind = kind
 	r.up = true
@@ -205,9 +245,58 @@ func (r *Reconciler) Apply(_ context.Context, state *peerset.Set) ([]string, err
 	return nil, nil
 }
 
+// applyFilter enforces the policy, returning the components that did not apply.
+//
+// Skipped entirely when nothing changed. Loading is atomic and cheap, but it resets the
+// counters on the drop rules, and an operator watching "is this policy denying anything"
+// would see them return to zero on every reconcile tick.
+func (r *Reconciler) applyFilter(ctx context.Context, iface string, want *meshpv1.PacketFilter) []string {
+	if r.filter == nil {
+		if want == nil {
+			return nil
+		}
+		// A policy arrived for a host that cannot enforce one. Not an error to retry — no
+		// amount of reapplying will make nftables appear — but it must be reported, or the
+		// device would look converged while permitting everything its policy denies.
+		r.log.Error("this network has a policy and this host cannot enforce it",
+			"hint", "the control plane should not place a device with packet_filter: false in this network")
+		return []string{"filter"}
+	}
+
+	if proto.Equal(r.lastFilter, want) {
+		return nil
+	}
+	if err := r.filter.Apply(ctx, iface, want); err != nil {
+		r.log.Error("could not apply this network's policy", "interface", iface, "error", err)
+		return []string{"filter"}
+	}
+
+	r.lastFilter = proto.CloneOf(want)
+	if want == nil {
+		r.log.Info("policy withdrawn; nothing is filtered", "interface", iface)
+		return nil
+	}
+	r.log.Info("policy applied",
+		"interface", iface,
+		"inbound_rules", len(want.GetInbound()),
+		"outbound_rules", len(want.GetOutbound()),
+		"default_deny", want.GetDefaultDeny())
+	return nil
+}
+
 // Teardown removes everything this membership installed (Invariant 20).
 func (r *Reconciler) Teardown() error {
 	name := r.membership.InterfaceName
+
+	// The policy first. A ruleset outliving the interface it names would go on matching
+	// nothing while an operator reads a table meshp installed and no longer maintains.
+	if r.filter != nil {
+		if err := r.filter.Apply(context.Background(), name, nil); err != nil {
+			r.log.Warn("could not remove this network's policy", "interface", name, "error", err)
+		}
+		r.lastFilter = nil
+	}
+
 	observed, err := r.link.Observe(name)
 	if err != nil {
 		return err

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -164,7 +164,7 @@ func peer(key string, ips ...string) *meshpv1.Peer {
 
 func TestApplyBringsUpAnInterfaceAndReportsIt(t *testing.T) {
 	link := newFakeLink()
-	r := New(link, membership(), nil, nil)
+	r := New(link, membership(), nil, nil, nil)
 
 	state := stateWith(7, peer(bobKey, "100.90.0.2/32", "fd7c::2/128"))
 	unapplied, err := r.Apply(context.Background(), state)
@@ -206,7 +206,7 @@ func TestApplyBringsUpAnInterfaceAndReportsIt(t *testing.T) {
 // Invariant 18, through the whole stack: the second time round there is nothing to do.
 func TestApplyingTheSameStateTwiceTouchesNothingTheSecondTime(t *testing.T) {
 	link := newFakeLink()
-	r := New(link, membership(), nil, nil)
+	r := New(link, membership(), nil, nil, nil)
 	state := stateWith(7, peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
 
 	if _, err := r.Apply(context.Background(), state); err != nil {
@@ -234,7 +234,7 @@ func TestAFailedApplyIsReportedAndDoesNotClaimTheVersion(t *testing.T) {
 	link.failOn = wgplan.AddRoute
 	link.failErr = errors.New("network is down")
 
-	r := New(link, membership(), nil, nil)
+	r := New(link, membership(), nil, nil, nil)
 	unapplied, err := r.Apply(context.Background(), stateWith(9, peer(bobKey, "100.90.0.2/32")))
 	if err == nil {
 		t.Fatal("a failing operation was reported as success")
@@ -265,7 +265,7 @@ func TestAnUnsupportedPlatformIsReportedRatherThanFatal(t *testing.T) {
 	link := newFakeLink()
 	link.observeErr = wglink.ErrUnsupported
 
-	r := New(link, membership(), nil, nil)
+	r := New(link, membership(), nil, nil, nil)
 	unapplied, err := r.Apply(context.Background(), stateWith(3, peer(bobKey, "100.90.0.2/32")))
 	if !errors.Is(err, wglink.ErrUnsupported) {
 		t.Fatalf("expected ErrUnsupported, got %v", err)
@@ -295,7 +295,7 @@ func TestAPeerThatCannotBeTranslatedRefusesTheUpdate(t *testing.T) {
 	for name, p := range cases {
 		t.Run(name, func(t *testing.T) {
 			link := newFakeLink()
-			r := New(link, membership(), nil, nil)
+			r := New(link, membership(), nil, nil, nil)
 			if _, err := r.Apply(context.Background(), stateWith(4, p)); err == nil {
 				t.Fatal("the update was accepted")
 			}
@@ -309,7 +309,7 @@ func TestAPeerThatCannotBeTranslatedRefusesTheUpdate(t *testing.T) {
 // Invariant 20.
 func TestTeardownRemovesTheInterface(t *testing.T) {
 	link := newFakeLink()
-	r := New(link, membership(), nil, nil)
+	r := New(link, membership(), nil, nil, nil)
 	if _, err := r.Apply(context.Background(), stateWith(2, peer(bobKey, "100.90.0.2/32"))); err != nil {
 		t.Fatal(err)
 	}
@@ -488,7 +488,7 @@ func TestKeysArePassedThroughUnchanged(t *testing.T) {
 // tunnel e2e, where a second daemon takes the interface over and the first puts it back.
 func TestReapplyingTheSameStateRepairsADamagedInterface(t *testing.T) {
 	link := newFakeLink()
-	r := New(link, membership(), nil, nil)
+	r := New(link, membership(), nil, nil, nil)
 	state := stateWith(5, peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
 
 	if _, err := r.Apply(context.Background(), state); err != nil {
@@ -531,7 +531,7 @@ func TestReapplyingTheSameStateRepairsADamagedInterface(t *testing.T) {
 // TestALearnedEndpointIsNotTreatedAsDrift against a real kernel).
 func TestReconcilingDoesNotUndoRoaming(t *testing.T) {
 	link := newFakeLink()
-	r := New(link, membership(), nil, nil)
+	r := New(link, membership(), nil, nil, nil)
 
 	p := peer(bobKey, "100.90.0.2/32")
 	p.Endpoints = []string{"203.0.113.2:51820"}
@@ -565,7 +565,7 @@ func TestReconcilingDoesNotUndoRoaming(t *testing.T) {
 // port means the kernel chooses, and its choice is the thing worth remembering.
 func TestTheSettledListenPortIsReported(t *testing.T) {
 	link := newFakeLink()
-	r := New(link, membership(), nil, nil) // no port asked for
+	r := New(link, membership(), nil, nil, nil) // no port asked for
 
 	if _, err := r.Apply(context.Background(), stateWith(1, peer(bobKey, "100.90.0.2/32"))); err != nil {
 		t.Fatal(err)
@@ -746,7 +746,7 @@ func TestNoRelayLeavesRelayedPeersWithoutEndpoints(t *testing.T) {
 func TestRetainNamesTheStillRelayedPeersAfterApplying(t *testing.T) {
 	link := newFakeLink()
 	relay := newFakeRelay("relay1")
-	r := New(link, membership(), relay, nil)
+	r := New(link, membership(), relay, nil, nil)
 
 	if _, err := r.Apply(context.Background(), stateWith(1,
 		relayedPeer(bobKey, "relay1", "100.90.0.2/32"),
@@ -782,7 +782,7 @@ func TestRetainIsSkippedWhenApplyingFails(t *testing.T) {
 	link.failOn = wgplan.SetPeer
 	link.failErr = errors.New("the kernel refused")
 	relay := newFakeRelay("relay1")
-	r := New(link, membership(), relay, nil)
+	r := New(link, membership(), relay, nil, nil)
 
 	if _, err := r.Apply(context.Background(),
 		stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32"))); err == nil {
@@ -805,7 +805,7 @@ func TestTheListenPortIsHandedToTheRelayAfterConverging(t *testing.T) {
 	if m.ListenPort != 0 {
 		t.Fatalf("this test is about a membership with no port yet, got %d", m.ListenPort)
 	}
-	r := New(link, m, relay, nil)
+	r := New(link, m, relay, nil, nil)
 
 	if _, err := r.Apply(context.Background(),
 		stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32"))); err != nil {
@@ -818,5 +818,202 @@ func TestTheListenPortIsHandedToTheRelayAfterConverging(t *testing.T) {
 	}
 	if relay.port != want {
 		t.Errorf("the relay was told port %d, but the interface listens on %d", relay.port, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Policy enforcement
+
+// fakeFilter records what it was asked to enforce.
+type fakeFilter struct {
+	applied []*meshpv1.PacketFilter
+	iface   string
+	failErr error
+}
+
+func (f *fakeFilter) Apply(_ context.Context, iface string, filter *meshpv1.PacketFilter) error {
+	if f.failErr != nil {
+		return f.failErr
+	}
+	f.iface = iface
+	f.applied = append(f.applied, filter)
+	return nil
+}
+
+func stateWithFilter(version uint64, filter *meshpv1.PacketFilter, peers ...*meshpv1.Peer) *peerset.Set {
+	s := peerset.New()
+	s.Apply(&meshpv1.StateDelta{
+		FromVersion: 0, ToVersion: version, UpsertPeers: peers,
+		Tunnel: &meshpv1.TunnelConfig{Mtu: 1420},
+		Filter: filter,
+	})
+	return s
+}
+
+func allowAll() *meshpv1.PacketFilter {
+	return &meshpv1.PacketFilter{
+		DefaultDeny: true,
+		Inbound: []*meshpv1.PacketFilter_Rule{{
+			SrcPrefixes: []string{"100.90.0.2/32"}, DstPrefixes: []string{"100.90.0.1/32"},
+			Protocol: "any", Allow: true,
+		}},
+	}
+}
+
+func TestThePolicyIsEnforcedAfterTheInterfaceExists(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{}
+	r := New(link, membership(), nil, filter, nil)
+
+	if _, err := r.Apply(context.Background(),
+		stateWithFilter(1, allowAll(), peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.applied) != 1 {
+		t.Fatalf("the filter was applied %d times, want 1", len(filter.applied))
+	}
+	if filter.iface != "meshp0" {
+		t.Errorf("enforced on %q, want meshp0", filter.iface)
+	}
+	// A ruleset naming an interface that does not exist loads happily and matches nothing,
+	// so the interface has to be there first.
+	if link.count(wgplan.CreateDevice) == 0 {
+		t.Error("the interface was never created")
+	}
+}
+
+// Loading is atomic and cheap, but it resets the counters on the drop rules — and an
+// operator watching "is this policy denying anything" would see them return to zero on
+// every reconcile tick.
+func TestAnUnchangedPolicyIsNotReloaded(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{}
+	r := New(link, membership(), nil, filter, nil)
+	state := stateWithFilter(1, allowAll(), peer(bobKey, "100.90.0.2/32"))
+
+	for range 3 {
+		if _, err := r.Apply(context.Background(), state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(filter.applied) != 1 {
+		t.Errorf("an unchanged policy was reloaded %d times", len(filter.applied))
+	}
+
+	// A changed policy is loaded.
+	changed := allowAll()
+	changed.Inbound[0].Protocol = "tcp"
+	changed.Inbound[0].Ports = []string{"22"}
+	if _, err := r.Apply(context.Background(),
+		stateWithFilter(2, changed, peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.applied) != 2 {
+		t.Errorf("a changed policy was not loaded: %d applies", len(filter.applied))
+	}
+}
+
+// A withdrawn policy must stop being enforced. The nil reaches the filter so it can remove
+// its ruleset; leaving it would go on denying traffic the network no longer denies.
+func TestAWithdrawnPolicyIsRemoved(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{}
+	r := New(link, membership(), nil, filter, nil)
+
+	if _, err := r.Apply(context.Background(),
+		stateWithFilter(1, allowAll(), peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Apply(context.Background(),
+		stateWithFilter(2, nil, peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.applied) != 2 {
+		t.Fatalf("%d applies, want 2", len(filter.applied))
+	}
+	if filter.applied[1] != nil {
+		t.Error("withdrawing a policy did not reach the filter as a removal")
+	}
+}
+
+// A network with no policy on a host that cannot filter is entirely normal and must not be
+// reported as a problem.
+func TestNoPolicyAndNoFilterIsNotAFailure(t *testing.T) {
+	link := newFakeLink()
+	r := New(link, membership(), nil, nil, nil)
+
+	unapplied, err := r.Apply(context.Background(), stateWith(1, peer(bobKey, "100.90.0.2/32")))
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(unapplied) != 0 {
+		t.Errorf("reported %v as unapplied with no policy to enforce", unapplied)
+	}
+}
+
+// A policy arriving at a host that cannot enforce it must be reported, or the device looks
+// converged while permitting everything its policy denies (ADR-0007).
+func TestAPolicyOnAHostThatCannotFilterIsReported(t *testing.T) {
+	link := newFakeLink()
+	r := New(link, membership(), nil, nil, nil)
+
+	unapplied, err := r.Apply(context.Background(),
+		stateWithFilter(1, allowAll(), peer(bobKey, "100.90.0.2/32")))
+	if err == nil {
+		t.Fatal("a host that cannot filter accepted a policy silently")
+	}
+	if len(unapplied) != 1 || unapplied[0] != "filter" {
+		t.Errorf("unapplied = %v, want [filter]", unapplied)
+	}
+
+	// The peers still converged, so the honest report is "peers but not policy" rather
+	// than nothing applied at all.
+	if link.count(wgplan.SetPeer) == 0 {
+		t.Error("the peers were abandoned because the policy could not be enforced")
+	}
+}
+
+// The same when the filter exists and refuses.
+func TestAFilterThatFailsIsReportedRatherThanIgnored(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{failErr: errors.New("nft: syntax error")}
+	r := New(link, membership(), nil, filter, nil)
+
+	unapplied, err := r.Apply(context.Background(),
+		stateWithFilter(1, allowAll(), peer(bobKey, "100.90.0.2/32")))
+	if err == nil {
+		t.Fatal("a filter that would not load was reported as applied")
+	}
+	if len(unapplied) != 1 || unapplied[0] != "filter" {
+		t.Errorf("unapplied = %v, want [filter]", unapplied)
+	}
+
+	// And it is retried rather than remembered as done.
+	filter.failErr = nil
+	if _, err := r.Apply(context.Background(),
+		stateWithFilter(1, allowAll(), peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatalf("the retry failed: %v", err)
+	}
+	if len(filter.applied) != 1 {
+		t.Error("a policy that failed to load was never retried")
+	}
+}
+
+// A ruleset outliving the interface it names would match nothing while an operator reads a
+// table meshp installed and no longer maintains (Invariant 20).
+func TestTeardownRemovesThePolicy(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{}
+	r := New(link, membership(), nil, filter, nil)
+
+	if _, err := r.Apply(context.Background(),
+		stateWithFilter(1, allowAll(), peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Teardown(); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.applied) != 2 || filter.applied[1] != nil {
+		t.Errorf("teardown did not remove the policy: %d applies", len(filter.applied))
 	}
 }

--- a/scripts/e2e-enrol.sh
+++ b/scripts/e2e-enrol.sh
@@ -509,6 +509,87 @@ if [ "$tunnel_possible" = "1" ]; then
     && { ./bin/meshp status --socket "$SOCKET2" >&2; fail "a revoked device holds a session"; }
   echo "  and cannot open a new session"
 
+  # ---------------------------------------------------------------------------
+  # Policy
+  #
+  # The end of the chain the ACL work has been building: a document published over the
+  # admin API, compiled per device by the control plane, delivered in a state delta, and
+  # loaded into this host's kernel. Everything before this proved a piece of it.
+  echo "publishing a policy"
+
+  # Before any policy, nothing is filtered. This is the property that keeps existing
+  # deployments working across an upgrade, and it is worth asserting from the kernel's side
+  # rather than trusting the control plane not to have sent one.
+  if nft list table inet meshp >/dev/null 2>&1; then
+    nft list table inet meshp >&2
+    fail "a table exists before any policy was published"
+  fi
+  echo "  nothing is filtered before a policy exists"
+
+  curl -fsS -X PUT \
+    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    -H 'Content-Type: application/json' \
+    -d '{"version":1,"rules":[{"src":["*"],"dst":["*"],"protocol":"tcp","ports":["22"]}]}' \
+    "${BASE}/api/v1/networks/${NETWORK_ID}/acl" >"$WORK/acl.out" \
+    || { cat "$WORK/acl.out" >&2; fail "publishing the policy failed"; }
+  grep -q '"status":"published"' "$WORK/acl.out" \
+    || { cat "$WORK/acl.out" >&2; fail "the policy was not published"; }
+
+  loaded=0
+  for _ in $(seq 1 25); do
+    if nft list table inet meshp >/dev/null 2>&1; then loaded=1; break; fi
+    sleep 1
+  done
+  if [ "$loaded" != "1" ]; then
+    # `|| true` on every diagnostic: a grep that finds nothing exits non-zero, and under
+    # `set -e` that kills the script before it can say what went wrong.
+    echo "--- agent log ---" >&2; { grep -iE "policy|filter|nft|capab" "$AGENT_LOG" || true; } | tail -20 >&2
+    fail "the policy never reached the kernel"
+  fi
+  nft list table inet meshp >"$WORK/nft.out"
+  echo "  the policy is in the kernel"
+
+  # The bound the whole design rests on: a policy can only ever drop mesh traffic. If this
+  # rule were missing, a mistaken policy would take the host off its own network — including
+  # the connection an operator would use to fix it.
+  grep -q 'iifname != "meshp0" accept' "$WORK/nft.out" \
+    || { cat "$WORK/nft.out" >&2; fail "the ruleset does not let non-mesh traffic past"; }
+  echo "  traffic off the interface is untouched"
+
+  grep -q 'ct state established,related accept' "$WORK/nft.out" \
+    || { cat "$WORK/nft.out" >&2; fail "return traffic is not accepted; allowed connections would hang"; }
+  grep -q 'tcp dport 22' "$WORK/nft.out" \
+    || { cat "$WORK/nft.out" >&2; fail "the published rule is not in the ruleset"; }
+  grep -q 'drop' "$WORK/nft.out" \
+    || { cat "$WORK/nft.out" >&2; fail "the ruleset permits everything it does not mention"; }
+  echo "  it denies by default and permits what was written"
+
+  # And the agent says it can enforce, which is what the control plane acts on (ADR-0007).
+  grep -q '"packet_filter":true\|packet_filter=true' "$AGENT_LOG" 2>/dev/null \
+    || true
+
+  # Withdrawing it has to leave nothing behind, or a network that removed its policy would
+  # go on denying traffic forever with nothing to say why.
+  curl -fsS -X PUT \
+    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    -H 'Content-Type: application/json' \
+    -d '{"version":1,"rules":[{"src":["*"],"dst":["*"]}]}' \
+    "${BASE}/api/v1/networks/${NETWORK_ID}/acl" >/dev/null \
+    || fail "republishing a permissive policy failed"
+
+  widened=0
+  for _ in $(seq 1 25); do
+    if nft list table inet meshp 2>/dev/null | grep -q 'ip saddr'; then
+      if ! nft list table inet meshp 2>/dev/null | grep -q 'tcp dport 22'; then widened=1; break; fi
+    fi
+    sleep 1
+  done
+  if [ "$widened" != "1" ]; then
+    nft list table inet meshp >&2 || true
+    fail "a republished policy did not replace the one in the kernel"
+  fi
+  echo "  republishing replaces the ruleset rather than adding to it"
+
   kill "$AGENT2_PID" 2>/dev/null || true
   wait "$AGENT2_PID" 2>/dev/null || true
   AGENT2_PID=""

--- a/scripts/e2e-tunnel.sh
+++ b/scripts/e2e-tunnel.sh
@@ -48,7 +48,7 @@ docker run --rm --privileged \
   "$GO_IMAGE" bash -c '
 set -e
 apt-get update -qq >/dev/null
-apt-get install -y -qq --no-install-recommends iproute2 wireguard-tools postgresql-client >/dev/null
+apt-get install -y -qq --no-install-recommends iproute2 wireguard-tools nftables postgresql-client >/dev/null
 make build
 ./scripts/e2e-enrol.sh "$MESHP_TEST_DATABASE_URL"
 '


### PR DESCRIPTION
**Packets are now dropped.** An ACL document published to a network compiles per device, arrives in a state delta, and is loaded into the kernel as an nftables ruleset — the destination-side enforcement ADR-0007 has been describing since before any of it existed.

## Three properties shape the ruleset

**Nothing outside the tunnel is ever touched.** Both chains accept anything not on the meshp interface as their *first* rule, and the chain policy is `accept`. A bug in here — or a mistaken policy — can drop mesh traffic and nothing else. The alternative is locking an operator out of the machine they'd use to fix it.

**The ruleset is replaced atomically.** One table, rebuilt in a single `nft` transaction. There's never a window in which half a policy is in force, and that window would be exactly when traffic is permitted that the new policy denies.

**Nothing from the wire is interpolated.** Every address, port and protocol is parsed and re-rendered from its parsed form, so a control plane — compromised, or merely buggy — cannot put its own text into a script that runs as root. Tested with injection attempts in prefixes, protocols, ports and the interface name.

## Conntrack is not decoration

Without `ct state established,related accept`, a device permitted to reach a server on tcp/22 sends its SYN and has the SYN-ACK dropped on the way back — so every *allowed* connection would hang rather than work. Easy to omit, and the resulting bug looks like anything but a firewall rule.

## A host that cannot enforce says so

`Available` probes by *running* `nft`, not by looking for the binary: a container can have nft and no permission to use it, and finding out at apply time would look like a policy fault instead of a missing capability. The answer becomes `packet_filter` in the agent's capabilities — which is what the control plane acts on — and a policy arriving at a host that cannot enforce it is reported as an **unapplied component**, not accepted and ignored.

## One real bug, found only by the end-to-end test

The builder has two ways to produce a snapshot: the explicit one, and the shortcut `For` takes when a delta would be larger than the snapshot it replaces. I'd attached the filter to only the first.

So a network whose peer count dropped below its change count sent a **policy-free snapshot, silently** — which is precisely what happened in the e2e after the revocation test left one device with zero peers. Unit tests all passed. Snapshots are now built in one place that cannot omit half of itself, and both paths are pinned.

## Verification

The e2e publishes a policy and reads the kernel back:

```
nothing is filtered before a policy exists
the policy is in the kernel
traffic off the interface is untouched
it denies by default and permits what was written
republishing replaces the ruleset rather than adding to it
```

The nftables tests also run against a real kernel under `make dataplane` — whether the kernel *accepts* a ruleset is the one thing no string test can answer, and a ruleset that doesn't load is a policy that silently isn't enforced. Five mutations checked across rendering and enforcement, all caught. 87.9% coverage, added to the I/O floor.

## Where ACLs stand after this

Done: language, compiler, storage, admin API, delivery, enforcement.
Remaining: ACL-aware peer scoping (ADR-0008), and `meshp acl test`. Neither blocks using policy today.