### PR TITLE
feat(routes): let client reports drive advertiser health

### DIFF
--- a/internal/session/reachability.go
+++ b/internal/session/reachability.go
@@ -1,0 +1,75 @@
+package session
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/meshpnet/meshp/internal/health"
+	"github.com/meshpnet/meshp/internal/logx"
+	"github.com/meshpnet/meshp/internal/store"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// handleReachabilityReport folds a device's verdict on its advertiser into that
+// advertiser's health.
+//
+// This is the signal the whole failover story rests on. The control plane can reach an
+// advertiser's host and learn almost nothing: what matters is whether traffic sent through
+// it arrives, and only the devices actually using it can say. So the agents report, the
+// monitor fuses, and selection reorders — without anybody asking the control plane a
+// question first.
+//
+// The network comes from the session rather than the report, so a device can only ever
+// speak about advertisers in a network it belongs to. Everything else in the message is a
+// claim by a device about itself, which is exactly the sort of claim to bound.
+func (s *Server) handleReachabilityReport(ctx context.Context, sess *Session, report *meshpv1.ReachabilityReport) {
+	advertiserID, err := uuid.Parse(report.GetAdvertiserId())
+	if err != nil {
+		// Not worth ending a session over. A newer agent may report about something this
+		// build does not model, and the report is advisory (ADR-0008).
+		s.log.Debug("ignoring a reachability report with an unusable advertiser id",
+			"membership_id", sess.MembershipID)
+		return
+	}
+
+	observed := health.SignalFail
+	if report.GetReachable() {
+		observed = health.SignalOK
+	}
+
+	transition, err := s.store.ObserveAdvertiser(ctx, store.ObserveRequest{
+		NetworkID:    sess.NetworkID,
+		AdvertiserID: advertiserID,
+		Observed:     observed,
+		Clock:        s.clk,
+	})
+	if err != nil {
+		// Including a report about an advertiser in another network, which is refused
+		// rather than acted on.
+		s.log.Warn("could not record a reachability report",
+			"membership_id", sess.MembershipID, "advertiser_id", advertiserID,
+			"error", logx.SafeError(err))
+		return
+	}
+
+	if transition.Changed {
+		// Logged at info because this is the event an operator asks about six weeks later,
+		// wanting to know why their traffic moved.
+		s.log.Info("advertiser health changed",
+			"advertiser_id", advertiserID,
+			"from", string(transition.From), "to", string(transition.To),
+			"reason", logx.Safe(transition.Reason),
+			"reported_by", sess.MembershipID)
+	}
+
+	if from := report.GetSwitchedFromAdvertiserId(); from != "" {
+		// The agent moved itself, which is what it is meant to do (ADR-0003). Recorded as a
+		// decision rather than as drift: the server ordered the candidates and the agent
+		// chose among them, so this is the system working.
+		s.log.Info("a device moved between advertisers",
+			"membership_id", sess.MembershipID,
+			"from", logx.Safe(from), "to", advertiserID.String(),
+			"reason", logx.Safe(report.GetSwitchReason()))
+	}
+}

--- a/internal/session/server.go
+++ b/internal/session/server.go
@@ -350,6 +350,9 @@ func (s *Server) readLoop(ctx context.Context, conn *websocket.Conn, sess *Sessi
 		case *meshpv1.ClientMessage_StateAck:
 			s.handleAck(ctx, sess, payload.StateAck)
 
+		case *meshpv1.ClientMessage_ReachabilityReport:
+			s.handleReachabilityReport(ctx, sess, payload.ReachabilityReport)
+
 		case *meshpv1.ClientMessage_RelayTokenRequest:
 			s.handleRelayTokenRequest(ctx, sess)
 

--- a/internal/store/gen/routegroups.sql.go
+++ b/internal/store/gen/routegroups.sql.go
@@ -203,6 +203,68 @@ func (q *Queries) DeleteRouteGroup(ctx context.Context, arg DeleteRouteGroupPara
 	return result.RowsAffected(), nil
 }
 
+const getAdvertiserForReport = `-- name: GetAdvertiserForReport :one
+SELECT a.id, a.route_group_id, g.network_id
+FROM route_advertisers a
+JOIN route_groups g ON g.id = a.route_group_id
+WHERE a.id = $1 AND g.network_id = $2
+`
+
+type GetAdvertiserForReportParams struct {
+	ID        uuid.UUID
+	NetworkID uuid.UUID
+}
+
+type GetAdvertiserForReportRow struct {
+	ID           uuid.UUID
+	RouteGroupID uuid.UUID
+	NetworkID    uuid.UUID
+}
+
+// The advertiser a device claims to be using, scoped to the network the session belongs to.
+//
+// Scoped, because the id arrives from a device: without this a device in one network could
+// report health for an advertiser in another, and steer a network it cannot see.
+func (q *Queries) GetAdvertiserForReport(ctx context.Context, arg GetAdvertiserForReportParams) (GetAdvertiserForReportRow, error) {
+	row := q.db.QueryRow(ctx, getAdvertiserForReport, arg.ID, arg.NetworkID)
+	var i GetAdvertiserForReportRow
+	err := row.Scan(&i.ID, &i.RouteGroupID, &i.NetworkID)
+	return i, err
+}
+
+const getAdvertiserHealth = `-- name: GetAdvertiserHealth :one
+SELECT advertiser_id, state, consecutive_ok, consecutive_fail, consecutive_partial,
+       last_improved_at, last_checked_at
+FROM advertiser_health
+WHERE advertiser_id = $1
+`
+
+type GetAdvertiserHealthRow struct {
+	AdvertiserID       uuid.UUID
+	State              string
+	ConsecutiveOk      int32
+	ConsecutiveFail    int32
+	ConsecutivePartial int32
+	LastImprovedAt     *time.Time
+	LastCheckedAt      *time.Time
+}
+
+// What the control plane last concluded about an advertiser, if anything.
+func (q *Queries) GetAdvertiserHealth(ctx context.Context, advertiserID uuid.UUID) (GetAdvertiserHealthRow, error) {
+	row := q.db.QueryRow(ctx, getAdvertiserHealth, advertiserID)
+	var i GetAdvertiserHealthRow
+	err := row.Scan(
+		&i.AdvertiserID,
+		&i.State,
+		&i.ConsecutiveOk,
+		&i.ConsecutiveFail,
+		&i.ConsecutivePartial,
+		&i.LastImprovedAt,
+		&i.LastCheckedAt,
+	)
+	return i, err
+}
+
 const getRouteGroupBySlug = `-- name: GetRouteGroupBySlug :one
 SELECT id, network_id, slug, name, kind, selection_mode,
        auto_failback, failback_delay_seconds, stable_egress_ip, created_at
@@ -441,6 +503,49 @@ func (q *Queries) ListRouteGroups(ctx context.Context, networkID uuid.UUID) ([]L
 		return nil, err
 	}
 	return items, nil
+}
+
+const upsertAdvertiserHealth = `-- name: UpsertAdvertiserHealth :exec
+INSERT INTO advertiser_health (
+    advertiser_id, state, consecutive_ok, consecutive_fail, consecutive_partial,
+    last_improved_at, last_checked_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (advertiser_id) DO UPDATE SET
+    state = EXCLUDED.state,
+    consecutive_ok = EXCLUDED.consecutive_ok,
+    consecutive_fail = EXCLUDED.consecutive_fail,
+    consecutive_partial = EXCLUDED.consecutive_partial,
+    last_improved_at = EXCLUDED.last_improved_at,
+    last_checked_at = EXCLUDED.last_checked_at
+`
+
+type UpsertAdvertiserHealthParams struct {
+	AdvertiserID       uuid.UUID
+	State              string
+	ConsecutiveOk      int32
+	ConsecutiveFail    int32
+	ConsecutivePartial int32
+	LastImprovedAt     *time.Time
+	LastCheckedAt      *time.Time
+}
+
+// Store what the monitor concluded.
+//
+// The whole snapshot rather than the state alone: the counters are what make the next
+// observation mean anything, and a state persisted without them would restart every
+// hysteresis window on each control-plane restart — turning a policy designed to resist
+// flapping into one that flaps on deploys.
+func (q *Queries) UpsertAdvertiserHealth(ctx context.Context, arg UpsertAdvertiserHealthParams) error {
+	_, err := q.db.Exec(ctx, upsertAdvertiserHealth,
+		arg.AdvertiserID,
+		arg.State,
+		arg.ConsecutiveOk,
+		arg.ConsecutiveFail,
+		arg.ConsecutivePartial,
+		arg.LastImprovedAt,
+		arg.LastCheckedAt,
+	)
+	return err
 }
 
 const upsertRouteAdvertiser = `-- name: UpsertRouteAdvertiser :one

--- a/internal/store/health.go
+++ b/internal/store/health.go
@@ -1,0 +1,129 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/meshpnet/meshp/internal/clock"
+	"github.com/meshpnet/meshp/internal/health"
+	dbgen "github.com/meshpnet/meshp/internal/store/gen"
+)
+
+// ErrNoSuchAdvertiser means the advertiser named is not in that network.
+//
+// Distinct from a database error because it arrives from a device: a report naming an
+// advertiser in another network is refused rather than acted on, or a device could steer a
+// network it cannot see.
+var ErrNoSuchAdvertiser = errors.New("store: no such advertiser in this network")
+
+// ObserveAdvertiser folds one client's report into an advertiser's health.
+//
+// The monitor's whole snapshot is persisted, not just the state. The counters are what make
+// the next observation mean anything, and a state stored without them would restart every
+// hysteresis window on each control-plane restart — turning a policy designed to resist
+// flapping into one that flaps on deploys.
+//
+// The state version moves only when the state actually changed. Recomputing every agent's
+// candidate order because one device sent a routine "still fine" would make a healthy
+// network busier than a broken one.
+func (s *Store) ObserveAdvertiser(ctx context.Context, req ObserveRequest) (health.Transition, error) {
+	var out health.Transition
+
+	err := s.InTx(ctx, func(q *dbgen.Queries) error {
+		row, err := q.GetAdvertiserForReport(ctx, dbgen.GetAdvertiserForReportParams{
+			ID: req.AdvertiserID, NetworkID: req.NetworkID,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNoSuchAdvertiser
+		}
+		if err != nil {
+			return fmt.Errorf("store: loading the advertiser: %w", err)
+		}
+
+		clk := req.Clock
+		if clk == nil {
+			clk = clock.System{}
+		}
+		monitor := health.NewMonitor(health.DefaultPolicy(), clk)
+
+		// Restored before observing, so the counters carry across restarts and across the
+		// many sessions reporting about the same advertiser.
+		if stored, err := q.GetAdvertiserHealth(ctx, req.AdvertiserID); err == nil {
+			monitor.Restore(health.Snapshot{
+				State:              health.State(stored.State),
+				ConsecutiveOK:      int(stored.ConsecutiveOk),
+				ConsecutiveFail:    int(stored.ConsecutiveFail),
+				ConsecutivePartial: int(stored.ConsecutivePartial),
+				LastImprovedAt:     timeOrZero(stored.LastImprovedAt),
+				LastReportAt:       timeOrZero(stored.LastCheckedAt),
+			})
+		} else if !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("store: loading advertiser health: %w", err)
+		}
+
+		// Only what a client observed. The advertiser's own self-report and a control-plane
+		// probe are the other two inputs health.Report takes, and neither exists yet —
+		// leaving them unknown is honest, and the monitor is built to fuse what it has.
+		out = monitor.Observe(health.Report{ClientObserved: req.Observed})
+
+		snapshot := monitor.Snapshot()
+		if err := q.UpsertAdvertiserHealth(ctx, dbgen.UpsertAdvertiserHealthParams{
+			AdvertiserID:       req.AdvertiserID,
+			State:              string(snapshot.State),
+			ConsecutiveOk:      int32(snapshot.ConsecutiveOK),
+			ConsecutiveFail:    int32(snapshot.ConsecutiveFail),
+			ConsecutivePartial: int32(snapshot.ConsecutivePartial),
+			LastImprovedAt:     nilIfZero(snapshot.LastImprovedAt),
+			LastCheckedAt:      nilIfZero(snapshot.LastReportAt),
+		}); err != nil {
+			return fmt.Errorf("store: storing advertiser health: %w", err)
+		}
+
+		if !out.Changed {
+			return nil
+		}
+		// It changed, so every device's candidate order may have changed with it. This is
+		// the whole point of the feature: an advertiser going unhealthy has to reach the
+		// devices routing through it without them asking.
+		if _, err := BumpVersion(ctx, q, row.NetworkID, RoutesChanged()); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return health.Transition{}, err
+	}
+	return out, nil
+}
+
+// ObserveRequest is one client's verdict on the advertiser it is using.
+type ObserveRequest struct {
+	NetworkID    uuid.UUID
+	AdvertiserID uuid.UUID
+
+	// Observed is what the device routing through this advertiser saw. Aggregation across
+	// devices — so one laptop's broken Wi-Fi is not mistaken for a broken exit — is the
+	// monitor's job, not this call's.
+	Observed health.Signal
+
+	Clock clock.Clock
+}
+
+func timeOrZero(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
+func nilIfZero(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}

--- a/internal/store/health_test.go
+++ b/internal/store/health_test.go
@@ -1,0 +1,238 @@
+package store
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/meshpnet/meshp/internal/clock"
+	"github.com/meshpnet/meshp/internal/health"
+)
+
+// advertiserFor returns an advertiser id for a device carrying a group.
+func advertiserFor(t *testing.T, s seeded, slug string, membershipID uuid.UUID) uuid.UUID {
+	t.Helper()
+	if err := s.Advertise(testContext(t), AdvertiseRequest{
+		NetworkID: s.netID, GroupSlug: slug, MembershipID: membershipID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var id uuid.UUID
+	if err := s.pool.QueryRow(testContext(t),
+		`SELECT id FROM route_advertisers WHERE membership_id = $1`, membershipID).Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// The signal the whole failover story rests on: devices report, the monitor fuses, and an
+// advertiser that stops working stops being offered.
+func TestClientReportsDriveAdvertiserHealth(t *testing.T) {
+	s, addDevice := seedNetwork(t)
+	ctx := testContext(t)
+	clk := clock.NewFake()
+	membershipID := addDevice()
+	subnetGroup(t, s, "branch")
+	advertiserID := advertiserFor(t, s, "branch", membershipID)
+
+	// Enough consecutive failures to cross the policy's threshold. The exact number is the
+	// policy's business; what matters here is that reports accumulate rather than each one
+	// deciding on its own.
+	var last health.Transition
+	for range 10 {
+		clk.Advance(time.Minute)
+		got, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+			NetworkID: s.netID, AdvertiserID: advertiserID,
+			Observed: health.SignalFail, Clock: clk,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		last = got
+	}
+	if last.To == health.StateHealthy || last.To == health.StateUnknown {
+		t.Fatalf("after ten failing reports the advertiser is %q", last.To)
+	}
+
+	// And it is persisted, so the next control plane to start does not begin again from
+	// nothing — which would restart every hysteresis window on each deploy.
+	var state string
+	var fails int32
+	if err := s.pool.QueryRow(ctx,
+		`SELECT state, consecutive_fail FROM advertiser_health WHERE advertiser_id = $1`,
+		advertiserID).Scan(&state, &fails); err != nil {
+		t.Fatal(err)
+	}
+	if fails == 0 {
+		t.Error("the counters were not persisted, so hysteresis restarts on every deploy")
+	}
+}
+
+// An advertiser going unhealthy has to reach the devices routing through it without them
+// asking, so the state version moves — but only when it actually changed.
+func TestOnlyARealChangeMovesTheStateVersion(t *testing.T) {
+	s, addDevice := seedNetwork(t)
+	ctx := testContext(t)
+	clk := clock.NewFake()
+	membershipID := addDevice()
+	subnetGroup(t, s, "branch")
+	advertiserID := advertiserFor(t, s, "branch", membershipID)
+
+	version := func() int64 {
+		t.Helper()
+		var v int64
+		if err := s.pool.QueryRow(ctx,
+			`SELECT state_version FROM networks WHERE id = $1`, s.netID).Scan(&v); err != nil {
+			t.Fatal(err)
+		}
+		return v
+	}
+
+	// Drive it to a settled state first.
+	for range 10 {
+		clk.Advance(time.Minute)
+		if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+			NetworkID: s.netID, AdvertiserID: advertiserID,
+			Observed: health.SignalFail, Clock: clk,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	settled := version()
+	for range 5 {
+		clk.Advance(time.Minute)
+		transition, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+			NetworkID: s.netID, AdvertiserID: advertiserID,
+			Observed: health.SignalFail, Clock: clk,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if transition.Changed {
+			t.Fatal("a repeat of the same verdict was reported as a change")
+		}
+	}
+	if after := version(); after != settled {
+		t.Errorf("routine reports moved the state version %d -> %d; a healthy network "+
+			"would be busier than a broken one", settled, after)
+	}
+}
+
+// A device can only ever speak about advertisers in a network it belongs to. Without this
+// a device in one network could steer another it cannot see.
+func TestAReportAboutAnotherNetworkIsRefused(t *testing.T) {
+	s, addDevice := seedNetwork(t)
+	ctx := testContext(t)
+	membershipID := addDevice()
+	subnetGroup(t, s, "branch")
+	advertiserID := advertiserFor(t, s, "branch", membershipID)
+
+	if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+		NetworkID: uuid.New(), AdvertiserID: advertiserID, Observed: health.SignalFail,
+	}); !errors.Is(err, ErrNoSuchAdvertiser) {
+		t.Errorf("error = %v, want ErrNoSuchAdvertiser", err)
+	}
+	if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+		NetworkID: s.netID, AdvertiserID: uuid.New(), Observed: health.SignalFail,
+	}); !errors.Is(err, ErrNoSuchAdvertiser) {
+		t.Errorf("unknown advertiser: error = %v, want ErrNoSuchAdvertiser", err)
+	}
+}
+
+// Health reaches selection, which is the only reason any of this exists.
+func TestAnUnhealthyAdvertiserIsRankedBelowAnUnknownOne(t *testing.T) {
+	s, addDevice := seedNetwork(t)
+	ctx := testContext(t)
+	clk := clock.NewFake()
+	broken, fresh := addDevice(), addDevice()
+	group := subnetGroup(t, s, "branch")
+	brokenID := advertiserFor(t, s, "branch", broken)
+	_ = advertiserFor(t, s, "branch", fresh)
+
+	for range 10 {
+		clk.Advance(time.Minute)
+		if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+			NetworkID: s.netID, AdvertiserID: brokenID,
+			Observed: health.SignalFail, Clock: clk,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rows, err := s.Advertisers(ctx, []uuid.UUID{group.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range rows {
+		if row.ID != brokenID {
+			continue
+		}
+		if row.HealthState == nil {
+			t.Fatal("the failing advertiser has no health for selection to read")
+		}
+		if health.State(*row.HealthState).Usable() {
+			t.Errorf("the failing advertiser is still usable: %q", *row.HealthState)
+		}
+		return
+	}
+	t.Fatal("the failing advertiser is no longer listed at all")
+}
+
+// The counters have to accumulate across reports, and across control-plane restarts. Each
+// call builds a fresh Monitor — there is no in-memory state between them — so if the stored
+// snapshot were not restored first, every observation would begin again from nothing and a
+// policy designed to resist flapping would flap on every deploy.
+//
+// Asserted on the count rather than on the resulting state, because a state that happens to
+// degrade on the first failure would hide this entirely. An earlier version of this file
+// tested only the state and passed with the restore removed.
+func TestCountersAccumulateAcrossReports(t *testing.T) {
+	s, addDevice := seedNetwork(t)
+	ctx := testContext(t)
+	clk := clock.NewFake()
+	membershipID := addDevice()
+	subnetGroup(t, s, "branch")
+	advertiserID := advertiserFor(t, s, "branch", membershipID)
+
+	const reports = 4
+	for range reports {
+		clk.Advance(time.Minute)
+		if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+			NetworkID: s.netID, AdvertiserID: advertiserID,
+			Observed: health.SignalFail, Clock: clk,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var fails int32
+	if err := s.pool.QueryRow(ctx,
+		`SELECT consecutive_fail FROM advertiser_health WHERE advertiser_id = $1`,
+		advertiserID).Scan(&fails); err != nil {
+		t.Fatal(err)
+	}
+	if fails != reports {
+		t.Fatalf("consecutive_fail = %d after %d failing reports; the stored counters are "+
+			"not being restored, so hysteresis restarts on every report", fails, reports)
+	}
+
+	// And a success resets it, which is the other half of the same mechanism.
+	clk.Advance(time.Minute)
+	if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+		NetworkID: s.netID, AdvertiserID: advertiserID,
+		Observed: health.SignalOK, Clock: clk,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.pool.QueryRow(ctx,
+		`SELECT consecutive_fail FROM advertiser_health WHERE advertiser_id = $1`,
+		advertiserID).Scan(&fails); err != nil {
+		t.Fatal(err)
+	}
+	if fails != 0 {
+		t.Errorf("consecutive_fail = %d after a success, want 0", fails)
+	}
+}

--- a/queries/routegroups.sql
+++ b/queries/routegroups.sql
@@ -103,3 +103,39 @@ ORDER BY a.route_group_id, a.priority, a.id;
 -- name: DeleteRouteAdvertiser :execrows
 DELETE FROM route_advertisers
 WHERE route_group_id = $1 AND membership_id = $2;
+
+-- name: GetAdvertiserHealth :one
+-- What the control plane last concluded about an advertiser, if anything.
+SELECT advertiser_id, state, consecutive_ok, consecutive_fail, consecutive_partial,
+       last_improved_at, last_checked_at
+FROM advertiser_health
+WHERE advertiser_id = $1;
+
+-- name: UpsertAdvertiserHealth :exec
+-- Store what the monitor concluded.
+--
+-- The whole snapshot rather than the state alone: the counters are what make the next
+-- observation mean anything, and a state persisted without them would restart every
+-- hysteresis window on each control-plane restart — turning a policy designed to resist
+-- flapping into one that flaps on deploys.
+INSERT INTO advertiser_health (
+    advertiser_id, state, consecutive_ok, consecutive_fail, consecutive_partial,
+    last_improved_at, last_checked_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (advertiser_id) DO UPDATE SET
+    state = EXCLUDED.state,
+    consecutive_ok = EXCLUDED.consecutive_ok,
+    consecutive_fail = EXCLUDED.consecutive_fail,
+    consecutive_partial = EXCLUDED.consecutive_partial,
+    last_improved_at = EXCLUDED.last_improved_at,
+    last_checked_at = EXCLUDED.last_checked_at;
+
+-- name: GetAdvertiserForReport :one
+-- The advertiser a device claims to be using, scoped to the network the session belongs to.
+--
+-- Scoped, because the id arrives from a device: without this a device in one network could
+-- report health for an advertiser in another, and steer a network it cannot see.
+SELECT a.id, a.route_group_id, g.network_id
+FROM route_advertisers a
+JOIN route_groups g ON g.id = a.route_group_id
+WHERE a.id = $1 AND g.network_id = $2;


### PR DESCRIPTION
The selection logic has consumed health since it was written and **nothing ever produced any** — every advertiser was `unknown`, so failover ordered candidates by priority and never by whether they worked. This closes that loop.

## Devices report, because they're the only ones who can

The control plane can reach an advertiser's host and learn almost nothing. What matters is whether traffic sent *through* it arrives, and only the devices using it observe that. `ReachabilityReport` has been in the protocol since the beginning for exactly this, wired to nothing.

## The whole snapshot is persisted, not just the state

Each report builds a fresh `Monitor` — there's no in-memory state between them. A state stored without its counters would restart every hysteresis window on each report *and* each restart, turning a policy designed to resist flapping into one that flaps on deploys.

## Only a real change moves the state version

Recomputing every agent's candidate order because one device sent a routine "still fine" would make a healthy network busier than a broken one.

## The network comes from the session, never the report

Everything else in that message is a device's claim about itself. Without this, a device in one network could report health for an advertiser in another and steer a network it cannot see.

Only `ClientObserved` is filled in — `health.Report` also takes the advertiser's self-report and a control-plane probe, neither of which exists yet. Leaving them as "nothing to say" is honest, and the monitor is built to fuse whatever it has.

## A test that proved nothing

`TestClientReportsDriveAdvertiserHealth` asserts on the resulting *state*, and **passed with the restore removed entirely** — the state degrades even when every report starts from scratch, so it was never testing accumulation. A mutation caught it.

`TestCountersAccumulateAcrossReports` asserts on the count itself: four failing reports must leave `consecutive_fail` at four, not one, and a success must reset it. That one fails when the restore is removed — which is what the first was supposed to do.

Three of four mutations caught before that; four of four after.

## What's still missing

**No agent sends this yet.** The agent-side probing — pick a candidate, probe it, report, switch on failure — is the other half and is its own slice. What's here is the server side: when a report arrives, health moves, and selection reorders.

Egress plus fail-closed (ADR-0011) remains the other open item.