### PR TITLE
fix(health): a client's verdict is authoritative on arrival

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -11,10 +11,25 @@
 //
 // Second, moving traffic is not free. Every reassignment breaks live connections
 // (Invariant 11), so a monitor that changes its mind readily is worse than one
-// that is slightly slow. The hysteresis here is deliberately asymmetric:
-// degradation is immediate, improvement is rate limited. Being slow to distrust
-// a broken advertiser costs users their traffic; being slow to trust a recovered
-// one costs nothing but a little capacity.
+// that is slightly slow. The hysteresis here is deliberately asymmetric, and the
+// asymmetry runs along which signal is speaking rather than along the direction
+// of the change.
+//
+// A client's verdict is authoritative on arrival, because the agent has already
+// applied its own hysteresis before sending one (internal/routeprobe counts
+// failures and successes and holds a minimum time before moving). So a client
+// report improves the state on its own evidence, bounded in time by the cooldown
+// rather than by a second sample count. Counting samples again would apply the
+// same filter twice, and since agents report on change rather than on a timer,
+// the second count is over events and never reaches a threshold sized for
+// polling.
+//
+// Degradation keeps its sample count, which is not symmetry but a different
+// concern: nothing here aggregates across clients yet, so that counter is the
+// only thing between one device's broken Wi-Fi and an advertiser marked
+// unhealthy for the whole network. Being slow to distrust a broken advertiser
+// costs users their traffic, and distrusting a working one on one device's word
+// costs everyone else theirs.
 package health
 
 import (
@@ -308,7 +323,7 @@ func (m *Monitor) Observe(r Report) Transition {
 	case verdictNone:
 	}
 
-	want, reason := m.desiredLocked(v)
+	want, reason := m.desiredLocked(v, r)
 	return m.transitionLocked(want, reason, now)
 }
 
@@ -321,7 +336,7 @@ func (m *Monitor) Tick() Transition {
 }
 
 // desiredLocked computes the state the evidence points at, ignoring cooldown.
-func (m *Monitor) desiredLocked(v verdict) (State, string) {
+func (m *Monitor) desiredLocked(v verdict, r Report) (State, string) {
 	switch v {
 	case verdictFail:
 		if m.consecutiveFail >= m.policy.FailThreshold {
@@ -332,6 +347,25 @@ func (m *Monitor) desiredLocked(v verdict) (State, string) {
 			return StateDegraded, fmt.Sprintf("%d consecutive checks with disagreeing signals", m.consecutivePartial)
 		}
 	case verdictOK:
+		// A client's verdict arrives already filtered. The agent counts its own
+		// failures and successes and holds a minimum time before it moves at all
+		// (internal/routeprobe), so by the time a report is sent the hysteresis
+		// has been applied once. Counting samples again here applies it twice —
+		// and because agents report on change rather than on a timer, the second
+		// count is over events and never reaches a threshold sized for polling.
+		// One client would contribute one sample and the advertiser would sit at
+		// unknown forever, which is what this used to do.
+		//
+		// Deliberately not symmetric with the failure path above. That counter is
+		// the only thing standing between one device's broken Wi-Fi and an
+		// advertiser marked unhealthy for the whole network, because the
+		// cross-client aggregation Report describes does not exist yet. Improving
+		// too readily costs nothing by comparison: an advertiser wrongly called
+		// healthy is one the agents will demote again from their own probes, and
+		// the cooldown in transitionLocked still bounds how often it can happen.
+		if r.ClientObserved == SignalOK {
+			return StateHealthy, "the devices routing through it report reaching it"
+		}
 		if m.consecutiveOK >= m.policy.RecoverThreshold {
 			return StateHealthy, fmt.Sprintf("%d consecutive successful checks", m.consecutiveOK)
 		}

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -63,19 +63,40 @@ func TestVerdictFusion(t *testing.T) {
 	}
 }
 
+// Starting unknown is not the same as starting healthy — and how much evidence it takes to
+// leave depends on who is speaking.
 func TestStartsUnknownAndNeedsEvidence(t *testing.T) {
 	m := NewMonitor(testPolicy(), clock.NewFake())
 	if got := m.State(); got != StateUnknown {
 		t.Fatalf("initial state = %v, want %v", got, StateUnknown)
 	}
-	// One good check is not enough to declare an advertiser fit for traffic.
+
+	// A client's verdict is enough on its own. The agent counted its own failures and
+	// successes and waited out a minimum hold before sending this, so requiring a run of
+	// them here is the same filter applied twice — and since agents report on change
+	// rather than on a timer, the second one never fills.
 	m.Observe(allOK)
-	if got := m.State(); got != StateUnknown {
-		t.Errorf("after 1 of 3 successes: state = %v, want %v", got, StateUnknown)
-	}
-	observeN(m, allOK, 2)
 	if got := m.State(); got != StateHealthy {
-		t.Errorf("after 3 successes: state = %v, want %v", got, StateHealthy)
+		t.Errorf("a client reporting it works left it at %v", got)
+	}
+}
+
+// A polled signal still has to clear the counter, because its samples are raw.
+//
+// Nothing polls yet — the control probe and the advertiser's self-report are both unbuilt —
+// so this covers the path that exists for when they arrive, and pins the distinction that
+// makes the client path defensible rather than merely convenient.
+func TestAPolledSignalStillNeedsARunOfSuccesses(t *testing.T) {
+	m := NewMonitor(testPolicy(), clock.NewFake())
+	polled := Report{SelfReport: SignalOK, ControlProbe: SignalOK}
+
+	m.Observe(polled)
+	if got := m.State(); got != StateUnknown {
+		t.Errorf("one polled success promoted straight to %v", got)
+	}
+	observeN(m, polled, 2)
+	if got := m.State(); got != StateHealthy {
+		t.Errorf("after 3 polled successes: state = %v, want %v", got, StateHealthy)
 	}
 }
 
@@ -134,25 +155,50 @@ func TestSilenceGoesOffline(t *testing.T) {
 // Going offline must discard progress toward recovery. Otherwise an advertiser
 // that banks nine successes, vanishes, and returns with one more is promoted on
 // the strength of evidence gathered before it disappeared.
+//
+// Driven by a polled signal, because banked progress is only observable where the counter
+// governs. A client's verdict does not accumulate — it is authoritative when it arrives —
+// so it could never be promoted on stale evidence in the first place.
 func TestOfflineResetsRecoveryProgress(t *testing.T) {
 	clk := clock.NewFake()
 	p := testPolicy()
 	p.RecoverThreshold = 3
 	m := NewMonitor(p, clk)
+	polled := Report{SelfReport: SignalOK, ControlProbe: SignalOK}
 
-	observeN(m, allOK, 2) // two of the three needed
+	observeN(m, polled, 2) // two of the three needed
 	clk.Advance(2 * time.Minute)
 	if tr := m.Tick(); tr.To != StateOffline {
 		t.Fatalf("state = %v, want %v", tr.To, StateOffline)
 	}
 
-	m.Observe(allOK)
+	m.Observe(polled)
 	if got := m.State(); got == StateHealthy {
 		t.Error("one success after going offline promoted straight to healthy")
 	}
-	observeN(m, allOK, 2)
+	observeN(m, polled, 2)
 	if got := m.State(); got != StateHealthy {
 		t.Errorf("after a fresh run of 3: state = %v, want %v", got, StateHealthy)
+	}
+}
+
+// The other half of the same rule: an advertiser that comes back and is reported working by
+// a device actually routing through it is promoted at once. That is not stale evidence — it
+// is the freshest evidence available, from the only vantage point that measures what users
+// experience. Withholding it would leave a working gateway ranked below its peers until
+// nine more reports arrived that the agent has no reason to send.
+func TestAReturningAdvertiserIsPromotedOnAClientsWord(t *testing.T) {
+	clk := clock.NewFake()
+	m := NewMonitor(testPolicy(), clk)
+
+	observeN(m, allOK, 1)
+	clk.Advance(2 * time.Minute)
+	if tr := m.Tick(); tr.To != StateOffline {
+		t.Fatalf("state = %v, want %v", tr.To, StateOffline)
+	}
+
+	if tr := m.Observe(allOK); tr.To != StateHealthy {
+		t.Errorf("a returning advertiser reported reachable is %v, want healthy", tr.To)
 	}
 }
 

--- a/scripts/e2e-failover.sh
+++ b/scripts/e2e-failover.sh
@@ -353,25 +353,16 @@ if [ "$reported" != "1" ]; then
 fi
 echo "  the control plane recorded the client's verdict (consecutive_ok=${observed})"
 
-# A healthy report must never make an advertiser unselectable. Asserted as "still
-# selectable" rather than as "healthy", and the difference is a finding rather than a
-# looser test:
-#
-# the agent reports only on change, and the monitor needs RecoverThreshold consecutive
-# healthy observations to leave a state. One client therefore contributes exactly one
-# observation and the advertiser stays 'unknown' indefinitely — it only reaches 'healthy'
-# if ten *different* clients happen to report, which is not a design so much as an
-# accident of arithmetic. Selection treats unknown as usable and ranks it last, so nothing
-# breaks today; what breaks is an operator's view, where every advertiser is permanently
-# 'unknown'. Pinning 'healthy' here would assert behaviour this deployment cannot produce,
-# and pinning 'unknown' would freeze the mismatch into a test.
+# One report from one device is enough, because it arrives already filtered: the agent
+# counted its own failures and successes and held a minimum time before sending it, so the
+# control plane does not count samples again. This assertion could not be made until it
+# did — an advertiser used to sit at 'unknown' until ten different clients happened to
+# report, which was arithmetic rather than design.
 state="$(psql "$DB_URL" -tAqc \
   "SELECT state FROM advertiser_health WHERE advertiser_id = '${ADVERTISER_ROW}'")"
-case "$state" in
-  healthy|degraded|unknown) ;;
-  *) fail "a healthy report left the advertiser '${state}', which selection will not use" ;;
-esac
-echo "  and left it selectable (state=${state})"
+[ "$state" = "healthy" ] \
+  || fail "one client reported it reachable and it is '${state}', want healthy"
+echo "  and moved it to healthy on that one report"
 
 echo
 echo "two agents, two namespaces, one real handshake, and a verdict that reached the control plane"


### PR DESCRIPTION
An advertiser stayed `unknown` however healthy it was — found by `scripts/e2e-failover.sh` as soon as it could observe a real client reporting on a real advertiser.

### Two things were wrong

**The counter is sized for a polled signal.** Improvement needs `RecoverThreshold` (10) consecutive successes. The only signal that exists is the client report, and it is *event-driven*: `internal/routeprobe` sends one on change and on first verdict, never on a timer. One client contributes exactly one sample, so the counter never passes 1. Ten *different* clients would do it — arithmetic rather than design.

**It counted hysteresis twice.** The agent applies `FailThreshold=3`, `RecoverThreshold=10` and `MinHold=60s` before sending anything. What reaches the control plane is already filtered — which is what `health.Report`'s own doc comment has claimed all along: *"By the time it arrives here it is authoritative."*

So a client-observed success now moves the state on its own evidence, bounded in time by the cooldown rather than by a second sample count.

### Why it is not symmetric

Not for the reason the package comment used to give. **Degradation was never immediate** either — it has always needed `FailThreshold` consecutive failures, and it keeps them.

That counter is the only thing between one device's broken Wi-Fi and an advertiser marked unhealthy for the *whole network*, because the cross-client aggregation `health.Report` describes doesn't exist yet. Improving too readily costs little by comparison — the agents demote it again from their own probes.

The package comment now says so. It described an asymmetry along the direction of change, when the real one runs along which signal is speaking.

### Tests, re-derived rather than adjusted

Two failed. Both named properties that are still true, but observed them through a signal that no longer behaves that way.

- `TestStartsUnknownAndNeedsEvidence` asserted one success isn't enough. It still isn't — **for a polled signal**. Split, with the counter path now covered by `TestAPolledSignalStillNeedsARunOfSuccesses`. Nothing polls yet, but the path exists for when the control probe does.
- `TestOfflineResetsRecoveryProgress` names a property still true, whose code still runs. Banked progress is only observable where the counter governs, so it's driven by a polled signal now. Its other half is new: an advertiser that returns and is reported working by a device routing through it is promoted at once — not stale evidence, the freshest there is.

### Verification

Mutation tested, all caught:

| mutation | |
|---|---|
| client verdict no longer authoritative | caught |
| polled signal treated as pre-filtered | caught |
| same shortcut wired into the failure path | caught |

The third matters most — it proves the asymmetry is load-bearing and covered, not just asserted in a comment.

End to end against real interfaces and a real database:

```
  the control plane recorded the client's verdict (consecutive_ok=1)
  and moved it to healthy on that one report
```