### PR TITLE
feat(egress): claim the default route, behind the lock

### DIFF
--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -103,7 +103,20 @@ func (a *agent) reconcilerFor(m agentstate.Membership, relay tunnel.Relay, choos
 		AddressV4:     m.AddressV4,
 		AddressV6:     m.AddressV6,
 		ListenPort:    m.ListenPort,
-	}, relay, a.filterOrNil(), log).WithChooser(chooser)
+		ControlURL:    m.ControlURL,
+	}, relay, a.filterOrNil(), log).WithChooser(chooser).WithEgress(routerOrNil())
+}
+
+// routerOrNil converts a possibly-absent router into the interface.
+//
+// Explicit for the same reason relayOrNil and filterOrNil are: a nil *wglink.Router assigned
+// straight to an interface is a non-nil interface holding a nil pointer, so every downstream
+// nil check would pass and the reconciler would believe this host can claim a default route.
+func routerOrNil() tunnel.Egress {
+	if r := wglink.NewRouter(); r != nil {
+		return r
+	}
+	return nil
 }
 
 // reclaimEgressLock removes a fail-closed lock left behind by a previous life.
@@ -123,6 +136,18 @@ func (a *agent) reconcilerFor(m agentstate.Membership, relay tunnel.Relay, choos
 // Reported only when one was actually found, because "removed a lock" and "there was
 // nothing to remove" are different events and only the first explains an outage.
 func (a *agent) reclaimEgressLock() {
+	// The routing first, for the same reason a release does it first: rules pointing at a
+	// table whose tunnel is gone send traffic nowhere, and they outlive this process exactly
+	// as the lock does.
+	if held, err := wglink.EgressHeld(); err == nil && held {
+		a.log.Warn("found a default route claimed by a previous run",
+			"cause", "meshpd exited or was killed while sending everything through the tunnel")
+		if err := wglink.NewRouter().Release(); err != nil {
+			a.log.Error("could not release it; this device may have no working routing",
+				"error", err)
+		}
+	}
+
 	filter := a.ensureFilter()
 	if filter == nil || !nftables.LockHeld(a.ctx) {
 		return
@@ -131,7 +156,7 @@ func (a *agent) reclaimEgressLock() {
 	a.log.Warn("found a fail-closed lock from a previous run; this device had no egress",
 		"table", nftables.LockTableName,
 		"cause", "meshpd exited or was killed while a default route was claimed")
-	if err := filter.ApplyLock(a.ctx, nftables.LockSpec{}); err != nil {
+	if err := filter.ApplyLock(a.ctx, "", nil, nil); err != nil {
 		// The worst outcome this project has: a machine with no network and no obvious
 		// cause. Say what it is and how to undo it by hand, because whoever reads this is
 		// at a console on a host that cannot reach anything.

--- a/internal/nftables/filter.go
+++ b/internal/nftables/filter.go
@@ -2,6 +2,7 @@ package nftables
 
 import (
 	"context"
+	"net/netip"
 
 	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
 )
@@ -30,25 +31,25 @@ func (f *Filter) Apply(ctx context.Context, iface string, filter *meshpv1.Packet
 	return Apply(ctx, script)
 }
 
-// ApplyForward makes this host carry what it has been assigned, or stop carrying.
-//
-// Forwarding is enabled before the rules rather than after: rules that permit forwarding on
-// a host whose kernel will not forward are correct and do nothing, and the gap between the
-// two would be a window where a gateway looks configured and drops everything.
 // ApplyLock makes this device refuse egress that does not go through the tunnel, or stops
 // it refusing.
 //
-// A zero LockSpec removes the lock. That is the only way it comes off from here — the rules
-// are system state and outlive this process on purpose (ADR-0011), so nothing about the
-// agent exiting takes them away.
-func (f *Filter) ApplyLock(ctx context.Context, spec LockSpec) error {
-	script, err := RenderLock(spec)
+// An empty interface name removes the lock. That is the only way it comes off from here —
+// the rules are system state and outlive this process on purpose (ADR-0011), so nothing
+// about the agent exiting takes them away.
+func (f *Filter) ApplyLock(ctx context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix) error {
+	script, err := RenderLock(LockSpec{Interface: iface, Endpoints: endpoints, Excluded: excluded})
 	if err != nil {
 		return err
 	}
 	return Apply(ctx, script)
 }
 
+// ApplyForward makes this host carry what it has been assigned, or stop carrying.
+//
+// Forwarding is enabled before the rules rather than after: rules that permit forwarding on
+// a host whose kernel will not forward are correct and do nothing, and the gap between the
+// two would be a window where a gateway looks configured and drops everything.
 func (f *Filter) ApplyForward(ctx context.Context, iface string, groups []*meshpv1.AdvertisedRoutes_Group) error {
 	if len(groups) > 0 {
 		if _, err := EnableForwarding(); err != nil {

--- a/internal/tunnel/egress.go
+++ b/internal/tunnel/egress.go
@@ -1,0 +1,137 @@
+package tunnel
+
+import (
+	"context"
+	"net/netip"
+
+	"github.com/meshpnet/meshp/internal/egress"
+	"github.com/meshpnet/meshp/internal/logx"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// applyEgress claims or releases a full tunnel.
+//
+// The order is the safety property, and it reverses on the way out.
+//
+// Claiming: work out what must stay reachable, install the lock, and only then take the
+// default route. ADR-0011 requires the lock before the route because the gap between them is
+// a device sending the user's traffic in clear over whatever network it happens to be on, at
+// the moment it believes it is protected.
+//
+// Releasing: routing first, then the lock. A lock still in place with the route gone refuses
+// everything and the machine has no network; a route still in place with the lock gone leaks
+// until the lock goes. Neither is good and the first is worse.
+//
+// Nothing here is best effort. If the carve-out cannot be computed the group is unhonoured
+// and no lock is installed, because a device that locks itself away from its control plane
+// is off the network for a reason nobody watching can see.
+func (r *Reconciler) applyEgress(ctx context.Context, iface string, want bool, relays, excluded []string) []string {
+	if !want {
+		r.releaseEgress(ctx)
+		return nil
+	}
+	if r.egress == nil || r.filter == nil {
+		r.log.Error("this device is meant to send everything through the tunnel and cannot",
+			"hint", "a full tunnel needs policy routing and a packet filter; this host has one or neither")
+		return []string{"egress"}
+	}
+
+	// Two sources, because neither knows enough alone. The control plane sends the
+	// exclusions only it can work out — the exit's own endpoint, prefixes an administrator
+	// named — and the device adds the ones only it can see: the network it is attached to,
+	// and the link-local world underneath it.
+	carve, err := egress.Compute(ctx, egress.Inputs{
+		ControlURL:     r.membership.ControlURL,
+		RelayEndpoints: relays,
+		LocalPrefixes:  egress.LocalNetworks(iface),
+		ExtraPrefixes:  excluded,
+	}, nil)
+	if err != nil {
+		// The branch that decides whether a mistake here costs a feature or a machine.
+		r.log.Error("not claiming a default route",
+			"error", logx.SafeError(err),
+			"consequence", "this device would have had no way back to its control plane")
+		return []string{"egress"}
+	}
+
+	if err := r.filter.ApplyLock(ctx, iface, carve.Endpoints, carve.Prefixes); err != nil {
+		r.log.Error("cannot refuse egress outside the tunnel; not claiming a default route",
+			"error", logx.SafeError(err))
+		return []string{"egress"}
+	}
+	if err := r.egress.Claim(iface); err != nil {
+		// The lock is on and the route is not, which is the safe half of a half-done claim:
+		// the device sends nothing rather than sending it the wrong way. Taking the lock off
+		// again would restore the leak it was installed to prevent, so it stays, the group is
+		// unhonoured, and the next pass tries the claim again.
+		r.log.Error("cannot claim the default route; egress stays refused",
+			"error", logx.SafeError(err))
+		return []string{"egress"}
+	}
+
+	if !r.claimed {
+		r.log.Info("this device now sends everything through the tunnel",
+			"interface", iface,
+			"kept_direct", len(carve.Prefixes), "endpoints_kept", len(carve.Endpoints))
+	}
+	r.claimed = true
+	return nil
+}
+
+// releaseEgress undoes a claim, if this reconciler made one.
+func (r *Reconciler) releaseEgress(ctx context.Context) {
+	if !r.claimed {
+		return
+	}
+
+	var failed error
+	if r.egress != nil {
+		failed = r.egress.Release()
+	}
+	// The lock comes off even when the routing did not, and its error is kept only if
+	// nothing else failed first. Leaving a lock behind because a route would not release is
+	// how a device ends up refusing everything with no explanation.
+	if r.filter != nil {
+		if err := r.filter.ApplyLock(ctx, "", nil, nil); err != nil && failed == nil {
+			failed = err
+		}
+	}
+	if failed != nil {
+		r.log.Error("could not stop sending everything through the tunnel",
+			"error", logx.SafeError(failed),
+			"consequence", "this device may have no egress until meshpd restarts and reclaims")
+		return
+	}
+
+	r.claimed = false
+	r.log.Info("no longer sending everything through the tunnel")
+}
+
+// wantsEgress reports whether any assigned group asks for a default route, and what the
+// control plane says must stay off it.
+func wantsEgress(state routeGroupSource) (bool, []string) {
+	want := false
+	for _, group := range state.RouteGroups() {
+		for _, raw := range group.GetPrefixes() {
+			if prefix, err := netip.ParsePrefix(raw); err == nil && prefix.Bits() == 0 {
+				want = true
+			}
+		}
+	}
+	return want, state.Tunnel().GetExcludedPrefixes()
+}
+
+// routeGroupSource is the part of desired state a claim reads.
+type routeGroupSource interface {
+	RouteGroups() []*meshpv1.RouteGroupAssignment
+	Tunnel() *meshpv1.TunnelConfig
+}
+
+// relayEndpointsOf lists the relay addresses a claim must keep reachable.
+func relayEndpointsOf(relays *meshpv1.RelayConfig) []string {
+	var out []string
+	for _, relay := range relays.GetRelays() {
+		out = append(out, relay.GetEndpoints()...)
+	}
+	return out
+}

--- a/internal/tunnel/egress_test.go
+++ b/internal/tunnel/egress_test.go
@@ -1,0 +1,149 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/meshpnet/meshp/internal/peerset"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+func egressState(version uint64) *peerset.Set {
+	return stateWithRoutes(version,
+		[]*meshpv1.RouteGroupAssignment{assignmentTo("exit", bobKey, "0.0.0.0/0", "::/0")},
+		peer(bobKey, "100.90.0.2/32"))
+}
+
+func withEgress(t *testing.T) (*Reconciler, *fakeFilter, *fakeEgress, *[]string) {
+	t.Helper()
+	order := &[]string{}
+	filter := &fakeFilter{order: order}
+	router := &fakeEgress{order: order}
+	m := membership()
+	m.ControlURL = "https://198.51.100.10:8443"
+	r := New(newFakeLink(), m, nil, filter, nil)
+	r.egress = router
+	return r, filter, router, order
+}
+
+// The ordering the whole feature rests on: the lock is installed before the route is
+// claimed. The gap between them, in the other order, is a device sending the user's traffic
+// in clear over whatever network it is on at the moment it believes it is protected.
+func TestTheLockGoesOnBeforeTheRouteIsClaimed(t *testing.T) {
+	r, _, _, order := withEgress(t)
+
+	if _, err := r.Apply(context.Background(), egressState(1)); err != nil {
+		t.Fatal(err)
+	}
+	// One sequence, not two, because what is under test is which came first.
+	if got := strings.Join(*order, ", "); got != "lock meshp0, claim meshp0" {
+		t.Errorf("order was %q, want the lock installed before the route was claimed", got)
+	}
+}
+
+// And the reverse on the way out. A lock still in place with the route gone refuses
+// everything and the machine has no network.
+func TestTheRouteIsReleasedBeforeTheLockComesOff(t *testing.T) {
+	r, _, _, order := withEgress(t)
+	if _, err := r.Apply(context.Background(), egressState(1)); err != nil {
+		t.Fatal(err)
+	}
+
+	// The group goes away.
+	plain := stateWithRoutes(2, nil, peer(bobKey, "100.90.0.2/32"))
+	if _, err := r.Apply(context.Background(), plain); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := strings.Join(*order, ", "); got != "lock meshp0, claim meshp0, release, unlock" {
+		t.Errorf("order was %q, want the route released before the lock came off", got)
+	}
+}
+
+// A claim that cannot be made safely is not made at all. Without a control plane address
+// the device would lock itself away from the one channel that could tell it to stop.
+func TestAClaimIsRefusedWithoutAWayBackToTheControlPlane(t *testing.T) {
+	filter := &fakeFilter{}
+	router := &fakeEgress{}
+	r := New(newFakeLink(), membership(), nil, filter, nil) // no ControlURL
+	r.egress = router
+
+	unapplied, err := r.Apply(context.Background(), egressState(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slicesContain(unapplied, "egress") {
+		t.Errorf("unapplied = %v, want egress reported", unapplied)
+	}
+	if len(router.events) != 0 {
+		t.Errorf("a default route was claimed anyway: %v", router.events)
+	}
+	if len(filter.locks) != 0 {
+		t.Errorf("a lock was installed with no way back: %v", filter.locks)
+	}
+}
+
+// A host that cannot do one half must not do the other. Half of this feature is not a
+// degraded version of it.
+func TestAHostThatCannotRouteDoesNotLockItself(t *testing.T) {
+	filter := &fakeFilter{}
+	m := membership()
+	m.ControlURL = "https://198.51.100.10:8443"
+	r := New(newFakeLink(), m, nil, filter, nil) // no egress implementation
+
+	unapplied, err := r.Apply(context.Background(), egressState(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slicesContain(unapplied, "egress") {
+		t.Errorf("unapplied = %v, want egress reported", unapplied)
+	}
+	if len(filter.locks) != 0 {
+		t.Errorf("a host that cannot claim a route locked itself anyway: %v", filter.locks)
+	}
+}
+
+// The safe half of a half-done claim. If the route will not go on, the lock stays: this
+// device sends nothing rather than sending it the wrong way, and the next pass tries again.
+func TestAFailedClaimLeavesTheLockOn(t *testing.T) {
+	r, filter, router, _ := withEgress(t)
+	router.claimErr = errors.New("netlink said no")
+
+	unapplied, err := r.Apply(context.Background(), egressState(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slicesContain(unapplied, "egress") {
+		t.Errorf("unapplied = %v, want egress reported", unapplied)
+	}
+	if len(filter.locks) == 0 || filter.locks[len(filter.locks)-1] != "meshp0" {
+		t.Errorf("the lock was not left in place after a failed claim: %v", filter.locks)
+	}
+}
+
+// The carve-out reaches the lock. A lock that permitted nothing would refuse the control
+// plane and the relay along with everything else.
+func TestTheCarveoutReachesTheLock(t *testing.T) {
+	r, filter, _, _ := withEgress(t)
+
+	if _, err := r.Apply(context.Background(), egressState(1)); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.endpoints) == 0 || len(filter.endpoints[0]) == 0 {
+		t.Fatal("the lock was given no endpoints, so the control plane is unreachable")
+	}
+	var sawControl bool
+	for _, ep := range filter.endpoints[0] {
+		if ep.String() == "198.51.100.10:8443" {
+			sawControl = true
+		}
+	}
+	if !sawControl {
+		t.Errorf("the control plane is not in the lock's endpoints: %v", filter.endpoints[0])
+	}
+	if len(filter.excluded[0]) == 0 {
+		t.Error("the lock was given no excluded prefixes, so link-local traffic is refused")
+	}
+}

--- a/internal/tunnel/routegroups.go
+++ b/internal/tunnel/routegroups.go
@@ -50,17 +50,15 @@ func applyRouteGroups(iface *wgplan.Interface, assignments []*meshpv1.RouteGroup
 		}
 
 		if defaultRoute {
-			// Refused rather than half-done. Claiming a default route needs the excluded
-			// prefixes that keep the tunnel's own endpoint, the physical gateway and the LAN
-			// out of it, and the fail-closed behaviour that blocks egress while the tunnel is
-			// down (ADR-0011). None of that exists yet, and installing 0.0.0.0/0 without it
-			// would send this device's own path to its control plane and its relay into a
-			// tunnel that depends on them — taking the host off the network with no way back.
-			log.Error("not claiming a default route for an egress group",
-				"group", logx.Safe(name),
-				"reason", "internet egress needs excluded prefixes and fail-closed handling (ADR-0011)")
-			unhonoured = append(unhonoured, name)
-			continue
+			// Both halves, because WireGuard needs one and the routing table must not get
+			// the other. A peer carrying a default route needs 0.0.0.0/0 and ::/0 in its
+			// allowed IPs or the kernel will not send it anything outside the mesh — but
+			// wgplan deliberately derives no system route from a zero-length prefix, since a
+			// default route in the main table would capture the outer packets carrying this
+			// very tunnel. The system route lives in the egress table instead, installed
+			// with the rules that exempt the tunnel's own traffic (ADR-0019).
+			prefixes = append(prefixes,
+				netip.MustParsePrefix("0.0.0.0/0"), netip.MustParsePrefix("::/0"))
 		}
 
 		// The chooser's answer, not the server's first preference. The server orders the

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -74,6 +74,13 @@ type Membership struct {
 	// that has never come up says; the port the device settles on is reported back so it
 	// can be kept for next time.
 	ListenPort int
+
+	// ControlURL is where this membership's control plane lives.
+	//
+	// Needed only to claim a default route, and not optional there: it is the address that
+	// must stay reachable outside the tunnel, or the device locks itself away from the one
+	// channel that could tell it to stop (ADR-0011).
+	ControlURL string
 }
 
 // Reconciler applies desired state to a real interface.
@@ -104,6 +111,15 @@ type Reconciler struct {
 	// before there was a chooser.
 	chooser *routeprobe.Chooser
 
+	// egress claims the default route for a full tunnel, or is nil where this platform
+	// cannot. Kept beside the filter because the two are applied together and in an order
+	// that matters.
+	egress Egress
+
+	// claimed is whether this reconciler currently holds a default route, so releasing
+	// happens once rather than on every pass through a state that does not want one.
+	claimed bool
+
 	// lastAdvertised is the same idea for forwarding, and matters more: reloading the NAT
 	// table flushes its conntrack-independent counters and, on some kernels, disturbs
 	// in-flight masqueraded flows. An unchanged assignment is left alone.
@@ -130,6 +146,27 @@ type Filter interface {
 	// list means stop: a device that has been withdrawn must not go on being a gateway
 	// nobody knows about.
 	ApplyForward(ctx context.Context, iface string, groups []*meshpv1.AdvertisedRoutes_Group) error
+
+	// ApplyLock makes the host refuse egress that does not go through the tunnel. An empty
+	// interface name removes it, which is the only way it comes off: these rules are system
+	// state and outlive the process on purpose (ADR-0011).
+	ApplyLock(ctx context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix) error
+}
+
+// Egress claims and releases a full tunnel's routing.
+//
+// Separate from Filter because they are different halves of the same guarantee and fail
+// differently: the filter refuses traffic that would leave the wrong way, and this decides
+// which way is the right one. Nil where the platform cannot do it, in which case a device
+// asked for a default route reports the group unhonoured rather than half-claiming it.
+type Egress interface {
+	// Claim sends everything except the tunnel's own packets through the tunnel. Which
+	// packets are the tunnel's own, and how they are recognised, belongs to the
+	// implementation — this package has no business knowing about firewall marks.
+	Claim(iface string) error
+
+	// Release gives the routing back.
+	Release() error
 }
 
 // New returns a Reconciler for one membership. relay and filter may be nil.
@@ -141,6 +178,15 @@ func New(link wglink.Link, m Membership, relay Relay, filter Filter, log *slog.L
 		link: link, membership: m, relay: relay, filter: filter,
 		log: log, kind: wglink.KindUnknown,
 	}
+}
+
+// WithEgress gives the reconciler the ability to claim a default route.
+//
+// Nil is meaningful and is the ordinary case: most devices are not full-tunnel, and a host
+// that cannot claim one reports the group unhonoured rather than half-claiming it.
+func (r *Reconciler) WithEgress(e Egress) *Reconciler {
+	r.egress = e
+	return r
 }
 
 // WithChooser gives the reconciler local failover.
@@ -284,6 +330,14 @@ func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, e
 			"interface", want.Name, "groups", len(unhonoured))
 		unapplied = append(unapplied, "route-groups")
 	}
+	// After the interface exists and before the filter, because claiming a default route
+	// installs its own lock and the two must not fight over the order they load in.
+	wantEgress, excluded := wantsEgress(state)
+	if failed := r.applyEgress(ctx, want.Name, wantEgress,
+		relayEndpointsOf(state.Relays()), excluded); failed != nil {
+		unapplied = append(unapplied, failed...)
+	}
+
 	if failed := r.applyForwarding(ctx, want.Name, state.Advertised()); failed != nil {
 		unapplied = append(unapplied, failed...)
 	}

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -833,6 +833,68 @@ type fakeFilter struct {
 	iface     string
 	failErr   error
 	fwdErr    error
+
+	// locks records every lock applied, by the interface it named. An empty name is a
+	// removal, so the sequence shows the order the lock went on and came off — which is
+	// the property that matters most about it.
+	locks     []string
+	lockErr   error
+	endpoints [][]netip.AddrPort
+	excluded  [][]netip.Prefix
+
+	// order, when set, is shared with the egress fake. Separate slices per fake record what
+	// each of them did and cannot show which happened first, and "the lock before the route"
+	// is the whole property under test — a mutation that swapped them survived until this
+	// existed.
+	order *[]string
+}
+
+func (f *fakeFilter) ApplyLock(_ context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix) error {
+	if f.lockErr != nil {
+		return f.lockErr
+	}
+	f.locks = append(f.locks, iface)
+	f.endpoints = append(f.endpoints, endpoints)
+	f.excluded = append(f.excluded, excluded)
+	if f.order != nil {
+		if iface == "" {
+			*f.order = append(*f.order, "unlock")
+		} else {
+			*f.order = append(*f.order, "lock "+iface)
+		}
+	}
+	return nil
+}
+
+// fakeEgress records claims and releases in order, which is what the ordering assertions
+// read: a claim that happened before its lock is the bug the whole feature is built around.
+type fakeEgress struct {
+	events   []string
+	claimErr error
+	relErr   error
+	order    *[]string
+}
+
+func (e *fakeEgress) Claim(iface string) error {
+	if e.claimErr != nil {
+		return e.claimErr
+	}
+	e.events = append(e.events, "claim "+iface)
+	if e.order != nil {
+		*e.order = append(*e.order, "claim "+iface)
+	}
+	return nil
+}
+
+func (e *fakeEgress) Release() error {
+	if e.relErr != nil {
+		return e.relErr
+	}
+	e.events = append(e.events, "release")
+	if e.order != nil {
+		*e.order = append(*e.order, "release")
+	}
+	return nil
 }
 
 func (f *fakeFilter) ApplyForward(_ context.Context, _ string, groups []*meshpv1.AdvertisedRoutes_Group) error {
@@ -1105,11 +1167,10 @@ func TestACarriedPrefixReachesTheCarrierAndTheRoutingTable(t *testing.T) {
 	}
 }
 
-// Claiming a default route needs the excluded prefixes that keep the tunnel's own endpoint
-// and the physical gateway out of it, and the fail-closed handling that blocks egress while
-// the tunnel is down (ADR-0011). Installing 0.0.0.0/0 without them would send this device's
-// own path to its control plane and its relay into a tunnel that depends on them.
-func TestAnEgressGroupIsRefusedUntilItIsSafe(t *testing.T) {
+// A peer carrying a default route needs it in its allowed IPs, because WireGuard will not
+// send a packet to a peer whose allowed IPs do not cover the destination. The system route
+// is a separate question, answered in wgplan and in the egress table.
+func TestAnEgressGroupPutsTheDefaultInAllowedIPs(t *testing.T) {
 	state := stateWithRoutes(1,
 		[]*meshpv1.RouteGroupAssignment{assignmentTo("exit", bobKey, "0.0.0.0/0", "::/0")},
 		peer(bobKey, "100.90.0.2/32"))
@@ -1118,26 +1179,34 @@ func TestAnEgressGroupIsRefusedUntilItIsSafe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("an egress group made the whole description fail: %v", err)
 	}
-	if len(unhonoured) != 1 || unhonoured[0] != "exit" {
-		t.Fatalf("unhonoured = %v, want [exit]", unhonoured)
+	if len(unhonoured) != 0 {
+		t.Fatalf("unhonoured = %v, want none", unhonoured)
 	}
-	if got := allowedIPsOf(iface, bobKey); slicesContain(got, "0.0.0.0/0") {
-		t.Fatalf("a default route was claimed anyway: %v", got)
+	got := allowedIPsOf(iface, bobKey)
+	for _, want := range []string{"0.0.0.0/0", "::/0"} {
+		if !slicesContain(got, want) {
+			t.Errorf("%s is not in the exit peer's allowed IPs: %v", want, got)
+		}
 	}
+}
 
-	// And it is reported, so the device does not look converged while carrying nothing.
+// And no system route in the main table for it. A default route there would capture the
+// outer packets carrying this very tunnel and route them into it — the tunnel never comes
+// up, and the kill switch is already installed by then.
+func TestNoMainTableRouteIsInstalledForADefaultRoute(t *testing.T) {
 	link := newFakeLink()
 	r := New(link, membership(), nil, nil, nil)
-	reported, err := r.Apply(context.Background(), state)
-	if err != nil {
-		t.Fatalf("Apply: %v", err)
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{assignmentTo("exit", bobKey, "0.0.0.0/0", "::/0")},
+		peer(bobKey, "100.90.0.2/32"))
+
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
 	}
-	if len(reported) != 1 || reported[0] != "route-groups" {
-		t.Errorf("unapplied = %v, want [route-groups]", reported)
-	}
-	// The peers still converged; one unusable group must not cost the rest.
-	if link.count(wgplan.SetPeer) == 0 {
-		t.Error("the peers were abandoned because a group could not be carried")
+	for _, op := range link.applied {
+		if op.Kind == wgplan.AddRoute && op.Prefix.Bits() == 0 {
+			t.Errorf("a default route was installed in the main table: %v", op)
+		}
 	}
 }
 

--- a/internal/wglink/egress_linux.go
+++ b/internal/wglink/egress_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package wglink
+
+// Router claims and releases a full tunnel's routing. It satisfies tunnel.Egress.
+//
+// A type rather than the bare functions so the mark stays an implementation detail: the
+// reconciler decides whether this device sends everything through the tunnel, and has no
+// business knowing how the tunnel's own packets are told apart from everything else.
+type Router struct{}
+
+// NewRouter returns something that can claim a default route, or nothing where the platform
+// cannot. Nil rather than a stub, so a device asked for a full tunnel it cannot deliver
+// reports the group unhonoured instead of pretending.
+func NewRouter() *Router { return &Router{} }
+
+// Claim marks the tunnel's own traffic and sends everything else through it.
+//
+// The mark first. A rule that exempts marked traffic exempts nothing until something is
+// marking it, and in that gap the tunnel's own packets are routed into the tunnel.
+func (r *Router) Claim(iface string) error {
+	if err := SetEgressMark(iface, EgressMark); err != nil {
+		return err
+	}
+	return ClaimDefaultRoute(iface, EgressMark)
+}
+
+// Release gives the routing back.
+func (r *Router) Release() error { return ReleaseDefaultRoute(EgressMark) }
+
+// EgressHeld reports whether a claim from a previous life is still in place.
+func EgressHeld() (bool, error) { return DefaultRouteClaimed(EgressMark) }

--- a/internal/wglink/egress_other.go
+++ b/internal/wglink/egress_other.go
@@ -1,0 +1,19 @@
+//go:build !linux
+
+package wglink
+
+// Router is unavailable off Linux, where there is no policy routing to claim with.
+type Router struct{}
+
+// NewRouter returns nothing, so a device asked for a full tunnel reports the group
+// unhonoured rather than claiming one it cannot enforce.
+func NewRouter() *Router { return nil }
+
+// Claim is unsupported off Linux.
+func (r *Router) Claim(string) error { return ErrUnsupported }
+
+// Release is unsupported off Linux.
+func (r *Router) Release() error { return ErrUnsupported }
+
+// EgressHeld is false everywhere but Linux, where nothing could have claimed one.
+func EgressHeld() (bool, error) { return false, nil }

--- a/internal/wgplan/wgplan.go
+++ b/internal/wgplan/wgplan.go
@@ -424,9 +424,16 @@ func (i Interface) Validate() error {
 	// Overlaps that are not exact duplicates: one peer holding 10.0.0.0/24 and another
 	// holding 10.0.0.5/32 is the same silent theft, and comparing prefixes for equality
 	// alone would miss it.
+	// Between peers, never within one. A single peer holding both 0.0.0.0/0 and its own
+	// /32 is redundant and entirely legal — every full-tunnel WireGuard config written by
+	// hand looks like that — and there is no theft to detect, because both prefixes lead to
+	// the same place.
 	prefixes := sortedPrefixes(claimed)
 	for a := range prefixes {
 		for b := a + 1; b < len(prefixes); b++ {
+			if claimed[prefixes[a]] == claimed[prefixes[b]] {
+				continue
+			}
 			if prefixes[a].Overlaps(prefixes[b]) {
 				return fmt.Errorf("wgplan: interface %s peer %s has %s, which overlaps %s held by %s",
 					i.Name, claimed[prefixes[a]], prefixes[a], prefixes[b], claimed[prefixes[b]])
@@ -457,10 +464,22 @@ func Teardown(observed Observed) Plan {
 }
 
 // wantRoutes is every peer address that should be routed at the interface.
+//
+// A default route is deliberately not among them. A full tunnel needs 0.0.0.0/0 in a peer's
+// allowed IPs, because WireGuard will not send a packet to a peer whose allowed IPs do not
+// cover the destination — but the matching system route must not go into the main table,
+// where it would capture the outer packets carrying the tunnel and route them into it. That
+// route belongs in the egress table, installed with the rules that exempt the tunnel's own
+// traffic (ADR-0019).
 func wantRoutes(want Interface) []netip.Prefix {
 	out := make([]netip.Prefix, 0, len(want.Peers))
 	for _, peer := range want.Peers {
-		out = append(out, peer.AllowedIPs...)
+		for _, prefix := range peer.AllowedIPs {
+			if prefix.Bits() == 0 {
+				continue
+			}
+			out = append(out, prefix)
+		}
 	}
 	return out
 }


### PR DESCRIPTION
Slice 4b of ADR-0011 — the first time a device can send everything through the tunnel. The four pieces built separately are now joined, and **the order they are joined in is the whole of what makes it safe.**

**Claiming:** work out what must stay reachable → install the lock → take the route. ADR-0011 requires the lock first because the gap the other way round is a device sending the user's traffic in clear over whatever network it is on, at the moment it believes it is protected.

**Releasing:** routing first, then the lock. A lock in place with the route gone refuses everything and the machine has no network; a route in place with the lock gone leaks until the lock goes. Neither is good and the first is worse.

### Nothing is best effort

- A carve-out that cannot be computed → **no lock installed**, group unhonoured. A device that locks itself away from its control plane is off the network for a reason nobody watching can see.
- A host with only one of the two halves → **refuses both**. Half of this feature is not a degraded version of it.
- A claim that fails after the lock is on → **the lock stays**. The device sends nothing rather than sending it the wrong way, and the next pass tries again.

### Two bugs found by wiring it, not by reading it

**`wgplan` refused a peer holding both `0.0.0.0/0` and its own `/32`** — its overlap check compared a peer against *itself*. That is legal, and is what every hand-written full-tunnel WireGuard config looks like. It now only compares across peers, where the theft it is looking for can actually happen.

**`wgplan` derived a system route from every allowed IP**, so a default route would have landed in the main table and captured the outer packets carrying the tunnel. A zero-length prefix is now skipped: the peer still needs it for cryptokey routing, and the system route belongs in the egress table with the rules that exempt the tunnel's own traffic (ADR-0019).

### The carve-out has two sources

Neither knows enough alone. The control plane sends what only it can work out — `TunnelConfig`'s own comment says the server computes it and the agent does not improvise — and the device adds the network it is attached to plus the link-local world underneath.

### Mutation testing found a hole in my own tests

Two mutations survived the first round: **both of the ordering ones** — which is to say, the only property this slice exists to guarantee.

The tests recorded the lock and the route into *separate* slices, so relative order was never observable. One shared event log later:

```
order was "claim meshp0, lock meshp0", want the lock installed before the route was claimed
```

Swapping either pair now fails with the sequence printed.

### Slices

1. ✅ kill switch · 2. ✅ reclamation · 3. ✅ carve-out · 4a. ✅ routing · **4b. ✅ this**
5. ⬜ `TunnelConfig.fail_closed` in desired state · 6. ⬜ DNS leak prevention · 7. ⬜ e2e