### PR TITLE
feat(routes): carry an assigned prefix on the peer that advertises it

### DIFF
--- a/internal/tunnel/routegroups.go
+++ b/internal/tunnel/routegroups.go
@@ -1,0 +1,114 @@
+package tunnel
+
+import (
+	"fmt"
+	"log/slog"
+	"net/netip"
+
+	"github.com/meshpnet/meshp/internal/logx"
+	"github.com/meshpnet/meshp/internal/wgplan"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// applyRouteGroups gives the carried prefixes to the peer that carries them.
+//
+// Both halves come from one change, which is the point. WireGuard will not accept or send a
+// packet for a prefix that is not in a peer's AllowedIPs, and the kernel will not send one
+// to the interface without a route — and wgplan derives the routes it installs from exactly
+// these AllowedIPs. Adding the prefix in one place therefore produces both, and they cannot
+// drift apart.
+//
+// The best candidate is taken and the rest ignored, for now. The server orders them and the
+// agent is meant to choose among them by probing (ADR-0003); until it probes, taking the
+// server's first preference is the honest subset of that — it is what the server would have
+// chosen, and no worse than having no route at all.
+//
+// Returns the group names it could not honour, which the caller reports as unapplied rather
+// than swallowing: a device quietly not carrying a prefix it was assigned is indistinguishable
+// from one that is, right up until somebody tries to use it.
+func applyRouteGroups(iface *wgplan.Interface, assignments []*meshpv1.RouteGroupAssignment, log *slog.Logger) []string {
+	if len(assignments) == 0 {
+		return nil
+	}
+
+	byKey := make(map[wgplan.Key]int, len(iface.Peers))
+	for i, peer := range iface.Peers {
+		byKey[peer.PublicKey] = i
+	}
+
+	var unhonoured []string
+	for _, assignment := range assignments {
+		name := assignment.GetName()
+
+		prefixes, defaultRoute, err := groupPrefixes(assignment)
+		if err != nil {
+			log.Error("a route group names a prefix this device cannot parse",
+				"group", logx.Safe(name), "error", err)
+			unhonoured = append(unhonoured, name)
+			continue
+		}
+
+		if defaultRoute {
+			// Refused rather than half-done. Claiming a default route needs the excluded
+			// prefixes that keep the tunnel's own endpoint, the physical gateway and the LAN
+			// out of it, and the fail-closed behaviour that blocks egress while the tunnel is
+			// down (ADR-0011). None of that exists yet, and installing 0.0.0.0/0 without it
+			// would send this device's own path to its control plane and its relay into a
+			// tunnel that depends on them — taking the host off the network with no way back.
+			log.Error("not claiming a default route for an egress group",
+				"group", logx.Safe(name),
+				"reason", "internet egress needs excluded prefixes and fail-closed handling (ADR-0011)")
+			unhonoured = append(unhonoured, name)
+			continue
+		}
+
+		candidates := assignment.GetCandidates()
+		if len(candidates) == 0 {
+			// The server withdraws a group nobody can carry rather than sending it empty,
+			// so this means the two ends disagree. Reported rather than ignored.
+			log.Warn("a route group arrived with no candidates", "group", logx.Safe(name))
+			unhonoured = append(unhonoured, name)
+			continue
+		}
+
+		best := candidates[0]
+		index, ok := byKey[wgplan.Key(best.GetPeerPublicKey())]
+		if !ok {
+			// Assigned a carrier that is not in this device's peer list. Nothing can be
+			// routed to a peer the interface does not have, and adding one from here would
+			// invent a peer the control plane did not send.
+			log.Error("the chosen carrier for a route group is not a peer of this device",
+				"group", logx.Safe(name), "peer", truncate(best.GetPeerPublicKey()))
+			unhonoured = append(unhonoured, name)
+			continue
+		}
+
+		iface.Peers[index].AllowedIPs = append(iface.Peers[index].AllowedIPs, prefixes...)
+		log.Debug("carrying a route group",
+			"group", logx.Safe(name), "via", truncate(best.GetPeerPublicKey()),
+			"prefixes", len(prefixes))
+	}
+	return unhonoured
+}
+
+// groupPrefixes parses an assignment's prefixes, and reports whether it claims a default
+// route.
+//
+// Parsed here rather than trusted: these reach the kernel's routing table, and a prefix
+// this build cannot read must not be approximated into one it can.
+func groupPrefixes(assignment *meshpv1.RouteGroupAssignment) (prefixes []netip.Prefix, defaultRoute bool, err error) {
+	for _, raw := range assignment.GetPrefixes() {
+		prefix, parseErr := netip.ParsePrefix(raw)
+		if parseErr != nil {
+			return nil, false, fmt.Errorf("prefix %q: %w", logx.Safe(raw), parseErr)
+		}
+		if prefix.Bits() == 0 {
+			return nil, true, nil
+		}
+		prefixes = append(prefixes, prefix.Masked())
+	}
+	if len(prefixes) == 0 {
+		return nil, false, fmt.Errorf("it carries no prefixes")
+	}
+	return prefixes, false, nil
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -157,7 +157,7 @@ func (r *Reconciler) Status() Status {
 // The returned components are the parts that did not converge, which the agent reports back
 // so the control plane knows this device is not where it says it is.
 func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, error) {
-	want, err := Desired(r.membership, state, r.relay, r.log)
+	want, unhonoured, err := Desired(r.membership, state, r.relay, r.log)
 	if err != nil {
 		// A description the kernel would refuse, or one wgplan judged unsafe. Reported
 		// rather than approximated: applying part of a rejected configuration is how an
@@ -242,6 +242,15 @@ func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, e
 	r.appliedV = state.Version()
 	r.port = port
 	r.mu.Unlock()
+
+	if len(unhonoured) > 0 {
+		// Unapplied without an error: the interface converged, and what did not is named so
+		// the control plane can see this device is not carrying everything it was assigned.
+		// An error here would report the whole apply as failed and hide the part that worked.
+		r.log.Warn("some route groups are not being carried",
+			"interface", want.Name, "groups", len(unhonoured))
+		return []string{"route-groups"}, nil
+	}
 	return nil, nil
 }
 
@@ -341,12 +350,15 @@ func (r *Reconciler) fail(err error) {
 // relay may be nil, and a relayed peer is then left without an endpoint rather than
 // refused. One peer whose relay this device is not attached to must not take down the
 // interface every other peer is reached through.
-func Desired(m Membership, state *peerset.Set, relay Relay, log *slog.Logger) (wgplan.Interface, error) {
+// The second return names route groups this device was assigned and could not carry. It is
+// a translation result rather than part of the interface description, which is why it comes
+// back separately: wgplan plans kernel operations, and "what is missing" is not one.
+func Desired(m Membership, state *peerset.Set, relay Relay, log *slog.Logger) (wgplan.Interface, []string, error) {
 	if log == nil {
 		log = slog.New(slog.DiscardHandler)
 	}
 	if m.PrivateKey == "" {
-		return wgplan.Interface{}, errors.New("tunnel: this membership has no WireGuard private key")
+		return wgplan.Interface{}, nil, errors.New("tunnel: this membership has no WireGuard private key")
 	}
 
 	iface := wgplan.Interface{
@@ -369,12 +381,12 @@ func Desired(m Membership, state *peerset.Set, relay Relay, log *slog.Logger) (w
 		}
 		prefix, err := hostPrefix(addr)
 		if err != nil {
-			return wgplan.Interface{}, fmt.Errorf("tunnel: this device's address %q: %w", addr, err)
+			return wgplan.Interface{}, nil, fmt.Errorf("tunnel: this device's address %q: %w", addr, err)
 		}
 		iface.Addresses = append(iface.Addresses, prefix)
 	}
 	if len(iface.Addresses) == 0 {
-		return wgplan.Interface{}, errors.New("tunnel: this membership holds no addresses")
+		return wgplan.Interface{}, nil, errors.New("tunnel: this membership holds no addresses")
 	}
 
 	for _, peer := range state.Peers() {
@@ -382,12 +394,19 @@ func Desired(m Membership, state *peerset.Set, relay Relay, log *slog.Logger) (w
 		if err != nil {
 			// Refused rather than skipped. A peer quietly dropped is a device that cannot be
 			// reached, with everything reporting success.
-			return wgplan.Interface{}, fmt.Errorf("tunnel: peer %s: %w",
+			return wgplan.Interface{}, nil, fmt.Errorf("tunnel: peer %s: %w",
 				truncate(peer.GetPublicKey()), err)
 		}
 		iface.Peers = append(iface.Peers, converted)
 	}
-	return iface, nil
+
+	// After the peers, because a carried prefix is added to the peer that carries it and
+	// there has to be a peer to add it to.
+	//
+	// Reported rather than fatal: one group this device cannot honour must not cost it the
+	// peers and prefixes it can.
+	unhonoured := applyRouteGroups(&iface, state.RouteGroups(), log)
+	return iface, unhonoured, nil
 }
 
 func peerFrom(p *meshpv1.Peer, relay Relay, log *slog.Logger) (wgplan.Peer, error) {

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -335,7 +335,7 @@ func TestDesiredRendersAddressesAsHostPrefixes(t *testing.T) {
 	m.AddressV4 = "100.90.0.1"
 	m.AddressV6 = "fd7c::1"
 
-	iface, err := Desired(m, stateWith(1), nil, nil)
+	iface, _, err := Desired(m, stateWith(1), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,7 +357,7 @@ func TestDesiredRefusesAnAddressThatIsNotOneHost(t *testing.T) {
 		m := membership()
 		m.AddressV4 = addr
 		m.AddressV6 = ""
-		if _, err := Desired(m, stateWith(1), nil, nil); err == nil {
+		if _, _, err := Desired(m, stateWith(1), nil, nil); err == nil {
 			t.Errorf("%s was accepted", addr)
 		}
 	}
@@ -370,7 +370,7 @@ func TestDesiredAcceptsAnAddressThatAlreadyCarriesItsPrefix(t *testing.T) {
 	m.AddressV4 = "100.90.0.1/32"
 	m.AddressV6 = "fd7c::1/128"
 
-	iface, err := Desired(m, stateWith(1), nil, nil)
+	iface, _, err := Desired(m, stateWith(1), nil, nil)
 	if err != nil {
 		t.Fatalf("Desired: %v", err)
 	}
@@ -383,14 +383,14 @@ func TestDesiredRefusesAMembershipWithNothingToWorkFrom(t *testing.T) {
 	t.Run("no private key", func(t *testing.T) {
 		m := membership()
 		m.PrivateKey = ""
-		if _, err := Desired(m, stateWith(1), nil, nil); err == nil {
+		if _, _, err := Desired(m, stateWith(1), nil, nil); err == nil {
 			t.Error("a membership with no private key was accepted")
 		}
 	})
 	t.Run("no addresses", func(t *testing.T) {
 		m := membership()
 		m.AddressV4, m.AddressV6 = "", ""
-		if _, err := Desired(m, stateWith(1), nil, nil); err == nil {
+		if _, _, err := Desired(m, stateWith(1), nil, nil); err == nil {
 			t.Error("a membership with no addresses was accepted")
 		}
 	})
@@ -405,7 +405,7 @@ func TestDesiredTakesTheMTUFromTheServer(t *testing.T) {
 		Tunnel: &meshpv1.TunnelConfig{Mtu: 1280},
 	})
 
-	iface, err := Desired(membership(), state, nil, nil)
+	iface, _, err := Desired(membership(), state, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -420,7 +420,7 @@ func TestDesiredFallsBackToADefaultMTU(t *testing.T) {
 	state := peerset.New()
 	state.Apply(&meshpv1.StateDelta{FromVersion: 0, ToVersion: 1})
 
-	iface, err := Desired(membership(), state, nil, nil)
+	iface, _, err := Desired(membership(), state, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -435,7 +435,7 @@ func TestDesiredFallsBackToADefaultMTU(t *testing.T) {
 // A peer with no endpoint is configured and unreachable, which is the honest state of every
 // peer today: nothing discovers endpoints yet.
 func TestAPeerWithNoEndpointIsStillConfigured(t *testing.T) {
-	iface, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -456,7 +456,7 @@ func TestTheFirstEndpointIsUsed(t *testing.T) {
 	p := peer(bobKey, "100.90.0.2/32")
 	p.Endpoints = []string{"203.0.113.2:51820", "198.51.100.2:51820"}
 
-	iface, err := Desired(membership(), stateWith(1, p), nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, p), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -468,7 +468,7 @@ func TestTheFirstEndpointIsUsed(t *testing.T) {
 // The key is carried through untouched. wgplan does not parse keys, so a translation that
 // mangled one would only fail at the kernel, on a real host, with a confusing message.
 func TestKeysArePassedThroughUnchanged(t *testing.T) {
-	iface, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -582,7 +582,7 @@ func TestARememberedPortIsAskedForAgain(t *testing.T) {
 	m := membership()
 	m.ListenPort = 51999
 
-	iface, err := Desired(m, stateWith(1), nil, nil)
+	iface, _, err := Desired(m, stateWith(1), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -593,7 +593,7 @@ func TestARememberedPortIsAskedForAgain(t *testing.T) {
 
 // A membership that has never come up asks for any port.
 func TestAMembershipWithNoPortAsksForAny(t *testing.T) {
-	iface, err := Desired(membership(), stateWith(1), nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -652,7 +652,7 @@ func relayedPeer(key, relayID string, ips ...string) *meshpv1.Peer {
 func TestARelayedPeerIsGivenItsLoopbackEndpoint(t *testing.T) {
 	relay := newFakeRelay("relay1")
 
-	iface, err := Desired(membership(),
+	iface, _, err := Desired(membership(),
 		stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32")), relay, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -681,7 +681,7 @@ func TestADirectEndpointWinsOverARelay(t *testing.T) {
 	p := relayedPeer(bobKey, "relay1", "100.90.0.2/32")
 	p.Endpoints = []string{"203.0.113.2:51820"}
 
-	iface, err := Desired(membership(), stateWith(1, p), relay, nil)
+	iface, _, err := Desired(membership(), stateWith(1, p), relay, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -701,7 +701,7 @@ func TestADirectEndpointWinsOverARelay(t *testing.T) {
 func TestAPeerOnAnUnreachableRelayDoesNotBreakTheOthers(t *testing.T) {
 	relay := newFakeRelay("relay1")
 
-	iface, err := Desired(membership(), stateWith(1,
+	iface, _, err := Desired(membership(), stateWith(1,
 		relayedPeer(bobKey, "relay1", "100.90.0.2/32"),
 		relayedPeer(carolKey, "relay2", "100.90.0.3/32"),
 	), relay, nil)
@@ -727,7 +727,7 @@ func TestAPeerOnAnUnreachableRelayDoesNotBreakTheOthers(t *testing.T) {
 // With no relay at all — no data plane, or a deployment that has not configured one — a
 // relayed peer is unreachable rather than refused.
 func TestNoRelayLeavesRelayedPeersWithoutEndpoints(t *testing.T) {
-	iface, err := Desired(membership(),
+	iface, _, err := Desired(membership(),
 		stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32")), nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1016,4 +1016,233 @@ func TestTeardownRemovesThePolicy(t *testing.T) {
 	if len(filter.applied) != 2 || filter.applied[1] != nil {
 		t.Errorf("teardown did not remove the policy: %d applies", len(filter.applied))
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Carried prefixes
+
+func assignmentTo(name, carrier string, prefixes ...string) *meshpv1.RouteGroupAssignment {
+	return &meshpv1.RouteGroupAssignment{
+		RouteGroupId: "group-" + name, Name: name, Prefixes: prefixes,
+		Candidates: []*meshpv1.RouteCandidate{{PeerPublicKey: carrier, Priority: 1}},
+	}
+}
+
+func stateWithRoutes(version uint64, assignments []*meshpv1.RouteGroupAssignment, peers ...*meshpv1.Peer) *peerset.Set {
+	s := peerset.New()
+	s.Apply(&meshpv1.StateDelta{
+		FromVersion: 0, ToVersion: version, UpsertPeers: peers,
+		Tunnel:      &meshpv1.TunnelConfig{Mtu: 1420},
+		RouteGroups: assignments,
+	})
+	return s
+}
+
+func allowedIPsOf(iface wgplan.Interface, key string) []string {
+	for _, p := range iface.Peers {
+		if string(p.PublicKey) == key {
+			out := make([]string, 0, len(p.AllowedIPs))
+			for _, a := range p.AllowedIPs {
+				out = append(out, a.String())
+			}
+			return out
+		}
+	}
+	return nil
+}
+
+// The MSP case, end to end through the translation: a branch LAN becomes both cryptokey
+// routing on the carrier and a system route at the interface. Both are required — WireGuard
+// will not carry a packet for a prefix outside AllowedIPs, and the kernel will not send one
+// to the interface without a route.
+func TestACarriedPrefixReachesTheCarrierAndTheRoutingTable(t *testing.T) {
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch-lan", bobKey, "192.168.10.0/24")},
+		peer(bobKey, "100.90.0.2/32"))
+
+	iface, unhonoured, err := Desired(membership(), state, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unhonoured) != 0 {
+		t.Fatalf("reported %v as unhonoured", unhonoured)
+	}
+
+	got := allowedIPsOf(iface, bobKey)
+	if !slicesContain(got, "192.168.10.0/24") {
+		t.Fatalf("the carrier's allowed IPs are %v; the prefix is missing", got)
+	}
+	if !slicesContain(got, "100.90.0.2/32") {
+		t.Errorf("the carrier lost its own address: %v", got)
+	}
+
+	// And the route follows, because wgplan derives what it installs from these.
+	link := newFakeLink()
+	r := New(link, membership(), nil, nil, nil)
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	routed := false
+	for _, op := range link.applied {
+		if op.Kind == wgplan.AddRoute && op.Prefix.String() == "192.168.10.0/24" {
+			routed = true
+		}
+	}
+	if !routed {
+		t.Errorf("no route was installed for the carried prefix: %v", link.applied)
+	}
+}
+
+// Claiming a default route needs the excluded prefixes that keep the tunnel's own endpoint
+// and the physical gateway out of it, and the fail-closed handling that blocks egress while
+// the tunnel is down (ADR-0011). Installing 0.0.0.0/0 without them would send this device's
+// own path to its control plane and its relay into a tunnel that depends on them.
+func TestAnEgressGroupIsRefusedUntilItIsSafe(t *testing.T) {
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{assignmentTo("exit", bobKey, "0.0.0.0/0", "::/0")},
+		peer(bobKey, "100.90.0.2/32"))
+
+	iface, unhonoured, err := Desired(membership(), state, nil, nil)
+	if err != nil {
+		t.Fatalf("an egress group made the whole description fail: %v", err)
+	}
+	if len(unhonoured) != 1 || unhonoured[0] != "exit" {
+		t.Fatalf("unhonoured = %v, want [exit]", unhonoured)
+	}
+	if got := allowedIPsOf(iface, bobKey); slicesContain(got, "0.0.0.0/0") {
+		t.Fatalf("a default route was claimed anyway: %v", got)
+	}
+
+	// And it is reported, so the device does not look converged while carrying nothing.
+	link := newFakeLink()
+	r := New(link, membership(), nil, nil, nil)
+	reported, err := r.Apply(context.Background(), state)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(reported) != 1 || reported[0] != "route-groups" {
+		t.Errorf("unapplied = %v, want [route-groups]", reported)
+	}
+	// The peers still converged; one unusable group must not cost the rest.
+	if link.count(wgplan.SetPeer) == 0 {
+		t.Error("the peers were abandoned because a group could not be carried")
+	}
+}
+
+// Nothing can be routed to a peer the interface does not have, and inventing one here would
+// add a peer the control plane never sent.
+func TestACarrierThatIsNotAPeerIsReported(t *testing.T) {
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch-lan", carolKey, "192.168.10.0/24")},
+		peer(bobKey, "100.90.0.2/32"))
+
+	iface, unhonoured, err := Desired(membership(), state, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unhonoured) != 1 {
+		t.Fatalf("unhonoured = %v, want the group named", unhonoured)
+	}
+	if len(iface.Peers) != 1 {
+		t.Errorf("%d peers, want 1 — a peer was invented for the carrier", len(iface.Peers))
+	}
+}
+
+// A prefix that does not parse must not be approximated into one that does: these reach the
+// kernel's routing table.
+func TestAnUnparseablePrefixIsReportedRatherThanGuessed(t *testing.T) {
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch-lan", bobKey, "not-a-prefix")},
+		peer(bobKey, "100.90.0.2/32"))
+
+	_, unhonoured, err := Desired(membership(), state, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unhonoured) != 1 {
+		t.Errorf("unhonoured = %v, want the group named", unhonoured)
+	}
+}
+
+// The server orders the candidates and withdraws a group nobody can carry, so an empty list
+// means the two ends disagree.
+func TestAGroupWithNoCandidatesIsReported(t *testing.T) {
+	assignment := &meshpv1.RouteGroupAssignment{
+		RouteGroupId: "g", Name: "branch-lan", Prefixes: []string{"192.168.10.0/24"},
+	}
+	state := stateWithRoutes(1, []*meshpv1.RouteGroupAssignment{assignment},
+		peer(bobKey, "100.90.0.2/32"))
+
+	_, unhonoured, err := Desired(membership(), state, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unhonoured) != 1 {
+		t.Errorf("unhonoured = %v", unhonoured)
+	}
+}
+
+// The server orders candidates best first and the agent takes that order until it probes
+// (ADR-0003).
+func TestTheFirstCandidateCarriesIt(t *testing.T) {
+	assignment := &meshpv1.RouteGroupAssignment{
+		RouteGroupId: "g", Name: "branch-lan", Prefixes: []string{"192.168.10.0/24"},
+		Candidates: []*meshpv1.RouteCandidate{
+			{PeerPublicKey: bobKey, Priority: 1},
+			{PeerPublicKey: carolKey, Priority: 5},
+		},
+	}
+	state := stateWithRoutes(1, []*meshpv1.RouteGroupAssignment{assignment},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	iface, _, err := Desired(membership(), state, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slicesContain(allowedIPsOf(iface, bobKey), "192.168.10.0/24") {
+		t.Error("the preferred candidate is not carrying the prefix")
+	}
+	// And only one carries it: two peers claiming the same prefix is a configuration the
+	// kernel resolves arbitrarily.
+	if slicesContain(allowedIPsOf(iface, carolKey), "192.168.10.0/24") {
+		t.Error("a second candidate is also carrying the prefix")
+	}
+}
+
+// Withdrawing an assignment has to take the route with it, or the device keeps sending a
+// prefix into a tunnel nobody is carrying it through.
+func TestARemovedAssignmentRemovesItsRoute(t *testing.T) {
+	link := newFakeLink()
+	r := New(link, membership(), nil, nil, nil)
+
+	with := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch-lan", bobKey, "192.168.10.0/24")},
+		peer(bobKey, "100.90.0.2/32"))
+	if _, err := r.Apply(context.Background(), with); err != nil {
+		t.Fatal(err)
+	}
+
+	without := stateWithRoutes(2, nil, peer(bobKey, "100.90.0.2/32"))
+	if _, err := r.Apply(context.Background(), without); err != nil {
+		t.Fatal(err)
+	}
+
+	removed := false
+	for _, op := range link.applied {
+		if op.Kind == wgplan.RemoveRoute && op.Prefix.String() == "192.168.10.0/24" {
+			removed = true
+		}
+	}
+	if !removed {
+		t.Errorf("the route survived its assignment: %v", link.applied)
+	}
+}
+
+func slicesContain(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
The agent acts on its assignments. A branch office LAN assigned to a device now becomes a route in that device's kernel, pointed at the peer carrying it.

## Both halves from one change

WireGuard won't accept or send a packet for a prefix outside a peer's `AllowedIPs`, and the kernel won't send one to the interface without a route. Both are required — that's Invariant territory, and it's the mistake this codebase has hit before.

It turns out `wgplan` already derives the routes it installs from exactly those `AllowedIPs`. So adding the prefix to the carrier produces **both**, and they cannot drift apart. **Nothing new was needed in `wgplan`.**

## Egress groups are refused, deliberately and loudly

Claiming a default route needs the excluded prefixes that keep the tunnel's own endpoint, the physical gateway and the LAN out of it — plus the fail-closed handling that blocks egress while the tunnel is down (ADR-0011). **None of that exists yet.**

Installing `0.0.0.0/0` without it would send this device's own path to its control plane *and its relay* into a tunnel that depends on them. The host goes off the network with no way back.

So the group is reported as unapplied rather than half-honoured. An operator sees a device not carrying what it was assigned, instead of a device that has vanished.

## Unapplied without an error

Which is what the `Applier` contract is for. The interface converged; naming what didn't is more useful than reporting the whole apply as failed and hiding the part that worked. One group this device can't carry — an unparseable prefix, a carrier that isn't one of its peers, an assignment with no candidates — costs it that group and nothing else.

## The best candidate carries it, and only it

The server orders candidates and the agent is meant to choose by probing (ADR-0003). Until it probes, taking the server's first preference is the honest subset — it's what the server would have chosen anyway. Two peers claiming the same prefix is a configuration the kernel resolves arbitrarily, so exactly one gets it.

## A structural call

`Desired` returns the unhonoured groups rather than carrying them on `wgplan.Interface`. I put the field there first and took it back out: `wgplan` plans kernel operations, and "what is missing" isn't one. Putting it there would have made a clean type the place reporting lives.

## Verification

Four mutations checked — default route claimed, non-peer carrier used, prefix never reaching the carrier, unhonoured groups not reported — all caught. `internal/tunnel` at 94.8%. The e2e still passes end to end.

Next slice is the advertiser's own side: forwarding and NAT, so the device carrying a branch LAN actually passes packets into it.