### PR TITLE
feat(egress): reclaim a lock left behind by a dead agent

### DIFF
--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -106,6 +106,43 @@ func (a *agent) reconcilerFor(m agentstate.Membership, relay tunnel.Relay, choos
 	}, relay, a.filterOrNil(), log).WithChooser(chooser)
 }
 
+// reclaimEgressLock removes a fail-closed lock left behind by a previous life.
+//
+// This is the half of ADR-0011 that makes the other half safe to have. The rules survive
+// this process on purpose — that is the point of them, since agent crash and agent kill are
+// two of the cases the feature exists to cover — which means the only thing standing between
+// a `kill -9` and a machine somebody has to physically recover is a daemon that finds them
+// again and takes them off (Invariant 20).
+//
+// Unconditional, and deliberately so. At this moment there is no tunnel and no route claimed
+// through one, so a lock here is not protecting traffic; it is only denying it. Whatever
+// this run decides to be, it reinstalls the lock before it claims a route, which is the
+// order ADR-0011 requires anyway. The window between the two is a device that is not
+// tunnelled — which is exactly what it was while the daemon was dead.
+//
+// Reported only when one was actually found, because "removed a lock" and "there was
+// nothing to remove" are different events and only the first explains an outage.
+func (a *agent) reclaimEgressLock() {
+	filter := a.ensureFilter()
+	if filter == nil || !nftables.LockHeld(a.ctx) {
+		return
+	}
+
+	a.log.Warn("found a fail-closed lock from a previous run; this device had no egress",
+		"table", nftables.LockTableName,
+		"cause", "meshpd exited or was killed while a default route was claimed")
+	if err := filter.ApplyLock(a.ctx, nftables.LockSpec{}); err != nil {
+		// The worst outcome this project has: a machine with no network and no obvious
+		// cause. Say what it is and how to undo it by hand, because whoever reads this is
+		// at a console on a host that cannot reach anything.
+		a.log.Error("could not remove it; this device still has no egress",
+			"error", err,
+			"fix", "run: nft delete table inet "+nftables.LockTableName)
+		return
+	}
+	a.log.Info("removed it; egress is restored")
+}
+
 // ensureFilter opens the host's packet filter, once.
 //
 // Probed rather than assumed: a container can have nft installed and no permission to use

--- a/cmd/meshpd/main.go
+++ b/cmd/meshpd/main.go
@@ -83,6 +83,14 @@ func main() {
 
 func run(ctx context.Context, log *slog.Logger, stateDir, socketPath, socketGroup string, reconcileEvery time.Duration) error {
 	agent := newAgent(ctx, log, stateDir, reconcileEvery)
+
+	// Before the state is read, not after. Reading it can fail — a truncated write, a disk
+	// that filled, a file somebody edited — and that failure returns from here and exits.
+	// A device whose egress is being refused by rules a dead predecessor left behind would
+	// then stay that way for as long as the state file stayed broken, which is a machine
+	// bricked by a corrupt JSON file (ADR-0011, Invariant 20).
+	agent.reclaimEgressLock()
+
 	if err := agent.load(); err != nil {
 		return err
 	}

--- a/internal/nftables/apply_linux.go
+++ b/internal/nftables/apply_linux.go
@@ -69,3 +69,20 @@ func Apply(ctx context.Context, script string) error {
 	}
 	return nil
 }
+
+// LockHeld reports whether a fail-closed lock is currently installed.
+//
+// Asked rather than assumed so that removing one can be reported as the event it is. An
+// agent that quietly ran a removal on every start would leave no trace of the case that
+// matters — a machine whose egress was being refused because a previous run died holding
+// the line — and that is the single line an operator needs in the log to understand why
+// their network was down and then was not.
+func LockHeld(ctx context.Context) bool {
+	path, err := exec.LookPath("nft")
+	if err != nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(ctx, applyTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, path, "list", "table", "inet", LockTableName).Run() == nil
+}

--- a/internal/nftables/apply_other.go
+++ b/internal/nftables/apply_other.go
@@ -14,3 +14,7 @@ func Available(context.Context) bool { return false }
 
 // Apply is unsupported off Linux.
 func Apply(context.Context, string) error { return ErrUnsupported }
+
+// LockHeld is false everywhere but Linux, where there is nothing that could have installed
+// one to begin with.
+func LockHeld(context.Context) bool { return false }

--- a/internal/nftables/lock_linux_test.go
+++ b/internal/nftables/lock_linux_test.go
@@ -113,6 +113,12 @@ func TestTheLockCanBeTakenOff(t *testing.T) {
 	if !lockLoaded(t) {
 		t.Fatal("the lock is not loaded, so removing it proves nothing")
 	}
+	// What the agent asks at startup to decide whether it has something to reclaim, and
+	// whether to say so. A LockHeld that disagreed with the kernel would either leave a
+	// machine locked out or report an outage that never happened.
+	if !LockHeld(context.Background()) {
+		t.Error("LockHeld reports nothing while a lock is installed")
+	}
 
 	off, err := RenderLock(LockSpec{})
 	if err != nil {
@@ -123,6 +129,9 @@ func TestTheLockCanBeTakenOff(t *testing.T) {
 	}
 	if lockLoaded(t) {
 		t.Error("the lock survived its own removal")
+	}
+	if LockHeld(context.Background()) {
+		t.Error("LockHeld still reports a lock after it was removed")
 	}
 
 	// And removing one that is not there has to work, because the caller that needs it most

--- a/scripts/e2e-enrol.sh
+++ b/scripts/e2e-enrol.sh
@@ -48,6 +48,10 @@ cleanup() {
   [ -n "$AGENT_PID" ] && kill "$AGENT_PID" 2>/dev/null || true
   [ -n "$RELAY_PID" ] && kill "$RELAY_PID" 2>/dev/null || true
   [ -n "$CONTROL_PID" ] && kill "$CONTROL_PID" 2>/dev/null || true
+  # Never leave an egress lock behind on a host that ran this, however the run ended. The
+  # table this creates is empty and harmless, but leaving one named meshp_lock would make
+  # the next run's reclamation assertion pass before the daemon had done anything.
+  command -v nft >/dev/null 2>&1 && nft delete table inet meshp_lock 2>/dev/null || true
   rm -rf "$WORK"
 }
 trap cleanup EXIT
@@ -123,6 +127,22 @@ for _ in $(seq 1 30); do
 done
 curl -fsS "${CURL_CA[@]}" "${BASE}/readyz" >/dev/null 2>&1 || fail "control plane never became ready"
 
+# A fail-closed lock left behind by a previous life, so that starting the daemon has
+# something to reclaim (ADR-0011). This is the only thing standing between a `kill -9` and a
+# machine somebody has to physically recover, so it is asserted against the real binary
+# rather than only in a unit test.
+#
+# The table is created empty, with no chain and no policy. What is under test is whether
+# meshpd finds and removes a table it owns, and an empty one exercises exactly that — while
+# a real locking chain here would be installed in this host's root namespace and would take
+# the CI runner's own network away, including the connection this job is reporting over. The
+# rules themselves are proved against a real kernel in internal/nftables, inside a namespace.
+reclaimable=0
+if command -v nft >/dev/null 2>&1 && nft add table inet meshp_lock 2>/dev/null; then
+  reclaimable=1
+  echo "left a stale egress lock behind for the daemon to find"
+fi
+
 echo "starting meshpd with no state at all"
 # Deliberately before enrolment. An agent that gives up when it has nothing to do cannot
 # be joined without restarting a service, which is a paper cut people script around.
@@ -138,6 +158,40 @@ done
 grep -q 'not enrolled' "$WORK/status-before.out" \
   || fail "an unenrolled daemon did not say so: $(cat "$WORK/status-before.out")"
 echo "  socket answers: $(head -1 "$WORK/status-before.out")"
+
+# And the stale lock is gone. Asserted on a daemon that is not enrolled, which is the case
+# that matters most: a device whose membership was revoked, or whose state was wiped, still
+# has to get its network back. Nothing in desired state can rescue it, because it has none.
+if [ "$reclaimable" = "1" ]; then
+  if nft list table inet meshp_lock >/dev/null 2>&1; then
+    echo "--- agent log ---" >&2; head -20 "$AGENT_LOG" >&2
+    nft delete table inet meshp_lock 2>/dev/null || true
+    fail "the daemon started and left a previous run's egress lock in place"
+  fi
+  # And said so, because a machine that had no egress and then did needs one line in the log
+  # explaining it. Removing it silently is how the next person spends a day on it.
+  grep -q 'fail-closed lock from a previous run' "$AGENT_LOG" \
+    || { head -20 "$AGENT_LOG" >&2; fail "the lock was removed without a word about it"; }
+  echo "  the daemon reclaimed it and said so"
+
+  # And it happens before the state file is read, which is the whole of why the ordering in
+  # run() is what it is. Reading state can fail — a truncated write, a disk that filled, a
+  # file somebody edited — and that failure exits the daemon. A device whose egress is being
+  # refused would then stay that way for as long as its state file stayed broken: a machine
+  # bricked by malformed JSON.
+  nft add table inet meshp_lock 2>/dev/null || true
+  BROKEN="$WORK/broken"
+  mkdir -p "$BROKEN"
+  printf 'this is not json' >"$BROKEN/state.json"
+  ./bin/meshpd --state-dir "$BROKEN" --socket "$WORK/broken.sock" \
+    >"$WORK/broken.log" 2>&1 || true
+  if nft list table inet meshp_lock >/dev/null 2>&1; then
+    echo "--- daemon log ---" >&2; cat "$WORK/broken.log" >&2
+    nft delete table inet meshp_lock 2>/dev/null || true
+    fail "a daemon that could not read its state left the egress lock in place"
+  fi
+  echo "  and reclaims it even when the state file is unreadable"
+fi
 
 echo "the socket is owner-only"
 # A privilege boundary: anything that can reach this socket can enrol the device and,


### PR DESCRIPTION
Second slice of ADR-0011, and the one that makes the first safe to have.

The rules survive the process **on purpose** — agent crash and agent kill are two of the cases the feature exists to cover — so the only thing between a `kill -9` and a machine somebody has to physically recover is a daemon that finds them again and takes them off (Invariant 20).

`meshpd` now removes any `meshp_lock` table at startup, **and says so when it found one**. Removing it silently would leave no trace of the case that matters — a machine whose egress was refused because a previous run died holding the line — and that log line is what explains the outage to whoever is looking.

### Two decisions worth stating

**Unconditional.** At that moment there is no tunnel and no route claimed through one, so a lock is not protecting traffic, only denying it. Whatever this run decides to be, it reinstalls the lock *before* claiming a route — the order ADR-0011 requires anyway.

**Before the state file is read**, and that ordering is the point rather than a detail. Reading state can fail — a truncated write, a disk that filled, a file somebody edited — and that failure returns from `run()` and exits. Reclaiming afterwards would leave a device with no egress for as long as its state file stayed broken: **a machine bricked by malformed JSON.**

### Proved against the real binary

This is the recovery path, so a unit test alone would be the wrong evidence. The e2e leaves a stale lock behind before starting `meshpd` and asserts it was removed *and logged*:

```
left a stale egress lock behind for the daemon to find
starting meshpd with no state at all
  socket answers: not enrolled
  the daemon reclaimed it and said so
  and reclaims it even when the state file is unreadable
```

Asserted on a daemon that is **not enrolled** — the case that matters most, since a device whose membership was revoked or whose state was wiped has nothing in desired state that could rescue it.

The table the script leaves is empty, with no chain and no policy. What is under test is whether `meshpd` finds and removes a table it owns, and an empty one exercises exactly that — while a real locking chain in the runner's root namespace would take away the network the job reports over. The rules themselves are proved in `internal/nftables`, inside a namespace.

### Mutation tested through the real binary

| mutation | result |
|---|---|
| reclamation never runs | caught — *"the daemon started and left a previous run's egress lock in place"* |
| reclamation moved after `load()` | caught — *"a daemon that could not read its state left the egress lock in place"* |

The second is what makes the ordering a tested property rather than a comment.

### Slices

1. ✅ the kill switch (#51)
2. ✅ startup reclamation — this
3. ⬜ excluded prefixes
4. ⬜ claiming the default route, gated on the lock being installed first