### PR TITLE
feat(routes): select advertisers and tell devices who carries a prefix

### DIFF
--- a/internal/peerset/peerset.go
+++ b/internal/peerset/peerset.go
@@ -34,11 +34,18 @@ type Set struct {
 	tunnel  *meshpv1.TunnelConfig
 	relays  *meshpv1.RelayConfig
 	filter  *meshpv1.PacketFilter
+
+	// routeGroups is keyed by id, because a delta names groups to upsert and groups to
+	// withdraw rather than replacing the set.
+	routeGroups map[string]*meshpv1.RouteGroupAssignment
 }
 
 // New returns an empty set at version zero.
 func New() *Set {
-	return &Set{peers: make(map[string]*meshpv1.Peer)}
+	return &Set{
+		peers:       make(map[string]*meshpv1.Peer),
+		routeGroups: make(map[string]*meshpv1.RouteGroupAssignment),
+	}
 }
 
 // Version is the state version this set reflects.
@@ -60,6 +67,19 @@ func (s *Set) Tunnel() *meshpv1.TunnelConfig { return s.tunnel }
 // a policy, so everything is permitted, while an empty filter with default_deny set means
 // a policy exists and permits nothing.
 func (s *Set) Filter() *meshpv1.PacketFilter { return s.filter }
+
+// RouteGroups are the carried prefixes this device has been assigned, ordered by id.
+//
+// Sorted, so two sets with the same contents render identically and a reconciler comparing
+// them does not mistake map order for a change.
+func (s *Set) RouteGroups() []*meshpv1.RouteGroupAssignment {
+	out := make([]*meshpv1.RouteGroupAssignment, 0, len(s.routeGroups))
+	for _, g := range s.routeGroups {
+		out = append(out, g)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].GetRouteGroupId() < out[j].GetRouteGroupId() })
+	return out
+}
 
 // Relays is the relay configuration last received, or nil.
 //
@@ -110,6 +130,10 @@ func (s *Set) Apply(delta *meshpv1.StateDelta) {
 		// an agent that kept the last filter it saw would go on denying traffic its network
 		// no longer denies, with nothing to say why.
 		s.filter = nil
+		// And the assignments. A snapshot describes the whole world, so one naming no route
+		// groups means this device carries nothing — keeping the last set would leave it
+		// routing a prefix its network no longer asks it to.
+		s.routeGroups = make(map[string]*meshpv1.RouteGroupAssignment)
 	}
 
 	// Removals first. Within one delta a key that is both removed and upserted is a
@@ -131,6 +155,16 @@ func (s *Set) Apply(delta *meshpv1.StateDelta) {
 	}
 	if delta.GetFilter() != nil {
 		s.filter = proto.CloneOf(delta.GetFilter())
+	}
+
+	// Withdrawals first, so a group both withdrawn and reassigned in one delta ends up
+	// assigned — the same rule the peer list uses, and for the same reason: the upsert is
+	// the newer fact.
+	for _, id := range delta.GetRemovedRouteGroupIds() {
+		delete(s.routeGroups, id)
+	}
+	for _, group := range delta.GetRouteGroups() {
+		s.routeGroups[group.GetRouteGroupId()] = proto.CloneOf(group)
 	}
 	s.version = delta.GetToVersion()
 }
@@ -154,6 +188,10 @@ func (s *Set) Clone() *Set {
 	}
 	if s.filter != nil {
 		out.filter = proto.CloneOf(s.filter)
+	}
+	out.routeGroups = make(map[string]*meshpv1.RouteGroupAssignment, len(s.routeGroups))
+	for id, group := range s.routeGroups {
+		out.routeGroups[id] = proto.CloneOf(group)
 	}
 	return out
 }
@@ -216,6 +254,15 @@ func (s *Set) Equal(other *Set) bool {
 	}
 	if !proto.Equal(s.filter, other.filter) {
 		return false
+	}
+	if len(s.routeGroups) != len(other.routeGroups) {
+		return false
+	}
+	for id, mine := range s.routeGroups {
+		theirs, ok := other.routeGroups[id]
+		if !ok || !proto.Equal(mine, theirs) {
+			return false
+		}
 	}
 	for key, mine := range s.peers {
 		theirs, ok := other.peers[key]

--- a/internal/peerset/peerset_test.go
+++ b/internal/peerset/peerset_test.go
@@ -554,3 +554,111 @@ func TestCloneCopiesConfiguration(t *testing.T) {
 		t.Error("editing the clone's relays changed the original's")
 	}
 }
+
+func assignment(id string, prefixes ...string) *meshpv1.RouteGroupAssignment {
+	return &meshpv1.RouteGroupAssignment{RouteGroupId: id, Prefixes: prefixes}
+}
+
+// A snapshot describes the whole world, so one naming no route groups means this device
+// carries nothing. Keeping the last set would leave it routing a prefix its network no
+// longer asks it to — and a reconnect is delivered as a snapshot, so this is the path a
+// withdrawn assignment actually takes.
+func TestASnapshotClearsTheRouteGroups(t *testing.T) {
+	s := New()
+	first := snapshot(1)
+	first.RouteGroups = []*meshpv1.RouteGroupAssignment{assignment("g1", "192.168.10.0/24")}
+	s.Apply(first)
+	if len(s.RouteGroups()) != 1 {
+		t.Fatalf("the assignment was not kept: %+v", s.RouteGroups())
+	}
+
+	s.Apply(snapshot(2))
+	if got := s.RouteGroups(); len(got) != 0 {
+		t.Fatalf("a snapshot with no route groups left %+v behind", got)
+	}
+}
+
+// A delta names groups to upsert and groups to withdraw, so absent means unchanged.
+func TestADeltaUpsertsAndWithdrawsRouteGroups(t *testing.T) {
+	s := New()
+	first := snapshot(1)
+	first.RouteGroups = []*meshpv1.RouteGroupAssignment{
+		assignment("g1", "192.168.10.0/24"),
+		assignment("g2", "192.168.20.0/24"),
+	}
+	s.Apply(first)
+
+	// Unrelated change: the assignments stay.
+	s.Apply(delta(1, 2, []*meshpv1.Peer{peer("a", "100.90.0.1")}, nil))
+	if len(s.RouteGroups()) != 2 {
+		t.Fatalf("an unrelated delta changed the assignments: %+v", s.RouteGroups())
+	}
+
+	d := delta(2, 3, nil, nil)
+	d.RemovedRouteGroupIds = []string{"g1"}
+	d.RouteGroups = []*meshpv1.RouteGroupAssignment{assignment("g3", "10.0.0.0/8")}
+	s.Apply(d)
+
+	got := s.RouteGroups()
+	if len(got) != 2 {
+		t.Fatalf("%d assignments, want 2: %+v", len(got), got)
+	}
+	// Sorted by id, so two sets with the same contents render identically.
+	if got[0].GetRouteGroupId() != "g2" || got[1].GetRouteGroupId() != "g3" {
+		t.Errorf("assignments = %v %v", got[0].GetRouteGroupId(), got[1].GetRouteGroupId())
+	}
+}
+
+// A group both withdrawn and reassigned in one delta ends up assigned: the upsert is the
+// newer fact, the same rule the peer list uses.
+func TestAReassignedGroupSurvivesItsOwnWithdrawal(t *testing.T) {
+	s := New()
+	first := snapshot(1)
+	first.RouteGroups = []*meshpv1.RouteGroupAssignment{assignment("g1", "192.168.10.0/24")}
+	s.Apply(first)
+
+	d := delta(1, 2, nil, nil)
+	d.RemovedRouteGroupIds = []string{"g1"}
+	d.RouteGroups = []*meshpv1.RouteGroupAssignment{assignment("g1", "192.168.99.0/24")}
+	s.Apply(d)
+
+	got := s.RouteGroups()
+	if len(got) != 1 {
+		t.Fatalf("%d assignments, want 1", len(got))
+	}
+	if got[0].GetPrefixes()[0] != "192.168.99.0/24" {
+		t.Errorf("the withdrawal won over the reassignment: %v", got[0].GetPrefixes())
+	}
+}
+
+// Assignments are desired state like the peers are, so two sets that disagree about them
+// are not the same state — and Clone must copy them or the holder reads the session's.
+func TestRouteGroupsCountForEqualityAndAreCloned(t *testing.T) {
+	build := func(prefix string) *Set {
+		s := New()
+		d := snapshot(1)
+		d.RouteGroups = []*meshpv1.RouteGroupAssignment{assignment("g1", prefix)}
+		s.Apply(d)
+		return s
+	}
+
+	if !build("192.168.10.0/24").Equal(build("192.168.10.0/24")) {
+		t.Error("identical sets compared unequal")
+	}
+	if build("192.168.10.0/24").Equal(build("192.168.20.0/24")) {
+		t.Error("sets carrying different prefixes compared equal")
+	}
+	if build("192.168.10.0/24").Equal(New()) {
+		t.Error("a set with an assignment compared equal to one with none")
+	}
+
+	original := build("192.168.10.0/24")
+	clone := original.Clone()
+	if len(clone.RouteGroups()) != 1 {
+		t.Fatal("the clone lost the assignments")
+	}
+	clone.routeGroups["g1"].Prefixes[0] = "tampered"
+	if original.RouteGroups()[0].GetPrefixes()[0] != "192.168.10.0/24" {
+		t.Error("editing the clone changed the original")
+	}
+}

--- a/internal/session/routes.go
+++ b/internal/session/routes.go
@@ -1,0 +1,181 @@
+package session
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/meshpnet/meshp/internal/health"
+	"github.com/meshpnet/meshp/internal/routes"
+	"github.com/meshpnet/meshp/internal/store"
+	dbgen "github.com/meshpnet/meshp/internal/store/gen"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// routeGroupsFor computes what this device should be told about carried prefixes.
+//
+// The server owns the set of candidates and their order; the agent decides only which are
+// alive (ADR-0003). That split is why a candidate list is sent rather than a single answer:
+// an agent that has to ask the control plane before failing over cannot fail over during a
+// control-plane outage, which is exactly when it is most likely to need to.
+//
+// A device is never offered itself. An advertiser reaching its own group through the mesh
+// would be routing its own LAN traffic into a tunnel that comes back out of the same
+// machine, which at best is a loop and at worst takes the site off the internet.
+// Groups that exist and produce no assignment for this device come back as withdrawn ids
+// rather than as silence. Proto3 cannot tell an empty repeated field from an absent one, so
+// "you are assigned nothing" and "nothing about routes changed" would otherwise be the same
+// message — and a device that lost its last advertiser would keep routing to it forever.
+func (b *StateBuilder) routeGroupsFor(ctx context.Context, membership dbgen.GetMembershipForSessionRow) (assigned []*meshpv1.RouteGroupAssignment, withdrawn []string, err error) {
+	groups, err := b.store.RouteGroupsFor(ctx, membership.NetworkID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(groups) == 0 {
+		return nil, nil, nil
+	}
+
+	ids := make([]uuid.UUID, 0, len(groups))
+	for _, g := range groups {
+		ids = append(ids, g.ID)
+	}
+	advertiserRows, err := b.store.Advertisers(ctx, ids)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	byGroup := make(map[uuid.UUID][]dbgen.ListRouteAdvertisersRow, len(groups))
+	for _, row := range advertiserRows {
+		byGroup[row.RouteGroupID] = append(byGroup[row.RouteGroupID], row)
+	}
+
+	for _, group := range groups {
+		candidates := selectFor(group, byGroup[group.ID], membership.MembershipID)
+		if len(candidates) == 0 {
+			// A group with nobody to carry it is not an assignment. Sending one with an
+			// empty candidate list would have every agent install a route to nowhere, which
+			// blackholes the prefix instead of leaving it alone — so it is withdrawn, which
+			// says the same thing without the route.
+			withdrawn = append(withdrawn, group.ID.String())
+			continue
+		}
+		assigned = append(assigned, assignmentFor(group, candidates))
+	}
+	return assigned, withdrawn, nil
+}
+
+// selectFor orders one group's advertisers for one device.
+func selectFor(group store.RouteGroup, rows []dbgen.ListRouteAdvertisersRow, self uuid.UUID) []routes.Candidate {
+	advertisers := make([]routes.Advertiser, 0, len(rows))
+	for _, row := range rows {
+		if row.MembershipID == self {
+			continue
+		}
+		advertisers = append(advertisers, routes.Advertiser{
+			ID:            row.ID.String(),
+			PeerPublicKey: row.WireguardPublicKey,
+			Priority:      int(row.Priority),
+			Weight:        int(row.Weight),
+			Admin:         routes.AdminState(row.AdminState),
+			Health:        healthOf(row.HealthState),
+			Region:        row.Region,
+			City:          row.City,
+			DisplayName:   row.DeviceName,
+		})
+	}
+	if len(advertisers) == 0 {
+		return nil
+	}
+
+	return routes.Select(routes.Request{
+		// Keyed by the device, so two devices offered the same equal-priority advertisers
+		// are spread between them rather than both landing on whichever sorts first.
+		DeviceKey:   self.String(),
+		Mode:        routes.Mode(group.SelectionMode),
+		Advertisers: advertisers,
+	})
+}
+
+// healthOf reads what the health table recorded, treating an absent row as unknown.
+//
+// Unknown is selectable and ranks last. On a fresh deployment every advertiser is unknown,
+// and refusing to offer any of them would mean no egress at all until checks accumulate —
+// while the agent probes a candidate before using it, so proposing an untested one cannot
+// break a device.
+func healthOf(state *string) health.State {
+	if state == nil {
+		return health.StateUnknown
+	}
+	return health.State(*state)
+}
+
+func assignmentFor(group store.RouteGroup, candidates []routes.Candidate) *meshpv1.RouteGroupAssignment {
+	assignment := &meshpv1.RouteGroupAssignment{
+		RouteGroupId: group.ID.String(),
+		Name:         group.Name,
+		Mode:         modeOf(group.SelectionMode),
+	}
+
+	// An egress group carries the default route rather than prefixes of its own, which is
+	// why the store refuses to let it hold any: the two families are named here so an agent
+	// claiming a default route claims it for both.
+	if group.Kind == store.KindEgress {
+		assignment.Prefixes = []string{"0.0.0.0/0", "::/0"}
+	} else {
+		for _, prefix := range group.Prefixes {
+			assignment.Prefixes = append(assignment.Prefixes, prefix.String())
+		}
+	}
+
+	if group.StableEgressIP != nil {
+		assignment.StableEgressIp = group.StableEgressIP.String()
+	}
+
+	for _, candidate := range candidates {
+		assignment.Candidates = append(assignment.Candidates, &meshpv1.RouteCandidate{
+			AdvertiserId:  candidate.ID,
+			PeerPublicKey: candidate.PeerPublicKey,
+			Priority:      uint32(candidate.Priority),
+			Weight:        uint32(candidate.Weight),
+			ServerHealth:  healthTo(candidate.Admin, candidate.Health),
+			Region:        candidate.Region,
+			City:          candidate.City,
+			DisplayName:   candidate.DisplayName,
+		})
+	}
+	return assignment
+}
+
+func modeOf(mode string) meshpv1.RouteGroupAssignment_Mode {
+	if mode == string(routes.ModePinned) {
+		return meshpv1.RouteGroupAssignment_MODE_PINNED
+	}
+	return meshpv1.RouteGroupAssignment_MODE_FAILOVER
+}
+
+// healthTo renders the server's view for the agent.
+//
+// Draining is reported in the health field rather than alongside it, because to an agent
+// choosing a candidate the two mean the same thing: prefer somebody else, and keep working
+// if you are already here. Splitting them would give the agent a second axis to reason
+// about and no different action to take.
+func healthTo(admin routes.AdminState, state health.State) meshpv1.RouteCandidate_Health {
+	if admin == routes.AdminDraining {
+		return meshpv1.RouteCandidate_HEALTH_DRAINING
+	}
+	switch state {
+	case health.StateHealthy:
+		return meshpv1.RouteCandidate_HEALTH_HEALTHY
+	case health.StateDegraded:
+		return meshpv1.RouteCandidate_HEALTH_DEGRADED
+	case health.StateUnhealthy:
+		return meshpv1.RouteCandidate_HEALTH_UNHEALTHY
+	case health.StateOffline:
+		return meshpv1.RouteCandidate_HEALTH_OFFLINE
+	default:
+		// Unknown maps to unspecified rather than to healthy. The agent probes before
+		// using a candidate, so it does not need to be told an untested one is fine — and
+		// telling it so would be a claim the control plane cannot support.
+		return meshpv1.RouteCandidate_HEALTH_UNSPECIFIED
+	}
+}

--- a/internal/session/routes_test.go
+++ b/internal/session/routes_test.go
@@ -1,0 +1,295 @@
+package session
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/meshpnet/meshp/internal/store"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+func (f *fixture) subnetGroup(slug string, prefixes ...string) store.RouteGroup {
+	f.t.Helper()
+	var parsed []netip.Prefix
+	for _, p := range prefixes {
+		parsed = append(parsed, netip.MustParsePrefix(p))
+	}
+	group, err := f.store.CreateRouteGroup(f.ctx, store.CreateRouteGroupRequest{
+		NetworkID: f.netID, Slug: slug, Kind: store.KindSubnet, Prefixes: parsed,
+	})
+	if err != nil {
+		f.t.Fatalf("CreateRouteGroup: %v", err)
+	}
+	return group
+}
+
+func (f *fixture) advertise(slug string, d device, priority int32) {
+	f.t.Helper()
+	if err := f.store.Advertise(f.ctx, store.AdvertiseRequest{
+		NetworkID: f.netID, GroupSlug: slug, MembershipID: d.membershipID, Priority: priority,
+	}); err != nil {
+		f.t.Fatalf("Advertise: %v", err)
+	}
+}
+
+func (f *fixture) assignments(d device) []*meshpv1.RouteGroupAssignment {
+	f.t.Helper()
+	snapshot, err := NewStateBuilder(f.store).Snapshot(f.ctx, d.membershipID)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	return snapshot.GetRouteGroups()
+}
+
+// The ordinary case: a device is told which peers can carry a branch office's LAN.
+func TestADeviceIsToldWhoCarriesAPrefix(t *testing.T) {
+	f := newFixture(t)
+	laptop := f.enrolDevice("laptop")
+	router := f.enrolDevice("branch-router")
+	f.subnetGroup("branch-lan", "192.168.10.0/24")
+	f.advertise("branch-lan", router, 1)
+
+	got := f.assignments(laptop)
+	if len(got) != 1 {
+		t.Fatalf("%d assignments, want 1", len(got))
+	}
+	if len(got[0].GetPrefixes()) != 1 || got[0].GetPrefixes()[0] != "192.168.10.0/24" {
+		t.Errorf("prefixes = %v", got[0].GetPrefixes())
+	}
+	if len(got[0].GetCandidates()) != 1 {
+		t.Fatalf("%d candidates, want 1", len(got[0].GetCandidates()))
+	}
+	if got[0].GetCandidates()[0].GetPeerPublicKey() == "" {
+		t.Error("the candidate carries no key, so nothing could be routed to it")
+	}
+	if got[0].GetMode() != meshpv1.RouteGroupAssignment_MODE_FAILOVER {
+		t.Errorf("mode = %v", got[0].GetMode())
+	}
+}
+
+// An advertiser routing its own LAN into a tunnel that comes back out of the same machine
+// is at best a loop and at worst takes the site off the internet.
+func TestAnAdvertiserIsNotOfferedItself(t *testing.T) {
+	f := newFixture(t)
+	router := f.enrolDevice("branch-router")
+	f.subnetGroup("branch-lan", "192.168.10.0/24")
+	f.advertise("branch-lan", router, 1)
+
+	if got := f.assignments(router); len(got) != 0 {
+		t.Fatalf("the only advertiser was offered its own group: %+v", got)
+	}
+}
+
+// Candidates come ordered, best first, and the agent picks among them without asking. An
+// agent that had to ask could not fail over during a control-plane outage, which is exactly
+// when it is most likely to need to (ADR-0003).
+func TestCandidatesAreOrderedByPriority(t *testing.T) {
+	f := newFixture(t)
+	laptop := f.enrolDevice("laptop")
+	primary := f.enrolDevice("primary")
+	backup := f.enrolDevice("backup")
+	f.subnetGroup("branch-lan", "192.168.10.0/24")
+	f.advertise("branch-lan", backup, 10)
+	f.advertise("branch-lan", primary, 1)
+
+	got := f.assignments(laptop)
+	if len(got) != 1 || len(got[0].GetCandidates()) != 2 {
+		t.Fatalf("assignments = %+v", got)
+	}
+	if got[0].GetCandidates()[0].GetPriority() != 1 {
+		t.Errorf("the preferred candidate is priority %d, want 1",
+			got[0].GetCandidates()[0].GetPriority())
+	}
+}
+
+// A group nobody can carry is withdrawn rather than sent with an empty candidate list:
+// installing a route to nowhere blackholes the prefix instead of leaving it alone.
+func TestAGroupWithNoAdvertiserIsWithdrawnRatherThanEmpty(t *testing.T) {
+	f := newFixture(t)
+	laptop := f.enrolDevice("laptop")
+	group := f.subnetGroup("branch-lan", "192.168.10.0/24")
+
+	snapshot, err := NewStateBuilder(f.store).Snapshot(f.ctx, laptop.membershipID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.GetRouteGroups()) != 0 {
+		t.Errorf("a group with no advertiser was assigned: %+v", snapshot.GetRouteGroups())
+	}
+	// Proto3 cannot tell an empty repeated field from an absent one, so the withdrawal has
+	// to be said out loud or a device that lost its last advertiser would route to it forever.
+	found := false
+	for _, id := range snapshot.GetRemovedRouteGroupIds() {
+		if id == group.ID.String() {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the unassignable group was not withdrawn: %v", snapshot.GetRemovedRouteGroupIds())
+	}
+}
+
+// Losing the last advertiser must reach devices as a withdrawal, or they keep routing a
+// prefix at a device that no longer carries it.
+func TestWithdrawingTheLastAdvertiserWithdrawsTheGroup(t *testing.T) {
+	f := newFixture(t)
+	laptop := f.enrolDevice("laptop")
+	router := f.enrolDevice("branch-router")
+	group := f.subnetGroup("branch-lan", "192.168.10.0/24")
+	f.advertise("branch-lan", router, 1)
+
+	builder := NewStateBuilder(f.store)
+	before, err := builder.Snapshot(f.ctx, laptop.membershipID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(before.GetRouteGroups()) != 1 {
+		t.Fatalf("expected one assignment to begin with: %+v", before.GetRouteGroups())
+	}
+
+	if err := f.store.Withdraw(f.ctx, f.netID, "branch-lan", router.membershipID); err != nil {
+		t.Fatal(err)
+	}
+
+	delta, err := builder.For(f.ctx, laptop.membershipID, before.GetToVersion())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delta.GetFromVersion() == 0 {
+		// A snapshot clears the whole set, which is also correct.
+		if len(delta.GetRouteGroups()) != 0 {
+			t.Errorf("a snapshot still assigns the group: %+v", delta.GetRouteGroups())
+		}
+		return
+	}
+	withdrawn := false
+	for _, id := range delta.GetRemovedRouteGroupIds() {
+		if id == group.ID.String() {
+			withdrawn = true
+		}
+	}
+	if !withdrawn {
+		t.Errorf("the group was not withdrawn: %+v", delta)
+	}
+}
+
+// A revoked advertiser must stop being offered, or traffic is steered at a device that is
+// no longer in the network.
+func TestARevokedAdvertiserLeavesTheCandidates(t *testing.T) {
+	f := newFixture(t)
+	laptop := f.enrolDevice("laptop")
+	primary := f.enrolDevice("primary")
+	backup := f.enrolDevice("backup")
+	f.subnetGroup("branch-lan", "192.168.10.0/24")
+	f.advertise("branch-lan", primary, 1)
+	f.advertise("branch-lan", backup, 2)
+
+	if _, err := f.store.RevokeMembership(f.ctx, store.RevokeRequest{
+		NetworkID: f.netID, MembershipID: primary.membershipID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := f.assignments(laptop)
+	if len(got) != 1 {
+		t.Fatalf("assignments = %+v", got)
+	}
+	if len(got[0].GetCandidates()) != 1 {
+		t.Fatalf("%d candidates after a revocation, want 1", len(got[0].GetCandidates()))
+	}
+	if got[0].GetCandidates()[0].GetPriority() != 2 {
+		t.Error("the revoked advertiser is still being offered")
+	}
+}
+
+// An egress group carries the default route for both families, so an agent claiming one
+// claims it for both rather than leaving IPv6 to leak past.
+func TestAnEgressGroupCarriesBothDefaultRoutes(t *testing.T) {
+	f := newFixture(t)
+	laptop := f.enrolDevice("laptop")
+	exit := f.enrolDevice("exit")
+	if _, err := f.store.CreateRouteGroup(f.ctx, store.CreateRouteGroupRequest{
+		NetworkID: f.netID, Slug: "exit", Kind: store.KindEgress,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	f.advertise("exit", exit, 1)
+
+	got := f.assignments(laptop)
+	if len(got) != 1 {
+		t.Fatalf("assignments = %+v", got)
+	}
+	prefixes := got[0].GetPrefixes()
+	if len(prefixes) != 2 || prefixes[0] != "0.0.0.0/0" || prefixes[1] != "::/0" {
+		t.Errorf("prefixes = %v, want both default routes", prefixes)
+	}
+}
+
+// A route change reaches agents as a delta, and an unrelated change does not resend the
+// assignments — an agent diffing them would reinstall routes it already has.
+func TestAssignmentsAreSentOnlyWhenRoutesChange(t *testing.T) {
+	f := newFixture(t)
+	laptop := f.enrolDevice("laptop")
+	router := f.enrolDevice("router")
+	f.subnetGroup("branch-lan", "192.168.10.0/24")
+
+	builder := NewStateBuilder(f.store)
+	before, err := builder.Snapshot(f.ctx, laptop.membershipID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.advertise("branch-lan", router, 1)
+	delta, err := builder.For(f.ctx, laptop.membershipID, before.GetToVersion())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delta.GetFromVersion() != 0 && len(delta.GetRouteGroups()) == 0 {
+		t.Fatalf("a route change produced a delta with no assignments: %+v", delta)
+	}
+
+	// Now something unrelated.
+	at := delta.GetToVersion()
+	f.enrolDevice("someone-else")
+	next, err := builder.For(f.ctx, laptop.membershipID, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next.GetFromVersion() == 0 {
+		t.Skip("the builder chose a snapshot, which always carries assignments")
+	}
+	if len(next.GetRouteGroups()) != 0 {
+		t.Errorf("an unrelated peer change resent the assignments: %+v", next.GetRouteGroups())
+	}
+}
+
+// Nothing branches on it, but two computations of the same state must render identically or
+// every recomputation looks like a change.
+func TestAssignmentsAreDeterministic(t *testing.T) {
+	f := newFixture(t)
+	laptop := f.enrolDevice("laptop")
+	f.subnetGroup("branch-lan", "192.168.10.0/24")
+	for i, name := range []string{"a", "b", "c"} {
+		f.advertise("branch-lan", f.enrolDevice(name), int32(i%2))
+	}
+
+	first := f.assignments(laptop)
+	for range 10 {
+		got := f.assignments(laptop)
+		if len(got) != len(first) {
+			t.Fatalf("assignment count changed: %d then %d", len(first), len(got))
+		}
+		for i := range got {
+			a, b := got[i].GetCandidates(), first[i].GetCandidates()
+			if len(a) != len(b) {
+				t.Fatalf("candidate count changed")
+			}
+			for j := range a {
+				if a[j].GetAdvertiserId() != b[j].GetAdvertiserId() {
+					t.Fatalf("candidate order changed at %d: %s then %s",
+						j, b[j].GetAdvertiserId(), a[j].GetAdvertiserId())
+				}
+			}
+		}
+	}
+}

--- a/internal/session/state.go
+++ b/internal/session/state.go
@@ -161,6 +161,15 @@ func (b *StateBuilder) snapshotFromPeers(ctx context.Context, membership dbgen.G
 		return nil, err
 	}
 	delta.Filter = filter
+
+	// And the route groups, for the same reason: a snapshot is the whole world, so an agent
+	// reconnecting would otherwise carry no prefixes until one changed.
+	assignments, withdrawn, err := b.routeGroupsFor(ctx, membership)
+	if err != nil {
+		return nil, err
+	}
+	delta.RouteGroups = assignments
+	delta.RemovedRouteGroupIds = withdrawn
 	return delta, nil
 }
 
@@ -181,6 +190,7 @@ func (b *StateBuilder) delta(ctx context.Context, membership dbgen.GetMembership
 	upserts := make(map[uuid.UUID]struct{})
 	removes := make(map[string]struct{})
 	policyChanged := false
+	routesChanged := false
 
 	for _, change := range changes {
 		switch change.Kind {
@@ -188,6 +198,11 @@ func (b *StateBuilder) delta(ctx context.Context, membership dbgen.GetMembership
 			// Names no peer: it changes what every device may do, so the answer is to
 			// recompile this one's filter rather than to touch the peer list.
 			policyChanged = true
+
+		case "routes":
+			// Likewise: who carries a prefix is desired state for everyone, so this
+			// recomputes the assignments rather than touching peers.
+			routesChanged = true
 
 		case "peer_upsert":
 			if change.MembershipID == nil {
@@ -232,6 +247,18 @@ func (b *StateBuilder) delta(ctx context.Context, membership dbgen.GetMembership
 		delete(removes, peer.WireguardPublicKey)
 		delta.UpsertPeers = append(delta.UpsertPeers, b.peerFrom(
 			peer.WireguardPublicKey, peer.DeviceName, peer.Tags, peer.AddressV4, peer.AddressV6))
+	}
+
+	if routesChanged {
+		// Only when they changed. Recomputing on every delta would resend the whole
+		// assignment set for an unrelated peer change, and an agent diffing it would
+		// reinstall routes it already has.
+		assignments, withdrawn, err := b.routeGroupsFor(ctx, membership)
+		if err != nil {
+			return nil, err
+		}
+		delta.RouteGroups = assignments
+		delta.RemovedRouteGroupIds = withdrawn
 	}
 
 	if policyChanged {


### PR DESCRIPTION
`internal/routes` stops being 250 lines nothing imports. A device is now told, for each route group, an ordered list of candidates that can carry its prefixes, with the server's view of each one's health.

**Nothing installs a route yet** — the agent side and the advertiser's forwarding are the next slices.

## The server orders; the agent decides who's alive

That split (ADR-0003) is the whole reason a *list* is sent rather than an answer: an agent that must ask the control plane before failing over cannot fail over during a control-plane outage, which is exactly when it's most likely to need to.

## A device is never offered itself

An advertiser reaching its own group through the mesh would route its own LAN traffic into a tunnel that comes back out of the same machine — at best a loop, at worst the site off the internet.

## Empty and absent are different messages

A group nobody can carry is **withdrawn**, not sent empty. Proto3 can't tell an empty repeated field from an absent one, so "you are assigned nothing" and "nothing about routes changed" would be the same bytes — and a device that lost its last advertiser would keep routing to it forever. `removed_route_group_ids` exists for exactly this and is now used for it.

Sending an assignment with an empty candidate list would be worse still: every agent installs a route to nowhere, which *blackholes* the prefix rather than leaving it alone.

## Unknown health is selectable, and that's deliberate

On a fresh deployment every advertiser is unknown, and refusing to offer any would mean no egress until checks accumulate. The agent probes before using a candidate, so proposing an untested one can't break a device — this is the absence of information, not a failing check, so it isn't a violation of Invariant 8.

It's reported as `UNSPECIFIED` rather than `HEALTHY`, because telling an agent an untested advertiser is fine would be a claim the control plane can't support.

Draining is reported *in* the health field rather than beside it: to an agent choosing a candidate the two mean the same thing — prefer somebody else, keep working if you're already here — and a second axis with no distinct action is a second thing to get wrong.

## peerset folds the assignments

Keyed by id, with the same snapshot semantics the relay config and filter already have. A snapshot clears them, because **a reconnect is delivered as a snapshot** and that's the path a withdrawn assignment actually takes.

Nothing tested that until a mutation showed it passing with the clear removed — the same gap shape that made relays dead on arrival in #26 and that I've now hit three times. Four peerset tests added for it.

## Verification

Seven mutations checked across selection, delivery and folding; all now caught. Both `internal/routes` and `internal/health` are exercised through real advertiser state for the first time.