### PR TITLE
feat(routes): forward into a carried prefix, and rewrite the source

### DIFF
--- a/internal/nftables/apply_linux_test.go
+++ b/internal/nftables/apply_linux_test.go
@@ -186,3 +186,131 @@ func TestAMalformedScriptIsReportedWithItsReason(t *testing.T) {
 		t.Errorf("the error does not carry nft's complaint: %v", err)
 	}
 }
+
+// The forwarding ruleset has to load too, and it uses expressions the filter does not — a
+// nat hook, masquerade, snat. A mistake in any of them is invisible to a string test.
+func TestAForwardingRulesetLoads(t *testing.T) {
+	requireNFT(t)
+	ctx := context.Background()
+
+	groups := []*meshpv1.AdvertisedRoutes_Group{
+		{RouteGroupId: "g", Name: "branch", Prefixes: []string{"192.168.10.0/24", "fd00::/64"}},
+	}
+	script, err := RenderForward("meshp0", groups)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(ctx, script); err != nil {
+		t.Fatalf("the kernel refused the forwarding ruleset: %v", err)
+	}
+	t.Cleanup(func() {
+		if empty, err := RenderForward("meshp0", nil); err == nil {
+			_ = Apply(context.Background(), empty)
+		}
+	})
+
+	out, err := exec.Command("nft", "list", "table", "inet", ForwardTableName).CombinedOutput()
+	if err != nil {
+		t.Fatalf("listing the forwarding table: %v: %s", err, out)
+	}
+	for _, want := range []string{"masquerade", "192.168.10.0/24", "ct state established,related accept"} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("the loaded table does not contain %q:\n%s", want, out)
+		}
+	}
+}
+
+// snat is a different expression from masquerade and fails differently if it is wrong.
+func TestAStableEgressRulesetLoads(t *testing.T) {
+	requireNFT(t)
+	groups := []*meshpv1.AdvertisedRoutes_Group{
+		{RouteGroupId: "g", Prefixes: []string{"192.168.10.0/24"}, StableEgressIp: "203.0.113.7"},
+	}
+	script, err := RenderForward("meshp0", groups)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(context.Background(), script); err != nil {
+		t.Fatalf("the kernel refused a stable-egress ruleset: %v", err)
+	}
+	t.Cleanup(func() {
+		if empty, err := RenderForward("meshp0", nil); err == nil {
+			_ = Apply(context.Background(), empty)
+		}
+	})
+}
+
+// An egress advertiser's catch-all rules are the ones most likely to be rejected, because
+// they match on interface rather than on address.
+func TestAnEgressForwardingRulesetLoads(t *testing.T) {
+	requireNFT(t)
+	groups := []*meshpv1.AdvertisedRoutes_Group{
+		{RouteGroupId: "g", Prefixes: []string{"0.0.0.0/0", "::/0"}},
+	}
+	script, err := RenderForward("meshp0", groups)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(context.Background(), script); err != nil {
+		t.Fatalf("the kernel refused an egress ruleset: %v", err)
+	}
+	t.Cleanup(func() {
+		if empty, err := RenderForward("meshp0", nil); err == nil {
+			_ = Apply(context.Background(), empty)
+		}
+	})
+}
+
+// The two tables are separate so a policy change does not disturb a gateway's forwarding.
+func TestPolicyAndForwardingDoNotDisturbEachOther(t *testing.T) {
+	requireNFT(t)
+	ctx := context.Background()
+
+	fwd, err := RenderForward("meshp0", []*meshpv1.AdvertisedRoutes_Group{
+		{RouteGroupId: "g", Prefixes: []string{"192.168.10.0/24"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(ctx, fwd); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if empty, err := RenderForward("meshp0", nil); err == nil {
+			_ = Apply(context.Background(), empty)
+		}
+	})
+
+	// Now reload the policy, which rebuilds its own table entirely.
+	policy, err := Render("meshp0", sampleFilter())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(ctx, policy); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command("nft", "list", "table", "inet", ForwardTableName).CombinedOutput()
+	if err != nil {
+		t.Fatalf("the forwarding table did not survive a policy reload: %v: %s", err, out)
+	}
+	if !strings.Contains(string(out), "192.168.10.0/24") {
+		t.Errorf("forwarding lost its rules when the policy reloaded:\n%s", out)
+	}
+}
+
+// Enabling forwarding is asymmetric on purpose: never turned off, because a host can be
+// forwarding for Docker or another VPN and turning it off would break that silently.
+func TestEnablingForwardingIsIdempotent(t *testing.T) {
+	requireNFT(t)
+	if _, err := EnableForwarding(); err != nil {
+		t.Fatalf("EnableForwarding: %v", err)
+	}
+	changed, err := EnableForwarding()
+	if err != nil {
+		t.Fatalf("EnableForwarding again: %v", err)
+	}
+	if len(changed) != 0 {
+		t.Errorf("reported changing %v on a host where it was already on", changed)
+	}
+}

--- a/internal/nftables/filter.go
+++ b/internal/nftables/filter.go
@@ -29,3 +29,21 @@ func (f *Filter) Apply(ctx context.Context, iface string, filter *meshpv1.Packet
 	}
 	return Apply(ctx, script)
 }
+
+// ApplyForward makes this host carry what it has been assigned, or stop carrying.
+//
+// Forwarding is enabled before the rules rather than after: rules that permit forwarding on
+// a host whose kernel will not forward are correct and do nothing, and the gap between the
+// two would be a window where a gateway looks configured and drops everything.
+func (f *Filter) ApplyForward(ctx context.Context, iface string, groups []*meshpv1.AdvertisedRoutes_Group) error {
+	if len(groups) > 0 {
+		if _, err := EnableForwarding(); err != nil {
+			return err
+		}
+	}
+	script, err := RenderForward(iface, groups)
+	if err != nil {
+		return err
+	}
+	return Apply(ctx, script)
+}

--- a/internal/nftables/forward.go
+++ b/internal/nftables/forward.go
@@ -1,0 +1,175 @@
+package nftables
+
+import (
+	"fmt"
+	"net/netip"
+	"sort"
+	"strings"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// ForwardTableName is the table an advertiser's forwarding lives in.
+//
+// Its own table, separate from the policy table, because the two are rebuilt on different
+// events: a policy change must not disturb a gateway's forwarding, and a route group
+// changing must not reload a filter and reset its counters.
+const ForwardTableName = "meshp_fwd"
+
+// RenderForward turns what a device carries into a ruleset that carries it.
+//
+// Two things have to be true for a packet to cross, and both are here. The forward chain
+// has to accept it — a host that routes but does not forward drops it silently between the
+// interfaces — and the source address has to be rewritten, because a LAN device replying to
+// 100.90.0.2 has no route to it and never will: nothing on that network has heard of the
+// mesh, which is the whole point of putting a gateway in front of it.
+//
+// Empty groups render a script that removes the table. A device that has stopped carrying
+// must stop forwarding, and leaving the rules would make it a gateway nobody knows about.
+func RenderForward(iface string, groups []*meshpv1.AdvertisedRoutes_Group) (string, error) {
+	if !interfaceNamePattern.MatchString(iface) {
+		return "", fmt.Errorf("nftables: %q is not a usable interface name", iface)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "add table inet %s\n", ForwardTableName)
+	fmt.Fprintf(&b, "delete table inet %s\n", ForwardTableName)
+	if len(groups) == 0 {
+		return b.String(), nil
+	}
+
+	carried, egress, err := carriedPrefixes(groups)
+	if err != nil {
+		return "", err
+	}
+	if len(carried.v4) == 0 && len(carried.v6) == 0 && !egress {
+		return b.String(), nil
+	}
+
+	fmt.Fprintf(&b, "add table inet %s\n", ForwardTableName)
+
+	// policy accept with an explicit drop last, for the same reason the filter chains use
+	// it: a chain that somehow ends up empty must not cut this host off from forwarding it
+	// was already doing for something else — Docker, a VPN, anything.
+	fmt.Fprintf(&b, "add chain inet %s forward { type filter hook forward priority filter; policy accept; }\n",
+		ForwardTableName)
+
+	// Return traffic first. A LAN host answering a mesh device is a reply to a connection
+	// this gateway already accepted, and without conntrack every forwarded connection would
+	// establish and then hang.
+	fmt.Fprintf(&b, "add rule inet %s forward ct state established,related accept\n", ForwardTableName)
+
+	for _, side := range []struct {
+		family, saddr, daddr string
+		prefixes             []string
+	}{
+		{"ip", "ip saddr", "ip daddr", carried.v4},
+		{"ip6", "ip6 saddr", "ip6 daddr", carried.v6},
+	} {
+		if len(side.prefixes) == 0 {
+			continue
+		}
+		// Out of the tunnel and into what this device carries.
+		fmt.Fprintf(&b, "add rule inet %s forward iifname %q %s %s accept\n",
+			ForwardTableName, iface, side.daddr, set(side.prefixes))
+		// And back, so a mesh device can be answered by something it started talking to.
+		fmt.Fprintf(&b, "add rule inet %s forward oifname %q %s %s accept\n",
+			ForwardTableName, iface, side.saddr, set(side.prefixes))
+	}
+	if egress {
+		// An egress advertiser forwards anything out of the tunnel: that is what being
+		// somebody's way to the internet means.
+		fmt.Fprintf(&b, "add rule inet %s forward iifname %q accept\n", ForwardTableName, iface)
+	}
+
+	// Source rewriting, in postrouting so it happens after the routing decision has chosen
+	// the outgoing interface — which is what tells the kernel which address to masquerade to.
+	fmt.Fprintf(&b, "add chain inet %s postrouting { type nat hook postrouting priority srcnat; policy accept; }\n",
+		ForwardTableName)
+
+	stable := stableEgressOf(groups)
+	for _, side := range []struct {
+		saddr, daddr string
+		prefixes     []string
+	}{
+		{"ip saddr", "ip daddr", carried.v4},
+		{"ip6 saddr", "ip6 daddr", carried.v6},
+	} {
+		if len(side.prefixes) == 0 {
+			continue
+		}
+		fmt.Fprintf(&b, "add rule inet %s postrouting iifname %q %s %s %s\n",
+			ForwardTableName, iface, side.daddr, set(side.prefixes), stable)
+	}
+	if egress {
+		fmt.Fprintf(&b, "add rule inet %s postrouting iifname %q oifname != %q %s\n",
+			ForwardTableName, iface, iface, stable)
+	}
+
+	return b.String(), nil
+}
+
+// stableEgressOf renders the source-rewriting verb.
+//
+// snat when the group names an address, because a customer who has allowlisted an outbound
+// IP with a bank depends on it surviving a failover; masquerade otherwise, which takes
+// whatever address the outgoing interface happens to have and is what anyone without that
+// requirement wants.
+func stableEgressOf(groups []*meshpv1.AdvertisedRoutes_Group) string {
+	for _, g := range groups {
+		raw := g.GetStableEgressIp()
+		if raw == "" {
+			continue
+		}
+		// Parsed and re-rendered, never interpolated: this reaches a script that runs as
+		// root, and it arrives from the control plane.
+		addr, err := netip.ParseAddr(raw)
+		if err != nil {
+			continue
+		}
+		return "snat to " + addr.Unmap().String()
+	}
+	return "masquerade"
+}
+
+// carriedPrefixes splits what is carried by family, and reports whether a default route is
+// among it.
+func carriedPrefixes(groups []*meshpv1.AdvertisedRoutes_Group) (out families, egress bool, err error) {
+	seen := make(map[netip.Prefix]struct{})
+	for _, group := range groups {
+		for _, raw := range group.GetPrefixes() {
+			prefix, parseErr := netip.ParsePrefix(raw)
+			if parseErr != nil {
+				return families{}, false, fmt.Errorf(
+					"nftables: carried prefix %q is not a prefix: %w", raw, parseErr)
+			}
+			if prefix.Bits() == 0 {
+				// Handled by the catch-all rules rather than as a prefix match, because a
+				// 0.0.0.0/0 daddr match would also catch traffic to this host itself.
+				egress = true
+				continue
+			}
+			seen[prefix.Masked()] = struct{}{}
+		}
+	}
+
+	prefixes := make([]netip.Prefix, 0, len(seen))
+	for p := range seen {
+		prefixes = append(prefixes, p)
+	}
+	sort.Slice(prefixes, func(i, j int) bool {
+		a, b := prefixes[i], prefixes[j]
+		if a.Addr() != b.Addr() {
+			return a.Addr().Less(b.Addr())
+		}
+		return a.Bits() < b.Bits()
+	})
+	for _, p := range prefixes {
+		if p.Addr().Is4() {
+			out.v4 = append(out.v4, p.String())
+		} else {
+			out.v6 = append(out.v6, p.String())
+		}
+	}
+	return out, egress, nil
+}

--- a/internal/nftables/forwarding_linux.go
+++ b/internal/nftables/forwarding_linux.go
@@ -1,0 +1,46 @@
+//go:build linux
+
+package nftables
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// forwardingSysctls are what the kernel needs before it will pass a packet between
+// interfaces at all. Without them the ruleset above is correct and nothing crosses.
+var forwardingSysctls = []string{
+	"/proc/sys/net/ipv4/ip_forward",
+	"/proc/sys/net/ipv6/conf/all/forwarding",
+}
+
+// EnableForwarding turns on IP forwarding, and never turns it off.
+//
+// Asymmetric on purpose. A host can be forwarding because of Docker, another VPN, or
+// because somebody configured it that way years ago, and none of that is visible from here.
+// Turning it off when a device stops carrying a prefix would silently break whatever else
+// depended on it — a much worse failure than leaving a setting on, which costs nothing on a
+// host with no routes to use it.
+//
+// Already-on is not reported as a change, so an operator reading the log sees this only
+// when meshp actually altered the host.
+func EnableForwarding() (changed []string, err error) {
+	for _, path := range forwardingSysctls {
+		current, readErr := os.ReadFile(path)
+		if readErr != nil {
+			// A kernel without IPv6, or a container with a read-only proc. Reported per
+			// setting rather than fatally: forwarding IPv4 only is worth having.
+			continue
+		}
+		if strings.TrimSpace(string(current)) == "1" {
+			continue
+		}
+		if writeErr := os.WriteFile(path, []byte("1\n"), 0o644); writeErr != nil {
+			err = fmt.Errorf("nftables: enabling forwarding via %s: %w", path, writeErr)
+			continue
+		}
+		changed = append(changed, path)
+	}
+	return changed, err
+}

--- a/internal/nftables/forwarding_other.go
+++ b/internal/nftables/forwarding_other.go
@@ -1,0 +1,6 @@
+//go:build !linux
+
+package nftables
+
+// EnableForwarding does nothing off Linux, where there is no data plane to forward with.
+func EnableForwarding() ([]string, error) { return nil, nil }

--- a/internal/nftables/render_test.go
+++ b/internal/nftables/render_test.go
@@ -251,3 +251,126 @@ func firstOr(lines []string) string {
 	}
 	return lines[0]
 }
+
+// ---------------------------------------------------------------------------
+// Forwarding
+
+func carried(prefixes ...string) []*meshpv1.AdvertisedRoutes_Group {
+	return []*meshpv1.AdvertisedRoutes_Group{{RouteGroupId: "g", Name: "branch", Prefixes: prefixes}}
+}
+
+func renderFwd(t *testing.T, groups []*meshpv1.AdvertisedRoutes_Group) string {
+	t.Helper()
+	script, err := RenderForward("meshp0", groups)
+	if err != nil {
+		t.Fatalf("RenderForward: %v", err)
+	}
+	return script
+}
+
+// Two things have to be true for a packet to cross, and both must be here: the forward
+// chain has to accept it, and the source has to be rewritten — a LAN device replying to
+// 100.90.0.2 has no route to it and never will.
+func TestForwardingAcceptsAndRewrites(t *testing.T) {
+	script := renderFwd(t, carried("192.168.10.0/24"))
+
+	if !strings.Contains(script, `forward iifname "meshp0" ip daddr 192.168.10.0/24 accept`) {
+		t.Errorf("nothing accepts traffic out of the tunnel:\n%s", script)
+	}
+	if !strings.Contains(script, `forward oifname "meshp0" ip saddr 192.168.10.0/24 accept`) {
+		t.Errorf("nothing accepts the LAN answering back:\n%s", script)
+	}
+	if !strings.Contains(script, `postrouting iifname "meshp0" ip daddr 192.168.10.0/24 masquerade`) {
+		t.Errorf("the source is not rewritten, so the LAN has no route back:\n%s", script)
+	}
+	if !strings.Contains(script, "ct state established,related accept") {
+		t.Errorf("without conntrack every forwarded connection establishes and hangs:\n%s", script)
+	}
+	// Its own table: a policy change must not disturb a gateway's forwarding.
+	if !strings.Contains(script, "inet meshp_fwd") {
+		t.Errorf("forwarding shares the policy table:\n%s", script)
+	}
+}
+
+// A customer who has allowlisted an outbound IP with a bank depends on it surviving a
+// failover, which masquerade cannot promise and snat can.
+func TestAStableEgressAddressIsUsedWhenGiven(t *testing.T) {
+	groups := carried("192.168.10.0/24")
+	groups[0].StableEgressIp = "203.0.113.7"
+
+	script := renderFwd(t, groups)
+	if !strings.Contains(script, "snat to 203.0.113.7") {
+		t.Errorf("the stable egress address was not used:\n%s", script)
+	}
+	if strings.Contains(script, "masquerade") {
+		t.Errorf("it masquerades anyway, so the allowlisted address would change:\n%s", script)
+	}
+}
+
+// A device that has stopped carrying must stop forwarding, or it stays a gateway nobody
+// knows about.
+func TestNoGroupsRemovesTheTable(t *testing.T) {
+	script := renderFwd(t, nil)
+	if !strings.Contains(script, "delete table inet meshp_fwd") {
+		t.Fatalf("nothing removes the forwarding table:\n%s", script)
+	}
+	if strings.Contains(script, "masquerade") || strings.Contains(script, "add chain") {
+		t.Fatalf("it still installs forwarding rules:\n%s", script)
+	}
+}
+
+// An egress advertiser forwards anything out of the tunnel — that is what being somebody's
+// way to the internet means — but a 0.0.0.0/0 daddr match would also catch traffic to this
+// host itself, so it is a catch-all on the interface instead.
+func TestEgressForwardsEverythingOutOfTheTunnel(t *testing.T) {
+	script := renderFwd(t, carried("0.0.0.0/0", "::/0"))
+
+	if !strings.Contains(script, `forward iifname "meshp0" accept`) {
+		t.Errorf("an egress advertiser forwards nothing:\n%s", script)
+	}
+	if !strings.Contains(script, `postrouting iifname "meshp0" oifname != "meshp0" masquerade`) {
+		t.Errorf("egress traffic is not masqueraded:\n%s", script)
+	}
+	if strings.Contains(script, "daddr 0.0.0.0/0") {
+		t.Errorf("a default route was matched as a prefix, which also catches this host:\n%s", script)
+	}
+}
+
+// A chain that somehow ends up empty must not cut this host off from forwarding it was
+// already doing for something else — Docker, another VPN, anything.
+func TestForwardingFailsOpenForTheHost(t *testing.T) {
+	script := renderFwd(t, carried("192.168.10.0/24"))
+	if strings.Contains(script, "policy drop") {
+		t.Errorf("the forward chain defaults to drop:\n%s", script)
+	}
+}
+
+func TestForwardingRefusesWhatItCannotParse(t *testing.T) {
+	if _, err := RenderForward("meshp0", carried("not-a-prefix")); err == nil {
+		t.Error("rendered forwarding for a prefix it could not parse")
+	}
+	if _, err := RenderForward("meshp0; flush ruleset", carried("192.168.10.0/24")); err == nil {
+		t.Error("accepted an interface name that is not one")
+	}
+	// An unparseable stable address falls back to masquerade rather than reaching the
+	// script: forwarding with the wrong source is better than a ruleset that will not load.
+	groups := carried("192.168.10.0/24")
+	groups[0].StableEgressIp = "; drop"
+	script, err := RenderForward("meshp0", groups)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(script, "masquerade") || strings.Contains(script, "drop") {
+		t.Errorf("an unparseable egress address reached the script:\n%s", script)
+	}
+}
+
+func TestForwardRenderingIsDeterministic(t *testing.T) {
+	groups := carried("192.168.20.0/24", "192.168.10.0/24", "fd00::/64")
+	first := renderFwd(t, groups)
+	for range 20 {
+		if got := renderFwd(t, groups); got != first {
+			t.Fatalf("two renderings differ:\n%s\n---\n%s", first, got)
+		}
+	}
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -98,6 +98,11 @@ type Reconciler struct {
 	// counters an operator is reading.
 	lastFilter *meshpv1.PacketFilter
 
+	// lastAdvertised is the same idea for forwarding, and matters more: reloading the NAT
+	// table flushes its conntrack-independent counters and, on some kernels, disturbs
+	// in-flight masqueraded flows. An unchanged assignment is left alone.
+	lastAdvertised *meshpv1.AdvertisedRoutes
+
 	mu       sync.Mutex
 	kind     wglink.Kind
 	up       bool
@@ -114,6 +119,11 @@ type Filter interface {
 	// Apply makes the host enforce this filter. A nil filter means no policy, and must
 	// remove whatever was enforced before rather than leaving it in place.
 	Apply(ctx context.Context, iface string, filter *meshpv1.PacketFilter) error
+
+	// ApplyForward makes the host carry what it advertises, or stop carrying. An empty
+	// list means stop: a device that has been withdrawn must not go on being a gateway
+	// nobody knows about.
+	ApplyForward(ctx context.Context, iface string, groups []*meshpv1.AdvertisedRoutes_Group) error
 }
 
 // New returns a Reconciler for one membership. relay and filter may be nil.
@@ -243,15 +253,24 @@ func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, e
 	r.port = port
 	r.mu.Unlock()
 
+	// Named separately, because they are different failures with different fixes: a group
+	// this device cannot route is a configuration problem, and a host that cannot forward is
+	// a capability problem. Reporting both as one component would send an operator to the
+	// wrong end of it.
+	var unapplied []string
 	if len(unhonoured) > 0 {
-		// Unapplied without an error: the interface converged, and what did not is named so
-		// the control plane can see this device is not carrying everything it was assigned.
-		// An error here would report the whole apply as failed and hide the part that worked.
 		r.log.Warn("some route groups are not being carried",
 			"interface", want.Name, "groups", len(unhonoured))
-		return []string{"route-groups"}, nil
+		unapplied = append(unapplied, "route-groups")
 	}
-	return nil, nil
+	if failed := r.applyForwarding(ctx, want.Name, state.Advertised()); failed != nil {
+		unapplied = append(unapplied, failed...)
+	}
+
+	// Unapplied without an error: the interface converged, and what did not is named so the
+	// control plane can see this device is not where it says it is. An error here would
+	// report the whole apply as failed and hide the part that worked.
+	return unapplied, nil
 }
 
 // applyFilter enforces the policy, returning the components that did not apply.
@@ -293,17 +312,58 @@ func (r *Reconciler) applyFilter(ctx context.Context, iface string, want *meshpv
 	return nil
 }
 
+// applyForwarding makes this host carry what it advertises, or stop.
+//
+// Skipped when nothing changed, like the filter and for a sharper reason: rebuilding the NAT
+// table is not free for traffic already crossing it.
+//
+// A nil advertisement means the control plane has said nothing about forwarding — a network
+// with no route groups at all — and is left alone. An empty one means it has said this
+// device carries nothing, which must reach the kernel.
+func (r *Reconciler) applyForwarding(ctx context.Context, iface string, advertised *meshpv1.AdvertisedRoutes) []string {
+	if advertised == nil || r.filter == nil {
+		if advertised != nil && len(advertised.GetGroups()) > 0 {
+			r.log.Error("this device is meant to carry prefixes and cannot forward",
+				"hint", "forwarding needs nftables, which this host does not have")
+			return []string{"forwarding"}
+		}
+		return nil
+	}
+
+	if proto.Equal(r.lastAdvertised, advertised) {
+		return nil
+	}
+	if err := r.filter.ApplyForward(ctx, iface, advertised.GetGroups()); err != nil {
+		r.log.Error("could not carry the prefixes this device advertises",
+			"interface", iface, "error", err)
+		return []string{"forwarding"}
+	}
+
+	r.lastAdvertised = proto.CloneOf(advertised)
+	if n := len(advertised.GetGroups()); n > 0 {
+		r.log.Info("carrying prefixes for the network", "interface", iface, "groups", n)
+	} else {
+		r.log.Info("no longer carrying anything", "interface", iface)
+	}
+	return nil
+}
+
 // Teardown removes everything this membership installed (Invariant 20).
 func (r *Reconciler) Teardown() error {
 	name := r.membership.InterfaceName
 
-	// The policy first. A ruleset outliving the interface it names would go on matching
-	// nothing while an operator reads a table meshp installed and no longer maintains.
+	// The policy and the forwarding first. A ruleset outliving the interface it names would
+	// go on matching nothing while an operator reads a table meshp installed and no longer
+	// maintains — and forwarding rules that outlived it would leave the host a gateway for a
+	// network it has left.
 	if r.filter != nil {
 		if err := r.filter.Apply(context.Background(), name, nil); err != nil {
 			r.log.Warn("could not remove this network's policy", "interface", name, "error", err)
 		}
-		r.lastFilter = nil
+		if err := r.filter.ApplyForward(context.Background(), name, nil); err != nil {
+			r.log.Warn("could not stop carrying prefixes", "interface", name, "error", err)
+		}
+		r.lastFilter, r.lastAdvertised = nil, nil
 	}
 
 	observed, err := r.link.Observe(name)

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -826,9 +826,19 @@ func TestTheListenPortIsHandedToTheRelayAfterConverging(t *testing.T) {
 
 // fakeFilter records what it was asked to enforce.
 type fakeFilter struct {
-	applied []*meshpv1.PacketFilter
-	iface   string
-	failErr error
+	applied   []*meshpv1.PacketFilter
+	forwarded [][]*meshpv1.AdvertisedRoutes_Group
+	iface     string
+	failErr   error
+	fwdErr    error
+}
+
+func (f *fakeFilter) ApplyForward(_ context.Context, _ string, groups []*meshpv1.AdvertisedRoutes_Group) error {
+	if f.fwdErr != nil {
+		return f.fwdErr
+	}
+	f.forwarded = append(f.forwarded, groups)
+	return nil
 }
 
 func (f *fakeFilter) Apply(_ context.Context, iface string, filter *meshpv1.PacketFilter) error {
@@ -1245,4 +1255,149 @@ func slicesContain(haystack []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+func stateAdvertising(version uint64, advertised *meshpv1.AdvertisedRoutes, peers ...*meshpv1.Peer) *peerset.Set {
+	s := peerset.New()
+	s.Apply(&meshpv1.StateDelta{
+		FromVersion: 0, ToVersion: version, UpsertPeers: peers,
+		Tunnel:     &meshpv1.TunnelConfig{Mtu: 1420},
+		Advertised: advertised,
+	})
+	return s
+}
+
+func advertising(prefixes ...string) *meshpv1.AdvertisedRoutes {
+	return &meshpv1.AdvertisedRoutes{Groups: []*meshpv1.AdvertisedRoutes_Group{
+		{RouteGroupId: "g", Name: "branch", Prefixes: prefixes},
+	}}
+}
+
+func TestAnAdvertiserIsMadeToForward(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{}
+	r := New(link, membership(), nil, filter, nil)
+
+	if _, err := r.Apply(context.Background(),
+		stateAdvertising(1, advertising("192.168.10.0/24"), peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.forwarded) != 1 || len(filter.forwarded[0]) != 1 {
+		t.Fatalf("forwarding was configured %d times: %+v", len(filter.forwarded), filter.forwarded)
+	}
+}
+
+// A network that has never mentioned route groups says nothing about forwarding, and that
+// must not be read as "stop".
+func TestSilenceAboutForwardingIsLeftAlone(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{}
+	r := New(link, membership(), nil, filter, nil)
+
+	if _, err := r.Apply(context.Background(),
+		stateAdvertising(1, nil, peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.forwarded) != 0 {
+		t.Errorf("silence was read as an instruction: %+v", filter.forwarded)
+	}
+}
+
+// An explicit empty list means stop, and has to reach the kernel — otherwise a withdrawn
+// gateway keeps forwarding for a network that no longer routes to it.
+func TestBeingToldToCarryNothingStopsForwarding(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{}
+	r := New(link, membership(), nil, filter, nil)
+
+	if _, err := r.Apply(context.Background(),
+		stateAdvertising(1, advertising("192.168.10.0/24"), peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Apply(context.Background(),
+		stateAdvertising(2, &meshpv1.AdvertisedRoutes{}, peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.forwarded) != 2 {
+		t.Fatalf("%d forwarding applies, want 2", len(filter.forwarded))
+	}
+	if len(filter.forwarded[1]) != 0 {
+		t.Errorf("stopping did not reach the kernel: %+v", filter.forwarded[1])
+	}
+}
+
+// Rebuilding the NAT table is not free for traffic already crossing it.
+func TestUnchangedForwardingIsNotReapplied(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{}
+	r := New(link, membership(), nil, filter, nil)
+	state := stateAdvertising(1, advertising("192.168.10.0/24"), peer(bobKey, "100.90.0.2/32"))
+
+	for range 3 {
+		if _, err := r.Apply(context.Background(), state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(filter.forwarded) != 1 {
+		t.Errorf("forwarding was rebuilt %d times for an unchanged assignment", len(filter.forwarded))
+	}
+}
+
+// A device meant to carry prefixes on a host that cannot forward must say so, or it looks
+// like a working gateway that drops everything.
+func TestAHostThatCannotForwardReportsIt(t *testing.T) {
+	link := newFakeLink()
+	r := New(link, membership(), nil, nil, nil)
+
+	unapplied, err := r.Apply(context.Background(),
+		stateAdvertising(1, advertising("192.168.10.0/24"), peer(bobKey, "100.90.0.2/32")))
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(unapplied) != 1 || unapplied[0] != "forwarding" {
+		t.Errorf("unapplied = %v, want [forwarding]", unapplied)
+	}
+}
+
+// And a failure to load is reported rather than remembered as done.
+func TestForwardingThatFailsIsRetried(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{fwdErr: errors.New("nft: no such table")}
+	r := New(link, membership(), nil, filter, nil)
+	state := stateAdvertising(1, advertising("192.168.10.0/24"), peer(bobKey, "100.90.0.2/32"))
+
+	unapplied, err := r.Apply(context.Background(), state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unapplied) != 1 || unapplied[0] != "forwarding" {
+		t.Fatalf("unapplied = %v", unapplied)
+	}
+
+	filter.fwdErr = nil
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.forwarded) != 1 {
+		t.Error("forwarding that failed to load was never retried")
+	}
+}
+
+// Forwarding rules outliving the interface would leave the host a gateway for a network it
+// has left (Invariant 20).
+func TestTeardownStopsForwarding(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{}
+	r := New(link, membership(), nil, filter, nil)
+
+	if _, err := r.Apply(context.Background(),
+		stateAdvertising(1, advertising("192.168.10.0/24"), peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Teardown(); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.forwarded) != 2 || len(filter.forwarded[1]) != 0 {
+		t.Errorf("teardown did not stop forwarding: %+v", filter.forwarded)
+	}
 }


### PR DESCRIPTION
A device that advertises a branch office LAN now passes packets into it. This is the far end of the chain: an assignment tells a laptop where to send traffic for `192.168.10.0/24`, and this makes the device on the other side of the tunnel actually deliver it.

## Two halves, both required

**The forward chain has to accept it.** A host that routes but doesn't forward drops the packet silently between interfaces.

**The source has to be rewritten.** A LAN device replying to `100.90.0.2` has no route to it and never will — nothing on that network has heard of the mesh, which is the entire reason there's a gateway in front of it.

Either half alone produces a path that looks configured and carries nothing.

## Its own table

Separate from the policy table, because the two are rebuilt on different events. Sharing would mean a policy change disturbing a gateway's forwarding, and a route change resetting a filter's drop counters. A real-kernel test loads one and reloads the other to check they don't interfere.

## snat vs masquerade

`snat` when a group names a stable egress address; `masquerade` otherwise. A customer who has allowlisted an outbound IP with a bank depends on it surviving a failover — a promise masquerade can't make.

An address that doesn't parse falls back to masquerade rather than reaching the script. Forwarding from the wrong source is bad; a ruleset that won't load at all is worse.

## Forwarding is enabled and never disabled

Asymmetric on purpose. A host can be forwarding for Docker, another VPN, or because somebody configured it years ago — none of which is visible from here. Turning it off when a device stops carrying would silently break whatever depended on it. Leaving a setting on costs nothing on a host with no routes to use it.

## One bug, caught by its own test

Forwarding failures were being appended to the route-group list and then reported as `route-groups`, because the return value was hardcoded from the earlier slice. They're named separately now: a group this device can't route is a *configuration* problem, a host that can't forward is a *capability* problem, and reporting both as one sends an operator to the wrong end of it.

## Verification

Real-kernel tests under `make dataplane` load the forwarding ruleset, the `snat` variant, and the egress catch-alls — which use expressions the filter never exercises. Plus the two-table independence check.

`internal/nftables` 87.1%, `internal/tunnel` 94.8%.

## What's still missing for a full path

The route is installed, the gateway forwards, the source is rewritten. What hasn't been tested is a **packet actually crossing end to end** — that needs two containers and a fake LAN, which is a test harness rather than a feature. Worth doing before anyone relies on this.

Egress groups also still refuse to install a default route on the *client* side (ADR-0011 fail-closed isn't built), so the egress forwarding rules here have no client to serve yet.