### PR TITLE
feat(routes): decide when to leave an advertiser and when to come back

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ CROSS_TARGETS := linux/amd64 linux/arm64 linux/arm \
 # are held lower rather than pretended into the top tier. Packages needing PostgreSQL
 # are checked separately: without a database their tests skip, and the figure would be
 # meaningless rather than merely low.
-COVER_FLOOR_PKGS := internal/acl internal/tlsconf internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan internal/relayproto internal/relay internal/relaytoken
+COVER_FLOOR_PKGS := internal/acl internal/routeprobe internal/tlsconf internal/clock internal/health internal/ipam internal/routes internal/keys internal/challenge internal/logx internal/controlurl internal/peerset internal/wgplan internal/relayproto internal/relay internal/relaytoken
 COVER_FLOOR      := 90
 
 COVER_FLOOR_IO_PKGS := internal/nftables internal/agentapi internal/agentstate internal/httpx internal/tunnel internal/relayclient internal/relayforward internal/relaylink internal/sessionclient

--- a/internal/routeprobe/routeprobe.go
+++ b/internal/routeprobe/routeprobe.go
@@ -1,0 +1,261 @@
+// Package routeprobe decides which advertiser a device is using, and when to move.
+//
+// The server orders the candidates and the agent picks among them (ADR-0003). This is the
+// picking: given a stream of probe results, it says which candidate is current, when to
+// fall back, and when to return. Nothing here probes anything — that is I/O, and keeping it
+// out means the interesting decisions are testable against a fake clock rather than against
+// a network that has to be broken on cue.
+//
+// Two ideas shape it.
+//
+// **Falling back is cheap and coming back is not.** A device that moves to a working
+// advertiser has lost nothing; one that returns to a flapping advertiser loses every
+// connection each time it moves. So failures are counted low, recoveries are counted high,
+// and a minimum hold applies to the return but never to the escape.
+//
+// **The order is the server's.** This never invents a preference: it walks the list it was
+// given, and the only question it answers is how far down to be. An agent that reordered
+// candidates locally would make two devices behind the same policy disagree about what the
+// policy says.
+package routeprobe
+
+import (
+	"time"
+
+	"github.com/meshpnet/meshp/internal/clock"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// Defaults are used when a policy leaves a field at zero.
+//
+// A control plane that has not thought about failover should still get behaviour that does
+// not flap, so absent means "sensible" rather than "immediate".
+const (
+	DefaultFailThreshold    = 3
+	DefaultRecoverThreshold = 10
+	DefaultMinHold          = 60 * time.Second
+)
+
+// Chooser tracks which candidate is in use for each route group.
+//
+// Safe for concurrent use: the reconciler asks which candidate to configure while a prober
+// is folding results in.
+type Chooser struct {
+	clk    clock.Clock
+	groups map[string]*groupState
+}
+
+type groupState struct {
+	// currentID is the advertiser in use, empty before anything has been chosen.
+	currentID string
+
+	consecutiveFail int
+	consecutiveOK   int
+
+	// switchedAt is when the current choice was made, and what min-hold is measured from.
+	switchedAt time.Time
+
+	// preferredID is the head of the server's list. Kept so recovery has something to aim
+	// at: coming back means returning to the server's first preference, not merely to
+	// whatever happens to be one place up.
+	preferredID string
+}
+
+// New returns a Chooser.
+func New(clk clock.Clock) *Chooser {
+	if clk == nil {
+		clk = clock.System{}
+	}
+	return &Chooser{clk: clk, groups: make(map[string]*groupState)}
+}
+
+// Current returns the candidate to use for an assignment.
+//
+// The server's first preference until something has been observed to fail, which is the
+// honest default: an agent that has not probed knows nothing that the server does not.
+//
+// A candidate that has disappeared from the assignment is abandoned immediately, with no
+// hold: the server withdrawing a candidate is not a failure to be hysteretic about, it is
+// an instruction.
+func (c *Chooser) Current(assignment *meshpv1.RouteGroupAssignment) *meshpv1.RouteCandidate {
+	candidates := assignment.GetCandidates()
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	id := assignment.GetRouteGroupId()
+	state, ok := c.groups[id]
+	if !ok {
+		state = &groupState{}
+		c.groups[id] = state
+	}
+	state.preferredID = candidates[0].GetAdvertiserId()
+
+	// Pinned means never move, whatever is observed. It exists for groups whose egress
+	// address is allowlisted somewhere: moving would change the address, and a broken path
+	// is a better outcome than a working path from an address a bank will refuse.
+	if assignment.GetMode() == meshpv1.RouteGroupAssignment_MODE_PINNED {
+		state.currentID = candidates[0].GetAdvertiserId()
+		return candidates[0]
+	}
+
+	if state.currentID == "" {
+		state.currentID = candidates[0].GetAdvertiserId()
+		state.switchedAt = c.clk.Now()
+		return candidates[0]
+	}
+	for _, candidate := range candidates {
+		if candidate.GetAdvertiserId() == state.currentID {
+			return candidate
+		}
+	}
+
+	// The current choice is gone from the list.
+	state.currentID = candidates[0].GetAdvertiserId()
+	state.switchedAt = c.clk.Now()
+	state.consecutiveFail, state.consecutiveOK = 0, 0
+	return candidates[0]
+}
+
+// Result is what a probe of the current candidate found.
+type Result struct {
+	// Reachable is the quorum verdict across the probe targets, not one target's answer:
+	// a single target measures that target's path rather than the advertiser's health.
+	Reachable bool
+
+	// RTT is informational and reported onward; nothing here branches on it.
+	RTT time.Duration
+}
+
+// Decision is what a probe result led to.
+type Decision struct {
+	// Report is true when the control plane should be told. Every change is reported, and
+	// so is the first result for a group — a device that only spoke up on change would
+	// leave an advertiser at "unknown" for as long as it kept working, which is exactly
+	// when the server most wants to hear that it does.
+	Report bool
+
+	// Switched names the advertiser left behind, empty when nothing moved.
+	Switched string
+
+	// Reason is written for whoever reads an audit log later, wanting to know why their
+	// traffic moved.
+	Reason string
+
+	// Current is the advertiser now in use.
+	Current string
+}
+
+// Observe folds a probe result in and reports what it led to.
+func (c *Chooser) Observe(assignment *meshpv1.RouteGroupAssignment, result Result) Decision {
+	id := assignment.GetRouteGroupId()
+	state, ok := c.groups[id]
+	if !ok || state.currentID == "" {
+		// Nothing has been chosen, so there is nothing to have probed.
+		return Decision{}
+	}
+
+	policy := assignment.GetLocalFailover()
+	failThreshold := orDefault(int(policy.GetFailThreshold()), DefaultFailThreshold)
+	recoverThreshold := orDefault(int(policy.GetRecoverThreshold()), DefaultRecoverThreshold)
+	minHold := DefaultMinHold
+	if policy.GetMinHoldSeconds() > 0 {
+		minHold = time.Duration(policy.GetMinHoldSeconds()) * time.Second
+	}
+
+	first := state.consecutiveFail == 0 && state.consecutiveOK == 0
+	decision := Decision{Current: state.currentID, Report: first}
+
+	if !result.Reachable {
+		state.consecutiveOK = 0
+		state.consecutiveFail++
+		if state.consecutiveFail < failThreshold {
+			return decision
+		}
+		// No hold on the way out. A minimum time between switches exists to stop a device
+		// oscillating back to something broken, not to keep it sitting on something that
+		// has already failed the threshold.
+		if next := c.fallback(assignment, state); next != "" {
+			decision.Switched = state.currentID
+			decision.Reason = "the advertiser in use stopped answering probes"
+			c.moveTo(state, next)
+			decision.Current = next
+			decision.Report = true
+		}
+		return decision
+	}
+
+	state.consecutiveFail = 0
+	state.consecutiveOK++
+
+	// Already where the server would put us; nothing to return to.
+	if state.currentID == state.preferredID {
+		return decision
+	}
+	if !assignment.GetLocalFailover().GetEnabled() && policy != nil {
+		// Failover switched off means stay where you are once you have moved, rather than
+		// oscillate under a policy that says not to.
+		return decision
+	}
+	if state.consecutiveOK < recoverThreshold {
+		return decision
+	}
+	if c.clk.Now().Sub(state.switchedAt) < minHold {
+		// The hold applies here and only here. Returning early to an advertiser that is
+		// intermittently healthy is how a device ends up moving every few seconds, and each
+		// move costs every connection through it.
+		return decision
+	}
+
+	decision.Switched = state.currentID
+	decision.Reason = "the preferred advertiser is answering again"
+	c.moveTo(state, state.preferredID)
+	decision.Current = state.preferredID
+	decision.Report = true
+	return decision
+}
+
+// fallback picks the next candidate after the current one, or nothing.
+func (c *Chooser) fallback(assignment *meshpv1.RouteGroupAssignment, state *groupState) string {
+	candidates := assignment.GetCandidates()
+	for i, candidate := range candidates {
+		if candidate.GetAdvertiserId() != state.currentID {
+			continue
+		}
+		if i+1 < len(candidates) {
+			return candidates[i+1].GetAdvertiserId()
+		}
+		// The last one failed. Staying put rather than wrapping to the front: the front is
+		// where this started, and cycling a list of advertisers that are all failing would
+		// move a device continuously while nothing improved.
+		return ""
+	}
+	return ""
+}
+
+func (c *Chooser) moveTo(state *groupState, advertiserID string) {
+	state.currentID = advertiserID
+	state.switchedAt = c.clk.Now()
+	state.consecutiveFail, state.consecutiveOK = 0, 0
+}
+
+// Forget drops state for groups no longer assigned, so a device that carried a prefix for a
+// while does not remember its choice forever.
+func (c *Chooser) Forget(assigned []*meshpv1.RouteGroupAssignment) {
+	keep := make(map[string]struct{}, len(assigned))
+	for _, a := range assigned {
+		keep[a.GetRouteGroupId()] = struct{}{}
+	}
+	for id := range c.groups {
+		if _, ok := keep[id]; !ok {
+			delete(c.groups, id)
+		}
+	}
+}
+
+func orDefault(v, fallback int) int {
+	if v <= 0 {
+		return fallback
+	}
+	return v
+}

--- a/internal/routeprobe/routeprobe_test.go
+++ b/internal/routeprobe/routeprobe_test.go
@@ -1,0 +1,276 @@
+package routeprobe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/clock"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+func assignment(ids ...string) *meshpv1.RouteGroupAssignment {
+	a := &meshpv1.RouteGroupAssignment{RouteGroupId: "g", Name: "branch"}
+	for i, id := range ids {
+		a.Candidates = append(a.Candidates, &meshpv1.RouteCandidate{
+			AdvertiserId: id, Priority: uint32(i + 1),
+		})
+	}
+	a.LocalFailover = &meshpv1.LocalFailoverPolicy{Enabled: true}
+	return a
+}
+
+func fail(t *testing.T, c *Chooser, a *meshpv1.RouteGroupAssignment, n int) Decision {
+	t.Helper()
+	var last Decision
+	for range n {
+		last = c.Observe(a, Result{Reachable: false})
+	}
+	return last
+}
+
+func succeed(t *testing.T, c *Chooser, a *meshpv1.RouteGroupAssignment, n int) Decision {
+	t.Helper()
+	var last Decision
+	for range n {
+		last = c.Observe(a, Result{Reachable: true})
+	}
+	return last
+}
+
+// An agent that has not probed knows nothing the server does not, so it starts where the
+// server put it.
+func TestItStartsAtTheServersFirstPreference(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+
+	if got := c.Current(a); got.GetAdvertiserId() != "primary" {
+		t.Fatalf("started at %q, want primary", got.GetAdvertiserId())
+	}
+}
+
+// The point of the whole package: an advertiser that stops answering is left behind.
+func TestItFallsBackAfterEnoughFailures(t *testing.T) {
+	clk := clock.NewFake()
+	c := New(clk)
+	a := assignment("primary", "backup")
+	c.Current(a)
+
+	// Below the threshold, nothing moves. One failed probe is a packet loss, not an outage.
+	if d := fail(t, c, a, DefaultFailThreshold-1); d.Switched != "" {
+		t.Fatalf("moved after %d failures: %+v", DefaultFailThreshold-1, d)
+	}
+	if got := c.Current(a); got.GetAdvertiserId() != "primary" {
+		t.Fatalf("moved early to %q", got.GetAdvertiserId())
+	}
+
+	d := c.Observe(a, Result{Reachable: false})
+	if d.Switched != "primary" || d.Current != "backup" {
+		t.Fatalf("decision = %+v, want a move from primary to backup", d)
+	}
+	if !d.Report {
+		t.Error("a switch was not reported; the control plane would never learn of it")
+	}
+	if d.Reason == "" {
+		t.Error("no reason was given for the move")
+	}
+	if got := c.Current(a); got.GetAdvertiserId() != "backup" {
+		t.Errorf("Current is %q after the move", got.GetAdvertiserId())
+	}
+}
+
+// Falling back is cheap and coming back is not. A hold on the escape would keep a device
+// sitting on something that has already failed the threshold.
+func TestThereIsNoHoldOnTheWayOut(t *testing.T) {
+	clk := clock.NewFake()
+	c := New(clk)
+	a := assignment("primary", "backup", "third")
+	a.LocalFailover.MinHoldSeconds = 3600
+	c.Current(a)
+
+	if d := fail(t, c, a, DefaultFailThreshold); d.Current != "backup" {
+		t.Fatalf("did not leave a failing advertiser under a long hold: %+v", d)
+	}
+	// And on again, immediately, without waiting out the hold.
+	if d := fail(t, c, a, DefaultFailThreshold); d.Current != "third" {
+		t.Fatalf("did not move on from the second failing advertiser: %+v", d)
+	}
+}
+
+// Returning to a flapping advertiser costs every connection each time. So recovery needs
+// more evidence than failure, and it waits.
+func TestComingBackNeedsMoreEvidenceAndTime(t *testing.T) {
+	clk := clock.NewFake()
+	c := New(clk)
+	a := assignment("primary", "backup")
+	a.LocalFailover.MinHoldSeconds = 60
+	c.Current(a)
+	fail(t, c, a, DefaultFailThreshold)
+
+	// Enough successes, but too soon.
+	if d := succeed(t, c, a, DefaultRecoverThreshold); d.Switched != "" {
+		t.Fatalf("returned before the hold elapsed: %+v", d)
+	}
+	if got := c.Current(a); got.GetAdvertiserId() != "backup" {
+		t.Fatalf("Current is %q, want backup", got.GetAdvertiserId())
+	}
+
+	clk.Advance(2 * time.Minute)
+	d := succeed(t, c, a, 1)
+	if d.Switched != "backup" || d.Current != "primary" {
+		t.Fatalf("did not return once the hold elapsed: %+v", d)
+	}
+	if !d.Report {
+		t.Error("the return was not reported")
+	}
+}
+
+// Too few successes must not be enough, however long has passed.
+func TestTimeAloneDoesNotBringItBack(t *testing.T) {
+	clk := clock.NewFake()
+	c := New(clk)
+	a := assignment("primary", "backup")
+	c.Current(a)
+	fail(t, c, a, DefaultFailThreshold)
+
+	clk.Advance(time.Hour)
+	if d := succeed(t, c, a, DefaultRecoverThreshold-1); d.Switched != "" {
+		t.Fatalf("returned on %d successes: %+v", DefaultRecoverThreshold-1, d)
+	}
+}
+
+// A run of successes broken by a failure starts again, or an advertiser that works nine
+// times out of ten would be treated as recovered.
+func TestAFailureResetsTheRecoveryCount(t *testing.T) {
+	clk := clock.NewFake()
+	c := New(clk)
+	a := assignment("primary", "backup")
+	c.Current(a)
+	fail(t, c, a, DefaultFailThreshold)
+	clk.Advance(time.Hour)
+
+	succeed(t, c, a, DefaultRecoverThreshold-1)
+	c.Observe(a, Result{Reachable: false})
+	if d := succeed(t, c, a, DefaultRecoverThreshold-1); d.Switched != "" {
+		t.Fatalf("a broken run still counted as recovery: %+v", d)
+	}
+	if d := succeed(t, c, a, 1); d.Switched != "backup" {
+		t.Fatalf("did not recover once the run was long enough: %+v", d)
+	}
+}
+
+// The last candidate failing has nowhere to go. Wrapping to the front would move a device
+// continuously while nothing improved.
+func TestTheLastCandidateIsNotWrappedPast(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("only")
+	c.Current(a)
+
+	if d := fail(t, c, a, DefaultFailThreshold*3); d.Switched != "" {
+		t.Fatalf("moved away from the only candidate: %+v", d)
+	}
+	if got := c.Current(a); got.GetAdvertiserId() != "only" {
+		t.Errorf("Current is %q", got.GetAdvertiserId())
+	}
+}
+
+// Pinned means never move, whatever is observed. It exists for groups whose egress address
+// is allowlisted somewhere: a broken path is a better outcome than a working path from an
+// address a bank will refuse.
+func TestPinnedNeverMoves(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	a.Mode = meshpv1.RouteGroupAssignment_MODE_PINNED
+	c.Current(a)
+
+	if d := fail(t, c, a, DefaultFailThreshold*3); d.Switched != "" {
+		t.Fatalf("a pinned group moved: %+v", d)
+	}
+	if got := c.Current(a); got.GetAdvertiserId() != "primary" {
+		t.Errorf("Current is %q, want primary", got.GetAdvertiserId())
+	}
+}
+
+// The server withdrawing a candidate is an instruction, not a failure, so there is nothing
+// to be hysteretic about.
+func TestACandidateThatDisappearsIsAbandonedAtOnce(t *testing.T) {
+	clk := clock.NewFake()
+	c := New(clk)
+	a := assignment("primary", "backup")
+	c.Current(a)
+	fail(t, c, a, DefaultFailThreshold)
+	if got := c.Current(a); got.GetAdvertiserId() != "backup" {
+		t.Fatalf("expected to be on backup, got %q", got.GetAdvertiserId())
+	}
+
+	// The server drops backup from the list entirely.
+	narrowed := assignment("primary")
+	narrowed.RouteGroupId = "g"
+	if got := c.Current(narrowed); got.GetAdvertiserId() != "primary" {
+		t.Fatalf("kept using a withdrawn candidate: %q", got.GetAdvertiserId())
+	}
+}
+
+// The first result is reported even when nothing changed. A device that only spoke up on
+// change would leave a working advertiser at "unknown" for as long as it kept working —
+// which is exactly when the server most wants to hear that it does.
+func TestTheFirstResultIsAlwaysReported(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	c.Current(a)
+
+	if d := c.Observe(a, Result{Reachable: true}); !d.Report {
+		t.Fatal("the first result was not reported")
+	}
+	if d := c.Observe(a, Result{Reachable: true}); d.Report {
+		t.Error("a routine repeat was reported; a healthy network would be noisier than a broken one")
+	}
+}
+
+// Observing a group nothing has been chosen for is not a crash and not a decision.
+func TestObservingAnUnknownGroupDoesNothing(t *testing.T) {
+	c := New(clock.NewFake())
+	if d := c.Observe(assignment("primary"), Result{Reachable: false}); d.Report || d.Switched != "" {
+		t.Errorf("decision = %+v, want nothing", d)
+	}
+}
+
+func TestAnAssignmentWithNoCandidatesHasNoCurrent(t *testing.T) {
+	c := New(clock.NewFake())
+	if got := c.Current(&meshpv1.RouteGroupAssignment{RouteGroupId: "g"}); got != nil {
+		t.Errorf("Current = %+v, want nothing", got)
+	}
+}
+
+// A device that carried a prefix for a while must not remember its choice forever.
+func TestForgetDropsGroupsNoLongerAssigned(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	c.Current(a)
+	fail(t, c, a, DefaultFailThreshold)
+
+	c.Forget(nil)
+	// Back to the server's first preference, because nothing is remembered.
+	if got := c.Current(a); got.GetAdvertiserId() != "primary" {
+		t.Errorf("Current is %q after forgetting", got.GetAdvertiserId())
+	}
+}
+
+// A policy that names its own thresholds is honoured; one that names none gets defaults
+// that do not flap.
+func TestPolicyThresholdsAreHonoured(t *testing.T) {
+	clk := clock.NewFake()
+	c := New(clk)
+	a := assignment("primary", "backup")
+	a.LocalFailover = &meshpv1.LocalFailoverPolicy{
+		Enabled: true, FailThreshold: 1, RecoverThreshold: 1, MinHoldSeconds: 1,
+	}
+	c.Current(a)
+
+	if d := c.Observe(a, Result{Reachable: false}); d.Current != "backup" {
+		t.Fatalf("a fail threshold of one did not move on the first failure: %+v", d)
+	}
+	clk.Advance(2 * time.Second)
+	if d := c.Observe(a, Result{Reachable: true}); d.Current != "primary" {
+		t.Fatalf("a recover threshold of one did not return: %+v", d)
+	}
+}


### PR DESCRIPTION
The agent's half of failover, as the *decision* it is rather than the I/O it needs. Given a stream of probe results it says which candidate is current, when to fall back and when to return — and probes nothing, so the interesting behaviour is testable against a fake clock instead of a network that has to break on cue.

**Nothing probes yet and nothing sends the report.** Wiring this to real probes and to `ReachabilityReport` is the next slice; the control plane has consumed those reports since #39.

## Falling back is cheap; coming back is not

A device that moves to a working advertiser has lost nothing. One that returns to a *flapping* advertiser loses every connection each time it moves.

So: failures counted low, recoveries counted high, and **the minimum hold applies to the return and never to the escape**. A hold on the way out would keep a device sitting on something that has already failed its threshold.

## The order is the server's

This never invents a preference — it walks the list it was given and answers only how far down to be. An agent that reordered locally would make two devices behind the same policy disagree about what the policy says.

Recovery aims at the *head* of that list rather than one place up, because the server's first preference is the only thing "back" can mean.

## Edges that are decisions, not oversights

- **The last candidate failing has nowhere to go.** Wrapping to the front would move a device continuously while nothing improved.
- **Pinned groups never move.** They exist for egress addresses allowlisted with a bank or vendor, where a broken path beats a working path from an address that gets refused.
- **A withdrawn candidate is abandoned at once**, no hold — a withdrawal is an instruction, not a failure to be hysteretic about.
- **The first result is always reported.** A device that only spoke up on change would leave a working advertiser at `unknown` for as long as it kept working, which is exactly when the server most wants to hear that it does.

## Mutation testing, honestly

Six checked. Three of my first attempts didn't compile, and a fourth **mutated a line next to the one it meant** — it passed while proving nothing, because the reset it claimed to test lives on the other branch. Redone precisely, all six are caught.

95.3% coverage, added to the strict floor.