### PR TITLE
feat(egress): route a full tunnel without capturing its own packets

### DIFF
--- a/internal/wglink/policyroute_linux.go
+++ b/internal/wglink/policyroute_linux.go
@@ -1,0 +1,286 @@
+//go:build linux
+
+package wglink
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+
+	"github.com/jsimonetti/rtnetlink/v2"
+	"golang.org/x/sys/unix"
+	"golang.zx2c4.com/wireguard/wgctrl"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+// The full-tunnel routing mechanism, decided in ADR-0019.
+//
+// A device claiming a default route has one problem to solve: the outer WireGuard packets
+// carrying the tunnel must not be sent into it. Put 0.0.0.0/0 on the tunnel in the main
+// table and the packets to the relay match it, get encapsulated, and are routed back into
+// the tunnel they belong to — the tunnel never establishes, and since ADR-0011 installs the
+// kill switch first, the device is off the network entirely.
+//
+// So WireGuard marks its own packets and three rules sort them out:
+//
+//	32764:  from all lookup main suppress_prefixlength 0
+//	32765:  not from all fwmark <mark> lookup <table>
+//	32766:  from all lookup main                          (the kernel's own)
+//
+// An ordinary packet to a LAN address matches a specific route in main and goes out on the
+// LAN. An ordinary packet to the internet finds only main's default route, which the first
+// rule suppresses, so it falls to the second and takes the tunnel. A packet WireGuard
+// generated carries the mark, fails `not fwmark`, falls past both, and follows whatever the
+// real default route happens to be.
+//
+// The last part is the point. Nothing here records the gateway, so a laptop moving from
+// Wi-Fi to tethering rewrites none of this: the marked traffic follows main, and main has
+// already changed by itself. The alternative — a host route to each endpoint via the
+// current gateway — has to be rebuilt on every roam, which is a race on the device that
+// roams most, while a kill switch is holding the line.
+//
+// The ordering matters and the wrong way round is a bricked machine. If the mark rule came
+// first, every unmarked packet would take the tunnel immediately, including packets to the
+// local network — so a device would lose its own LAN, its printer, and the gateway its
+// outer packets leave through.
+
+const (
+	// EgressMark is the firewall mark WireGuard puts on its own outer packets.
+	//
+	// The same number is used for the routing table, as wg-quick does: one value to
+	// recognise, one to remove, and no chance of the two drifting apart. It is high and
+	// arbitrary to stay clear of the marks other software picks, which conventionally live
+	// in the low bits.
+	EgressMark uint32 = 0x6d657368 // "mesh"
+
+	// EgressTable is the routing table holding the tunnel's default route.
+	EgressTable uint32 = 0x6d657368
+
+	// suppressPriority must be lower than markPriority: main's specific routes have to be
+	// consulted before anything is handed to the tunnel.
+	suppressPriority uint32 = 32764
+	markPriority     uint32 = 32765
+)
+
+// ClaimDefaultRoute sends everything except the tunnel's own packets through the tunnel.
+//
+// Idempotent, because the reconciler is a loop. Adding a rule that already exists returns
+// EEXIST rather than replacing it, and a device that accumulated one rule per pass would
+// end up with thousands.
+func ClaimDefaultRoute(iface string, mark uint32) error {
+	link, err := net.InterfaceByName(iface)
+	if err != nil {
+		return fmt.Errorf("wglink: no interface %s to claim a default route through: %w", iface, err)
+	}
+
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return fmt.Errorf("wglink: rtnetlink: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// The table first, then the rules that point at it. A rule naming an empty table sends
+	// traffic nowhere; a table nothing points at is inert. So the harmless order is the one
+	// where the table is ready before anything is directed into it.
+	for _, def := range []netip.Prefix{
+		netip.MustParsePrefix("0.0.0.0/0"),
+		netip.MustParsePrefix("::/0"),
+	} {
+		if err := addTableDefault(conn, uint32(link.Index), def); err != nil {
+			return err
+		}
+	}
+
+	for _, family := range []uint8{unix.AF_INET, unix.AF_INET6} {
+		if err := addRule(conn, suppressRule(family)); err != nil {
+			return err
+		}
+		if err := addRule(conn, markRule(family, mark)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReleaseDefaultRoute takes it all off again.
+//
+// Rules come off before the table, the reverse of installing them: a rule pointing at a
+// table that has just been emptied is a rule that blackholes everything it matches, and
+// this runs on a device whose traffic is going through it.
+//
+// Every step is attempted even when an earlier one fails, and the first error is returned
+// at the end. Stopping at the first failure is right for an apply, which can be retried,
+// and wrong for a teardown: what is left behind after a partial teardown is precisely the
+// stuck state this exists to clear (Invariant 20).
+func ReleaseDefaultRoute(mark uint32) error {
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return fmt.Errorf("wglink: rtnetlink: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	var first error
+	keep := func(err error) {
+		if err != nil && first == nil {
+			first = err
+		}
+	}
+	for _, family := range []uint8{unix.AF_INET, unix.AF_INET6} {
+		keep(deleteRule(conn, markRule(family, mark)))
+		keep(deleteRule(conn, suppressRule(family)))
+	}
+	keep(flushEgressTable(conn))
+	return first
+}
+
+// DefaultRouteClaimed reports whether the rules are installed.
+//
+// Asked at startup for the same reason the kill switch is: these outlive the process, so a
+// daemon that died holding them leaves a device routing through a tunnel that is gone, and
+// something has to notice and say so.
+func DefaultRouteClaimed(mark uint32) (bool, error) {
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return false, fmt.Errorf("wglink: rtnetlink: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	rules, err := conn.Rule.List()
+	if err != nil {
+		return false, fmt.Errorf("wglink: listing rules: %w", err)
+	}
+	for _, r := range rules {
+		if r.Attributes == nil || r.Attributes.FwMark == nil {
+			continue
+		}
+		if *r.Attributes.FwMark == mark {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// suppressRule consults main but ignores its default route, so specific routes — the local
+// network, anything an administrator added — keep winning over the tunnel.
+func suppressRule(family uint8) *rtnetlink.RuleMessage {
+	zero := uint32(0)
+	priority := suppressPriority
+	table := uint32(unix.RT_TABLE_MAIN)
+	return &rtnetlink.RuleMessage{
+		Family: family,
+		Action: unix.RTN_UNICAST,
+		Table:  unix.RT_TABLE_MAIN,
+		Attributes: &rtnetlink.RuleAttributes{
+			Priority:          &priority,
+			Table:             &table,
+			SuppressPrefixLen: &zero,
+		},
+	}
+}
+
+// markRule sends everything that is not the tunnel's own traffic to the tunnel's table.
+func markRule(family uint8, mark uint32) *rtnetlink.RuleMessage {
+	priority := markPriority
+	table := EgressTable
+	m := mark
+	return &rtnetlink.RuleMessage{
+		Family: family,
+		Action: unix.RTN_UNICAST,
+		// Inverted: this matches packets that do NOT carry the mark. The marked ones are
+		// WireGuard's own, and they have to fall through to the ordinary default route or
+		// the tunnel has no way to reach its relay.
+		Flags: unix.FIB_RULE_INVERT,
+		Attributes: &rtnetlink.RuleAttributes{
+			Priority: &priority,
+			FwMark:   &m,
+			Table:    &table,
+		},
+	}
+}
+
+// addTableDefault puts a default route through the tunnel into the egress table.
+func addTableDefault(conn *rtnetlink.Conn, index uint32, prefix netip.Prefix) error {
+	family := uint8(unix.AF_INET)
+	if prefix.Addr().Is6() {
+		family = unix.AF_INET6
+	}
+	table := EgressTable
+	msg := &rtnetlink.RouteMessage{
+		Family: family,
+		// Unspecified in the header because the identifier does not fit in a byte; the
+		// attribute below carries it.
+		Table:     unix.RT_TABLE_UNSPEC,
+		Protocol:  RouteProtocol,
+		Scope:     unix.RT_SCOPE_UNIVERSE,
+		Type:      unix.RTN_UNICAST,
+		DstLength: 0,
+		Attributes: rtnetlink.RouteAttributes{
+			Dst:      net.IP(prefix.Addr().AsSlice()),
+			OutIface: index,
+			Table:    table,
+		},
+	}
+	if err := conn.Route.Add(msg); err != nil && !errors.Is(err, unix.EEXIST) {
+		return fmt.Errorf("wglink: adding the tunnel default route for %s: %w", prefix, err)
+	}
+	return nil
+}
+
+// flushEgressTable removes the routes this package put in the egress table, and only those:
+// they carry meshp's protocol number, which is what makes removal exact rather than a guess
+// at what else might be in there.
+func flushEgressTable(conn *rtnetlink.Conn) error {
+	routes, err := conn.Route.List()
+	if err != nil {
+		return fmt.Errorf("wglink: listing routes: %w", err)
+	}
+	var first error
+	for _, r := range routes {
+		if r.Attributes.Table != EgressTable || r.Protocol != RouteProtocol {
+			continue
+		}
+		msg := r
+		if err := conn.Route.Delete(&msg); err != nil && !errors.Is(err, unix.ESRCH) && first == nil {
+			first = fmt.Errorf("wglink: removing a tunnel default route: %w", err)
+		}
+	}
+	return first
+}
+
+func addRule(conn *rtnetlink.Conn, msg *rtnetlink.RuleMessage) error {
+	if err := conn.Rule.Add(msg); err != nil && !errors.Is(err, unix.EEXIST) {
+		return fmt.Errorf("wglink: adding a routing rule: %w", err)
+	}
+	return nil
+}
+
+func deleteRule(conn *rtnetlink.Conn, msg *rtnetlink.RuleMessage) error {
+	if err := conn.Rule.Delete(msg); err != nil &&
+		!errors.Is(err, unix.ENOENT) && !errors.Is(err, unix.ESRCH) {
+		return fmt.Errorf("wglink: removing a routing rule: %w", err)
+	}
+	return nil
+}
+
+// SetEgressMark tells WireGuard to mark the packets it sends.
+//
+// Separate from ClaimDefaultRoute because they fail differently and a caller needs to tell
+// them apart: this touches the WireGuard device, which may not exist yet, while the rules
+// touch the routing table, which always does. Both are needed for a full tunnel, and the
+// mark must be set first — a rule that exempts marked traffic exempts nothing until
+// something is marking it, and in the gap the tunnel's own packets are routed into the
+// tunnel.
+func SetEgressMark(iface string, mark uint32) error {
+	client, err := wgctrl.New()
+	if err != nil {
+		return fmt.Errorf("wglink: opening the WireGuard control socket: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	m := int(mark)
+	if err := client.ConfigureDevice(iface, wgtypes.Config{FirewallMark: &m}); err != nil {
+		return fmt.Errorf("wglink: marking %s's traffic: %w", iface, err)
+	}
+	return nil
+}

--- a/internal/wglink/policyroute_linux_test.go
+++ b/internal/wglink/policyroute_linux_test.go
@@ -151,7 +151,7 @@ func claimInNS(t *testing.T) {
 		}
 		held, err := DefaultRouteClaimed(EgressMark)
 		if err != nil || !held {
-			return fmt.Errorf("DefaultRouteClaimed = %v, %v after claiming", held, err)
+			return fmt.Errorf("DefaultRouteClaimed = %v after claiming: %w", held, err)
 		}
 		return nil
 	})
@@ -170,7 +170,7 @@ func releaseInNS(t *testing.T) {
 		}
 		held, err := DefaultRouteClaimed(EgressMark)
 		if err != nil || held {
-			return fmt.Errorf("DefaultRouteClaimed = %v, %v after releasing", held, err)
+			return fmt.Errorf("DefaultRouteClaimed = %v after releasing: %w", held, err)
 		}
 		return nil
 	})

--- a/internal/wglink/policyroute_linux_test.go
+++ b/internal/wglink/policyroute_linux_test.go
@@ -1,0 +1,212 @@
+//go:build linux
+
+package wglink
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The routing mechanism from ADR-0019, against a real kernel.
+//
+// These assert routing decisions rather than traffic, using `ip route get`, which answers
+// the question the kernel would ask itself for a packet — including with a mark, which is
+// the whole point here. That makes the three cases directly observable without a WireGuard
+// device, a relay, or anything to send.
+//
+// Everything runs inside a namespace. Installing these rules in the root namespace would
+// send the machine's own traffic into a table whose default route is a dummy interface,
+// which on a CI runner takes away the connection the job is reporting over.
+
+const (
+	prns    = "meshproute" // the namespace
+	prTun   = "meshptun0"  // stands in for the tunnel
+	prGW    = "10.97.0.1"
+	prOther = "8.8.8.8"
+)
+
+func prRun(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	full := append([]string{"netns", "exec", prns}, args...)
+	out, err := exec.Command("ip", full...).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func prMust(t *testing.T, args ...string) string {
+	t.Helper()
+	out, err := prRun(t, args...)
+	if err != nil {
+		t.Fatalf("ip netns exec %s %s: %v: %s", prns, strings.Join(args, " "), err, out)
+	}
+	return out
+}
+
+// routeFor asks the kernel where a packet would go, optionally carrying the mark.
+func routeFor(t *testing.T, dest string, mark bool) string {
+	t.Helper()
+	args := []string{"ip", "route", "get", dest}
+	if mark {
+		args = append(args, "mark", "0x6d657368")
+	}
+	out, err := prRun(t, args...)
+	if err != nil {
+		t.Fatalf("route get %s (mark=%v): %v: %s", dest, mark, err, out)
+	}
+	return out
+}
+
+func setupPolicyRouteNS(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("ip"); err != nil {
+		t.Skip("iproute2 is unavailable; run this in the privileged container")
+	}
+	_ = exec.Command("ip", "netns", "del", prns).Run()
+	if out, err := exec.Command("ip", "netns", "add", prns).CombinedOutput(); err != nil {
+		t.Skipf("cannot create a network namespace here: %v: %s", err, out)
+	}
+	t.Cleanup(func() { _ = exec.Command("ip", "netns", "del", prns).Run() })
+
+	// A LAN with a gateway, and a dummy standing in for the tunnel. Enough for the kernel
+	// to have a real decision to make: a specific route, a default route, and somewhere
+	// else the rules can send things.
+	prMust(t, "ip", "link", "set", "lo", "up")
+	prMust(t, "ip", "link", "add", "eth0", "type", "dummy")
+	prMust(t, "ip", "addr", "add", "10.97.0.2/24", "dev", "eth0")
+	prMust(t, "ip", "link", "set", "eth0", "up")
+	prMust(t, "ip", "route", "add", "default", "via", prGW, "dev", "eth0")
+	prMust(t, "ip", "link", "add", prTun, "type", "dummy")
+	prMust(t, "ip", "link", "set", prTun, "up")
+}
+
+// claimInNS runs the claim inside the namespace.
+//
+// Re-executing this test binary under `ip netns exec` is the only way to get these netlink
+// calls into another namespace: rules are installed by whichever namespace the calling
+// thread is in, and Go offers no supported way to move a live goroutine between them.
+func claimInNS(t *testing.T) { inNS(t, "claim") }
+
+// releaseInNS undoes it, inside the same namespace and by the same route.
+func releaseInNS(t *testing.T) { inNS(t, "release") }
+
+func inNS(t *testing.T, action string) {
+	t.Helper()
+	// The binary's real path, resolved here rather than as /proc/self/exe inside the
+	// shell below — by then /proc/self is the shell, not this test.
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("finding this test binary: %v", err)
+	}
+	// Through a shell, because `ip` parses anything beginning with a dash as its own
+	// option and would reject -test.run before ever starting the binary.
+	cmd := exec.Command("ip", "netns", "exec", prns, "sh", "-c",
+		"exec "+self+" -test.run TestPolicyRouteHelper")
+	cmd.Env = append(os.Environ(), helperEnv+"="+action)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s inside the namespace: %v\n%s", action, err, out)
+	}
+}
+
+// helperEnv marks the re-executed run, so the helper below does nothing during an ordinary
+// `go test` and only acts when it is the one deliberately started inside a namespace.
+const helperEnv = "MESHP_POLICYROUTE_HELPER"
+
+// TestPolicyRouteHelper is the half that runs inside the namespace. It is started by name
+// from the test below and skips otherwise.
+func TestPolicyRouteHelper(t *testing.T) {
+	switch os.Getenv(helperEnv) {
+	case "claim":
+		if err := ClaimDefaultRoute(prTun, EgressMark); err != nil {
+			t.Fatalf("ClaimDefaultRoute: %v", err)
+		}
+		// Twice, because the reconciler is a loop: a second claim must add nothing rather
+		// than accumulate a rule per pass.
+		if err := ClaimDefaultRoute(prTun, EgressMark); err != nil {
+			t.Fatalf("ClaimDefaultRoute, second time: %v", err)
+		}
+		if held, err := DefaultRouteClaimed(EgressMark); err != nil || !held {
+			t.Fatalf("DefaultRouteClaimed = %v, %v after claiming", held, err)
+		}
+	case "release":
+		if err := ReleaseDefaultRoute(EgressMark); err != nil {
+			t.Fatalf("ReleaseDefaultRoute: %v", err)
+		}
+		// And again, because the caller that needs this most is a daemon starting up with
+		// no idea what its previous life did.
+		if err := ReleaseDefaultRoute(EgressMark); err != nil {
+			t.Fatalf("ReleaseDefaultRoute, second time: %v", err)
+		}
+		if held, err := DefaultRouteClaimed(EgressMark); err != nil || held {
+			t.Fatalf("DefaultRouteClaimed = %v, %v after releasing", held, err)
+		}
+	default:
+		t.Skip("driven from the policy-routing tests")
+	}
+}
+
+// The three cases, and getting any of them wrong is a broken device.
+func TestTheKernelRoutesTheThreeCasesCorrectly(t *testing.T) {
+	setupPolicyRouteNS(t)
+
+	// Before the claim, everything follows the ordinary default route. Without this the
+	// assertions below cannot tell a working mechanism from a namespace that never had a
+	// route to begin with.
+	if before := routeFor(t, prOther, false); !strings.Contains(before, "via "+prGW) {
+		t.Fatalf("before claiming, %s did not use the gateway: %s", prOther, before)
+	}
+
+	claimInNS(t)
+
+	// 1. Ordinary traffic takes the tunnel. This is what claiming a default route means.
+	if got := routeFor(t, prOther, false); !strings.Contains(got, prTun) {
+		t.Errorf("ordinary traffic did not take the tunnel: %s", got)
+	}
+
+	// 2. The tunnel's own packets do not. A marked packet has to follow the real default
+	// route, or the outer WireGuard traffic is routed into the tunnel carrying it and the
+	// tunnel never establishes — with the kill switch already installed.
+	if got := routeFor(t, prOther, true); !strings.Contains(got, "via "+prGW) {
+		t.Errorf("the tunnel's own traffic was routed into the tunnel: %s", got)
+	}
+
+	// 3. The local network is untouched. A device that loses its own LAN has lost its
+	// printer, its NAS, and the gateway its outer packets leave through — and it is the
+	// case that breaks if the two rules are installed in the wrong order.
+	if got := routeFor(t, "10.97.0.5", false); !strings.Contains(got, "eth0") {
+		t.Errorf("the local network was routed into the tunnel: %s", got)
+	}
+}
+
+// Giving the network back, which is what decides whether this mechanism is safe to have.
+// These rules outlive the process, so a device that could not be released would be one
+// routing through a tunnel that is gone.
+func TestReleasingGivesTheRoutingBack(t *testing.T) {
+	setupPolicyRouteNS(t)
+
+	claimInNS(t)
+	if got := routeFor(t, prOther, false); !strings.Contains(got, prTun) {
+		t.Fatalf("nothing was claimed, so releasing proves nothing: %s", got)
+	}
+
+	releaseInNS(t)
+	if got := routeFor(t, prOther, false); !strings.Contains(got, "via "+prGW) {
+		t.Errorf("ordinary traffic did not go back to the gateway after releasing: %s", got)
+	}
+	if got := routeFor(t, "10.97.0.5", false); !strings.Contains(got, "eth0") {
+		t.Errorf("the local network is wrong after releasing: %s", got)
+	}
+
+	// And the table is empty. Routing is already correct without this — once the rules are
+	// gone nothing consults the table, so leaving routes in it changes no decision, and a
+	// test that only asked where packets go would not notice.
+	//
+	// It is asserted anyway because Invariant 20 is about what is left behind rather than
+	// about what still works. A table holding a route to an interface that no longer exists
+	// is state this process created and did not remove, and the next person to look at the
+	// machine has to work out whose it is.
+	if out := prMust(t, "ip", "route", "show", "table", fmt.Sprint(EgressTable)); out != "" {
+		t.Errorf("the egress table still holds routes after releasing:\n%s", out)
+	}
+}

--- a/internal/wglink/policyroute_linux_test.go
+++ b/internal/wglink/policyroute_linux_test.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 // The routing mechanism from ADR-0019, against a real kernel.
@@ -86,64 +89,91 @@ func setupPolicyRouteNS(t *testing.T) {
 // Re-executing this test binary under `ip netns exec` is the only way to get these netlink
 // calls into another namespace: rules are installed by whichever namespace the calling
 // thread is in, and Go offers no supported way to move a live goroutine between them.
-func claimInNS(t *testing.T) { inNS(t, "claim") }
-
-// releaseInNS undoes it, inside the same namespace and by the same route.
-func releaseInNS(t *testing.T) { inNS(t, "release") }
-
-func inNS(t *testing.T, action string) {
+// inNamespace runs fn with this thread inside the namespace.
+//
+// Entering it directly rather than re-executing the test binary under `ip netns exec`. A
+// re-exec needs a second Test function that does nothing in an ordinary run, and CI refuses
+// any skip in the data-plane log on the grounds that a skipped data-plane test reports
+// success without testing anything. That guard is right, so the helper had to go.
+//
+// The thread is locked for the duration because a namespace is a property of a thread, not
+// of a process: an unlocked goroutine could be rescheduled onto a thread that is still in
+// the original namespace, and the netlink calls would quietly land in the wrong place.
+//
+// If the return fails the thread stays locked and is never unlocked, so it dies with this
+// goroutine instead of going back into the pool still inside the namespace. A poisoned
+// worker thread would make unrelated tests fail later, somewhere else, for no visible reason.
+func inNamespace(t *testing.T, ns string, fn func() error) {
 	t.Helper()
-	// The binary's real path, resolved here rather than as /proc/self/exe inside the
-	// shell below — by then /proc/self is the shell, not this test.
-	self, err := os.Executable()
+	runtime.LockOSThread()
+
+	original, err := os.Open("/proc/self/ns/net")
 	if err != nil {
-		t.Fatalf("finding this test binary: %v", err)
+		runtime.UnlockOSThread()
+		t.Fatalf("opening this namespace: %v", err)
 	}
-	// Through a shell, because `ip` parses anything beginning with a dash as its own
-	// option and would reject -test.run before ever starting the binary.
-	cmd := exec.Command("ip", "netns", "exec", prns, "sh", "-c",
-		"exec "+self+" -test.run TestPolicyRouteHelper")
-	cmd.Env = append(os.Environ(), helperEnv+"="+action)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("%s inside the namespace: %v\n%s", action, err, out)
+	defer func() { _ = original.Close() }()
+
+	target, err := os.Open("/var/run/netns/" + ns)
+	if err != nil {
+		runtime.UnlockOSThread()
+		t.Fatalf("opening namespace %s: %v", ns, err)
+	}
+	defer func() { _ = target.Close() }()
+
+	if err := unix.Setns(int(target.Fd()), unix.CLONE_NEWNET); err != nil {
+		runtime.UnlockOSThread()
+		t.Fatalf("entering namespace %s: %v", ns, err)
+	}
+
+	fnErr := fn()
+
+	if err := unix.Setns(int(original.Fd()), unix.CLONE_NEWNET); err != nil {
+		t.Fatalf("could not return from namespace %s: %v", ns, err)
+	}
+	runtime.UnlockOSThread()
+
+	if fnErr != nil {
+		t.Fatalf("inside namespace %s: %v", ns, fnErr)
 	}
 }
 
-// helperEnv marks the re-executed run, so the helper below does nothing during an ordinary
-// `go test` and only acts when it is the one deliberately started inside a namespace.
-const helperEnv = "MESHP_POLICYROUTE_HELPER"
-
-// TestPolicyRouteHelper is the half that runs inside the namespace. It is started by name
-// from the test below and skips otherwise.
-func TestPolicyRouteHelper(t *testing.T) {
-	switch os.Getenv(helperEnv) {
-	case "claim":
+func claimInNS(t *testing.T) {
+	t.Helper()
+	inNamespace(t, prns, func() error {
 		if err := ClaimDefaultRoute(prTun, EgressMark); err != nil {
-			t.Fatalf("ClaimDefaultRoute: %v", err)
+			return err
 		}
 		// Twice, because the reconciler is a loop: a second claim must add nothing rather
 		// than accumulate a rule per pass.
 		if err := ClaimDefaultRoute(prTun, EgressMark); err != nil {
-			t.Fatalf("ClaimDefaultRoute, second time: %v", err)
+			return fmt.Errorf("second claim: %w", err)
 		}
-		if held, err := DefaultRouteClaimed(EgressMark); err != nil || !held {
-			t.Fatalf("DefaultRouteClaimed = %v, %v after claiming", held, err)
+		held, err := DefaultRouteClaimed(EgressMark)
+		if err != nil || !held {
+			return fmt.Errorf("DefaultRouteClaimed = %v, %v after claiming", held, err)
 		}
-	case "release":
+		return nil
+	})
+}
+
+func releaseInNS(t *testing.T) {
+	t.Helper()
+	inNamespace(t, prns, func() error {
 		if err := ReleaseDefaultRoute(EgressMark); err != nil {
-			t.Fatalf("ReleaseDefaultRoute: %v", err)
+			return err
 		}
 		// And again, because the caller that needs this most is a daemon starting up with
 		// no idea what its previous life did.
 		if err := ReleaseDefaultRoute(EgressMark); err != nil {
-			t.Fatalf("ReleaseDefaultRoute, second time: %v", err)
+			return fmt.Errorf("second release: %w", err)
 		}
-		if held, err := DefaultRouteClaimed(EgressMark); err != nil || held {
-			t.Fatalf("DefaultRouteClaimed = %v, %v after releasing", held, err)
+		held, err := DefaultRouteClaimed(EgressMark)
+		if err != nil || held {
+			return fmt.Errorf("DefaultRouteClaimed = %v, %v after releasing", held, err)
 		}
-	default:
-		t.Skip("driven from the policy-routing tests")
-	}
+		return nil
+	})
 }
 
 // The three cases, and getting any of them wrong is a broken device.


### PR DESCRIPTION
Slice 4a of ADR-0011, and the mechanism ADR-0019 settled on. **The routing only** — no lock, no claim, nothing in `cmd/` calling it.

### The problem

A device claiming a default route has one problem: the outer WireGuard packets carrying the tunnel must not be sent into it. Put `0.0.0.0/0` on the tunnel in the main table and the packets to the relay match it, get encapsulated, and are routed back into the tunnel they belong to. The tunnel never establishes — and because ADR-0011 installs the kill switch *first*, the device is off the network entirely.

### Three rules

```
32764:  from all lookup main suppress_prefixlength 0
32765:  not from all fwmark <mark> lookup <table>
32766:  from all lookup main                          (the kernel's own)
```

- **LAN traffic** matches a specific route in main and stays on the LAN.
- **Internet traffic** finds only main's default route, which the first rule suppresses, so it falls through and takes the tunnel.
- **WireGuard's own packets** carry the mark, fail `not fwmark`, fall past both, and follow whatever the real default route is.

That last part is why this shape beat host routes via the current gateway: **nothing here records the gateway**, because main already knows it. A laptop moving from Wi-Fi to tethering rewrites none of this. The alternative has to be rebuilt on every roam — a race on the device that roams most, while a kill switch holds the line.

### Tested by asking the kernel

`ip route get`, with and without the mark, which makes all three cases observable without a WireGuard device, a relay, or anything to send.

In a namespace, because these rules in the root namespace would send the runner's own traffic into a table whose default route is a dummy interface. The claim runs by re-executing the test binary under `ip netns exec`, since rules are installed in whichever namespace the calling thread is in.

### Mutation tested

| mutation | |
|---|---|
| **rules installed in the wrong order** | caught |
| mark rule not inverted | caught |
| no suppression of main's default route | caught |
| release leaves the rules behind | caught |
| release leaves the table populated | caught (after strengthening) |

The ordering one is the one that matters: swapped, every unmarked packet takes the tunnel immediately — **including packets to the local network**. A device that has lost its own LAN, its printer, and the gateway its outer packets leave through.

The table one survived the first round. Once the rules are gone nothing consults the table, so routing is correct either way and a test that only asked where packets go could not see it. Asserted anyway, because **Invariant 20 is about what is left behind rather than about what still works**.

### Slices

1. ✅ kill switch (#51) · 2. ✅ reclamation (#52) · 3. ✅ carve-out (#53) · **4a. ✅ this**
4b. ⬜ the claim itself — wires this to the lock and the carve-out, and is the edge into `cmd/`