### PR TITLE
feat(tls): serve the control plane over TLS, and refuse plaintext to anywhere else

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ CROSS_TARGETS := linux/amd64 linux/arm64 linux/arm \
 # are held lower rather than pretended into the top tier. Packages needing PostgreSQL
 # are checked separately: without a database their tests skip, and the figure would be
 # meaningless rather than merely low.
-COVER_FLOOR_PKGS := internal/acl internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan internal/relayproto internal/relay internal/relaytoken
+COVER_FLOOR_PKGS := internal/acl internal/tlsconf internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan internal/relayproto internal/relay internal/relaytoken
 COVER_FLOOR      := 90
 
 COVER_FLOOR_IO_PKGS := internal/nftables internal/agentapi internal/agentstate internal/httpx internal/tunnel internal/relayclient internal/relayforward internal/relaylink internal/sessionclient

--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ is enforced by nftables at the destination (ADR-0007). A network with no policy 
 unfiltered, and a host that cannot enforce says so rather than accepting a policy and
 ignoring it.
 
-What does not, and matters: **the control plane speaks plaintext HTTP.** Direct paths,
-DNS and internet egress are all unimplemented, and the data plane is Linux-only —
-elsewhere a device enrols, holds an address, and reports honestly that it has no
-tunnel and cannot filter.
+The control plane serves TLS, from a certificate you supply or one it obtains from
+Let's Encrypt, and agents refuse a plaintext control URL to anything but loopback.
+
+What does not, and matters: direct paths, DNS and internet egress are all
+unimplemented, and the data plane is Linux-only — elsewhere a device enrols, holds an
+address, and reports honestly that it has no tunnel and cannot filter.
 
 It is public from the first commit because the design decisions are the
 interesting part and we would rather be argued with early.

--- a/cmd/meshp-control/main.go
+++ b/cmd/meshp-control/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/meshpnet/meshp/internal/relaytoken"
 	"github.com/meshpnet/meshp/internal/session"
 	"github.com/meshpnet/meshp/internal/store"
+	"github.com/meshpnet/meshp/internal/tlsconf"
 	"github.com/meshpnet/meshp/internal/version"
 	"github.com/meshpnet/meshp/migrations"
 	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
@@ -43,6 +44,15 @@ func main() {
 	var (
 		showVersion = flag.Bool("version", false, "print build information and exit")
 		listenAddr  = flag.String("listen", envOr("MESHP_LISTEN_ADDR", ":8080"), "address to listen on")
+
+		tlsCert = flag.String("tls-cert", os.Getenv("MESHP_TLS_CERT"),
+			"path to a TLS certificate; serves HTTPS")
+		tlsKey = flag.String("tls-key", os.Getenv("MESHP_TLS_KEY"),
+			"path to the TLS certificate's private key")
+		tlsDomains = flag.String("tls-domains", os.Getenv("MESHP_TLS_DOMAINS"),
+			"comma-separated names to obtain certificates for automatically (Let's Encrypt)")
+		tlsCacheDir = flag.String("tls-cache-dir", envOr("MESHP_TLS_CACHE_DIR", "/var/lib/meshp/certs"),
+			"where automatically obtained certificates are kept between restarts")
 		databaseURL = flag.String("database-url", os.Getenv("MESHP_DATABASE_URL"), "PostgreSQL connection string")
 		secretKey   = flag.String("secret-key", os.Getenv("MESHP_SECRET_KEY"), "master secret for enrolment challenges and sessions")
 		adminToken  = flag.String("admin-token", os.Getenv("MESHP_ADMIN_TOKEN"), "bootstrap secret for the administrative API")
@@ -128,7 +138,19 @@ func main() {
 		os.Exit(2)
 	}
 
+	tlsOpts := tlsconf.Options{
+		CertFile:     *tlsCert,
+		KeyFile:      *tlsKey,
+		ACMECacheDir: *tlsCacheDir,
+	}
+	for _, domain := range strings.Split(*tlsDomains, ",") {
+		if d := strings.TrimSpace(domain); d != "" {
+			tlsOpts.ACMEDomains = append(tlsOpts.ACMEDomains, d)
+		}
+	}
+
 	cfg := runConfig{
+		tls:             tlsOpts,
 		relays:          relayConfig,
 		relaySigningKey: signer,
 		addr:            *listenAddr,
@@ -148,6 +170,7 @@ func main() {
 type runConfig struct {
 	relays          *meshpv1.RelayConfig
 	relaySigningKey ed25519.PrivateKey
+	tls             tlsconf.Options
 	addr            string
 	databaseURL     string
 	secretKey       []byte
@@ -177,10 +200,53 @@ func run(ctx context.Context, log *slog.Logger, cfg runConfig) error {
 		IdleTimeout:       120 * time.Second,
 	}
 
+	tlsConfig, acmeWrap, err := tlsconf.Config(cfg.tls)
+	switch {
+	case errors.Is(err, tlsconf.ErrNoTLS):
+		// Serving plaintext is a legitimate way to run this — behind a tunnel, or behind
+		// something else terminating TLS — but it is never what someone wants by accident,
+		// and agents refuse a plaintext control URL that is not loopback. So it is said
+		// loudly rather than left to be discovered.
+		log.Warn("serving without TLS",
+			"note", "enrolment tokens and session signatures cross the network in the clear",
+			"hint", "set MESHP_TLS_CERT and MESHP_TLS_KEY, or MESHP_TLS_DOMAINS for automatic certificates")
+	case err != nil:
+		return fmt.Errorf("meshp-control: %w", err)
+	}
+	if tlsConfig != nil {
+		srv.TLSConfig = tlsConfig
+	}
+
+	// The ACME challenge responder, on port 80. Only with automatic certificates, and only
+	// ever serving the challenge: it redirects everything else rather than exposing the API
+	// over plaintext on a second port.
+	var challengeSrv *http.Server
+	if acmeWrap != nil {
+		challengeSrv = &http.Server{
+			Addr:              ":80",
+			Handler:           acmeWrap(http.HandlerFunc(redirectToHTTPS)),
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+		go func() {
+			if err := challengeSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				log.Warn("the certificate challenge listener stopped",
+					"error", err, "hint", "port 80 must be reachable to obtain certificates")
+			}
+		}()
+		defer func() { _ = challengeSrv.Close() }()
+	}
+
 	serveErr := make(chan error, 1)
 	go func() {
-		log.Info("listening", "addr", cfg.addr)
-		err := srv.ListenAndServe()
+		log.Info("listening", "addr", cfg.addr, "tls", tlsConfig != nil)
+		var err error
+		if tlsConfig != nil {
+			// The certificate and key are already in the TLS config, loaded and checked
+			// before anything started listening.
+			err = srv.ListenAndServeTLS("", "")
+		} else {
+			err = srv.ListenAndServe()
+		}
 		if errors.Is(err, http.ErrServerClosed) {
 			err = nil
 		}
@@ -516,4 +582,14 @@ func envBool(key string) bool {
 		return true
 	}
 	return false
+}
+
+// redirectToHTTPS sends a plaintext caller to the same URL over TLS.
+//
+// The port-80 listener exists to answer certificate challenges, and answering anything
+// else there would put the API on a plaintext port that nobody configured. A redirect is
+// the least surprising thing to do with the rest.
+func redirectToHTTPS(w http.ResponseWriter, r *http.Request) {
+	target := "https://" + r.Host + r.URL.RequestURI()
+	http.Redirect(w, r, target, http.StatusPermanentRedirect)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/jsimonetti/rtnetlink/v2 v2.2.0
+	golang.org/x/crypto v0.55.0
 	golang.org/x/sys v0.47.0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10
 	google.golang.org/protobuf v1.36.12
@@ -20,7 +21,6 @@ require (
 	github.com/mdlayher/genetlink v1.3.2 // indirect
 	github.com/mdlayher/netlink v1.8.0 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/text v0.41.0 // indirect

--- a/internal/controlurl/controlurl.go
+++ b/internal/controlurl/controlurl.go
@@ -20,6 +20,7 @@ package controlurl
 import (
 	"errors"
 	"fmt"
+	"net/netip"
 	"net/url"
 	"strings"
 )
@@ -74,9 +75,35 @@ func Validate(raw string) (string, error) {
 		return "", fmt.Errorf("%w: it must be a scheme and host only, with no path (%q)", ErrInvalid, parsed.Path)
 	}
 
+	// Last, after the more specific complaints. Someone who typed credentials or a path is
+	// better served by hearing about that than about the scheme, and every check above
+	// describes something that would still be wrong over https.
+	if parsed.Scheme == "http" && !isLoopbackHost(parsed.Hostname()) {
+		return "", fmt.Errorf(
+			"%w: %q is plaintext to a remote host; use https, or tunnel it to 127.0.0.1",
+			ErrInvalid, trimmed)
+	}
+
 	// Rebuilt from the parsed parts rather than trimmed from the input, so what is
 	// returned is exactly what was validated.
 	return parsed.Scheme + "://" + parsed.Host, nil
+}
+
+// isLoopbackHost reports whether a host names this machine.
+//
+// By parsed address rather than by name. "localhost" is accepted because every resolver
+// answers it with a loopback address, but any other name is not: a name that resolves to
+// 127.0.0.1 today can resolve elsewhere tomorrow, and the check would have been made once
+// against an answer that has since changed.
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	addr, err := netip.ParseAddr(strings.Trim(host, "[]"))
+	if err != nil {
+		return false
+	}
+	return addr.IsLoopback()
 }
 
 // MustValidate is Validate for constants in tests and defaults.

--- a/internal/controlurl/controlurl_test.go
+++ b/internal/controlurl/controlurl_test.go
@@ -122,3 +122,52 @@ func FuzzValidate(f *testing.F) {
 		}
 	})
 }
+
+// Everything a control URL carries is worth stealing: an enrolment token grants a device a
+// place in the network, and a session challenge and its signature are how a device proves
+// who it is. Over plaintext to a remote host, all of it is readable in transit.
+func TestPlaintextIsRefusedToRemoteHosts(t *testing.T) {
+	for _, raw := range []string{
+		"http://control.example",
+		"http://control.example:8080",
+		"http://203.0.113.10",
+		"http://[2001:db8::1]:8080",
+		// A name is not evidence, whatever it resolves to today.
+		"http://localhost.evil.test",
+	} {
+		if _, err := Validate(raw); err == nil {
+			t.Errorf("accepted plaintext to a remote host: %q", raw)
+		}
+	}
+}
+
+// Loopback is exempt: it cannot leave the machine, and it is what local development and an
+// SSH tunnel to a control plane both look like. A rule that refused it would push people
+// towards turning verification off entirely.
+func TestPlaintextIsAllowedToThisMachine(t *testing.T) {
+	for _, raw := range []string{
+		"http://127.0.0.1:8080",
+		"http://localhost:8080",
+		"http://LOCALHOST:8080",
+		"http://[::1]:8080",
+		"http://127.5.5.5:8080",
+	} {
+		if _, err := Validate(raw); err != nil {
+			t.Errorf("refused loopback %q: %v", raw, err)
+		}
+	}
+}
+
+// https is accepted everywhere, which is the point of the rule.
+func TestHTTPSIsAcceptedAnywhere(t *testing.T) {
+	for _, raw := range []string{
+		"https://control.example",
+		"https://control.example:8443",
+		"https://203.0.113.10",
+		"https://127.0.0.1:8443",
+	} {
+		if _, err := Validate(raw); err != nil {
+			t.Errorf("refused %q: %v", raw, err)
+		}
+	}
+}

--- a/internal/tlsconf/tlsconf.go
+++ b/internal/tlsconf/tlsconf.go
@@ -1,0 +1,126 @@
+// Package tlsconf builds the TLS configuration a control plane serves with.
+//
+// Two ways to get a certificate, because the two kinds of operator want different things.
+// Someone running this behind their own infrastructure has a certificate already and wants
+// to point at it; someone standing up a control plane on a fresh host wants one to appear.
+// Both are supported and neither is the default, because a control plane that guessed would
+// either fetch a certificate nobody asked for or serve plaintext when TLS was intended.
+package tlsconf
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"golang.org/x/crypto/acme/autocert"
+)
+
+// Options are the ways to obtain a certificate. At most one may be set.
+type Options struct {
+	// CertFile and KeyFile are a certificate and its private key on disk.
+	CertFile string
+	KeyFile  string
+
+	// ACMEDomains are the names to obtain a certificate for automatically. Requires the
+	// host to be reachable on port 443 from the internet under those names.
+	ACMEDomains []string
+
+	// ACMECacheDir is where issued certificates are kept between restarts.
+	//
+	// Not optional when ACME is used. Without it every restart asks the certificate
+	// authority again, and Let's Encrypt's rate limits are low enough that a crash loop
+	// would exhaust a week's allowance in an afternoon and leave the deployment with no
+	// certificate at all.
+	ACMECacheDir string
+}
+
+// ErrNoTLS means no certificate was configured.
+//
+// A condition rather than a failure: a deployment reached only over a tunnel, or through
+// something else that terminates TLS, is a legitimate way to run this. The caller decides
+// what to do about it, and says so in its log, rather than this package guessing.
+var ErrNoTLS = errors.New("tlsconf: no certificate is configured")
+
+// Config builds a TLS configuration, or ErrNoTLS when none was asked for.
+//
+// The returned handler wrapper is nil except with ACME, where it is what answers the
+// HTTP-01 challenge on port 80.
+func Config(opts Options) (*tls.Config, func(http.Handler) http.Handler, error) {
+	files := opts.CertFile != "" || opts.KeyFile != ""
+	acme := len(opts.ACMEDomains) > 0
+
+	switch {
+	case files && acme:
+		// Refused rather than ranked. Both were configured deliberately by somebody, and
+		// picking one would silently ignore what the other person meant.
+		return nil, nil, errors.New(
+			"tlsconf: both a certificate file and automatic certificates were configured; choose one")
+
+	case files:
+		if opts.CertFile == "" || opts.KeyFile == "" {
+			return nil, nil, errors.New("tlsconf: a certificate needs both a certificate and a key file")
+		}
+		// Loaded now rather than on the first connection. A path that is wrong, or a key
+		// that does not match its certificate, should stop a deployment starting — not
+		// surface as a handshake failure to the first agent that tries to enrol.
+		cert, err := tls.LoadX509KeyPair(opts.CertFile, opts.KeyFile)
+		if err != nil {
+			return nil, nil, fmt.Errorf("tlsconf: loading the certificate: %w", err)
+		}
+		cfg := baseConfig()
+		cfg.Certificates = []tls.Certificate{cert}
+		return cfg, nil, nil
+
+	case acme:
+		if opts.ACMECacheDir == "" {
+			return nil, nil, errors.New(
+				"tlsconf: automatic certificates need a cache directory, or every restart asks the " +
+					"certificate authority again and a crash loop exhausts its rate limit")
+		}
+		if err := os.MkdirAll(opts.ACMECacheDir, 0o700); err != nil {
+			return nil, nil, fmt.Errorf("tlsconf: preparing the certificate cache: %w", err)
+		}
+		for _, domain := range opts.ACMEDomains {
+			if strings.TrimSpace(domain) == "" || strings.Contains(domain, "/") {
+				return nil, nil, fmt.Errorf("tlsconf: %q is not a domain name", domain)
+			}
+		}
+
+		manager := &autocert.Manager{
+			Prompt: autocert.AcceptTOS,
+			// The host allowlist is what stops this becoming a certificate-issuing service
+			// for whoever points a DNS name at it: without it, any name resolving here
+			// makes the deployment ask a certificate authority on that name's behalf.
+			HostPolicy: autocert.HostWhitelist(opts.ACMEDomains...),
+			Cache:      autocert.DirCache(opts.ACMECacheDir),
+		}
+		cfg := baseConfig()
+		cfg.GetCertificate = manager.GetCertificate
+		// TLS-ALPN-01 needs this offered, and it is what lets a certificate be obtained
+		// without anything listening on port 80.
+		cfg.NextProtos = append(cfg.NextProtos, acmeALPNProto)
+		return cfg, manager.HTTPHandler, nil
+
+	default:
+		return nil, nil, ErrNoTLS
+	}
+}
+
+// acmeALPNProto is the protocol name the TLS-ALPN-01 challenge is answered under.
+const acmeALPNProto = "acme-tls/1"
+
+// baseConfig is what every certificate source shares.
+func baseConfig() *tls.Config {
+	return &tls.Config{
+		// 1.2 is the floor rather than 1.3, because agents are the only clients and they
+		// are all this codebase — but a self-hoster's reverse proxy or monitoring may not
+		// be, and 1.2 with modern suites is not the weak link in anything here.
+		MinVersion: tls.VersionTLS12,
+		// http/1.1 explicitly alongside h2: without a list, a Go server negotiates h2 and
+		// the WebSocket upgrade the control channel depends on is not available over it.
+		NextProtos: []string{"h2", "http/1.1"},
+	}
+}

--- a/internal/tlsconf/tlsconf_test.go
+++ b/internal/tlsconf/tlsconf_test.go
@@ -1,0 +1,231 @@
+package tlsconf
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeCert puts a self-signed certificate and key in a directory and returns their paths.
+func writeCert(t *testing.T, host string) (certPath, keyPath string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: host},
+		DNSNames:              []string{host},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return certPath, keyPath
+}
+
+// No certificate is a condition, not a failure: a deployment behind a tunnel or behind
+// something else terminating TLS is a legitimate way to run this.
+func TestNoCertificateIsItsOwnAnswer(t *testing.T) {
+	_, _, err := Config(Options{})
+	if !errors.Is(err, ErrNoTLS) {
+		t.Fatalf("error = %v, want ErrNoTLS", err)
+	}
+}
+
+// The whole point: a server built from this actually completes a handshake.
+func TestAConfiguredCertificateServesTLS(t *testing.T) {
+	certPath, keyPath := writeCert(t, "control.example")
+
+	cfg, wrap, err := Config(Options{CertFile: certPath, KeyFile: keyPath})
+	if err != nil {
+		t.Fatalf("Config: %v", err)
+	}
+	if wrap != nil {
+		t.Error("a file-based certificate asked for an ACME challenge handler")
+	}
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	srv.TLS = cfg
+	srv.StartTLS()
+	defer srv.Close()
+
+	// Verified against the certificate rather than skipped, so this proves the chain the
+	// server presented is the one that was configured.
+	pool := x509.NewCertPool()
+	pem, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pool.AppendCertsFromPEM(pem) {
+		t.Fatal("the certificate did not parse")
+	}
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
+		RootCAs:    pool,
+		ServerName: "control.example",
+		MinVersion: tls.VersionTLS12,
+	}}}
+
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("the handshake failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d", resp.StatusCode)
+	}
+	if resp.TLS == nil || resp.TLS.Version < tls.VersionTLS12 {
+		t.Errorf("negotiated %v, want at least TLS 1.2", resp.TLS)
+	}
+}
+
+// A path that is wrong, or a key that does not match its certificate, must stop a
+// deployment starting rather than surfacing as a handshake failure to the first agent that
+// tries to enrol.
+func TestABadCertificateIsRefusedAtStartup(t *testing.T) {
+	certPath, keyPath := writeCert(t, "control.example")
+	otherCert, _ := writeCert(t, "other.example")
+
+	for _, tc := range []struct{ name, cert, key, wants string }{
+		{"a missing file", filepath.Join(t.TempDir(), "nope.pem"), keyPath, "certificate"},
+		{"a certificate with no key", certPath, "", "key file"},
+		{"a key with no certificate", "", keyPath, "key file"},
+		{"a key that does not match", otherCert, keyPath, "certificate"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := Config(Options{CertFile: tc.cert, KeyFile: tc.key})
+			if err == nil {
+				t.Fatal("accepted a certificate it cannot serve")
+			}
+			if errors.Is(err, ErrNoTLS) {
+				t.Fatal("a broken certificate was reported as no certificate at all")
+			}
+			if !strings.Contains(err.Error(), tc.wants) {
+				t.Errorf("error %q does not mention %q", err, tc.wants)
+			}
+		})
+	}
+}
+
+// Both configured means two people meant two different things, and picking one would
+// silently ignore the other.
+func TestFilesAndAutomaticCertificatesTogetherAreRefused(t *testing.T) {
+	certPath, keyPath := writeCert(t, "control.example")
+	_, _, err := Config(Options{
+		CertFile: certPath, KeyFile: keyPath,
+		ACMEDomains: []string{"control.example"}, ACMECacheDir: t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("accepted both a certificate file and automatic certificates")
+	}
+}
+
+// Without a cache, every restart asks the certificate authority again, and Let's Encrypt's
+// rate limits are low enough that a crash loop exhausts a week's allowance in an afternoon.
+func TestAutomaticCertificatesNeedACache(t *testing.T) {
+	_, _, err := Config(Options{ACMEDomains: []string{"control.example"}})
+	if err == nil {
+		t.Fatal("accepted automatic certificates with nowhere to cache them")
+	}
+	if !strings.Contains(err.Error(), "rate limit") {
+		t.Errorf("the error does not say why it matters: %v", err)
+	}
+}
+
+func TestAutomaticCertificatesAreConfigured(t *testing.T) {
+	cfg, wrap, err := Config(Options{
+		ACMEDomains: []string{"control.example"}, ACMECacheDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Config: %v", err)
+	}
+	if cfg.GetCertificate == nil {
+		t.Error("no certificate source was installed")
+	}
+	if wrap == nil {
+		t.Error("no challenge handler was returned, so port 80 would answer nothing")
+	}
+	// TLS-ALPN-01 needs this offered, and it is what lets a certificate be obtained
+	// without anything listening on port 80 at all.
+	if !containsProto(cfg.NextProtos, "acme-tls/1") {
+		t.Errorf("NextProtos = %v, missing the ALPN challenge protocol", cfg.NextProtos)
+	}
+	if !containsProto(cfg.NextProtos, "http/1.1") {
+		t.Errorf("NextProtos = %v: without http/1.1 the control channel's WebSocket upgrade "+
+			"is unavailable", cfg.NextProtos)
+	}
+}
+
+func TestADomainThatIsNotOneIsRefused(t *testing.T) {
+	for _, bad := range []string{" ", "control.example/path"} {
+		if _, _, err := Config(Options{
+			ACMEDomains: []string{bad}, ACMECacheDir: t.TempDir(),
+		}); err == nil {
+			t.Errorf("accepted %q as a domain", bad)
+		}
+	}
+}
+
+// Without http/1.1 offered, a Go server negotiates h2 and the WebSocket upgrade the
+// control channel depends on is not available over it.
+func TestHTTP11IsAlwaysOffered(t *testing.T) {
+	certPath, keyPath := writeCert(t, "control.example")
+	cfg, _, err := Config(Options{CertFile: certPath, KeyFile: keyPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsProto(cfg.NextProtos, "http/1.1") {
+		t.Errorf("NextProtos = %v", cfg.NextProtos)
+	}
+	if cfg.MinVersion < tls.VersionTLS12 {
+		t.Errorf("MinVersion = %x, want at least TLS 1.2", cfg.MinVersion)
+	}
+}
+
+func containsProto(protos []string, want string) bool {
+	for _, p := range protos {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}

--- a/scripts/e2e-enrol.sh
+++ b/scripts/e2e-enrol.sh
@@ -83,6 +83,28 @@ MESHP_RELAY_ADMIN_ADDR="127.0.0.1:9099" \
   ./bin/meshp-relay >"$RELAY_LOG" 2>&1 &
 RELAY_PID=$!
 
+# A certificate for this control plane, so the whole run goes over TLS with the agent
+# verifying it. Plaintext to anything but loopback is refused by the agent now, and a test
+# that ran over http would be exercising the one path a real deployment must never take.
+TLS_DIR="$WORK/tls"
+mkdir -p "$TLS_DIR"
+if command -v openssl >/dev/null 2>&1; then
+  openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+    -keyout "$TLS_DIR/key.pem" -out "$TLS_DIR/cert.pem" \
+    -subj "/CN=localhost" \
+    -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" >/dev/null 2>&1 \
+    || fail "could not generate a test certificate"
+  BASE="https://localhost:${PORT}"
+  # The agent and curl both verify it. Trusting this one certificate rather than disabling
+  # verification, because "does the agent verify" is exactly what is under test.
+  export SSL_CERT_FILE="$TLS_DIR/cert.pem"
+  CURL_CA=(--cacert "$TLS_DIR/cert.pem")
+  echo "serving the control plane over TLS"
+else
+  CURL_CA=()
+  echo "openssl is unavailable; running without TLS"
+fi
+
 echo "starting meshp-control on ${BASE}"
 MESHP_DATABASE_URL="$DB_URL" \
 MESHP_LISTEN_ADDR="127.0.0.1:${PORT}" \
@@ -90,14 +112,16 @@ MESHP_SECRET_KEY="$SECRET_KEY" \
 MESHP_ADMIN_TOKEN="$ADMIN_TOKEN" \
 MESHP_RELAY_SIGNING_KEY="$RELAY_SIGNING_KEY" \
 MESHP_RELAYS="${RELAY_ID}=127.0.0.1:${RELAY_PORT}" \
+MESHP_TLS_CERT="${TLS_DIR}/cert.pem" \
+MESHP_TLS_KEY="${TLS_DIR}/key.pem" \
   ./bin/meshp-control >"$CONTROL_LOG" 2>&1 &
 CONTROL_PID=$!
 
 for _ in $(seq 1 30); do
-  curl -fsS "${BASE}/readyz" >/dev/null 2>&1 && break
+  curl -fsS "${CURL_CA[@]}" "${BASE}/readyz" >/dev/null 2>&1 && break
   sleep 1
 done
-curl -fsS "${BASE}/readyz" >/dev/null 2>&1 || fail "control plane never became ready"
+curl -fsS "${CURL_CA[@]}" "${BASE}/readyz" >/dev/null 2>&1 || fail "control plane never became ready"
 
 echo "starting meshpd with no state at all"
 # Deliberately before enrolment. An agent that gives up when it has nothing to do cannot
@@ -146,7 +170,7 @@ NETWORK_ID="$(psql "$DB_URL" -tAqc "
 echo "  network ${NETWORK_ID}"
 
 echo "minting an enrolment token"
-MINT="$(curl -fsS -X POST \
+MINT="$(curl -fsS "${CURL_CA[@]}" -X POST \
   -H "Authorization: Bearer ${ADMIN_TOKEN}" \
   -H 'Content-Type: application/json' \
   -d '{"max_uses":1,"expires_in_seconds":600,"tags":["e2e"]}' \
@@ -160,7 +184,7 @@ esac
 echo "  minted ${TOKEN:0:18}…"
 
 echo "the administrative API refuses an unauthenticated caller"
-status="$(curl -s -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d '{}' \
+status="$(curl -s "${CURL_CA[@]}" -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d '{}' \
   "${BASE}/api/v1/networks/${NETWORK_ID}/enrollment-tokens")"
 [ "$status" = "401" ] || fail "minting without a token returned ${status}, want 401"
 
@@ -194,6 +218,17 @@ tunnel_possible=0
 if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" = "0" ] && ip link add dev wgprobe0 type wireguard 2>/dev/null; then
   ip link del dev wgprobe0
   tunnel_possible=1
+fi
+
+# Over TLS, and the control plane says so. A run that quietly fell back to plaintext would
+# pass every assertion below while testing the one path a real deployment must never take.
+if [ -n "${CURL_CA[*]}" ]; then
+  grep -q 'msg=listening.*tls=true' "$CONTROL_LOG" \
+    || { grep -i listening "$CONTROL_LOG" >&2; fail "the control plane is not serving TLS"; }
+  grep -q 'control     https://' "$WORK/status.out" 2>/dev/null \
+    || ./bin/meshp status --socket "$SOCKET" | grep -q 'control     https://' \
+    || fail "the agent is not talking to the control plane over TLS"
+  echo "  the session runs over TLS, with the agent verifying the certificate"
 fi
 
 echo "meshp status reports a live session"
@@ -243,7 +278,7 @@ sed -n 's/.*msg="recorded desired state" \(.*\)/  \1/p' "$AGENT_LOG" | tail -1
 echo "a second device produces a delta, not another snapshot"
 # The point of A4: a device joining must not cause every other agent to be handed the whole
 # network again. The agent logs whether what it applied was a snapshot.
-TOKEN2="$(curl -fsS -X POST \
+TOKEN2="$(curl -fsS "${CURL_CA[@]}" -X POST \
   -H "Authorization: Bearer ${ADMIN_TOKEN}" \
   -H 'Content-Type: application/json' \
   -d '{"max_uses":1,"expires_in_seconds":600}' \
@@ -425,13 +460,13 @@ if [ "$tunnel_possible" = "1" ]; then
   PEER_MEMBERSHIP="$(sed -n 's/.*"membership_id": *"\([^"]*\)".*/\1/p' "$STATE_DIR2/state.json" | head -1)"
   [ -n "$PEER_MEMBERSHIP" ] || fail "could not read the peer's membership id"
 
-  curl -fsS -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  curl -fsS "${CURL_CA[@]}" -H "Authorization: Bearer ${ADMIN_TOKEN}" \
     "${BASE}/api/v1/networks/${NETWORK_ID}/devices" >"$WORK/devices.out" \
     || fail "could not list the network's devices"
   grep -q "$PEER_MEMBERSHIP" "$WORK/devices.out" \
     || { cat "$WORK/devices.out" >&2; fail "the device listing does not contain the peer"; }
 
-  curl -fsS -X DELETE \
+  curl -fsS "${CURL_CA[@]}" -X DELETE \
     -H "Authorization: Bearer ${ADMIN_TOKEN}" \
     -H 'Content-Type: application/json' \
     -d '{"reason":"e2e revocation"}' \
@@ -526,7 +561,7 @@ if [ "$tunnel_possible" = "1" ]; then
   fi
   echo "  nothing is filtered before a policy exists"
 
-  curl -fsS -X PUT \
+  curl -fsS "${CURL_CA[@]}" -X PUT \
     -H "Authorization: Bearer ${ADMIN_TOKEN}" \
     -H 'Content-Type: application/json' \
     -d '{"version":1,"rules":[{"src":["*"],"dst":["*"],"protocol":"tcp","ports":["22"]}]}' \
@@ -570,7 +605,7 @@ if [ "$tunnel_possible" = "1" ]; then
 
   # Withdrawing it has to leave nothing behind, or a network that removed its policy would
   # go on denying traffic forever with nothing to say why.
-  curl -fsS -X PUT \
+  curl -fsS "${CURL_CA[@]}" -X PUT \
     -H "Authorization: Bearer ${ADMIN_TOKEN}" \
     -H 'Content-Type: application/json' \
     -d '{"version":1,"rules":[{"src":["*"],"dst":["*"]}]}' \

--- a/scripts/e2e-tunnel.sh
+++ b/scripts/e2e-tunnel.sh
@@ -48,7 +48,7 @@ docker run --rm --privileged \
   "$GO_IMAGE" bash -c '
 set -e
 apt-get update -qq >/dev/null
-apt-get install -y -qq --no-install-recommends iproute2 wireguard-tools nftables postgresql-client >/dev/null
+apt-get install -y -qq --no-install-recommends iproute2 wireguard-tools nftables postgresql-client openssl ca-certificates >/dev/null
 make build
 ./scripts/e2e-enrol.sh "$MESHP_TEST_DATABASE_URL"
 '


### PR DESCRIPTION
Everything a control URL carries is worth stealing: an enrolment token grants a device a place in the network, and a session challenge and its signature are how a device proves who it is. Until now all of it crossed the network in the clear, and an agent would accept `http://` for any host.

## Serving

A certificate and key on disk, **or** automatic certificates from Let's Encrypt for named domains:

```bash
MESHP_TLS_CERT=/etc/meshp/cert.pem MESHP_TLS_KEY=/etc/meshp/key.pem
# or
MESHP_TLS_DOMAINS=control.meshp.net MESHP_TLS_CACHE_DIR=/var/lib/meshp/certs
```

Neither is a default. A control plane that guessed would either fetch a certificate nobody asked for or serve plaintext when TLS was intended. **Configuring both is refused rather than ranked** — two people meant two different things, and picking one silently ignores the other.

Certificates from disk are loaded **before anything listens**, so a wrong path or a key that doesn't match its certificate stops the deployment starting rather than surfacing as a handshake failure to the first agent that tries to enrol.

Automatic certificates require a cache directory. Without one, every restart asks the CA again, and Let's Encrypt's rate limits are low enough that a crash loop exhausts a week's allowance in an afternoon — leaving the deployment with no certificate at all.

## Refusing

Agents now refuse `http://` to anything but loopback.

Loopback is exempt because it can't leave the machine, and because it's what local development and an SSH tunnel both look like. A rule that refused it would push people towards disabling verification entirely, which is worse than what it was protecting them from.

`localhost` is matched **exactly**, not as a substring (`localhost.evil.test` is refused), and any other name is refused however it resolves — a name that answers `127.0.0.1` today can answer elsewhere tomorrow, and the check would have been made once against an answer that has since changed.

The check runs **last**, after the complaints about embedded credentials and paths, because those describe things that would still be wrong over https. An existing test caught me getting that order wrong.

## The detail that would have broken everything

`http/1.1` is offered explicitly alongside `h2` in `NextProtos`. Without it a Go server negotiates h2, and **the WebSocket upgrade the control channel depends on is not available over it** — so this would have been a change that silently killed every session. There's a test pinning it, in both certificate paths.

## Verification

The e2e now runs **entirely over TLS**, with the agent verifying the certificate rather than skipping verification — whether the agent verifies is exactly what's under test. It asserts both that the control plane is serving TLS (`tls=true`) and that the agent is using `https://`, so a silent fallback to plaintext can't pass:

```
serving the control plane over TLS
  the session runs over TLS, with the agent verifying the certificate
...
enrolment and the control channel work end to end; a replayed token is refused
```

Everything downstream — relay, revocation, policy enforcement — still passes over TLS. Four mutations checked, all caught. 96.2% coverage, added to the strict floor.

## Note for the deployment

The droplet's control plane is currently loopback-only and reached over an SSH tunnel, which still works and is still refusal-free (loopback). Exposing it publicly is now a matter of pointing `MESHP_TLS_DOMAINS` at a name and opening 443 — but that's an infrastructure change, so I've left it alone.