### PR TITLE
feat(routes): fail over from an advertiser that has gone silent

### DIFF
--- a/internal/tunnel/probe.go
+++ b/internal/tunnel/probe.go
@@ -1,0 +1,75 @@
+package tunnel
+
+import (
+	"time"
+
+	"github.com/meshpnet/meshp/internal/routeprobe"
+	"github.com/meshpnet/meshp/internal/wgplan"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// livenessGrace is how stale a handshake may be before the peer counts as unreachable.
+//
+// WireGuard rekeys well inside two minutes on a peer carrying traffic, and a peer with a
+// keepalive answers regardless. Longer than REJECT_AFTER_TIME on purpose: the question is
+// whether this advertiser is reachable at all, not whether the current session is fresh, and
+// declaring a working advertiser dead because a rekey was a few seconds late would move a
+// device for no reason.
+const livenessGrace = 3 * time.Minute
+
+// probeFromHandshake reads the observed interface for a verdict on one advertiser.
+//
+// An honest first probe rather than the intended one. What the failover policy asks for is
+// traffic sent *through* the advertiser to diverse targets, which measures what a user
+// experiences; this measures only whether the advertiser itself is reachable. The
+// difference matters — a gateway whose own uplink has failed still handshakes — so this
+// catches an advertiser that is off or unreachable and not one that is present and useless.
+//
+// It is worth having anyway because it costs nothing: the reconciler already reads this
+// from the kernel on every pass, so a device fails over from a dead gateway without a
+// single extra packet. Probing through the advertiser is the next slice, and this is the
+// subset that needs no new I/O to be true.
+func probeFromHandshake(observed wgplan.Observed, peerKey string) (routeprobe.Result, bool) {
+	for _, peer := range observed.Peers {
+		if string(peer.PublicKey) != peerKey {
+			continue
+		}
+		// No handshake yet is not a failure. A peer that has just been configured has not
+		// had time, and counting it against the advertiser would fail a device over before
+		// it had ever tried.
+		//
+		// Defensive rather than load-bearing, and said so because a mutation proved it:
+		// the kernel reports a zero age alongside no handshake, so falling through would
+		// read as reachable and reach the same answer. It stays because the two facts are
+		// separate — a future source of observations could report an age without a
+		// handshake — and because "no handshake" and "handshake three minutes ago" should
+		// not be one branch by accident.
+		if !peer.HasHandshake {
+			return routeprobe.Result{}, false
+		}
+		return routeprobe.Result{
+			Reachable: peer.HandshakeAge <= livenessGrace,
+			RTT:       0, // not measurable from a handshake
+		}, true
+	}
+	// The advertiser is not a peer of this device at all, which is a different problem and
+	// already reported as an unhonoured group.
+	return routeprobe.Result{}, false
+}
+
+// chosenCandidate is the candidate this device should use for an assignment.
+//
+// The chooser's answer rather than the server's first preference, which is the whole point
+// of the previous slice: the server orders the candidates and the agent decides how far
+// down the list to be (ADR-0003).
+func chosenCandidate(chooser *routeprobe.Chooser, assignment *meshpv1.RouteGroupAssignment) *meshpv1.RouteCandidate {
+	if chooser == nil {
+		// No chooser: take the server's order verbatim. That is what this did before local
+		// failover existed, and it is the right behaviour for a build without one.
+		if candidates := assignment.GetCandidates(); len(candidates) > 0 {
+			return candidates[0]
+		}
+		return nil
+	}
+	return chooser.Current(assignment)
+}

--- a/internal/tunnel/routegroups.go
+++ b/internal/tunnel/routegroups.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 
 	"github.com/meshpnet/meshp/internal/logx"
+	"github.com/meshpnet/meshp/internal/routeprobe"
 	"github.com/meshpnet/meshp/internal/wgplan"
 	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
 )
@@ -26,7 +27,7 @@ import (
 // Returns the group names it could not honour, which the caller reports as unapplied rather
 // than swallowing: a device quietly not carrying a prefix it was assigned is indistinguishable
 // from one that is, right up until somebody tries to use it.
-func applyRouteGroups(iface *wgplan.Interface, assignments []*meshpv1.RouteGroupAssignment, log *slog.Logger) []string {
+func applyRouteGroups(iface *wgplan.Interface, assignments []*meshpv1.RouteGroupAssignment, chooser *routeprobe.Chooser, log *slog.Logger) []string {
 	if len(assignments) == 0 {
 		return nil
 	}
@@ -62,16 +63,17 @@ func applyRouteGroups(iface *wgplan.Interface, assignments []*meshpv1.RouteGroup
 			continue
 		}
 
-		candidates := assignment.GetCandidates()
-		if len(candidates) == 0 {
+		// The chooser's answer, not the server's first preference. The server orders the
+		// candidates and the agent decides how far down the list to be (ADR-0003), which is
+		// what makes a device fail over without asking the control plane first.
+		best := chosenCandidate(chooser, assignment)
+		if best == nil {
 			// The server withdraws a group nobody can carry rather than sending it empty,
 			// so this means the two ends disagree. Reported rather than ignored.
 			log.Warn("a route group arrived with no candidates", "group", logx.Safe(name))
 			unhonoured = append(unhonoured, name)
 			continue
 		}
-
-		best := candidates[0]
 		index, ok := byKey[wgplan.Key(best.GetPeerPublicKey())]
 		if !ok {
 			// Assigned a carrier that is not in this device's peer list. Nothing can be

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/meshpnet/meshp/internal/logx"
 	"github.com/meshpnet/meshp/internal/peerset"
+	"github.com/meshpnet/meshp/internal/routeprobe"
 	"github.com/meshpnet/meshp/internal/wglink"
 	"github.com/meshpnet/meshp/internal/wgplan"
 	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
@@ -98,6 +99,11 @@ type Reconciler struct {
 	// counters an operator is reading.
 	lastFilter *meshpv1.PacketFilter
 
+	// chooser decides which candidate carries each group. Nil where local failover is not
+	// wanted, in which case the server's order is taken verbatim — which is what this did
+	// before there was a chooser.
+	chooser *routeprobe.Chooser
+
 	// lastAdvertised is the same idea for forwarding, and matters more: reloading the NAT
 	// table flushes its conntrack-independent counters and, on some kernels, disturbs
 	// in-flight masqueraded flows. An unchanged assignment is left alone.
@@ -137,6 +143,16 @@ func New(link wglink.Link, m Membership, relay Relay, filter Filter, log *slog.L
 	}
 }
 
+// WithChooser gives the reconciler local failover.
+//
+// Separate from New because a reconciler without one is a legitimate configuration — a
+// build with no probing takes the server's order, which is what every device did before
+// this existed — and because the chooser holds state that outlives one Apply.
+func (r *Reconciler) WithChooser(c *routeprobe.Chooser) *Reconciler {
+	r.chooser = c
+	return r
+}
+
 // Status is what the daemon reports about this tunnel.
 type Status struct {
 	Up             bool
@@ -167,7 +183,7 @@ func (r *Reconciler) Status() Status {
 // The returned components are the parts that did not converge, which the agent reports back
 // so the control plane knows this device is not where it says it is.
 func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, error) {
-	want, unhonoured, err := Desired(r.membership, state, r.relay, r.log)
+	want, unhonoured, err := Desired(r.membership, state, r.relay, r.chooser, r.log)
 	if err != nil {
 		// A description the kernel would refuse, or one wgplan judged unsafe. Reported
 		// rather than approximated: applying part of a rejected configuration is how an
@@ -200,6 +216,11 @@ func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, e
 			"peers", len(want.Peers),
 			"operations", len(plan.Ops))
 	}
+
+	// Every probe this pass costs is a read the reconciler already did. A device whose
+	// gateway has gone silent therefore fails over on the next tick without sending a
+	// single extra packet.
+	r.observeAdvertisers(observed, state.RouteGroups())
 
 	// Which implementation ended up behind it, read rather than assumed. ADR-0015 requires
 	// this to be reportable: a silent userspace fallback makes a tenfold difference in
@@ -312,6 +333,36 @@ func (r *Reconciler) applyFilter(ctx context.Context, iface string, want *meshpv
 	return nil
 }
 
+// observeAdvertisers folds what the interface shows into the chooser.
+//
+// Decisions are not acted on here. The chooser records them, and the next Apply configures
+// whatever it now points at — which keeps "decide" and "converge" in the order the rest of
+// this package uses, rather than reconfiguring an interface half way through reading it.
+func (r *Reconciler) observeAdvertisers(observed wgplan.Observed, assignments []*meshpv1.RouteGroupAssignment) {
+	if r.chooser == nil || len(assignments) == 0 {
+		return
+	}
+	for _, assignment := range assignments {
+		current := r.chooser.Current(assignment)
+		if current == nil {
+			continue
+		}
+		result, ok := probeFromHandshake(observed, current.GetPeerPublicKey())
+		if !ok {
+			continue
+		}
+		if decision := r.chooser.Observe(assignment, result); decision.Switched != "" {
+			r.log.Info("moving to another advertiser",
+				"group", logx.Safe(assignment.GetName()),
+				"from", logx.Safe(decision.Switched), "to", logx.Safe(decision.Current),
+				"reason", logx.Safe(decision.Reason))
+		}
+	}
+	// A group no longer assigned should not be remembered, or a device that carried a
+	// prefix for a while keeps its choice forever.
+	r.chooser.Forget(assignments)
+}
+
 // applyForwarding makes this host carry what it advertises, or stop.
 //
 // Skipped when nothing changed, like the filter and for a sharper reason: rebuilding the NAT
@@ -413,7 +464,7 @@ func (r *Reconciler) fail(err error) {
 // The second return names route groups this device was assigned and could not carry. It is
 // a translation result rather than part of the interface description, which is why it comes
 // back separately: wgplan plans kernel operations, and "what is missing" is not one.
-func Desired(m Membership, state *peerset.Set, relay Relay, log *slog.Logger) (wgplan.Interface, []string, error) {
+func Desired(m Membership, state *peerset.Set, relay Relay, chooser *routeprobe.Chooser, log *slog.Logger) (wgplan.Interface, []string, error) {
 	if log == nil {
 		log = slog.New(slog.DiscardHandler)
 	}
@@ -465,7 +516,7 @@ func Desired(m Membership, state *peerset.Set, relay Relay, log *slog.Logger) (w
 	//
 	// Reported rather than fatal: one group this device cannot honour must not cost it the
 	// peers and prefixes it can.
-	unhonoured := applyRouteGroups(&iface, state.RouteGroups(), log)
+	unhonoured := applyRouteGroups(&iface, state.RouteGroups(), chooser, log)
 	return iface, unhonoured, nil
 }
 

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/meshpnet/meshp/internal/clock"
 	"github.com/meshpnet/meshp/internal/peerset"
+	"github.com/meshpnet/meshp/internal/routeprobe"
 	"github.com/meshpnet/meshp/internal/wglink"
 	"github.com/meshpnet/meshp/internal/wgplan"
 	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
@@ -335,7 +337,7 @@ func TestDesiredRendersAddressesAsHostPrefixes(t *testing.T) {
 	m.AddressV4 = "100.90.0.1"
 	m.AddressV6 = "fd7c::1"
 
-	iface, _, err := Desired(m, stateWith(1), nil, nil)
+	iface, _, err := Desired(m, stateWith(1), nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,7 +359,7 @@ func TestDesiredRefusesAnAddressThatIsNotOneHost(t *testing.T) {
 		m := membership()
 		m.AddressV4 = addr
 		m.AddressV6 = ""
-		if _, _, err := Desired(m, stateWith(1), nil, nil); err == nil {
+		if _, _, err := Desired(m, stateWith(1), nil, nil, nil); err == nil {
 			t.Errorf("%s was accepted", addr)
 		}
 	}
@@ -370,7 +372,7 @@ func TestDesiredAcceptsAnAddressThatAlreadyCarriesItsPrefix(t *testing.T) {
 	m.AddressV4 = "100.90.0.1/32"
 	m.AddressV6 = "fd7c::1/128"
 
-	iface, _, err := Desired(m, stateWith(1), nil, nil)
+	iface, _, err := Desired(m, stateWith(1), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Desired: %v", err)
 	}
@@ -383,14 +385,14 @@ func TestDesiredRefusesAMembershipWithNothingToWorkFrom(t *testing.T) {
 	t.Run("no private key", func(t *testing.T) {
 		m := membership()
 		m.PrivateKey = ""
-		if _, _, err := Desired(m, stateWith(1), nil, nil); err == nil {
+		if _, _, err := Desired(m, stateWith(1), nil, nil, nil); err == nil {
 			t.Error("a membership with no private key was accepted")
 		}
 	})
 	t.Run("no addresses", func(t *testing.T) {
 		m := membership()
 		m.AddressV4, m.AddressV6 = "", ""
-		if _, _, err := Desired(m, stateWith(1), nil, nil); err == nil {
+		if _, _, err := Desired(m, stateWith(1), nil, nil, nil); err == nil {
 			t.Error("a membership with no addresses was accepted")
 		}
 	})
@@ -405,7 +407,7 @@ func TestDesiredTakesTheMTUFromTheServer(t *testing.T) {
 		Tunnel: &meshpv1.TunnelConfig{Mtu: 1280},
 	})
 
-	iface, _, err := Desired(membership(), state, nil, nil)
+	iface, _, err := Desired(membership(), state, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -420,7 +422,7 @@ func TestDesiredFallsBackToADefaultMTU(t *testing.T) {
 	state := peerset.New()
 	state.Apply(&meshpv1.StateDelta{FromVersion: 0, ToVersion: 1})
 
-	iface, _, err := Desired(membership(), state, nil, nil)
+	iface, _, err := Desired(membership(), state, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -435,7 +437,7 @@ func TestDesiredFallsBackToADefaultMTU(t *testing.T) {
 // A peer with no endpoint is configured and unreachable, which is the honest state of every
 // peer today: nothing discovers endpoints yet.
 func TestAPeerWithNoEndpointIsStillConfigured(t *testing.T) {
-	iface, _, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -456,7 +458,7 @@ func TestTheFirstEndpointIsUsed(t *testing.T) {
 	p := peer(bobKey, "100.90.0.2/32")
 	p.Endpoints = []string{"203.0.113.2:51820", "198.51.100.2:51820"}
 
-	iface, _, err := Desired(membership(), stateWith(1, p), nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, p), nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -468,7 +470,7 @@ func TestTheFirstEndpointIsUsed(t *testing.T) {
 // The key is carried through untouched. wgplan does not parse keys, so a translation that
 // mangled one would only fail at the kernel, on a real host, with a confusing message.
 func TestKeysArePassedThroughUnchanged(t *testing.T) {
-	iface, _, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -582,7 +584,7 @@ func TestARememberedPortIsAskedForAgain(t *testing.T) {
 	m := membership()
 	m.ListenPort = 51999
 
-	iface, _, err := Desired(m, stateWith(1), nil, nil)
+	iface, _, err := Desired(m, stateWith(1), nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -593,7 +595,7 @@ func TestARememberedPortIsAskedForAgain(t *testing.T) {
 
 // A membership that has never come up asks for any port.
 func TestAMembershipWithNoPortAsksForAny(t *testing.T) {
-	iface, _, err := Desired(membership(), stateWith(1), nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1), nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -653,7 +655,7 @@ func TestARelayedPeerIsGivenItsLoopbackEndpoint(t *testing.T) {
 	relay := newFakeRelay("relay1")
 
 	iface, _, err := Desired(membership(),
-		stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32")), relay, nil)
+		stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32")), relay, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -681,7 +683,7 @@ func TestADirectEndpointWinsOverARelay(t *testing.T) {
 	p := relayedPeer(bobKey, "relay1", "100.90.0.2/32")
 	p.Endpoints = []string{"203.0.113.2:51820"}
 
-	iface, _, err := Desired(membership(), stateWith(1, p), relay, nil)
+	iface, _, err := Desired(membership(), stateWith(1, p), relay, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -704,7 +706,7 @@ func TestAPeerOnAnUnreachableRelayDoesNotBreakTheOthers(t *testing.T) {
 	iface, _, err := Desired(membership(), stateWith(1,
 		relayedPeer(bobKey, "relay1", "100.90.0.2/32"),
 		relayedPeer(carolKey, "relay2", "100.90.0.3/32"),
-	), relay, nil)
+	), relay, nil, nil)
 	if err != nil {
 		t.Fatalf("one unreachable relay refused the whole interface: %v", err)
 	}
@@ -728,7 +730,7 @@ func TestAPeerOnAnUnreachableRelayDoesNotBreakTheOthers(t *testing.T) {
 // relayed peer is unreachable rather than refused.
 func TestNoRelayLeavesRelayedPeersWithoutEndpoints(t *testing.T) {
 	iface, _, err := Desired(membership(),
-		stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32")), nil, nil)
+		stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32")), nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1070,7 +1072,7 @@ func TestACarriedPrefixReachesTheCarrierAndTheRoutingTable(t *testing.T) {
 		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch-lan", bobKey, "192.168.10.0/24")},
 		peer(bobKey, "100.90.0.2/32"))
 
-	iface, unhonoured, err := Desired(membership(), state, nil, nil)
+	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1112,7 +1114,7 @@ func TestAnEgressGroupIsRefusedUntilItIsSafe(t *testing.T) {
 		[]*meshpv1.RouteGroupAssignment{assignmentTo("exit", bobKey, "0.0.0.0/0", "::/0")},
 		peer(bobKey, "100.90.0.2/32"))
 
-	iface, unhonoured, err := Desired(membership(), state, nil, nil)
+	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("an egress group made the whole description fail: %v", err)
 	}
@@ -1146,7 +1148,7 @@ func TestACarrierThatIsNotAPeerIsReported(t *testing.T) {
 		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch-lan", carolKey, "192.168.10.0/24")},
 		peer(bobKey, "100.90.0.2/32"))
 
-	iface, unhonoured, err := Desired(membership(), state, nil, nil)
+	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1165,7 +1167,7 @@ func TestAnUnparseablePrefixIsReportedRatherThanGuessed(t *testing.T) {
 		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch-lan", bobKey, "not-a-prefix")},
 		peer(bobKey, "100.90.0.2/32"))
 
-	_, unhonoured, err := Desired(membership(), state, nil, nil)
+	_, unhonoured, err := Desired(membership(), state, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1183,7 +1185,7 @@ func TestAGroupWithNoCandidatesIsReported(t *testing.T) {
 	state := stateWithRoutes(1, []*meshpv1.RouteGroupAssignment{assignment},
 		peer(bobKey, "100.90.0.2/32"))
 
-	_, unhonoured, err := Desired(membership(), state, nil, nil)
+	_, unhonoured, err := Desired(membership(), state, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1205,7 +1207,7 @@ func TestTheFirstCandidateCarriesIt(t *testing.T) {
 	state := stateWithRoutes(1, []*meshpv1.RouteGroupAssignment{assignment},
 		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
 
-	iface, _, err := Desired(membership(), state, nil, nil)
+	iface, _, err := Desired(membership(), state, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1399,5 +1401,146 @@ func TestTeardownStopsForwarding(t *testing.T) {
 	}
 	if len(filter.forwarded) != 2 || len(filter.forwarded[1]) != 0 {
 		t.Errorf("teardown did not stop forwarding: %+v", filter.forwarded)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Local failover
+
+func twoCandidates(name, first, second string, prefixes ...string) *meshpv1.RouteGroupAssignment {
+	return &meshpv1.RouteGroupAssignment{
+		RouteGroupId: "group-" + name, Name: name, Prefixes: prefixes,
+		Candidates: []*meshpv1.RouteCandidate{
+			{PeerPublicKey: first, AdvertiserId: "adv-first", Priority: 1},
+			{PeerPublicKey: second, AdvertiserId: "adv-second", Priority: 2},
+		},
+		LocalFailover: &meshpv1.LocalFailoverPolicy{Enabled: true, FailThreshold: 1},
+	}
+}
+
+// A device fails over from a gateway that has gone silent, without asking the control plane
+// and without sending a packet the reconciler was not already going to send.
+func TestADeviceFailsOverFromASilentAdvertiser(t *testing.T) {
+	clk := clock.NewFake()
+	link := newFakeLink()
+	r := New(link, membership(), nil, nil, nil).WithChooser(routeprobe.New(clk))
+
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{twoCandidates("branch", bobKey, carolKey, "192.168.10.0/24")},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	// Both peers handshaking: the first preference carries it.
+	for i := range link.observed.Peers {
+		link.observed.Peers[i].HasHandshake = true
+		link.observed.Peers[i].HandshakeAge = time.Second
+	}
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	for i := range link.observed.Peers {
+		link.observed.Peers[i].HasHandshake = true
+		link.observed.Peers[i].HandshakeAge = time.Second
+	}
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	iface, _, err := Desired(membership(), state, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = iface
+
+	// Now the first advertiser goes silent. The reconciler already reads this.
+	for i := range link.observed.Peers {
+		if string(link.observed.Peers[i].PublicKey) == bobKey {
+			link.observed.Peers[i].HandshakeAge = time.Hour
+		}
+	}
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+
+	// The prefix is now carried by the second candidate.
+	if !slicesContain(allowedIPsOf(currentInterface(t, r, state), carolKey), "192.168.10.0/24") {
+		t.Error("the device did not move to the second advertiser")
+	}
+}
+
+// currentInterface recomputes what the reconciler would configure now.
+func currentInterface(t *testing.T, r *Reconciler, state *peerset.Set) wgplan.Interface {
+	t.Helper()
+	iface, _, err := Desired(r.membership, state, r.relay, r.chooser, r.log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return iface
+}
+
+// A peer that has just been configured has not had time to handshake, and counting that
+// against the advertiser would fail a device over before it had ever tried.
+func TestNoHandshakeYetIsNotAFailure(t *testing.T) {
+	clk := clock.NewFake()
+	link := newFakeLink()
+	chooser := routeprobe.New(clk)
+	r := New(link, membership(), nil, nil, nil).WithChooser(chooser)
+
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{twoCandidates("branch", bobKey, carolKey, "192.168.10.0/24")},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	// HasHandshake stays false throughout.
+	for range 5 {
+		if _, err := r.Apply(context.Background(), state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !slicesContain(allowedIPsOf(currentInterface(t, r, state), bobKey), "192.168.10.0/24") {
+		t.Error("a device moved away from an advertiser that had not had time to handshake")
+	}
+}
+
+// Without a chooser the server's order is taken verbatim, which is what every device did
+// before local failover existed.
+func TestWithoutAChooserTheServersOrderStands(t *testing.T) {
+	link := newFakeLink()
+	r := New(link, membership(), nil, nil, nil)
+
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{twoCandidates("branch", bobKey, carolKey, "192.168.10.0/24")},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+	for i := range link.observed.Peers {
+		link.observed.Peers[i].HasHandshake = true
+		link.observed.Peers[i].HandshakeAge = time.Hour
+	}
+
+	for range 5 {
+		if _, err := r.Apply(context.Background(), state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !slicesContain(allowedIPsOf(currentInterface(t, r, state), bobKey), "192.168.10.0/24") {
+		t.Error("a build with no chooser moved off the server's first preference")
+	}
+}
+
+// A handshake within the grace window is reachable; one well outside it is not.
+func TestTheHandshakeGraceIsHonoured(t *testing.T) {
+	observed := wgplan.Observed{Peers: []wgplan.Peer{
+		{PublicKey: wgplan.Key(bobKey), HasHandshake: true, HandshakeAge: livenessGrace - time.Second},
+		{PublicKey: wgplan.Key(carolKey), HasHandshake: true, HandshakeAge: livenessGrace + time.Minute},
+	}}
+
+	if result, ok := probeFromHandshake(observed, bobKey); !ok || !result.Reachable {
+		t.Errorf("a fresh handshake was read as unreachable: %+v ok=%v", result, ok)
+	}
+	if result, ok := probeFromHandshake(observed, carolKey); !ok || result.Reachable {
+		t.Errorf("a stale handshake was read as reachable: %+v ok=%v", result, ok)
+	}
+	// A peer that is not on the interface is a different problem, already reported.
+	if _, ok := probeFromHandshake(observed, ourKey); ok {
+		t.Error("a peer that is not configured produced a verdict")
 	}
 }


### PR DESCRIPTION
The chooser from #40 now decides which candidate carries a prefix, instead of the reconciler always taking the server's first preference. **A device whose gateway stops answering moves to the next one on its own** — which is the point of the ADR-0003 split, since a device that had to ask the control plane couldn't fail over during a control-plane outage.

## The probe is an honest subset, not the whole thing

It's the handshake age the reconciler already reads.

The failover policy asks for traffic sent *through* an advertiser to diverse targets — that measures what a user experiences. This measures only whether the advertiser itself is reachable. **A gateway whose own uplink has failed still handshakes**, so this catches one that is off or unreachable, not one that is present and useless.

It's worth having anyway because it costs nothing: the kernel is read on every reconcile pass regardless, so a device fails over from a dead gateway **without a single extra packet**. Probing through the advertiser can be added later without changing anything this decides.

## Ordering

Observing happens after reading the interface. Decisions are recorded, and the next `Apply` configures whatever the chooser now points at — keeping "decide" and "converge" in the order the rest of the package uses, rather than reconfiguring an interface half way through reading it.

A reconciler without a chooser takes the server's order verbatim, which is what every device did before this existed.

## A guard I've documented rather than tested

A mutation showed that the `!HasHandshake` early return is **defensive, not load-bearing**: the kernel reports a zero handshake age alongside no handshake, so falling through reaches the same answer.

It stays — the two facts are separate, and "never handshaked" and "handshaked three minutes ago" shouldn't become one branch by accident — but the comment now says it's defensive rather than implying coverage it doesn't have. Two of three mutations caught; the third is why this note exists.

## What's left

**Nothing reports to the control plane yet.** The server has consumed `ReachabilityReport` since #39, and the agent now has something true to put in one — so the last step is sending it.