### PR TITLE
feat(routes): tell the control plane what this device observed

### DIFF
--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -20,6 +20,7 @@ import (
 	"github.com/meshpnet/meshp/internal/nftables"
 	"github.com/meshpnet/meshp/internal/peerset"
 	"github.com/meshpnet/meshp/internal/relaylink"
+	"github.com/meshpnet/meshp/internal/routeprobe"
 	"github.com/meshpnet/meshp/internal/sessionclient"
 	"github.com/meshpnet/meshp/internal/tunnel"
 	"github.com/meshpnet/meshp/internal/version"
@@ -92,7 +93,7 @@ func (a *agent) ensureLink() wglink.Link {
 // reason to refuse the session: the control channel is still worth having, the device is
 // still enrolled, and `meshp status` still has something true to report. What would be wrong
 // is claiming a tunnel exists.
-func (a *agent) reconcilerFor(m agentstate.Membership, relay tunnel.Relay, log *slog.Logger) *tunnel.Reconciler {
+func (a *agent) reconcilerFor(m agentstate.Membership, relay tunnel.Relay, chooser *routeprobe.Chooser, log *slog.Logger) *tunnel.Reconciler {
 	if a.ensureLink() == nil {
 		return nil
 	}
@@ -102,7 +103,7 @@ func (a *agent) reconcilerFor(m agentstate.Membership, relay tunnel.Relay, log *
 		AddressV4:     m.AddressV4,
 		AddressV6:     m.AddressV6,
 		ListenPort:    m.ListenPort,
-	}, relay, a.filterOrNil(), log)
+	}, relay, a.filterOrNil(), log).WithChooser(chooser)
 }
 
 // ensureFilter opens the host's packet filter, once.
@@ -297,12 +298,23 @@ func (a *agent) ensureSession(m agentstate.Membership) {
 	// Built before the reconciler, which needs it to give relayed peers an endpoint, and
 	// handed to the session, which is how the credential to use it arrives (ADR-0017).
 	relay := a.relayFor(m, log)
+
+	// One chooser for as long as this membership is supervised, shared by the two halves of
+	// the failover loop: the reconciler folds observations in and acts on the answer, and
+	// the session drains the verdicts out to the control plane.
+	//
+	// It sits outside the session deliberately. A control channel dropping and reconnecting
+	// must not reset the counters and hold times, because they are the whole mechanism — and
+	// a control-plane outage is precisely when a device has to be able to leave a dead
+	// gateway on its own (Invariant 15).
+	chooser := routeprobe.New(nil)
+
 	applier := &deviceApplier{
 		log:          log,
 		membershipID: m.MembershipID,
 		agent:        a,
 		relay:        relay,
-		reconciler:   a.reconcilerFor(m, relayOrNil(relay), log),
+		reconciler:   a.reconcilerFor(m, relayOrNil(relay), chooser, log),
 	}
 	client := sessionclient.New(sessionclient.Options{
 		ControlURL:   m.ControlURL,
@@ -314,6 +326,7 @@ func (a *agent) ensureSession(m agentstate.Membership) {
 		Relay:        relayCredentials(relay),
 		CanFilter:    a.ensureFilter() != nil,
 		Revoked:      &membershipRevoker{agent: a, membershipID: m.MembershipID},
+		Reachability: chooser,
 		Log:          log,
 	})
 	a.running[m.MembershipID] = &sessionHandle{

--- a/internal/routeprobe/report.go
+++ b/internal/routeprobe/report.go
@@ -1,0 +1,118 @@
+package routeprobe
+
+import (
+	"sort"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// This file is the other half of the failover loop. Deciding locally is what lets a device
+// leave a dead advertiser during a control-plane outage (ADR-0003), but a decision nobody
+// hears about only helps the device that made it. The control plane fuses reports from every
+// device using an advertiser and reorders the candidates it hands out — so one device's
+// observation is what stops the next device from being sent to the same dead gateway.
+//
+// Only what the chooser judged worth reporting is queued: a change, or the first verdict for
+// a group. Two reasons, and the second is the load-bearing one.
+//
+// A healthy network should be quieter than a broken one, or the reports arrive in the volume
+// that makes them useless. And the server folds each report as one observation of that
+// advertiser, so a device that reported on a timer would supply evidence in proportion to
+// how long it had been running rather than to what it had seen. Ten queued repeats of "still
+// fine" would clear a recovery threshold of ten on their own.
+//
+// The same argument decides the shape of the queue: **one report per group, newest wins.**
+// A backlog draining after a reconnection is exactly the inflation described above, and it
+// would arrive at the worst moment — when a device has just been out of touch and the server
+// is least sure what is true. Superseding instead means a reconnecting device says what it
+// believes now, once, which is all it actually knows.
+
+// recordLocked queues a verdict for the control plane, replacing any unsent one.
+//
+// Called with the lock held, from Observe.
+func (c *Chooser) recordLocked(groupID string, decision Decision, result Result) {
+	report := &meshpv1.ReachabilityReport{
+		RouteGroupId:             groupID,
+		AdvertiserId:             decision.Current,
+		Reachable:                result.Reachable,
+		RttMs:                    millis(result),
+		ConsecutiveFailures:      uint32(decision.ConsecutiveFailures),
+		SwitchedFromAdvertiserId: decision.Switched,
+		SwitchReason:             decision.Reason,
+	}
+
+	// A switch that has not been sent yet is carried forward rather than dropped, so long
+	// as the newer verdict is about the same advertiser and records no move of its own.
+	// The device is still on that advertiser having moved to it, so saying so stays true —
+	// and the alternative loses the one line an operator goes looking for six weeks later
+	// when they want to know why their traffic moved.
+	if previous, ok := c.pending[groupID]; ok && decision.Switched == "" &&
+		previous.GetSwitchedFromAdvertiserId() != "" &&
+		previous.GetAdvertiserId() == report.GetAdvertiserId() {
+		report.SwitchedFromAdvertiserId = previous.GetSwitchedFromAdvertiserId()
+		report.SwitchReason = previous.GetSwitchReason()
+	}
+
+	c.pending[groupID] = report
+}
+
+// Pending takes the reports waiting to be sent, in a stable order.
+//
+// Taking rather than copying: whatever is handed back is the caller's to deliver, and a
+// caller that cannot deliver hands it back with Requeue.
+func (c *Chooser) Pending() []*meshpv1.ReachabilityReport {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.pending) == 0 {
+		return nil
+	}
+	out := make([]*meshpv1.ReachabilityReport, 0, len(c.pending))
+	for _, report := range c.pending {
+		out = append(out, report)
+	}
+	clear(c.pending)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].GetRouteGroupId() < out[j].GetRouteGroupId()
+	})
+	return out
+}
+
+// Requeue puts back reports that could not be sent.
+//
+// A group with a newer verdict keeps the newer one. Returning something to the queue must
+// not be a way for a stale report to win, or a stuck writer would end up telling the control
+// plane that a gateway which has since failed is fine.
+//
+// Worth having rather than dropping on the floor: the reports that fail to send are the ones
+// produced while something is already wrong, which is when the control plane most needs
+// them.
+func (c *Chooser) Requeue(reports []*meshpv1.ReachabilityReport) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, report := range reports {
+		if report == nil {
+			continue
+		}
+		if _, newer := c.pending[report.GetRouteGroupId()]; newer {
+			continue
+		}
+		c.pending[report.GetRouteGroupId()] = report
+	}
+}
+
+// millis converts a round-trip time for the wire, clamped into what the field can hold.
+//
+// A handshake-derived probe reports zero, meaning "not measured". Nothing branches on it.
+func millis(result Result) uint32 {
+	ms := result.RTT.Milliseconds()
+	if ms <= 0 {
+		return 0
+	}
+	const maxUint32 = int64(^uint32(0))
+	if ms > maxUint32 {
+		return uint32(maxUint32)
+	}
+	return uint32(ms)
+}

--- a/internal/routeprobe/report_test.go
+++ b/internal/routeprobe/report_test.go
@@ -1,0 +1,339 @@
+package routeprobe
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/clock"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// named is an assignment for a particular group, so a test can hold two at once.
+func named(groupID string, ids ...string) *meshpv1.RouteGroupAssignment {
+	a := assignment(ids...)
+	a.RouteGroupId = groupID
+	return a
+}
+
+func only(t *testing.T, reports []*meshpv1.ReachabilityReport) *meshpv1.ReachabilityReport {
+	t.Helper()
+	if len(reports) != 1 {
+		t.Fatalf("got %d reports, want exactly one", len(reports))
+	}
+	return reports[0]
+}
+
+// The report that matters most: a device moved itself, and the control plane has to learn
+// both ends of the move and why.
+func TestASwitchIsReportedWithBothEndsAndAReason(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	c.Current(a)
+	fail(t, c, a, DefaultFailThreshold)
+
+	report := only(t, c.Pending())
+	if report.GetRouteGroupId() != "g" {
+		t.Errorf("route group is %q", report.GetRouteGroupId())
+	}
+	if report.GetAdvertiserId() != "backup" {
+		t.Errorf("reported advertiser is %q, want the one now in use", report.GetAdvertiserId())
+	}
+	if report.GetSwitchedFromAdvertiserId() != "primary" {
+		t.Errorf("switched-from is %q, want primary", report.GetSwitchedFromAdvertiserId())
+	}
+	if report.GetSwitchReason() == "" {
+		t.Error("no reason was carried; an operator reading an audit log learns nothing")
+	}
+	if report.GetReachable() {
+		t.Error("reported as reachable after failing its way off the advertiser")
+	}
+	// The count that caused the move, not the zero it was reset to.
+	if report.GetConsecutiveFailures() != uint32(DefaultFailThreshold) {
+		t.Errorf("consecutive failures = %d, want %d",
+			report.GetConsecutiveFailures(), DefaultFailThreshold)
+	}
+}
+
+// A working advertiser has to be reported too, or an advertiser that is fine stays at
+// "unknown" for exactly as long as it keeps being fine.
+func TestAFirstHealthyVerdictIsQueued(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	c.Current(a)
+	c.Observe(a, Result{Reachable: true})
+
+	report := only(t, c.Pending())
+	if !report.GetReachable() || report.GetAdvertiserId() != "primary" {
+		t.Errorf("report = %+v, want primary reachable", report)
+	}
+	if report.GetSwitchedFromAdvertiserId() != "" {
+		t.Errorf("a switch was reported where nothing moved: %q", report.GetSwitchedFromAdvertiserId())
+	}
+}
+
+// Nothing routine is sent. The server folds each report as one observation of an advertiser,
+// so a device that spoke on every pass would supply evidence in proportion to its uptime.
+func TestRoutineRepeatsAreNotQueued(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	c.Current(a)
+	succeed(t, c, a, 5)
+
+	if got := c.Pending(); len(got) != 1 {
+		t.Fatalf("got %d reports from five identical results, want one", len(got))
+	}
+	succeed(t, c, a, 5)
+	if got := c.Pending(); len(got) != 0 {
+		t.Errorf("got %d reports with nothing new to say", len(got))
+	}
+}
+
+// Draining hands them over. A second drain finding the same reports would send each one
+// twice, and the server counts what it receives.
+func TestDrainingEmptiesTheQueue(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	c.Current(a)
+	c.Observe(a, Result{Reachable: true})
+
+	if len(c.Pending()) != 1 {
+		t.Fatal("nothing was queued")
+	}
+	if got := c.Pending(); got != nil {
+		t.Errorf("draining twice produced %d reports the second time", len(got))
+	}
+}
+
+// A newer verdict replaces an unsent older one rather than queueing behind it. A backlog
+// draining after a reconnection is a device supplying ten observations for one opinion.
+func TestANewerVerdictSupersedesAnUnsentOne(t *testing.T) {
+	clk := clock.NewFake()
+	c := New(clk)
+	a := assignment("primary", "backup")
+	a.LocalFailover.MinHoldSeconds = 1
+	c.Current(a)
+
+	c.Observe(a, Result{Reachable: true})
+	fail(t, c, a, DefaultFailThreshold)
+
+	report := only(t, c.Pending())
+	if report.GetAdvertiserId() != "backup" {
+		t.Errorf("kept the stale verdict: %+v", report)
+	}
+}
+
+// The one thing a supersede must not lose. The switch is the line an operator goes looking
+// for later, and the verdict that replaces it is about the same advertiser — so saying "on
+// backup, having moved from primary" stays true.
+func TestAnUnsentSwitchSurvivesBeingSuperseded(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	c.Current(a)
+	fail(t, c, a, DefaultFailThreshold)
+
+	// Now on backup, which answers. Reported because the move reset the counters.
+	c.Observe(a, Result{Reachable: true})
+
+	report := only(t, c.Pending())
+	if !report.GetReachable() || report.GetAdvertiserId() != "backup" {
+		t.Fatalf("report = %+v, want the newer verdict about backup", report)
+	}
+	if report.GetSwitchedFromAdvertiserId() != "primary" {
+		t.Errorf("the move was lost: switched-from is %q", report.GetSwitchedFromAdvertiserId())
+	}
+	if report.GetSwitchReason() == "" {
+		t.Error("the reason was lost with it")
+	}
+}
+
+// Carrying it forward onto a different advertiser would invent a move that never happened.
+func TestASwitchIsNotCarriedOntoADifferentAdvertiser(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	c.Current(a)
+	fail(t, c, a, DefaultFailThreshold)
+
+	// The server withdraws both and offers a third, which this device is moved onto with no
+	// failure involved.
+	replaced := named("g", "third")
+	if got := c.Current(replaced); got.GetAdvertiserId() != "third" {
+		t.Fatalf("expected to be moved to third, got %q", got.GetAdvertiserId())
+	}
+	c.Observe(replaced, Result{Reachable: true})
+
+	report := only(t, c.Pending())
+	if report.GetAdvertiserId() != "third" {
+		t.Fatalf("report = %+v, want one about third", report)
+	}
+	if report.GetSwitchedFromAdvertiserId() != "" {
+		t.Errorf("invented a move to third from %q", report.GetSwitchedFromAdvertiserId())
+	}
+}
+
+// What could not be sent is kept. These are produced when something is already wrong, which
+// is when the control plane most needs them.
+func TestRequeuedReportsComeBack(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	c.Current(a)
+	c.Observe(a, Result{Reachable: true})
+
+	undelivered := c.Pending()
+	c.Requeue(undelivered)
+
+	if got := c.Pending(); len(got) != 1 || got[0].GetAdvertiserId() != "primary" {
+		t.Errorf("got %+v after requeueing, want the report back", got)
+	}
+}
+
+// A stale report handed back must not overwrite what has happened since, or a stuck writer
+// ends up telling the control plane that a gateway which has since failed is fine.
+func TestARequeuedReportDoesNotBeatANewerOne(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	c.Current(a)
+	c.Observe(a, Result{Reachable: true})
+	stale := c.Pending()
+
+	fail(t, c, a, DefaultFailThreshold)
+	c.Requeue(stale)
+
+	report := only(t, c.Pending())
+	if report.GetAdvertiserId() != "backup" || report.GetReachable() {
+		t.Errorf("report = %+v, want the newer verdict to have won", report)
+	}
+}
+
+// A verdict about a group this device has been taken out of would be folded into that
+// advertiser's health on behalf of a device no longer behind it.
+func TestForgettingAGroupDropsItsUnsentReport(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	c.Current(a)
+	c.Observe(a, Result{Reachable: true})
+
+	c.Forget(nil)
+	if got := c.Pending(); len(got) != 0 {
+		t.Errorf("got %d reports about a group this device has left", len(got))
+	}
+}
+
+// The same, for a report handed back after its group was forgotten. It has no group state to
+// be found by, so a sweep that only walked the groups would leave it queued for the life of
+// the process.
+func TestARequeuedReportForAForgottenGroupIsSweptToo(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	c.Current(a)
+	c.Observe(a, Result{Reachable: true})
+	undelivered := c.Pending()
+
+	c.Forget(nil)
+	c.Requeue(undelivered)
+	c.Forget(nil)
+
+	if got := c.Pending(); len(got) != 0 {
+		t.Errorf("got %d reports about a forgotten group", len(got))
+	}
+}
+
+// Repeated because map iteration is randomised rather than arbitrary: one drain coming out
+// sorted proves nothing, and a single round of this passed against an unsorted
+// implementation.
+func TestReportsComeOutInAStableOrder(t *testing.T) {
+	want := []string{"g1", "g2", "g3", "g4", "g5"}
+
+	for range 20 {
+		c := New(clock.NewFake())
+		for _, id := range []string{"g3", "g5", "g1", "g4", "g2"} {
+			a := named(id, "primary")
+			c.Current(a)
+			c.Observe(a, Result{Reachable: true})
+		}
+
+		got := c.Pending()
+		if len(got) != len(want) {
+			t.Fatalf("got %d reports, want one per group", len(got))
+		}
+		for i, id := range want {
+			if got[i].GetRouteGroupId() != id {
+				t.Fatalf("report %d is for %q, want %q", i, got[i].GetRouteGroupId(), id)
+			}
+		}
+	}
+}
+
+// A direct test of what recordLocked promises, rather than of a state the Chooser can reach.
+//
+// It cannot reach this one: a report that records a switch always names the advertiser just
+// moved to, which is never the one an unsent report is about. The clause is still worth
+// having and worth covering — the correctness it protects is "newer switch wins", and that
+// must not quietly depend on an argument about advertiser identity holding forever.
+func TestANewerSwitchIsNotOverwrittenByAnOlderOne(t *testing.T) {
+	c := New(clock.NewFake())
+	c.pending["g"] = &meshpv1.ReachabilityReport{
+		RouteGroupId:             "g",
+		AdvertiserId:             "backup",
+		SwitchedFromAdvertiserId: "primary",
+		SwitchReason:             "the older move",
+	}
+
+	c.recordLocked("g", Decision{
+		Current:  "backup",
+		Switched: "third",
+		Reason:   "the newer move",
+	}, Result{Reachable: true})
+
+	report := only(t, c.Pending())
+	if report.GetSwitchedFromAdvertiserId() != "third" {
+		t.Errorf("switched-from is %q, want the newer move's", report.GetSwitchedFromAdvertiserId())
+	}
+	if report.GetSwitchReason() != "the newer move" {
+		t.Errorf("reason is %q", report.GetSwitchReason())
+	}
+}
+
+func TestRoundTripTimesAreClampedToWhatTheFieldHolds(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rtt  time.Duration
+		want uint32
+	}{
+		{"unmeasured", 0, 0},
+		{"ordinary", 42 * time.Millisecond, 42},
+		{"nonsense", -1 * time.Second, 0},
+		{"absurd", 1 << 60, ^uint32(0)},
+	} {
+		if got := millis(Result{RTT: tc.rtt}); got != tc.want {
+			t.Errorf("%s: millis(%v) = %d, want %d", tc.name, tc.rtt, got, tc.want)
+		}
+	}
+}
+
+// The reconciler folds results in on its own timer while the session drains them out, and the
+// reconciler is entered both from that timer and from an arriving state delta. Meaningless
+// without -race, which is why the suite runs with it.
+func TestObservingAndDrainingAreSafeTogether(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	c.Current(a)
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for i := range 200 {
+				c.Observe(a, Result{Reachable: i%2 == 0})
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range 200 {
+				c.Requeue(c.Pending())
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/routeprobe/routeprobe.go
+++ b/internal/routeprobe/routeprobe.go
@@ -20,6 +20,7 @@
 package routeprobe
 
 import (
+	"sync"
 	"time"
 
 	"github.com/meshpnet/meshp/internal/clock"
@@ -38,11 +39,18 @@ const (
 
 // Chooser tracks which candidate is in use for each route group.
 //
-// Safe for concurrent use: the reconciler asks which candidate to configure while a prober
-// is folding results in.
+// Safe for concurrent use, and it has to be: the reconciler folds results in from its own
+// timer while the session drains reports out to the control plane, and the reconciler
+// itself is entered both from that timer and from an arriving state delta.
 type Chooser struct {
-	clk    clock.Clock
+	clk clock.Clock
+
+	mu     sync.Mutex
 	groups map[string]*groupState
+
+	// pending holds at most one unsent report per group. Why one and not a queue is in
+	// report.go, and it is a correctness argument rather than a tidiness one.
+	pending map[string]*meshpv1.ReachabilityReport
 }
 
 type groupState struct {
@@ -66,7 +74,11 @@ func New(clk clock.Clock) *Chooser {
 	if clk == nil {
 		clk = clock.System{}
 	}
-	return &Chooser{clk: clk, groups: make(map[string]*groupState)}
+	return &Chooser{
+		clk:     clk,
+		groups:  make(map[string]*groupState),
+		pending: make(map[string]*meshpv1.ReachabilityReport),
+	}
 }
 
 // Current returns the candidate to use for an assignment.
@@ -82,6 +94,9 @@ func (c *Chooser) Current(assignment *meshpv1.RouteGroupAssignment) *meshpv1.Rou
 	if len(candidates) == 0 {
 		return nil
 	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	id := assignment.GetRouteGroupId()
 	state, ok := c.groups[id]
@@ -144,10 +159,27 @@ type Decision struct {
 
 	// Current is the advertiser now in use.
 	Current string
+
+	// ConsecutiveFailures is how many failures in a row this result makes, and on a
+	// decision that moved, how many it took to move. Reported onward so the control plane
+	// can tell an advertiser that failed once from one that failed three times, which is
+	// the difference between a lost packet and an outage.
+	ConsecutiveFailures int
 }
 
 // Observe folds a probe result in and reports what it led to.
 func (c *Chooser) Observe(assignment *meshpv1.RouteGroupAssignment, result Result) Decision {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	decision := c.observeLocked(assignment, result)
+	if decision.Report {
+		c.recordLocked(assignment.GetRouteGroupId(), decision, result)
+	}
+	return decision
+}
+
+func (c *Chooser) observeLocked(assignment *meshpv1.RouteGroupAssignment, result Result) Decision {
 	id := assignment.GetRouteGroupId()
 	state, ok := c.groups[id]
 	if !ok || state.currentID == "" {
@@ -169,6 +201,9 @@ func (c *Chooser) Observe(assignment *meshpv1.RouteGroupAssignment, result Resul
 	if !result.Reachable {
 		state.consecutiveOK = 0
 		state.consecutiveFail++
+		// Read before any move. Moving resets the counter, so taking it afterwards would
+		// report every switch as having been caused by nothing.
+		decision.ConsecutiveFailures = state.consecutiveFail
 		if state.consecutiveFail < failThreshold {
 			return decision
 		}
@@ -241,7 +276,14 @@ func (c *Chooser) moveTo(state *groupState, advertiserID string) {
 
 // Forget drops state for groups no longer assigned, so a device that carried a prefix for a
 // while does not remember its choice forever.
+//
+// Unsent reports go with it. A verdict about a group this device has been taken out of is
+// not news the control plane can use: it would be folded into that advertiser's health on
+// behalf of a device that is no longer behind it.
 func (c *Chooser) Forget(assigned []*meshpv1.RouteGroupAssignment) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	keep := make(map[string]struct{}, len(assigned))
 	for _, a := range assigned {
 		keep[a.GetRouteGroupId()] = struct{}{}
@@ -249,6 +291,14 @@ func (c *Chooser) Forget(assigned []*meshpv1.RouteGroupAssignment) {
 	for id := range c.groups {
 		if _, ok := keep[id]; !ok {
 			delete(c.groups, id)
+		}
+	}
+	// Swept separately rather than alongside the groups: a report handed back by Requeue
+	// after its group was forgotten has no group state to be found by, and would otherwise
+	// sit in the queue for the life of the process.
+	for id := range c.pending {
+		if _, ok := keep[id]; !ok {
+			delete(c.pending, id)
 		}
 	}
 }

--- a/internal/sessionclient/client.go
+++ b/internal/sessionclient/client.go
@@ -35,11 +35,16 @@ import (
 	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
 )
 
-const (
-	// heartbeatInterval is well inside the server's idle timeout, so a healthy
-	// connection is never mistaken for a dead one.
-	heartbeatInterval = 25 * time.Second
+// heartbeatInterval is well inside the server's idle timeout, so a healthy connection is
+// never mistaken for a dead one.
+//
+// A variable so a test can shorten it. The heartbeat is not only a liveness tick — it is the
+// only thing that carries a reachability report on a network quiet enough to send no state
+// deltas, which is exactly the network where a device failing over has news worth hearing.
+// Leaving that call site untestable is how it comes to be missing.
+var heartbeatInterval = 25 * time.Second
 
+const (
 	dialTimeout     = 20 * time.Second
 	writeTimeout    = 10 * time.Second
 	readIdleTimeout = 90 * time.Second
@@ -102,6 +107,27 @@ type Revoker interface {
 	Revoked(reason string, wipeLocalState bool)
 }
 
+// ReachabilityReports supplies this device's verdicts on the advertisers it is routing
+// through.
+//
+// The control plane cannot learn this by asking. It can reach an advertiser's host and still
+// know nothing about whether traffic sent through it arrives, so the devices behind it are
+// the only source — and their reports are what reorder the candidates every other device is
+// handed. A device that decided locally and never said so would keep the next device being
+// sent to the same dead gateway.
+//
+// Behind an interface for the reason the relay credentials are: what produces these is the
+// reconciler, on its own timer, and the session must be able to drop without the device
+// forgetting what it has observed (Invariant 15).
+type ReachabilityReports interface {
+	// Pending takes the reports waiting to be sent. Taking, not copying: what comes back
+	// is this client's to deliver.
+	Pending() []*meshpv1.ReachabilityReport
+
+	// Requeue hands back what could not be sent.
+	Requeue(reports []*meshpv1.ReachabilityReport)
+}
+
 // Options configures a Client.
 type Options struct {
 	ControlURL   string
@@ -121,6 +147,10 @@ type Options struct {
 	// Revoked is told when the control plane ends this membership. Nil is fine: the
 	// membership is over either way.
 	Revoked Revoker
+
+	// Reachability is asked for advertiser verdicts to send on. Nil on a build with no
+	// data plane, which has nothing to observe and so nothing to say.
+	Reachability ReachabilityReports
 
 	// CanFilter is whether this host can enforce a packet filter.
 	//
@@ -235,6 +265,33 @@ func (c *Client) maybeRequestRelayToken(outbound chan<- *meshpv1.ClientMessage) 
 		Payload: &meshpv1.ClientMessage_RelayTokenRequest{RelayTokenRequest: &meshpv1.RelayTokenRequest{}},
 	}:
 	default:
+	}
+}
+
+// sendReachabilityReports passes on what this device has observed about its advertisers.
+//
+// Sent on the heartbeat and again as soon as state has been applied. The second matters more
+// than it looks: applying state is what runs a reconcile, which is what produces a verdict,
+// so waiting for the next tick would sit on the news for up to 25 seconds — and a device
+// that has just failed over is exactly the device the control plane wants to hear from.
+//
+// A full queue stops the run and hands the rest back. The writer is already behind, and a
+// report that waits is better than one that is lost: these are produced when something is
+// already wrong.
+func (c *Client) sendReachabilityReports(outbound chan<- *meshpv1.ClientMessage) {
+	if c.opts.Reachability == nil {
+		return
+	}
+	reports := c.opts.Reachability.Pending()
+	for i, report := range reports {
+		select {
+		case outbound <- &meshpv1.ClientMessage{
+			Payload: &meshpv1.ClientMessage_ReachabilityReport{ReachabilityReport: report},
+		}:
+		default:
+			c.opts.Reachability.Requeue(reports[i:])
+			return
+		}
 	}
 }
 
@@ -429,6 +486,11 @@ func (c *Client) RunOnce(ctx context.Context, applier Applier) error {
 				// notice on a timer rather than only when state changes. The heartbeat is
 				// already the agent's "still here" tick and needs no goroutine of its own.
 				c.maybeRequestRelayToken(outbound)
+
+				// And the reconciler runs on its own timer, so a verdict can be produced
+				// with no state delta anywhere near it. Without this, a device on a quiet
+				// network would hold the news of its own failover indefinitely.
+				c.sendReachabilityReports(outbound)
 			}
 		}
 	}()
@@ -470,6 +532,10 @@ func (c *Client) RunOnce(ctx context.Context, applier Applier) error {
 			// moment worth asking — waiting for the next heartbeat would leave every peer
 			// relay-less for up to 25 seconds after a join.
 			c.maybeRequestRelayToken(outbound)
+
+			// Applying state ran a reconcile, which is what produces a verdict, so this is
+			// the earliest moment there is anything to send.
+			c.sendReachabilityReports(outbound)
 
 		case *meshpv1.ServerMessage_RelayToken:
 			c.handleRelayToken(payload.RelayToken)

--- a/internal/sessionclient/client_test.go
+++ b/internal/sessionclient/client_test.go
@@ -172,30 +172,8 @@ func (noopApplier) Apply(context.Context, *peerset.Set) ([]string, error) { retu
 // start runs one session against fc and returns the connection the server holds.
 func start(t *testing.T, fc *fakeControl, sink RelayCredentials) *websocket.Conn {
 	t.Helper()
-
-	identity, err := keys.NewIdentity()
-	if err != nil {
-		t.Fatalf("identity: %v", err)
-	}
-	client := New(Options{
-		ControlURL:   fc.srv.URL,
-		Identity:     identity,
-		MembershipID: uuid.New(),
-		Relay:        sink,
-	})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	go func() { _ = client.RunOnce(ctx, noopApplier{}) }()
-
-	select {
-	case conn := <-fc.conn:
-		t.Cleanup(func() { _ = conn.CloseNow() })
-		return conn
-	case <-time.After(5 * time.Second):
-		t.Fatal("the agent never opened a session")
-		return nil
-	}
+	_, conn := startSession(t, fc, Options{Relay: sink}, noopApplier{})
+	return conn
 }
 
 func stateWithRelay() *meshpv1.ServerMessage {
@@ -387,16 +365,22 @@ func (a *recordingApplier) count() int {
 // startWith is start, with an applier of the caller's choosing.
 func startWith(t *testing.T, fc *fakeControl, applier Applier) (*Client, *websocket.Conn) {
 	t.Helper()
+	return startSession(t, fc, Options{}, applier)
+}
+
+// startSession runs one session with whatever options and applier a test needs. Everything
+// that identifies the session is filled in here so no caller has to.
+func startSession(t *testing.T, fc *fakeControl, opts Options, applier Applier) (*Client, *websocket.Conn) {
+	t.Helper()
 
 	identity, err := keys.NewIdentity()
 	if err != nil {
 		t.Fatalf("identity: %v", err)
 	}
-	client := New(Options{
-		ControlURL:   fc.srv.URL,
-		Identity:     identity,
-		MembershipID: uuid.New(),
-	})
+	opts.ControlURL = fc.srv.URL
+	opts.Identity = identity
+	opts.MembershipID = uuid.New()
+	client := New(opts)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)

--- a/internal/sessionclient/reachability_test.go
+++ b/internal/sessionclient/reachability_test.go
@@ -1,0 +1,202 @@
+package sessionclient
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// fakeReports stands in for the chooser: it hands out verdicts and remembers what came back.
+type fakeReports struct {
+	mu       sync.Mutex
+	pending  []*meshpv1.ReachabilityReport
+	requeued []*meshpv1.ReachabilityReport
+}
+
+func (f *fakeReports) Pending() []*meshpv1.ReachabilityReport {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := f.pending
+	f.pending = nil
+	return out
+}
+
+func (f *fakeReports) Requeue(reports []*meshpv1.ReachabilityReport) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.requeued = append(f.requeued, reports...)
+}
+
+func (f *fakeReports) handedBack() []*meshpv1.ReachabilityReport {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]*meshpv1.ReachabilityReport(nil), f.requeued...)
+}
+
+func aReport(group, advertiser string) *meshpv1.ReachabilityReport {
+	return &meshpv1.ReachabilityReport{
+		RouteGroupId:             group,
+		AdvertiserId:             advertiser,
+		Reachable:                false,
+		ConsecutiveFailures:      3,
+		SwitchedFromAdvertiserId: "primary",
+		SwitchReason:             "the advertiser in use stopped answering probes",
+	}
+}
+
+// awaitReachabilityReport waits for one to arrive, and returns it.
+func (fc *fakeControl) awaitReachabilityReport(within time.Duration) *meshpv1.ReachabilityReport {
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		fc.mu.Lock()
+		for _, msg := range fc.received {
+			if payload, ok := msg.Payload.(*meshpv1.ClientMessage_ReachabilityReport); ok {
+				fc.mu.Unlock()
+				return payload.ReachabilityReport
+			}
+		}
+		fc.mu.Unlock()
+		time.Sleep(5 * time.Millisecond)
+	}
+	return nil
+}
+
+func (fc *fakeControl) reachabilityReports() int {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	n := 0
+	for _, msg := range fc.received {
+		if _, ok := msg.Payload.(*meshpv1.ClientMessage_ReachabilityReport); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// The last link in the failover loop. A device that decided locally and never said so keeps
+// the next device being sent to the same dead gateway.
+func TestAVerdictReachesTheControlPlaneWhenStateIsApplied(t *testing.T) {
+	fc := newFakeControl(t)
+	reports := &fakeReports{pending: []*meshpv1.ReachabilityReport{aReport("group-1", "backup")}}
+	_, conn := startSession(t, fc, Options{Reachability: reports}, noopApplier{})
+
+	// Applying state is what runs a reconcile, so it is the earliest moment there is
+	// anything to send.
+	fc.send(conn, &meshpv1.ServerMessage{Payload: &meshpv1.ServerMessage_StateDelta{
+		StateDelta: &meshpv1.StateDelta{FromVersion: 0, ToVersion: 1},
+	}})
+
+	got := fc.awaitReachabilityReport(5 * time.Second)
+	if got == nil {
+		t.Fatal("the agent never reported what it had observed")
+	}
+	if got.GetRouteGroupId() != "group-1" || got.GetAdvertiserId() != "backup" {
+		t.Errorf("report = %+v, want the one that was queued", got)
+	}
+	if got.GetSwitchedFromAdvertiserId() != "primary" || got.GetSwitchReason() == "" {
+		t.Errorf("the move was not carried onto the wire: %+v", got)
+	}
+	if got.GetConsecutiveFailures() != 3 {
+		t.Errorf("consecutive failures = %d, want 3", got.GetConsecutiveFailures())
+	}
+}
+
+// A quiet network sends no state deltas, and a device that has just failed over on one is
+// exactly the device worth hearing from. Without the heartbeat carrying reports, it would
+// hold that news until something else happened to arrive.
+func TestAVerdictIsSentOnTheHeartbeatWithNoStateAtAll(t *testing.T) {
+	original := heartbeatInterval
+	heartbeatInterval = 20 * time.Millisecond
+	t.Cleanup(func() { heartbeatInterval = original })
+
+	fc := newFakeControl(t)
+	reports := &fakeReports{pending: []*meshpv1.ReachabilityReport{aReport("group-1", "backup")}}
+	startSession(t, fc, Options{Reachability: reports}, noopApplier{})
+
+	if got := fc.awaitReachabilityReport(5 * time.Second); got == nil {
+		t.Fatal("nothing was reported on a session with no state deltas")
+	}
+}
+
+// A build with no data plane observes nothing and so has nothing to say.
+func TestNothingIsReportedWithoutAReporter(t *testing.T) {
+	original := heartbeatInterval
+	heartbeatInterval = 20 * time.Millisecond
+	t.Cleanup(func() { heartbeatInterval = original })
+
+	fc := newFakeControl(t)
+	_, conn := startSession(t, fc, Options{}, noopApplier{})
+	fc.send(conn, &meshpv1.ServerMessage{Payload: &meshpv1.ServerMessage_StateDelta{
+		StateDelta: &meshpv1.StateDelta{FromVersion: 0, ToVersion: 1},
+	}})
+
+	if got := fc.awaitReachabilityReport(300 * time.Millisecond); got != nil {
+		t.Fatalf("an agent with nothing to observe reported %+v", got)
+	}
+}
+
+// Every queued verdict goes, not just the first: a device in several route groups has
+// something to say about each of them.
+func TestEveryQueuedVerdictIsSent(t *testing.T) {
+	original := heartbeatInterval
+	heartbeatInterval = 20 * time.Millisecond
+	t.Cleanup(func() { heartbeatInterval = original })
+
+	fc := newFakeControl(t)
+	reports := &fakeReports{pending: []*meshpv1.ReachabilityReport{
+		aReport("group-1", "backup"), aReport("group-2", "third"), aReport("group-3", "fourth"),
+	}}
+	startSession(t, fc, Options{Reachability: reports}, noopApplier{})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if fc.reachabilityReports() >= 3 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("only %d of 3 verdicts were sent", fc.reachabilityReports())
+}
+
+// What will not fit is handed back rather than dropped. Reports are produced when something
+// is already wrong, so losing them costs exactly when it matters — and the writer being
+// behind is no reason to forget what was observed.
+func TestVerdictsThatDoNotFitAreHandedBack(t *testing.T) {
+	reports := &fakeReports{pending: []*meshpv1.ReachabilityReport{
+		aReport("group-1", "backup"), aReport("group-2", "third"), aReport("group-3", "fourth"),
+	}}
+	c := New(Options{Reachability: reports})
+
+	// One slot, three reports: the writer is as far behind as it can be.
+	outbound := make(chan *meshpv1.ClientMessage, 1)
+	c.sendReachabilityReports(outbound)
+
+	if len(outbound) != 1 {
+		t.Fatalf("queued %d messages into one slot", len(outbound))
+	}
+	handedBack := reports.handedBack()
+	if len(handedBack) != 2 {
+		t.Fatalf("handed back %d reports, want the 2 that did not fit", len(handedBack))
+	}
+	for i, want := range []string{"group-2", "group-3"} {
+		if handedBack[i].GetRouteGroupId() != want {
+			t.Errorf("handed back %q at %d, want %q", handedBack[i].GetRouteGroupId(), i, want)
+		}
+	}
+}
+
+// Nothing observed means nothing on the wire. An agent that sent an empty report every tick
+// would fold into the server's health monitor as a real observation.
+func TestAnEmptyQueueSendsNothing(t *testing.T) {
+	reports := &fakeReports{}
+	c := New(Options{Reachability: reports})
+
+	outbound := make(chan *meshpv1.ClientMessage, 4)
+	c.sendReachabilityReports(outbound)
+
+	if len(outbound) != 0 {
+		t.Errorf("sent %d messages with nothing to report", len(outbound))
+	}
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -339,9 +339,12 @@ func (r *Reconciler) applyFilter(ctx context.Context, iface string, want *meshpv
 // whatever it now points at — which keeps "decide" and "converge" in the order the rest of
 // this package uses, rather than reconfiguring an interface half way through reading it.
 func (r *Reconciler) observeAdvertisers(observed wgplan.Observed, assignments []*meshpv1.RouteGroupAssignment) {
-	if r.chooser == nil || len(assignments) == 0 {
+	if r.chooser == nil {
 		return
 	}
+	// Deliberately not short-circuiting on an empty list. A device taken out of every route
+	// group is the one case where forgetting matters most, and returning early here left it
+	// holding a choice and an unsent verdict about prefixes it no longer carries.
 	for _, assignment := range assignments {
 		current := r.chooser.Current(assignment)
 		if current == nil {

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -1544,3 +1544,111 @@ func TestTheHandshakeGraceIsHonoured(t *testing.T) {
 		t.Error("a peer that is not configured produced a verdict")
 	}
 }
+
+// The middle link of the failover loop: a reconcile pass has to leave the control plane
+// something to read. The chooser deciding locally is only half the point — the other half is
+// every other device being reordered away from the same dead gateway, and that needs the
+// verdict to leave this one.
+func TestAReconcilePassQueuesAVerdictForTheControlPlane(t *testing.T) {
+	clk := clock.NewFake()
+	link := newFakeLink()
+	chooser := routeprobe.New(clk)
+	r := New(link, membership(), nil, nil, nil).WithChooser(chooser)
+
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{twoCandidates("branch", bobKey, carolKey, "192.168.10.0/24")},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	// The first pass configures the peers; there is nothing on the interface to read yet.
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if got := chooser.Pending(); len(got) != 0 {
+		t.Fatalf("queued %d verdicts about peers that were not on the interface yet", len(got))
+	}
+
+	// Both answering, so this pass is a healthy verdict about the first preference.
+	for i := range link.observed.Peers {
+		link.observed.Peers[i].HasHandshake = true
+		link.observed.Peers[i].HandshakeAge = time.Second
+	}
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	first := chooser.Pending()
+	if len(first) != 1 {
+		t.Fatalf("a reconcile pass queued %d verdicts, want one per group", len(first))
+	}
+	if !first[0].GetReachable() || first[0].GetAdvertiserId() != "adv-first" {
+		t.Errorf("verdict = %+v, want a healthy one about the first advertiser", first[0])
+	}
+
+	// Now the advertiser in use goes silent.
+	for i := range link.observed.Peers {
+		if string(link.observed.Peers[i].PublicKey) == bobKey {
+			link.observed.Peers[i].HandshakeAge = time.Hour
+		}
+	}
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+
+	moved := chooser.Pending()
+	if len(moved) != 1 {
+		t.Fatalf("the move queued %d verdicts", len(moved))
+	}
+	if moved[0].GetSwitchedFromAdvertiserId() != "adv-first" || moved[0].GetAdvertiserId() != "adv-second" {
+		t.Errorf("verdict = %+v, want the move reported with both ends", moved[0])
+	}
+	if moved[0].GetSwitchReason() == "" {
+		t.Error("the move was queued with no reason for anyone reading an audit log later")
+	}
+}
+
+// A device taken out of a group must not still be reporting on its advertisers: the server
+// would fold that into the advertiser's health on behalf of a device no longer behind it.
+//
+// Run twice against the same setup, keeping the group and then withdrawing it, because
+// "nothing was queued" is the answer a broken version of this test gives too.
+func TestAVerdictIsNotQueuedForAGroupTheDeviceHasLeft(t *testing.T) {
+	queuedAfterWithdrawing := func(t *testing.T, withdraw bool) int {
+		t.Helper()
+		link := newFakeLink()
+		chooser := routeprobe.New(clock.NewFake())
+		r := New(link, membership(), nil, nil, nil).WithChooser(chooser)
+
+		assigned := []*meshpv1.RouteGroupAssignment{
+			twoCandidates("branch", bobKey, carolKey, "192.168.10.0/24"),
+		}
+		peers := []*meshpv1.Peer{peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32")}
+
+		// The first pass puts the peers on the interface; the second observes them and
+		// queues a verdict that nothing has drained.
+		if _, err := r.Apply(context.Background(), stateWithRoutes(1, assigned, peers...)); err != nil {
+			t.Fatal(err)
+		}
+		for i := range link.observed.Peers {
+			link.observed.Peers[i].HasHandshake = true
+			link.observed.Peers[i].HandshakeAge = time.Second
+		}
+		if _, err := r.Apply(context.Background(), stateWithRoutes(2, assigned, peers...)); err != nil {
+			t.Fatal(err)
+		}
+
+		next := assigned
+		if withdraw {
+			next = nil
+		}
+		if _, err := r.Apply(context.Background(), stateWithRoutes(3, next, peers...)); err != nil {
+			t.Fatal(err)
+		}
+		return len(chooser.Pending())
+	}
+
+	if got := queuedAfterWithdrawing(t, false); got != 1 {
+		t.Fatalf("a device still in the group queued %d verdicts, want one", got)
+	}
+	if got := queuedAfterWithdrawing(t, true); got != 0 {
+		t.Errorf("queued %d verdicts about a group this device has left", got)
+	}
+}


### PR DESCRIPTION
The last link in the failover loop. The server has consumed `ReachabilityReport` since #39, and the agent has had a true signal since #41 — but nothing carried one, so each device was learning about dead advertisers on its own and no other device benefited.

### What it does

`routeprobe.Chooser` queues a verdict whenever it decides something is worth saying, and the session drains the queue onto the control channel: after applying state (which is what runs a reconcile, so it is the earliest moment there is anything to send) and on the heartbeat (the only thing that carries news on a network quiet enough to send no deltas — which is the network a device failing over is most likely to be on).

### Why only changes, and why one report per group

Both fall out of the same fact: the server folds **each report as one observation** of that advertiser.

A device reporting on a timer would supply evidence in proportion to its uptime rather than to what it saw. A device draining a backlog after a reconnection would supply ten observations for one opinion — enough to clear a recovery threshold of ten by itself, at the moment the server is least sure what is true. So a newer verdict supersedes an unsent one instead of queueing behind it, and the queue is bounded by the number of groups.

The one thing a supersede must not lose is a switch, since that is the line an operator goes looking for six weeks later wanting to know why their traffic moved. It is carried forward when the newer verdict is about the same advertiser and records no move of its own.

### Two bugs, both live on main

**`meshpd` never called `WithChooser`.** Local failover was built across #40 and #41 and wired into nothing — no released agent could fail over. Same shape as the `peerset` relay drop: a mechanism with tests, reachable from no running code. Found by grepping for the call site before wiring the reporter through it.

**`observeAdvertisers` returned before `Forget` on an empty assignment list**, so a device taken out of *every* route group kept its choice and its unsent verdict for the life of the process. Found by a test written for the reporting change.

`Chooser` also needed a mutex. Its doc comment has claimed to be safe for concurrent use since #40 without one — harmless only because nothing shared it; draining from the session goroutine while the reconciler folds results in would have raced.

### Verification

`make ci` green. Fourteen mutations applied across the queue, the wiring and the send path — all caught. Two survived the first round and both were real gaps:

- the ordering test passed against an unsorted drain (three groups, and map iteration for a small map is a rotation of insertion order — a third of runs come out sorted by luck). It now repeats with five groups.
- one clause of the carry-forward guard is unreachable through the `Chooser`'s public API, because a report recording a switch always names the advertiser just moved to, which is never the one an unsent report is about. Rather than document it away, it is covered by a direct test of what `recordLocked` promises — the correctness at stake is "newer switch wins", and that should not silently depend on an argument about advertiser identity holding forever.

`sessionclient.heartbeatInterval` became a var so the heartbeat send path could be tested rather than assumed. That call site is the one that matters on a quiet network, and leaving it untestable is how it comes to be missing.

### Not covered

The daemon wiring itself has no test — `cmd/meshpd` has no test files, and the reconciler needs a real link. The real proof would be an end-to-end run, and the e2e script currently stands up no route group at all. That is the honest gap and the natural next slice.
