### PR TITLE
chore: add NOTICE and canonicalise authorship

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,11 @@
+# Canonical identities, so `git shortlog -sne` and every tool that respects a mailmap
+# report one author rather than one per address.
+#
+# A mailmap rather than a history rewrite. Rewriting would mean force-pushing main, which
+# the repository ruleset refuses on purpose, and would change every commit id in every
+# clone — a large amount of damage to tidy up attribution.
+#
+# The canonical address is the one in the DCO sign-off on every commit, which is the
+# identity of record for a contribution. The other is GitHub's per-account noreply address,
+# which is what a squash merge performed on github.com attributes the result to.
+Aswin Alexander Sam <aswinsam@gmail.com> <62598639+aswinsam@users.noreply.github.com>

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+meshp
+Copyright 2026 Aswin Alexander Sam
+
+Licensed under the Apache License, Version 2.0. See LICENSE for the full terms.

--- a/README.md
+++ b/README.md
@@ -276,4 +276,9 @@ repository, not in a public issue. See the organisation `SECURITY.md`.
 
 ## License
 
-[Apache 2.0](LICENSE).
+[Apache 2.0](LICENSE), with copyright and attribution in [NOTICE](NOTICE).
+
+Commercial use is permitted, including running this as a service and reselling it. That
+is deliberate rather than an oversight — see
+[ADR-0009](docs/adr/0009-licensing-and-commercial-boundary.md) for what is proprietary and
+why the boundary is an API rather than a licence.


### PR DESCRIPTION
Apache 2.0 §4(d) makes `NOTICE` the attribution mechanism, and this repository had none — copyright was inferred from the licence text rather than stated. Kept to three lines deliberately: a NOTICE is reproduced by everyone who redistributes, so anything unnecessary in it is a burden imposed downstream.

Copyright is held by an individual because that is who holds it today. It changes when an entity exists to hold it.

### Authorship

Split across two addresses — 42 commits under GitHub's per-account noreply address (what a squash merge on github.com attributes the result to) and 4 under the address in the DCO sign-off on every commit. `git shortlog -sne` now reports one author:

```
    97  Aswin Alexander Sam <aswinsam@gmail.com>
     3  dependabot[bot] <...>
```

A **mailmap rather than a history rewrite**. Rewriting would mean force-pushing `main`, which the ruleset refuses on purpose, and would change every commit id in every clone — disproportionate for tidying attribution. The canonical address is the one in the sign-off, since that is the identity of record for a contribution; it already appears in every commit message, so this discloses nothing new.

dependabot stays a separate author, which is correct: it is not a person.

### README

The licence section now states that commercial use and resale are permitted, and points at ADR-0009 for why. Reading "Apache 2.0" and assuming a non-commercial restriction is a plausible mistake, and it is the one thing about this licence a reader most needs to have right.