### PR TITLE
feat(egress): work out what must never go through the tunnel

### DIFF
--- a/internal/egress/carveout.go
+++ b/internal/egress/carveout.go
@@ -1,0 +1,279 @@
+// Package egress works out what a device must still reach directly when it sends
+// everything else through a tunnel.
+//
+// Claiming a default route is the one change an agent can make that removes its own ability
+// to be corrected. The route captures the traffic, the kill switch refuses what the route
+// did not send through the tunnel (ADR-0011), and between them they can take away the
+// session that would have told the device to stop — leaving a machine that is off the
+// network for a reason nobody watching can see. So the carve-out is not a convenience list.
+// Each entry is a way the device stays reachable, and getting it wrong is the failure the
+// whole feature is written around.
+//
+// It is computed in one place because two mechanisms consume it and they must agree. The
+// firewall decides what may leave without the tunnel; the routing table decides what is not
+// handed to the tunnel in the first place. A prefix in one and not the other produces a
+// device that is broken in a way that looks like neither: either traffic is routed into a
+// tunnel the firewall will not let it leave by, or it is left on the local link where the
+// firewall then refuses it.
+package egress
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// alwaysExcluded are the prefixes no device should ever push through a tunnel.
+//
+// None of them route beyond the local link, and all of them carry something the machine
+// needs in order to keep working: neighbour discovery and router advertisements, DHCP,
+// mDNS, and the addresses an interface uses before it has been configured at all. Capturing
+// them does not protect a user's privacy — nothing here leaves the link — and it does break
+// the network it is running on.
+var alwaysExcluded = []netip.Prefix{
+	netip.MustParsePrefix("169.254.0.0/16"), // IPv4 link-local, including APIPA
+	netip.MustParsePrefix("224.0.0.0/4"),    // IPv4 multicast
+	netip.MustParsePrefix("255.255.255.255/32"),
+	netip.MustParsePrefix("fe80::/10"), // IPv6 link-local, which NDP depends on
+	netip.MustParsePrefix("ff00::/8"),  // IPv6 multicast
+}
+
+// Resolver turns a host name into addresses. Injectable because what this computes decides
+// whether a device can be reached at all, and a test of that should not depend on DNS.
+type Resolver func(ctx context.Context, host string) ([]netip.Addr, error)
+
+// SystemResolver looks names up the way the rest of the process would.
+func SystemResolver(ctx context.Context, host string) ([]netip.Addr, error) {
+	return net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+}
+
+// Inputs are what the carve-out is computed from.
+type Inputs struct {
+	// ControlURL is where this device's control plane lives. Its address is the one entry
+	// that is not optional: without it the device cannot be told to stop, cannot be
+	// revoked, and cannot report that anything is wrong.
+	ControlURL string
+
+	// RelayEndpoints are the "host:port" addresses from desired state. Every peer is
+	// relayed until discovery exists (ADR-0002), so a device that cannot reach its relay
+	// has a tunnel that carries nothing — and a default route into it.
+	RelayEndpoints []string
+
+	// LocalPrefixes are the networks this device is directly attached to. Losing them
+	// costs the printer, the NAS and, more to the point, the gateway the outer WireGuard
+	// packets are sent through.
+	LocalPrefixes []netip.Prefix
+
+	// ExtraPrefixes are what an administrator has asked to keep off the tunnel.
+	ExtraPrefixes []string
+}
+
+// Carveout is what must stay reachable without the tunnel.
+type Carveout struct {
+	// Prefixes are destinations the default route must not capture and the lock must allow.
+	Prefixes []netip.Prefix
+
+	// Endpoints are single addresses with a port: the control plane and the relays. Kept
+	// apart from Prefixes because the firewall can be told the port, and a rule naming one
+	// port on one address is a smaller hole than a whole prefix.
+	Endpoints []netip.AddrPort
+}
+
+// ErrNoControlPlane means the control plane's address could not be determined.
+//
+// Returned rather than worked around. A device that claims a default route and installs a
+// lock without knowing where its control plane is has removed the only channel that could
+// undo either, and it has done so silently. Refusing is visible: the group goes unhonoured
+// and the control plane can see a device that is not where it should be.
+var ErrNoControlPlane = errors.New("egress: cannot determine the control plane's address")
+
+// Compute works out what must stay off the tunnel.
+//
+// A resolution failure for a relay is tolerated and one for the control plane is not. The
+// difference is what each costs: a device that cannot reach a relay has no working tunnel
+// and stays visibly unconverged, while a device that cannot reach its control plane cannot
+// be told anything at all, including to stop.
+func Compute(ctx context.Context, in Inputs, resolve Resolver) (Carveout, error) {
+	if resolve == nil {
+		resolve = SystemResolver
+	}
+
+	var out Carveout
+	control, err := endpointsOf(ctx, in.ControlURL, resolve)
+	if err != nil || len(control) == 0 {
+		return Carveout{}, fmt.Errorf("%w: %q", ErrNoControlPlane, in.ControlURL)
+	}
+	out.Endpoints = append(out.Endpoints, control...)
+
+	for _, raw := range in.RelayEndpoints {
+		// Best effort: a relay that will not resolve costs that relay.
+		if eps, err := hostPortEndpoints(ctx, raw, resolve); err == nil {
+			out.Endpoints = append(out.Endpoints, eps...)
+		}
+	}
+
+	prefixes := append([]netip.Prefix(nil), alwaysExcluded...)
+	prefixes = append(prefixes, in.LocalPrefixes...)
+	for _, raw := range in.ExtraPrefixes {
+		p, err := netip.ParsePrefix(strings.TrimSpace(raw))
+		if err != nil {
+			// One unusable exclusion costs that exclusion. Refusing the whole carve-out
+			// would leave the device with no route claimed at all over a typo.
+			continue
+		}
+		prefixes = append(prefixes, p)
+	}
+
+	out.Prefixes = normalise(prefixes)
+	out.Endpoints = normaliseEndpoints(out.Endpoints)
+	return out, nil
+}
+
+// normalise sorts, deduplicates, and refuses a default route.
+//
+// The default route is the one prefix that must never appear here. Excluding ::/0 or
+// 0.0.0.0/0 carves out everything, so the lock permits all traffic and the routing table
+// hands nothing to the tunnel — a device that reports itself fully tunnelled and is not.
+// That is precisely the dishonesty ADR-0011 exists to prevent, and it would arrive through
+// a single mistyped line of administrator configuration.
+func normalise(in []netip.Prefix) []netip.Prefix {
+	seen := make(map[netip.Prefix]struct{}, len(in))
+	out := make([]netip.Prefix, 0, len(in))
+	for _, p := range in {
+		if !p.IsValid() || p.Bits() == 0 {
+			continue
+		}
+		masked := netip.PrefixFrom(p.Addr().Unmap(), p.Bits()).Masked()
+		if _, dup := seen[masked]; dup {
+			continue
+		}
+		seen[masked] = struct{}{}
+		out = append(out, masked)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	return out
+}
+
+func normaliseEndpoints(in []netip.AddrPort) []netip.AddrPort {
+	seen := make(map[netip.AddrPort]struct{}, len(in))
+	out := make([]netip.AddrPort, 0, len(in))
+	for _, ep := range in {
+		if !ep.Addr().IsValid() || ep.Port() == 0 {
+			continue
+		}
+		norm := netip.AddrPortFrom(ep.Addr().Unmap(), ep.Port())
+		if _, dup := seen[norm]; dup {
+			continue
+		}
+		seen[norm] = struct{}{}
+		out = append(out, norm)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	return out
+}
+
+// endpointsOf turns a control URL into the addresses and port a session dials.
+func endpointsOf(ctx context.Context, raw string, resolve Resolver) ([]netip.AddrPort, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, errors.New("egress: no control url")
+	}
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return nil, err
+	}
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		// The scheme's default, because that is what was dialled.
+		switch u.Scheme {
+		case "https", "wss":
+			port = "443"
+		case "http", "ws":
+			port = "80"
+		default:
+			return nil, fmt.Errorf("egress: no port and no default for scheme %q", u.Scheme)
+		}
+	}
+	return resolveHostPort(ctx, host, port, resolve)
+}
+
+// hostPortEndpoints turns a "host:port" from desired state into addresses.
+func hostPortEndpoints(ctx context.Context, raw string, resolve Resolver) ([]netip.AddrPort, error) {
+	host, port, err := net.SplitHostPort(strings.TrimSpace(raw))
+	if err != nil {
+		return nil, err
+	}
+	return resolveHostPort(ctx, host, port, resolve)
+}
+
+func resolveHostPort(ctx context.Context, host, port string, resolve Resolver) ([]netip.AddrPort, error) {
+	n, err := strconv.ParseUint(port, 10, 16)
+	if err != nil || n == 0 {
+		return nil, fmt.Errorf("egress: %q is not a port", port)
+	}
+
+	// An address needs no resolver, which matters: a deployment that names its control
+	// plane by address stays reachable on a device whose DNS the lock is about to refuse.
+	if addr, err := netip.ParseAddr(host); err == nil {
+		return []netip.AddrPort{netip.AddrPortFrom(addr.Unmap(), uint16(n))}, nil
+	}
+
+	addrs, err := resolve(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]netip.AddrPort, 0, len(addrs))
+	for _, a := range addrs {
+		out = append(out, netip.AddrPortFrom(a.Unmap(), uint16(n)))
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("egress: %q resolved to nothing", host)
+	}
+	return out, nil
+}
+
+// LocalNetworks reports the networks this host is directly attached to.
+//
+// The tunnel is skipped by name: its own prefix is what the device is joining, and carving
+// it out would leave the mesh unreachable through the interface that serves it. Interfaces
+// that are down are skipped too, since a prefix on a link with no carrier is a hole in the
+// lock for a network that is not there.
+func LocalNetworks(skip string) []netip.Prefix {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+
+	var out []netip.Prefix
+	for _, iface := range ifaces {
+		if iface.Name == skip || iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			ipnet, ok := a.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			addr, ok := netip.AddrFromSlice(ipnet.IP)
+			if !ok {
+				continue
+			}
+			ones, _ := ipnet.Mask.Size()
+			p := netip.PrefixFrom(addr.Unmap(), ones)
+			if p.IsValid() {
+				out = append(out, p.Masked())
+			}
+		}
+	}
+	return normalise(out)
+}

--- a/internal/egress/carveout_test.go
+++ b/internal/egress/carveout_test.go
@@ -1,0 +1,246 @@
+package egress
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+// fixed answers whatever a test says, so what is under test is the decision rather than DNS.
+func fixed(answers map[string][]string) Resolver {
+	return func(_ context.Context, host string) ([]netip.Addr, error) {
+		raw, ok := answers[host]
+		if !ok {
+			return nil, errors.New("no such host")
+		}
+		out := make([]netip.Addr, 0, len(raw))
+		for _, s := range raw {
+			out = append(out, netip.MustParseAddr(s))
+		}
+		return out, nil
+	}
+}
+
+func compute(t *testing.T, in Inputs, r Resolver) Carveout {
+	t.Helper()
+	out, err := Compute(context.Background(), in, r)
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	return out
+}
+
+func hasPrefix(c Carveout, s string) bool {
+	want := netip.MustParsePrefix(s)
+	for _, p := range c.Prefixes {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasEndpoint(c Carveout, s string) bool {
+	want := netip.MustParseAddrPort(s)
+	for _, ep := range c.Endpoints {
+		if ep == want {
+			return true
+		}
+	}
+	return false
+}
+
+// The channel that can undo all of this. A device that claims a default route without
+// knowing where its control plane is has removed the only thing that could tell it to stop.
+func TestTheControlPlaneIsAlwaysCarvedOut(t *testing.T) {
+	got := compute(t, Inputs{ControlURL: "https://control.example:8443"},
+		fixed(map[string][]string{"control.example": {"198.51.100.10"}}))
+
+	if !hasEndpoint(got, "198.51.100.10:8443") {
+		t.Errorf("the control plane is not in the carve-out: %+v", got.Endpoints)
+	}
+}
+
+// Refusing is visible; claiming anyway is not. A device that cannot work out where its
+// control plane is must not lock itself away from it.
+func TestAnUnreachableControlPlaneRefusesTheWholeCarveout(t *testing.T) {
+	_, err := Compute(context.Background(),
+		Inputs{ControlURL: "https://control.example"}, fixed(nil))
+
+	if !errors.Is(err, ErrNoControlPlane) {
+		t.Fatalf("err = %v, want ErrNoControlPlane", err)
+	}
+}
+
+// A relay that will not resolve costs that relay. The device is then visibly unconverged
+// rather than invisibly cut off, which is the trade this makes on purpose.
+func TestAnUnresolvableRelayDoesNotCostTheCarveout(t *testing.T) {
+	got := compute(t, Inputs{
+		ControlURL:     "https://198.51.100.10:443",
+		RelayEndpoints: []string{"gone.example:3478", "203.0.113.9:3478"},
+	}, fixed(nil))
+
+	if !hasEndpoint(got, "203.0.113.9:3478") {
+		t.Errorf("the resolvable relay was lost with the unresolvable one: %+v", got.Endpoints)
+	}
+	if !hasEndpoint(got, "198.51.100.10:443") {
+		t.Error("the control plane was lost")
+	}
+}
+
+// An address needs no resolver, and that matters more here than it looks: a deployment
+// named by address stays reachable on a device whose DNS the lock is about to refuse.
+func TestAnAddressNeedsNoResolver(t *testing.T) {
+	got := compute(t, Inputs{ControlURL: "https://198.51.100.10:8443"}, fixed(nil))
+
+	if !hasEndpoint(got, "198.51.100.10:8443") {
+		t.Errorf("a control plane named by address was not carved out: %+v", got.Endpoints)
+	}
+}
+
+// The scheme's default port, because that is what a session actually dialled.
+func TestTheSchemeSuppliesTheDefaultPort(t *testing.T) {
+	got := compute(t, Inputs{ControlURL: "https://198.51.100.10"}, fixed(nil))
+
+	if !hasEndpoint(got, "198.51.100.10:443") {
+		t.Errorf("https did not default to 443: %+v", got.Endpoints)
+	}
+}
+
+// The one prefix that must never be carved out. Excluding a default route permits
+// everything and hands nothing to the tunnel: a device that reports itself fully tunnelled
+// and is not, which is the dishonesty ADR-0011 exists to prevent — arriving through one
+// mistyped line of configuration.
+func TestADefaultRouteIsNeverCarvedOut(t *testing.T) {
+	got := compute(t, Inputs{
+		ControlURL:    "https://198.51.100.10:443",
+		ExtraPrefixes: []string{"0.0.0.0/0", "::/0", "192.168.1.0/24"},
+	}, fixed(nil))
+
+	for _, p := range got.Prefixes {
+		if p.Bits() == 0 {
+			t.Errorf("a default route was carved out: %s", p)
+		}
+	}
+	if !hasPrefix(got, "192.168.1.0/24") {
+		t.Error("the usable exclusion was lost along with the default routes")
+	}
+}
+
+// Each of these keeps the machine working and none of them leaves the local link, so
+// capturing them protects nothing and breaks the network underneath.
+func TestTheLinkLocalWorldIsAlwaysCarvedOut(t *testing.T) {
+	got := compute(t, Inputs{ControlURL: "https://198.51.100.10:443"}, fixed(nil))
+
+	for _, want := range []struct{ prefix, why string }{
+		{"169.254.0.0/16", "IPv4 link-local, which is what a machine has before DHCP answers"},
+		{"224.0.0.0/4", "IPv4 multicast, which mDNS and discovery need"},
+		{"fe80::/10", "IPv6 link-local, which neighbour discovery depends on"},
+		{"ff00::/8", "IPv6 multicast, which router advertisements arrive on"},
+	} {
+		if !hasPrefix(got, want.prefix) {
+			t.Errorf("%s is not carved out\n  needed for: %s", want.prefix, want.why)
+		}
+	}
+}
+
+// The gateway the outer WireGuard packets leave through lives on one of these. Capturing
+// the local network is how a device tunnels itself off its own link.
+func TestTheLocalNetworkIsCarvedOut(t *testing.T) {
+	got := compute(t, Inputs{
+		ControlURL:    "https://198.51.100.10:443",
+		LocalPrefixes: []netip.Prefix{netip.MustParsePrefix("192.168.7.42/24")},
+	}, fixed(nil))
+
+	// Masked, because a route and a firewall rule want the network rather than the address
+	// the interface happens to hold on it.
+	if !hasPrefix(got, "192.168.7.0/24") {
+		t.Errorf("the local network is not carved out: %+v", got.Prefixes)
+	}
+}
+
+// One typo should cost that exclusion, not the device's route.
+func TestAnUnusableExtraPrefixIsSkipped(t *testing.T) {
+	got := compute(t, Inputs{
+		ControlURL:    "https://198.51.100.10:443",
+		ExtraPrefixes: []string{"not-a-prefix", "10.8.0.0/16"},
+	}, fixed(nil))
+
+	if !hasPrefix(got, "10.8.0.0/16") {
+		t.Errorf("a usable exclusion was lost with an unusable one: %+v", got.Prefixes)
+	}
+}
+
+// The same inputs must produce the same carve-out, or every reconcile pass reloads a lock
+// and rewrites a routing table that did not change.
+func TestTheCarveoutIsStable(t *testing.T) {
+	in := Inputs{
+		ControlURL:     "https://198.51.100.10:443",
+		RelayEndpoints: []string{"203.0.113.9:3478", "203.0.113.8:3478", "203.0.113.9:3478"},
+		LocalPrefixes: []netip.Prefix{
+			netip.MustParsePrefix("192.168.7.0/24"),
+			netip.MustParsePrefix("10.0.0.0/8"),
+			netip.MustParsePrefix("192.168.7.0/24"),
+		},
+	}
+	first := compute(t, in, fixed(nil))
+	second := compute(t, in, fixed(nil))
+
+	if len(first.Prefixes) != len(second.Prefixes) || len(first.Endpoints) != len(second.Endpoints) {
+		t.Fatalf("the same inputs produced different sizes: %+v vs %+v", first, second)
+	}
+	for i := range first.Prefixes {
+		if first.Prefixes[i] != second.Prefixes[i] {
+			t.Errorf("prefix %d differs: %s vs %s", i, first.Prefixes[i], second.Prefixes[i])
+		}
+	}
+	for i := range first.Endpoints {
+		if first.Endpoints[i] != second.Endpoints[i] {
+			t.Errorf("endpoint %d differs: %s vs %s", i, first.Endpoints[i], second.Endpoints[i])
+		}
+	}
+
+	// And a repeat is dropped rather than carried twice.
+	seen := map[netip.Prefix]int{}
+	for _, p := range first.Prefixes {
+		seen[p]++
+		if seen[p] > 1 {
+			t.Errorf("%s appears more than once", p)
+		}
+	}
+}
+
+// The tunnel's own interface must not be carved out: its prefix is the mesh the device is
+// joining, and excluding it would leave every peer unreachable through the interface that
+// serves them.
+func TestTheTunnelsOwnNetworkIsNotTreatedAsLocal(t *testing.T) {
+	all := LocalNetworks("")
+	withoutLo := LocalNetworks("lo")
+
+	// Loopback is skipped whatever is named, so naming it must change nothing. This is the
+	// cheap half of the property; the real one needs an interface named meshp0 to exist,
+	// which is the data-plane container's job rather than this test's.
+	if len(all) != len(withoutLo) {
+		t.Errorf("naming loopback changed the result: %v vs %v", all, withoutLo)
+	}
+	for _, p := range all {
+		if p.Addr().IsLoopback() {
+			t.Errorf("loopback %s was reported as a local network", p)
+		}
+		if p.Bits() == 0 {
+			t.Errorf("a default route was reported as a local network: %s", p)
+		}
+	}
+}
+
+func TestAMissingControlURLIsRefused(t *testing.T) {
+	_, err := Compute(context.Background(), Inputs{}, fixed(nil))
+	if !errors.Is(err, ErrNoControlPlane) {
+		t.Fatalf("err = %v, want ErrNoControlPlane", err)
+	}
+	if !strings.Contains(err.Error(), "control plane") {
+		t.Errorf("the error does not say what is missing: %v", err)
+	}
+}


### PR DESCRIPTION
Third slice of ADR-0011.

Claiming a default route is the one change an agent can make that removes its own ability to be corrected: the route captures the traffic, the lock refuses whatever the route did not send through the tunnel, and between them they can take away the session that would have said *stop*. So the carve-out is not a convenience list — each entry is a way the device stays reachable.

### Why one place

Two mechanisms consume it and they have to agree. The **firewall** decides what may leave without the tunnel; the **routing table** decides what is never handed to the tunnel at all. A prefix in one and not the other is a device broken in a way that looks like neither — traffic routed into a tunnel the firewall won't let it leave by, or left on the local link where the firewall then refuses it.

### What it refuses to do matters as much as what it collects

**A default route is never carved out.** Excluding `0.0.0.0/0` permits everything and hands nothing to the tunnel — a device that reports itself fully tunnelled and is not. That is the exact dishonesty ADR-0011 exists to prevent, arriving through one mistyped line of configuration.

**An unknown control plane refuses the whole carve-out.** A device that locks itself away from the only channel that could undo the lock is cut off for a reason nobody watching can see. A device that refuses is visibly unconverged, and the control plane can see it.

**Relays are the other way round, deliberately.** One that will not resolve costs that relay — the result is a tunnel that carries nothing, rather than a machine nobody can reach.

**Link-local, multicast and broadcast are always carved out.** None route past the local link, so capturing them protects nothing, and all carry something the machine needs: neighbour discovery, router advertisements, DHCP, mDNS, and the addresses an interface holds before it has been configured at all.

**An address needs no resolver** — which matters more than it looks. A deployment named by address stays reachable on a device whose DNS this lock is about to refuse.

### Mutation tested

| mutation | |
|---|---|
| a default route can be excluded | caught |
| an unknown control plane is tolerated | caught |
| link-local and multicast captured | caught |
| the local network captured | caught |
| one bad relay aborts everything | caught |
| prefixes left unmasked | caught |

The first two are the ones that matter: one silently disables the entire feature, the other is the bricking path.

### On ADR-0018

Reachable from no binary yet — tracked rather than silent. Task #2 carries the slices, and **slice 4 is where route claiming joins this to the lock**, which is the edge into `cmd/`.

### Slices

1. ✅ the kill switch (#51)
2. ✅ startup reclamation (#52)
3. ✅ excluded prefixes — this
4. ⬜ claiming the default route, gated on the lock going in first