### PR TITLE
feat(egress): the fail-closed kill switch, before anything claims a route

### DIFF
--- a/internal/nftables/filter.go
+++ b/internal/nftables/filter.go
@@ -35,6 +35,20 @@ func (f *Filter) Apply(ctx context.Context, iface string, filter *meshpv1.Packet
 // Forwarding is enabled before the rules rather than after: rules that permit forwarding on
 // a host whose kernel will not forward are correct and do nothing, and the gap between the
 // two would be a window where a gateway looks configured and drops everything.
+// ApplyLock makes this device refuse egress that does not go through the tunnel, or stops
+// it refusing.
+//
+// A zero LockSpec removes the lock. That is the only way it comes off from here — the rules
+// are system state and outlive this process on purpose (ADR-0011), so nothing about the
+// agent exiting takes them away.
+func (f *Filter) ApplyLock(ctx context.Context, spec LockSpec) error {
+	script, err := RenderLock(spec)
+	if err != nil {
+		return err
+	}
+	return Apply(ctx, script)
+}
+
 func (f *Filter) ApplyForward(ctx context.Context, iface string, groups []*meshpv1.AdvertisedRoutes_Group) error {
 	if len(groups) > 0 {
 		if _, err := EnableForwarding(); err != nil {

--- a/internal/nftables/lock.go
+++ b/internal/nftables/lock.go
@@ -1,0 +1,172 @@
+package nftables
+
+import (
+	"fmt"
+	"net/netip"
+	"sort"
+	"strings"
+)
+
+// LockTableName is the table a fail-closed device's egress rules live in.
+//
+// Its own table for the reason the forwarding rules have one, and for a sharper one besides:
+// this is the only table here that can take a machine off the network. Keeping it separate
+// means it can be found and removed on its own, by a `meshp down`, by an agent starting up
+// and finding what a previous life left behind, or by a person with a console and no idea
+// what meshp is.
+const LockTableName = "meshp_lock"
+
+// LockSpec is what a device may still reach while it fails closed.
+//
+// Everything not named here is refused. The fields are therefore not conveniences — each one
+// is a way for the device to stay usable and reachable while the tunnel is the only route
+// out, and omitting one is how this feature turns into a bricked machine (ADR-0011).
+type LockSpec struct {
+	// Interface is the tunnel. Traffic leaving through it is the entire point of claiming a
+	// default route, so it is always permitted.
+	Interface string
+
+	// Endpoints are the outer addresses that make the tunnel possible: the relay this device
+	// attaches to, and the control plane that can tell it to stop.
+	//
+	// Without these the lock deadlocks — no tunnel, because no egress; no egress, because no
+	// tunnel — and it deadlocks in the state where the machine cannot be told to unlock.
+	Endpoints []netip.AddrPort
+
+	// Excluded are prefixes an administrator has carved out, and the local network.
+	//
+	// A device that cannot reach its own LAN while tunnelled has lost its printer, its NAS
+	// and often its default gateway. What belongs in here is decided elsewhere; this only
+	// renders it.
+	Excluded []netip.Prefix
+}
+
+// RenderLock turns a lock specification into a ruleset that refuses everything else.
+//
+// An empty Interface renders a script that removes the table, which is how a device stops
+// failing closed — the same shape RenderForward uses for a device that has stopped carrying.
+//
+// Three deliberate differences from the other tables here.
+//
+// The chain's policy is drop rather than accept. Elsewhere a chain that somehow ends up
+// empty must not disturb traffic that has nothing to do with meshp; here an empty chain
+// means every rule that was holding the line is gone, and this is the one table whose whole
+// job is to fail closed rather than open.
+//
+// There is no blanket `ct state established,related accept`. The forwarding table needs one
+// or connections hang, but a connection established before the lock went up is exactly what
+// this exists to stop: the user's real address, still in use, after the tunnel dropped.
+//
+// The last rule rejects rather than drops. A dropped packet leaves an application hanging
+// until it times out, and the user learns nothing; a rejected one fails immediately with an
+// error the operating system already knows how to describe. ADR-0011 is explicit that there
+// will be users whose network broke because their laptop correctly refused to leak, and that
+// the error message is the product.
+func RenderLock(spec LockSpec) (string, error) {
+	var b strings.Builder
+
+	// add-then-delete so removal is idempotent: deleting a table that is not there is an
+	// error, and adding one that is already there is not.
+	fmt.Fprintf(&b, "add table inet %s\n", LockTableName)
+	fmt.Fprintf(&b, "delete table inet %s\n", LockTableName)
+	if spec.Interface == "" {
+		return b.String(), nil
+	}
+	if !interfaceNamePattern.MatchString(spec.Interface) {
+		return "", fmt.Errorf("nftables: %q is not a usable interface name", spec.Interface)
+	}
+
+	fmt.Fprintf(&b, "add table inet %s\n", LockTableName)
+	fmt.Fprintf(&b, "add chain inet %s output { type filter hook output priority filter; policy drop; }\n",
+		LockTableName)
+
+	// Loopback first, and unconditionally. The agent's own control socket, a local resolver
+	// and everything a desktop does with 127.0.0.1 go through here, and a lock that broke
+	// them would break the machine rather than its egress.
+	fmt.Fprintf(&b, "add rule inet %s output oif lo accept\n", LockTableName)
+
+	// The tunnel itself: this is what the traffic is supposed to use.
+	fmt.Fprintf(&b, "add rule inet %s output oifname %q accept\n", LockTableName, spec.Interface)
+
+	// The outer packets that carry the tunnel, and the control channel that can end it.
+	// Rendered from parsed addresses rather than interpolated text — this script runs as
+	// root and the endpoints arrive from the control plane.
+	for _, ep := range sortedEndpoints(spec.Endpoints) {
+		addr := ep.Addr().Unmap()
+		family := "ip"
+		if addr.Is6() {
+			family = "ip6"
+		}
+		fmt.Fprintf(&b, "add rule inet %s output %s daddr %s udp dport %d accept\n",
+			LockTableName, family, addr.String(), ep.Port())
+		fmt.Fprintf(&b, "add rule inet %s output %s daddr %s tcp dport %d accept\n",
+			LockTableName, family, addr.String(), ep.Port())
+	}
+
+	// The local network and anything else carved out.
+	excluded := splitPrefixes(spec.Excluded)
+	if len(excluded.v4) > 0 {
+		fmt.Fprintf(&b, "add rule inet %s output ip daddr %s accept\n", LockTableName, set(excluded.v4))
+	}
+	if len(excluded.v6) > 0 {
+		fmt.Fprintf(&b, "add rule inet %s output ip6 daddr %s accept\n", LockTableName, set(excluded.v6))
+	}
+
+	// Keeping the address the machine has. A device that cannot renew a DHCP lease loses its
+	// network some minutes later, and a device that cannot do neighbour discovery loses IPv6
+	// immediately — both of which look exactly like the bug this feature exists to prevent,
+	// and neither of which carries any of the user's traffic.
+	fmt.Fprintf(&b, "add rule inet %s output udp dport { 67, 68, 546, 547 } accept\n", LockTableName)
+	fmt.Fprintf(&b, "add rule inet %s output meta l4proto ipv6-icmp accept\n", LockTableName)
+
+	// And everything else is refused, audibly.
+	fmt.Fprintf(&b, "add rule inet %s output reject\n", LockTableName)
+
+	return b.String(), nil
+}
+
+// sortedEndpoints puts the endpoints in a stable order, so the same specification renders
+// the same script and an unchanged lock is not reloaded for nothing.
+func sortedEndpoints(in []netip.AddrPort) []netip.AddrPort {
+	out := make([]netip.AddrPort, 0, len(in))
+	seen := make(map[netip.AddrPort]struct{}, len(in))
+	for _, ep := range in {
+		if !ep.Addr().IsValid() || ep.Port() == 0 {
+			continue
+		}
+		norm := netip.AddrPortFrom(ep.Addr().Unmap(), ep.Port())
+		if _, dup := seen[norm]; dup {
+			continue
+		}
+		seen[norm] = struct{}{}
+		out = append(out, norm)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	return out
+}
+
+// splitPrefixes sorts prefixes into families, dropping anything unusable rather than
+// refusing the whole lock: a malformed exclusion should cost that exclusion, not leave the
+// device with no lock at all.
+func splitPrefixes(in []netip.Prefix) families {
+	var out families
+	seen := make(map[netip.Prefix]struct{}, len(in))
+	for _, p := range in {
+		if !p.IsValid() {
+			continue
+		}
+		norm := netip.PrefixFrom(p.Addr().Unmap(), p.Bits()).Masked()
+		if _, dup := seen[norm]; dup {
+			continue
+		}
+		seen[norm] = struct{}{}
+		if norm.Addr().Is4() {
+			out.v4 = append(out.v4, norm.String())
+		} else {
+			out.v6 = append(out.v6, norm.String())
+		}
+	}
+	sort.Strings(out.v4)
+	sort.Strings(out.v6)
+	return out
+}

--- a/internal/nftables/lock_linux_test.go
+++ b/internal/nftables/lock_linux_test.go
@@ -1,0 +1,240 @@
+//go:build linux
+
+package nftables
+
+import (
+	"context"
+	"net/netip"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A lock that renders correctly, loads, and does not actually stop anything is the worst of
+// the three outcomes: it reports a property the device does not have, which is the exact
+// dishonesty ADR-0011 exists to prevent. So these run against a real kernel and a real nft,
+// and the last two assert what a packet does rather than what a ruleset says.
+
+func requireLockableKernel(t *testing.T) {
+	t.Helper()
+	if !Available(context.Background()) {
+		t.Skip("nft is unavailable or unusable here; run this in the privileged container")
+	}
+	if _, err := exec.LookPath("ip"); err != nil {
+		t.Skip("iproute2 is unavailable; run this in the privileged container")
+	}
+	t.Cleanup(func() {
+		// Never leave a lock behind on a host that ran the tests. This is the cleanup path
+		// the feature itself depends on, so a test that skipped it would be leaving the
+		// machine in the state the ADR calls the worst bug we can ship.
+		if script, err := RenderLock(LockSpec{}); err == nil {
+			_ = Apply(context.Background(), script)
+		}
+	})
+}
+
+func lockLoaded(t *testing.T) bool {
+	t.Helper()
+	return exec.Command("nft", "list", "table", "inet", LockTableName).Run() == nil
+}
+
+// The kernel's opinion of the ruleset, which is the only one that counts. Every expression
+// here — the reject verb, the port set, the ipv6-icmp match — is one nft could parse
+// differently from how the manual reads.
+func TestTheKernelAcceptsTheLock(t *testing.T) {
+	requireLockableKernel(t)
+
+	spec := LockSpec{
+		Interface: "meshp0",
+		Endpoints: []netip.AddrPort{
+			netip.MustParseAddrPort("198.51.100.7:3478"),
+			netip.MustParseAddrPort("[2001:db8::1]:443"),
+		},
+		Excluded: []netip.Prefix{netip.MustParsePrefix("192.168.1.0/24")},
+	}
+	script, err := RenderLock(spec)
+	if err != nil {
+		t.Fatalf("RenderLock: %v", err)
+	}
+	if err := Apply(context.Background(), script); err != nil {
+		t.Fatalf("the kernel refused the lock: %v\n%s", err, script)
+	}
+	if !lockLoaded(t) {
+		t.Fatal("the lock applied without error and is not in the kernel")
+	}
+
+	out, err := exec.Command("nft", "list", "table", "inet", LockTableName).CombinedOutput()
+	if err != nil {
+		t.Fatalf("listing: %v: %s", err, out)
+	}
+	if !strings.Contains(string(out), "policy drop") {
+		t.Errorf("the loaded chain does not drop by default:\n%s", out)
+	}
+}
+
+// Applying twice must be a no-op rather than an accumulation. The reconciler is a loop, so
+// anything that grows a rule per pass grows without bound.
+func TestApplyingTheLockTwiceChangesNothing(t *testing.T) {
+	requireLockableKernel(t)
+
+	spec := LockSpec{Interface: "meshp0", Endpoints: []netip.AddrPort{
+		netip.MustParseAddrPort("198.51.100.7:3478"),
+	}}
+	script, err := RenderLock(spec)
+	if err != nil {
+		t.Fatalf("RenderLock: %v", err)
+	}
+	if err := Apply(context.Background(), script); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	first, _ := exec.Command("nft", "list", "table", "inet", LockTableName).CombinedOutput()
+	if err := Apply(context.Background(), script); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	second, _ := exec.Command("nft", "list", "table", "inet", LockTableName).CombinedOutput()
+
+	if string(first) != string(second) {
+		t.Errorf("applying the lock twice changed it:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+}
+
+// Removal, which is the path that decides whether this feature is safe to have at all.
+func TestTheLockCanBeTakenOff(t *testing.T) {
+	requireLockableKernel(t)
+
+	script, err := RenderLock(LockSpec{Interface: "meshp0"})
+	if err != nil {
+		t.Fatalf("RenderLock: %v", err)
+	}
+	if err := Apply(context.Background(), script); err != nil {
+		t.Fatalf("applying: %v", err)
+	}
+	if !lockLoaded(t) {
+		t.Fatal("the lock is not loaded, so removing it proves nothing")
+	}
+
+	off, err := RenderLock(LockSpec{})
+	if err != nil {
+		t.Fatalf("RenderLock(empty): %v", err)
+	}
+	if err := Apply(context.Background(), off); err != nil {
+		t.Fatalf("removing: %v", err)
+	}
+	if lockLoaded(t) {
+		t.Error("the lock survived its own removal")
+	}
+
+	// And removing one that is not there has to work, because the caller that needs it most
+	// is an agent starting up with no idea what its previous life left behind.
+	if err := Apply(context.Background(), off); err != nil {
+		t.Errorf("removing a lock that was not installed failed: %v", err)
+	}
+}
+
+// What a packet actually does.
+//
+// Run inside a namespace with one veth to the host, because a locked chain in the root
+// namespace would cut off the machine running the tests — including, on a CI runner, the
+// job's own connection. The namespace gives a real routing table, a real interface and a
+// real reachable address to be denied.
+func TestTheLockStopsAndRestoresRealTraffic(t *testing.T) {
+	requireLockableKernel(t)
+
+	const ns = "meshplock"
+	const hostIP = "10.98.0.1"
+	const nsIP = "10.98.0.2"
+
+	_ = exec.Command("ip", "netns", "del", ns).Run()
+	if out, err := exec.Command("ip", "netns", "add", ns).CombinedOutput(); err != nil {
+		t.Skipf("cannot create a network namespace here: %v: %s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("ip", "netns", "del", ns).Run()
+		_ = exec.Command("ip", "link", "del", "vlock0").Run()
+	})
+
+	for _, args := range [][]string{
+		{"ip", "link", "add", "vlock0", "type", "veth", "peer", "name", "vlock1"},
+		{"ip", "addr", "add", hostIP + "/24", "dev", "vlock0"},
+		{"ip", "link", "set", "vlock0", "up"},
+		{"ip", "link", "set", "vlock1", "netns", ns},
+		{"ip", "-n", ns, "addr", "add", nsIP + "/24", "dev", "vlock1"},
+		{"ip", "-n", ns, "link", "set", "vlock1", "up"},
+		{"ip", "-n", ns, "link", "set", "lo", "up"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%s: %v: %s", strings.Join(args, " "), err, out)
+		}
+	}
+
+	reaches := func(target string) bool {
+		return exec.Command("ip", "netns", "exec", ns,
+			"ping", "-c", "1", "-W", "2", target).Run() == nil
+	}
+	applyInNS := func(t *testing.T, script string) {
+		t.Helper()
+		cmd := exec.Command("ip", "netns", "exec", ns, "nft", "-f", "-")
+		cmd.Stdin = strings.NewReader(script)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("applying in the namespace: %v: %s\n%s", err, out, script)
+		}
+	}
+
+	// Without this the rest proves nothing: a lock that blocks traffic which was never
+	// flowing is indistinguishable from one that works.
+	if !reaches(hostIP) {
+		t.Skip("the namespace cannot reach the host before any lock; nothing to prove")
+	}
+
+	locked, err := RenderLock(LockSpec{Interface: "meshp0"})
+	if err != nil {
+		t.Fatalf("RenderLock: %v", err)
+	}
+	applyInNS(t, locked)
+	if reaches(hostIP) {
+		t.Error("traffic still left the namespace with the lock on")
+	}
+
+	// And it fails audibly rather than hanging. A dropped packet leaves the application
+	// waiting out its own timeout and tells the user nothing; the refusal is what ADR-0011
+	// means by the error message being the product. Timed rather than matched on text
+	// because ping's wording varies: a rejection returns in microseconds over a veth, and
+	// the -W 3 below is what a silent drop would cost instead.
+	started := time.Now()
+	_ = exec.Command("ip", "netns", "exec", ns, "ping", "-c", "1", "-W", "3", hostIP).Run()
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Errorf("the lock took %s to refuse a packet, so it is dropping silently rather "+
+			"than rejecting; applications will hang instead of failing", elapsed.Round(time.Millisecond))
+	}
+
+	// Loopback has to survive, or the lock takes the machine out rather than its egress.
+	if !reaches("127.0.0.1") {
+		t.Error("the lock broke loopback, which takes the machine out rather than its egress")
+	}
+
+	// An exclusion is how the local network keeps working while tunnelled.
+	excluded, err := RenderLock(LockSpec{
+		Interface: "meshp0",
+		Excluded:  []netip.Prefix{netip.MustParsePrefix(hostIP + "/32")},
+	})
+	if err != nil {
+		t.Fatalf("RenderLock: %v", err)
+	}
+	applyInNS(t, excluded)
+	if !reaches(hostIP) {
+		t.Error("an excluded prefix was still blocked")
+	}
+
+	// And taking the lock off gives the network back. This is the assertion that decides
+	// whether the feature is safe to ship: everything above is recoverable only if this
+	// works every time.
+	off, err := RenderLock(LockSpec{})
+	if err != nil {
+		t.Fatalf("RenderLock(empty): %v", err)
+	}
+	applyInNS(t, off)
+	if !reaches(hostIP) {
+		t.Error("the network did not come back after the lock was removed")
+	}
+}

--- a/internal/nftables/lock_test.go
+++ b/internal/nftables/lock_test.go
@@ -1,0 +1,137 @@
+package nftables
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+func aLock() LockSpec {
+	return LockSpec{
+		Interface: "meshp0",
+		Endpoints: []netip.AddrPort{
+			netip.MustParseAddrPort("198.51.100.7:3478"),
+			netip.MustParseAddrPort("[2001:db8::1]:443"),
+		},
+		Excluded: []netip.Prefix{
+			netip.MustParsePrefix("192.168.1.0/24"),
+			netip.MustParsePrefix("fd00::/64"),
+		},
+	}
+}
+
+func renderLock(t *testing.T, spec LockSpec) string {
+	t.Helper()
+	script, err := RenderLock(spec)
+	if err != nil {
+		t.Fatalf("RenderLock: %v", err)
+	}
+	return script
+}
+
+// The whole point: anything not named is refused.
+func TestTheLockRefusesWhatItDoesNotName(t *testing.T) {
+	script := renderLock(t, aLock())
+
+	if !strings.Contains(script, "policy drop") {
+		t.Error("the output chain does not default to dropping; an empty chain would leak")
+	}
+	if !strings.Contains(script, "output reject") {
+		t.Error("nothing refuses the traffic that matched no rule")
+	}
+}
+
+// Each of these is a way the machine stays usable while it fails closed. Losing one is not a
+// degraded lock, it is a device somebody has to physically recover.
+func TestTheLockLetsTheMachineKeepWorking(t *testing.T) {
+	script := renderLock(t, aLock())
+
+	for _, want := range []struct {
+		rule, why string
+	}{
+		{"output oif lo accept", "loopback, or the agent cannot reach its own socket"},
+		{`output oifname "meshp0" accept`, "the tunnel, which is what the traffic is for"},
+		{"ip daddr 198.51.100.7 udp dport 3478 accept", "the relay, or the tunnel cannot come up"},
+		{"ip6 daddr 2001:db8::1 tcp dport 443 accept", "the control plane, over IPv6"},
+		{"ip daddr 192.168.1.0/24 accept", "the local network"},
+		{"ip6 daddr fd00::/64 accept", "the local network, over IPv6"},
+		{"udp dport { 67, 68, 546, 547 } accept", "DHCP, or the lease expires and the machine falls off"},
+		{"meta l4proto ipv6-icmp accept", "neighbour discovery, or IPv6 stops working at once"},
+	} {
+		if !strings.Contains(script, want.rule) {
+			t.Errorf("missing %q\n  needed for: %s\n%s", want.rule, want.why, script)
+		}
+	}
+}
+
+// A connection that was already open when the tunnel dropped is precisely what this exists
+// to stop. The forwarding table needs conntrack or connections hang; this must not have it.
+func TestTheLockDoesNotSpareEstablishedConnections(t *testing.T) {
+	script := renderLock(t, aLock())
+
+	if strings.Contains(script, "ct state established") {
+		t.Error("established connections are spared, so a leak in progress continues after the tunnel drops")
+	}
+}
+
+// Rules that outlive the process are only safe if they can be taken off deliberately.
+func TestAnEmptySpecRemovesTheLock(t *testing.T) {
+	script := renderLock(t, LockSpec{})
+
+	if !strings.Contains(script, "delete table inet "+LockTableName) {
+		t.Fatalf("an empty spec does not remove the table:\n%s", script)
+	}
+	if strings.Contains(script, "policy drop") {
+		t.Errorf("an empty spec still installed a locking chain:\n%s", script)
+	}
+}
+
+// Removal has to work whether or not a lock is currently installed, because the caller that
+// needs it most is an agent starting up with no idea what its previous life did.
+func TestRemovalIsIdempotent(t *testing.T) {
+	script := renderLock(t, LockSpec{})
+
+	add := strings.Index(script, "add table inet "+LockTableName)
+	del := strings.Index(script, "delete table inet "+LockTableName)
+	if add < 0 || del < 0 || add > del {
+		t.Errorf("removal does not add before deleting, so it fails when no table exists:\n%s", script)
+	}
+}
+
+// The script runs as root and the endpoints come from the control plane.
+func TestTheLockRefusesAnUnusableInterfaceName(t *testing.T) {
+	_, err := RenderLock(LockSpec{Interface: "meshp0; rm -rf /"})
+	if err == nil {
+		t.Fatal("an interface name with a shell metacharacter was accepted")
+	}
+}
+
+// An exclusion nobody can parse should cost that exclusion, not the whole lock. Refusing to
+// render would leave the device with no lock at all, which is the failure that matters.
+func TestAnUnusableExclusionDoesNotCostTheLock(t *testing.T) {
+	spec := aLock()
+	spec.Excluded = append(spec.Excluded, netip.Prefix{})
+	script := renderLock(t, spec)
+
+	if !strings.Contains(script, "output reject") {
+		t.Error("one bad exclusion removed the lock entirely")
+	}
+	if !strings.Contains(script, "ip daddr 192.168.1.0/24 accept") {
+		t.Error("the usable exclusions were lost with the unusable one")
+	}
+}
+
+// The same specification has to render the same script, or every reconcile pass reloads a
+// ruleset that has not changed and resets its counters.
+func TestTheSameSpecRendersTheSameScript(t *testing.T) {
+	spec := aLock()
+	shuffled := LockSpec{
+		Interface: spec.Interface,
+		Endpoints: []netip.AddrPort{spec.Endpoints[1], spec.Endpoints[0], spec.Endpoints[1]},
+		Excluded:  []netip.Prefix{spec.Excluded[1], spec.Excluded[0]},
+	}
+
+	if renderLock(t, spec) != renderLock(t, shuffled) {
+		t.Error("the same lock rendered differently depending on the order it was given in")
+	}
+}


### PR DESCRIPTION
First slice of ADR-0011. **The brake, built and proved on its own before the accelerator exists** — nothing here claims a default route, and nothing in `cmd/` calls it yet.

That ordering is the safety property, not tidiness. ADR-0011 names the failure mode as *"a machine with no working network and no obvious cause"* and calls it the worst bug this project can ship. A device only becomes able to lock itself out once something claims a route, so the removal path gets proved first, against a real kernel, with no way to reach it from a running daemon.

### Why its own table

`meshp_lock` is the only table here that can take a machine off the network. It has to be findable and removable on its own — by a teardown, by an agent starting up and finding what a previous life left behind, or by a person with a console and no idea what meshp is.

### Three deliberate departures from the other tables

Each because this one fails **closed** rather than open:

- **Policy is `drop`, not `accept`.** Elsewhere an empty chain must not disturb traffic unrelated to meshp. Here an empty chain means every rule holding the line is gone.
- **No blanket `ct state established,related accept`.** The forwarding table needs one or connections hang. A connection established *before* the lock went up is exactly what this exists to stop: the user's real address, still in use, after the tunnel dropped.
- **The last rule rejects rather than drops.** A dropped packet leaves an application hanging until it times out and tells the user nothing. ADR-0011: *the error message is the product.*

### What stays permitted is not a list of conveniences

Each entry is a way the machine stays usable while the tunnel is the only route out — loopback, the tunnel, the outer packets carrying it and the control channel that can end it, the local network, and **DHCP and neighbour discovery**. A device that cannot renew a lease falls off its network minutes later; one that cannot do neighbour discovery loses IPv6 at once. Both look exactly like the bug this prevents.

### Verification

Against a real kernel, including what a packet actually does: traffic stops, loopback survives, an excluded prefix still passes, and **removal gives the network back**. Run in a namespace, because a locked output chain in the root namespace would cut off the machine running the tests.

Mutation tested against that kernel:

| mutation | |
|---|---|
| chain defaults to accept | caught |
| nothing refuses unmatched traffic | caught |
| loopback not spared | caught |
| silent drop instead of reject | caught |

The last one is caught by timing, which is what makes *"fails audibly"* a tested property rather than a comment.

### On ADR-0018

This mechanism is deliberately reachable from no binary yet. That is a **tracked** state rather than a silent one — task #2 carries the slices, and the edge into `cmd/` arrives with route claiming, once startup reclamation exists to make it safe.