### PR TITLE
test(e2e): a client fails over from a dead gateway on its own

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,12 @@ jobs:
   integration:
     name: integration (postgres)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Generous because the failover run waits out a real liveness window: internal/tunnel
+    # treats a handshake as live for three minutes, so the earliest possible failover is a
+    # little past that, and a run where failover never happens waits the poll out before it
+    # can say so. Too tight a budget turns that into a job timeout, which reports the wrong
+    # cause — the message an operator needs is "the client never moved", not "cancelled".
+    timeout-minutes: 25
     services:
       postgres:
         image: postgres:16-alpine

--- a/scripts/e2e-failover.sh
+++ b/scripts/e2e-failover.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 #
-# Two live agents, each with its own interface, in their own network namespaces.
+# Three live agents, each with its own interface, in their own network namespaces.
 #
 # This is the topology e2e-enrol.sh cannot build. The control plane hands every device the
 # interface name meshp0, so two daemons on one host fight over it and the second has to be
-# stopped — which means everything that needs two devices *simultaneously alive* has never
-# run outside a unit test:
+# stopped — which means everything that needs several devices *simultaneously alive* has
+# never run outside a unit test:
 #
 #   a client and an advertiser completing a real WireGuard handshake
 #   the client deciding the advertiser is reachable from that handshake
 #   a ReachabilityReport crossing the control channel and reaching the database
+#   a client failing over to a standby when the primary stops answering, on its own
 #
 # The last one is the point. Local failover shipped across two releases wired into nothing
 # at all — cmd/meshpd never called WithChooser — and no test noticed, because a device with
@@ -21,11 +22,12 @@
 #
 #   root ns          mpbr0 10.99.0.1/24 ── meshp-control, meshp-relay
 #                      │
-#      ┌───────────────┴───────────────┐
-#   netns mpc 10.99.0.2            netns mpa 10.99.0.3
-#   the client                     the advertiser
+#      ┌───────────────┼───────────────┬───────────────┐
+#   netns mpc      netns mpa       netns mpb
+#   10.99.0.2      10.99.0.3       10.99.0.4
+#   the client     primary         standby
 #
-# The two agents never address each other directly: every peer is relayed until discovery
+# The agents never address each other directly: every peer is relayed until discovery
 # exists (ADR-0002), so their traffic goes out to the relay on the bridge and back. That is
 # also what makes this topology honest — it is the path a real deployment behind two NATs
 # takes.
@@ -47,8 +49,11 @@ HOST_IP="10.99.0.1"
 BRIDGE="mpbr0"
 CLIENT_NS="mpc"
 ADV_NS="mpa"
+ADV2_NS="mpb"
 CLIENT_IP="10.99.0.2"
 ADV_IP="10.99.0.3"
+ADV2_IP="10.99.0.4"
+ALL_NS="$CLIENT_NS $ADV_NS $ADV2_NS"
 
 # Short paths: a unix socket path has a hard limit near 100 bytes.
 WORK="$(mktemp -d /tmp/mpfo.XXXXXX)"
@@ -57,14 +62,27 @@ RELAY_LOG="$WORK/relay.log"
 CONTROL_PID=""
 RELAY_PID=""
 
+# retire_ns takes a namespace away completely: its processes first, then the namespace
+# itself, which destroys the interfaces inside it.
+#
+# Killing the daemon alone is not enough and it matters. A kernel WireGuard interface
+# answers handshakes on its own — meshpd created it and does not carry its packets — so a
+# gateway whose daemon is dead keeps handshaking, and a test that only killed the daemon
+# would wait out the liveness window and never see a failure.
+retire_ns() {
+  local ns="$1"
+  ip netns pids "$ns" 2>/dev/null | xargs -r kill 2>/dev/null || true
+  ip netns del "$ns" 2>/dev/null || true
+  ip link del "veth-${ns}" 2>/dev/null || true
+}
+
 cleanup() {
   [ -n "$RELAY_PID" ] && kill "$RELAY_PID" 2>/dev/null || true
   [ -n "$CONTROL_PID" ] && kill "$CONTROL_PID" 2>/dev/null || true
   # Deleting a namespace takes its processes and its interfaces with it, which is the tidiest
   # part of this whole approach: no daemon survives, and no meshp0 is left behind.
-  for ns in "$CLIENT_NS" "$ADV_NS"; do
-    ip netns pids "$ns" 2>/dev/null | xargs -r kill 2>/dev/null || true
-    ip netns del "$ns" 2>/dev/null || true
+  for ns in $ALL_NS; do
+    retire_ns "$ns"
   done
   ip link del "$BRIDGE" 2>/dev/null || true
   rm -rf "$WORK"
@@ -75,7 +93,7 @@ fail() {
   echo "FAIL: $*" >&2
   echo "--- control plane log ---" >&2; tail -40 "$CONTROL_LOG" >&2 2>/dev/null || true
   echo "--- relay log ---" >&2; tail -20 "$RELAY_LOG" >&2 2>/dev/null || true
-  for ns in "$CLIENT_NS" "$ADV_NS"; do
+  for ns in $ALL_NS; do
     echo "--- ${ns} agent log ---" >&2; tail -30 "$WORK/${ns}.log" >&2 2>/dev/null || true
   done
   exit 1
@@ -104,7 +122,7 @@ done
 # ---------------------------------------------------------------------------
 # The namespaces
 
-echo "building two network namespaces"
+echo "building three network namespaces"
 ip link add "$BRIDGE" type bridge
 ip addr add "${HOST_IP}/24" dev "$BRIDGE"
 ip link set "$BRIDGE" up
@@ -127,12 +145,13 @@ make_ns() {
 }
 make_ns "$CLIENT_NS" "$CLIENT_IP"
 make_ns "$ADV_NS" "$ADV_IP"
+make_ns "$ADV2_NS" "$ADV2_IP"
 
-ip netns exec "$CLIENT_NS" ping -c 1 -W 2 "$HOST_IP" >/dev/null 2>&1 \
-  || fail "the client namespace cannot reach the host"
-ip netns exec "$ADV_NS" ping -c 1 -W 2 "$HOST_IP" >/dev/null 2>&1 \
-  || fail "the advertiser namespace cannot reach the host"
-echo "  ${CLIENT_NS} ${CLIENT_IP} and ${ADV_NS} ${ADV_IP} both reach ${HOST_IP}"
+for ns in $ALL_NS; do
+  ip netns exec "$ns" ping -c 1 -W 2 "$HOST_IP" >/dev/null 2>&1 \
+    || fail "namespace ${ns} cannot reach the host"
+done
+echo "  ${ALL_NS} all reach ${HOST_IP}"
 
 # ---------------------------------------------------------------------------
 # The deployment
@@ -251,29 +270,39 @@ ready_ns() {
   fail "${ns} never reached a live session and interface"
 }
 
-echo "enrolling a client and an advertiser"
+echo "enrolling a client and two advertisers"
 join_ns "$CLIENT_NS" "failover-client"
-join_ns "$ADV_NS" "failover-advertiser"
-ready_ns "$CLIENT_NS"
-ready_ns "$ADV_NS"
+join_ns "$ADV_NS" "failover-primary"
+join_ns "$ADV2_NS" "failover-standby"
+for ns in $ALL_NS; do
+  ready_ns "$ns"
+done
 
-# Both agents hold meshp0, which is the whole reason for the namespaces.
-ip netns exec "$CLIENT_NS" wg show meshp0 >/dev/null 2>&1 \
-  || fail "the client has no meshp0"
-ip netns exec "$ADV_NS" wg show meshp0 >/dev/null 2>&1 \
-  || fail "the advertiser has no meshp0"
-echo "  two devices, both holding meshp0, in their own namespaces"
+# All three hold meshp0, which is the whole reason for the namespaces.
+for ns in $ALL_NS; do
+  ip netns exec "$ns" wg show meshp0 >/dev/null 2>&1 || fail "${ns} has no meshp0"
+done
+echo "  three devices, all holding meshp0, in their own namespaces"
 
-CLIENT_MEMBERSHIP="$(sed -n 's/.*"membership_id": *"\([^"]*\)".*/\1/p' \
-  "$WORK/${CLIENT_NS}-state/state.json" | head -1)"
-ADV_MEMBERSHIP="$(sed -n 's/.*"membership_id": *"\([^"]*\)".*/\1/p' \
-  "$WORK/${ADV_NS}-state/state.json" | head -1)"
-[ -n "$CLIENT_MEMBERSHIP" ] && [ -n "$ADV_MEMBERSHIP" ] \
-  || fail "could not read both membership ids"
+# membership_of and addr_of read what a device was given, from the state its own daemon
+# wrote. Reading it from there rather than from the API is a check in itself: the two have
+# to agree about who this device is.
+membership_of() {
+  sed -n 's/.*"membership_id": *"\([^"]*\)".*/\1/p' "$WORK/${1}-state/state.json" | head -1
+}
+addr_of() {
+  sed -n 's/.*"address_v4": *"\([^"]*\)".*/\1/p' "$WORK/${1}-state/state.json" \
+    | head -1 | cut -d/ -f1
+}
 
-ADV_ADDR="$(sed -n 's/.*"address_v4": *"\([^"]*\)".*/\1/p' \
-  "$WORK/${ADV_NS}-state/state.json" | head -1 | cut -d/ -f1)"
-[ -n "$ADV_ADDR" ] || fail "could not read the advertiser's mesh address"
+CLIENT_MEMBERSHIP="$(membership_of "$CLIENT_NS")"
+ADV_MEMBERSHIP="$(membership_of "$ADV_NS")"
+ADV2_MEMBERSHIP="$(membership_of "$ADV2_NS")"
+ADV_ADDR="$(addr_of "$ADV_NS")"
+ADV2_ADDR="$(addr_of "$ADV2_NS")"
+for v in "$CLIENT_MEMBERSHIP" "$ADV_MEMBERSHIP" "$ADV2_MEMBERSHIP" "$ADV_ADDR" "$ADV2_ADDR"; do
+  [ -n "$v" ] || fail "could not read every device's membership id and address"
+done
 
 # ---------------------------------------------------------------------------
 # A real handshake
@@ -312,15 +341,39 @@ api -X POST -d "{\"membership_id\":\"${ADV_MEMBERSHIP}\",\"priority\":1}" \
   "${BASE}/api/v1/networks/${NETWORK_ID}/route-groups/branch-lan/advertisers" >"$WORK/adv.out" \
   || { cat "$WORK/adv.out" >&2; fail "recording the advertiser failed"; }
 
+# A standby behind it. The server orders the candidates and the agent picks among them
+# (ADR-0003), so this is the list the client gets to choose from — priority 2 means the
+# client should be using the other one until it stops answering.
+api -X POST -d "{\"membership_id\":\"${ADV2_MEMBERSHIP}\",\"priority\":2}" \
+  "${BASE}/api/v1/networks/${NETWORK_ID}/route-groups/branch-lan/advertisers" >"$WORK/adv2.out" \
+  || { cat "$WORK/adv2.out" >&2; fail "recording the standby advertiser failed"; }
+
+# carrier_of names the mesh address of whichever peer holds the carried prefix.
+#
+# By address rather than by key because both are on the same line of `wg show allowed-ips`:
+# a peer's own /32 sits beside whatever prefixes it carries. Identifying the carrier matters
+# — "the prefix is on the interface" is satisfied by the wrong peer holding it, which is a
+# device sending the customer's traffic somewhere that cannot deliver it.
+carrier_of() {
+  local line
+  line="$(ip netns exec "$CLIENT_NS" wg show meshp0 allowed-ips 2>/dev/null | grep -F "$CARRIED" || true)"
+  case "$line" in
+    *"${ADV_ADDR}/32"*)  echo "$ADV_ADDR" ;;
+    *"${ADV2_ADDR}/32"*) echo "$ADV2_ADDR" ;;
+    *) echo "" ;;
+  esac
+}
+
 carried=0
 for _ in $(seq 1 30); do
-  if ip netns exec "$CLIENT_NS" wg show meshp0 allowed-ips 2>/dev/null | grep -qF "$CARRIED"; then
-    carried=1; break
-  fi
+  if [ "$(carrier_of)" = "$ADV_ADDR" ]; then carried=1; break; fi
   sleep 1
 done
-[ "$carried" = "1" ] || fail "the client never carried ${CARRIED}"
-echo "  the client routes ${CARRIED} through the advertiser"
+if [ "$carried" != "1" ]; then
+  ip netns exec "$CLIENT_NS" wg show meshp0 allowed-ips >&2
+  fail "the client never carried ${CARRIED} through the first-preference advertiser"
+fi
+echo "  the client routes ${CARRIED} through the primary (${ADV_ADDR})"
 
 # ---------------------------------------------------------------------------
 # The report
@@ -364,5 +417,67 @@ state="$(psql "$DB_URL" -tAqc \
   || fail "one client reported it reachable and it is '${state}', want healthy"
 echo "  and moved it to healthy on that one report"
 
+# ---------------------------------------------------------------------------
+# Failing over
+#
+# The primary goes away entirely — processes and namespace, which takes its interface with
+# it. Killing the daemon would not do: a kernel WireGuard interface answers handshakes on
+# its own, so the gateway would keep looking alive to the one signal the agent reads.
+#
+# Then nothing is done to the client at all. No command, no state delta, no control-plane
+# involvement of any kind. It has to work this out from the kernel it already reads every
+# reconcile pass, which is the entire claim of ADR-0003: a device that had to ask could not
+# fail over during a control-plane outage, and an outage is when it matters most.
+echo "retiring the primary advertiser"
+retire_ns "$ADV_NS"
+
+# The wait is real and cannot be tuned away. internal/tunnel treats a handshake as live for
+# livenessGrace (3 minutes) — deliberately longer than WireGuard's own rekey interval, so a
+# working advertiser is never declared dead over a late rekey — and internal/routeprobe then
+# wants FailThreshold consecutive failing passes before it moves. So the earliest possible
+# failover is a little over three minutes after the last successful handshake, and this
+# polls rather than sleeping so it reports the moment it happens.
+echo "  waiting for the client to notice (livenessGrace is 3m, so this takes a while)"
+started="$(date +%s)"
+moved=0
+for _ in $(seq 1 100); do
+  if [ "$(carrier_of)" = "$ADV2_ADDR" ]; then moved=1; break; fi
+  sleep 5
+done
+elapsed="$(( $(date +%s) - started ))"
+
+if [ "$moved" != "1" ]; then
+  echo "--- client allowed-ips ---" >&2
+  ip netns exec "$CLIENT_NS" wg show meshp0 allowed-ips >&2
+  echo "--- client handshakes ---" >&2
+  ip netns exec "$CLIENT_NS" wg show meshp0 latest-handshakes >&2
+  echo "--- client agent log ---" >&2
+  grep -iE "advertis|moving|route" "$WORK/${CLIENT_NS}.log" | tail -30 >&2 || true
+  fail "the client never moved to the standby after ${elapsed}s"
+fi
+echo "  moved to the standby (${ADV2_ADDR}) after ${elapsed}s, with nothing asked of the server"
+
+# The route follows the cryptokey routing, or the client accepts the customer's LAN and has
+# no way to send anything to it.
+ip netns exec "$CLIENT_NS" ip route show dev meshp0 | grep -qF "$CARRIED" \
+  || { ip netns exec "$CLIENT_NS" ip route show dev meshp0 >&2
+       fail "the carried prefix has no route after the move"; }
+echo "  and the route moved with it"
+
+# The move is reported, which is what lets every other device be reordered away from a
+# gateway this one found dead. Without it each device would have to rediscover the same
+# failure alone, three minutes at a time.
+told=0
+for _ in $(seq 1 30); do
+  if grep -q "a device moved between advertisers" "$CONTROL_LOG"; then told=1; break; fi
+  sleep 2
+done
+if [ "$told" != "1" ]; then
+  echo "--- control plane log ---" >&2; grep -iE "advertiser|reachab" "$CONTROL_LOG" | tail -20 >&2 || true
+  fail "the client moved and never told the control plane"
+fi
+sed -n 's/.*\(msg="a device moved between advertisers".*\)/  \1/p' "$CONTROL_LOG" | tail -1
+
 echo
-echo "two agents, two namespaces, one real handshake, and a verdict that reached the control plane"
+echo "three agents, three namespaces, a real handshake, a verdict that reached the control"
+echo "plane, and a failover the client worked out for itself"


### PR DESCRIPTION
The last claim in the route-group work that nothing executed.

Local failover has been built across four PRs, and every test of it was a unit test on the *decision* — fake clock, fake link. Whether a real device on a real kernel actually leaves a real gateway had never been run.

### The topology

A third namespace makes the primary disposable. It is then taken away entirely — processes **and** namespace, which destroys its interface.

Killing the daemon is not enough, and the difference matters: **a kernel WireGuard interface answers handshakes on its own.** A gateway whose daemon is dead keeps looking alive to the one signal the agent reads, so a test that only killed `meshpd` would wait out the liveness window and see nothing.

Then **nothing is done to the client** — no command, no state delta, no control-plane involvement. It works this out from the kernel it already reads every reconcile pass. That is the whole claim of ADR-0003: a device that had to ask could not fail over during a control-plane outage, which is when it needs to.

```
  the client routes 192.168.2.0/24 through the primary (100.91.2.2)
  moved to the standby (100.91.2.3) after 191s, with nothing asked of the server
  and the route moved with it
  msg="a device moved between advertisers" from=8da0fe17 to=9188cf7e
    reason="the advertiser in use stopped answering probes"
```

### 191 seconds is not slack

`internal/tunnel` treats a handshake as live for `livenessGrace` (3 min) — deliberately longer than WireGuard's rekey interval, so a working advertiser is never called dead over a late rekey — and `routeprobe` then wants `FailThreshold` consecutive failing passes. The earliest possible failover is a little past three minutes. The script polls rather than sleeping, so it reports the moment it happens.

### Which peer carries it

Now asserted **by address**, not just that the prefix is somewhere on the interface. The wrong peer holding it satisfies every other assertion here while sending the customer's traffic to a device that cannot deliver it.

### Mutation tested

Chooser consulted and its answer discarded — the exact shape of *failover is wired but inert*:

```
  the client routes 192.168.2.0/24 through the primary (100.91.2.2)   <- passes
  the control plane recorded the client's verdict (consecutive_ok=1)  <- passes
FAIL: the client never moved to the standby after 503s
```

Same signature as the `WithChooser` bug this harness was built for.

### One CI change

The integration job's timeout goes 15 → 25 minutes. A run where failover never happens waits the poll out before it can say so, and too tight a budget turns that into a job timeout — reporting the wrong cause. The message an operator needs is *"the client never moved"*, not *"cancelled"*.