### PR TITLE
feat(egress): refuse plaintext DNS outside the tunnel

### DIFF
--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -156,7 +156,7 @@ func (a *agent) reclaimEgressLock() {
 	a.log.Warn("found a fail-closed lock from a previous run; this device had no egress",
 		"table", nftables.LockTableName,
 		"cause", "meshpd exited or was killed while a default route was claimed")
-	if err := filter.ApplyLock(a.ctx, "", nil, nil); err != nil {
+	if err := filter.ApplyLock(a.ctx, "", nil, nil, false); err != nil {
 		// The worst outcome this project has: a machine with no network and no obvious
 		// cause. Say what it is and how to undo it by hand, because whoever reads this is
 		// at a console on a host that cannot reach anything.

--- a/internal/nftables/filter.go
+++ b/internal/nftables/filter.go
@@ -37,8 +37,11 @@ func (f *Filter) Apply(ctx context.Context, iface string, filter *meshpv1.Packet
 // An empty interface name removes the lock. That is the only way it comes off from here —
 // the rules are system state and outlive this process on purpose (ADR-0011), so nothing
 // about the agent exiting takes them away.
-func (f *Filter) ApplyLock(ctx context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix) error {
-	script, err := RenderLock(LockSpec{Interface: iface, Endpoints: endpoints, Excluded: excluded})
+func (f *Filter) ApplyLock(ctx context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix, preventDNSLeaks bool) error {
+	script, err := RenderLock(LockSpec{
+		Interface: iface, Endpoints: endpoints, Excluded: excluded,
+		PreventDNSLeaks: preventDNSLeaks,
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/nftables/lock.go
+++ b/internal/nftables/lock.go
@@ -39,6 +39,16 @@ type LockSpec struct {
 	// and often its default gateway. What belongs in here is decided elsewhere; this only
 	// renders it.
 	Excluded []netip.Prefix
+
+	// PreventDNSLeaks refuses plaintext DNS that is not going through the tunnel.
+	//
+	// The lock already refuses everything it does not name, so this is not about the wider
+	// internet — it is about the hole the carve-out has to leave. The local network is
+	// permitted so the device keeps its printer and its gateway, and the local network is
+	// also where the resolver lives. A tunnel that is up while queries go to the router
+	// discloses every name the user looks up to whoever runs that network, which is most of
+	// what they are doing and exactly what they turned the tunnel on to avoid.
+	PreventDNSLeaks bool
 }
 
 // RenderLock turns a lock specification into a ruleset that refuses everything else.
@@ -101,6 +111,20 @@ func RenderLock(spec LockSpec) (string, error) {
 			LockTableName, family, addr.String(), ep.Port())
 		fmt.Fprintf(&b, "add rule inet %s output %s daddr %s tcp dport %d accept\n",
 			LockTableName, family, addr.String(), ep.Port())
+	}
+
+	// Before the carve-out, and that order is the whole of this rule. Refusing DNS after
+	// the local network has been permitted would refuse nothing: the resolver is on the
+	// local network.
+	//
+	// Plaintext only, which is what ADR-0011 asks for. DNS over TLS on 853 does not
+	// disclose the query to the network it crosses, and DNS over HTTPS is indistinguishable
+	// from any other HTTPS — blocking 443 would take the device off the internet to close a
+	// hole that this rule cannot see anyway. mDNS on 5353 is left alone too: it never leaves
+	// the link, and refusing it costs the printer discovery the carve-out exists to keep.
+	if spec.PreventDNSLeaks {
+		fmt.Fprintf(&b, "add rule inet %s output udp dport 53 reject\n", LockTableName)
+		fmt.Fprintf(&b, "add rule inet %s output tcp dport 53 reject\n", LockTableName)
 	}
 
 	// The local network and anything else carved out.

--- a/internal/nftables/lock_test.go
+++ b/internal/nftables/lock_test.go
@@ -135,3 +135,67 @@ func TestTheSameSpecRendersTheSameScript(t *testing.T) {
 		t.Error("the same lock rendered differently depending on the order it was given in")
 	}
 }
+
+// The hole this closes is the one the carve-out has to leave. The local network is
+// permitted so the device keeps its printer and its gateway, and the resolver lives on the
+// local network — so a tunnel that is up while queries go to the router discloses every
+// name the user looks up to whoever runs that network.
+func TestPreventingDNSLeaksRefusesPlaintextDNS(t *testing.T) {
+	spec := aLock()
+	spec.PreventDNSLeaks = true
+	script := renderLock(t, spec)
+
+	for _, want := range []string{"udp dport 53 reject", "tcp dport 53 reject"} {
+		if !strings.Contains(script, want) {
+			t.Errorf("missing %q:\n%s", want, script)
+		}
+	}
+}
+
+// And it has to come first, because refusing DNS after the local network has been permitted
+// refuses nothing at all: the resolver is on the local network.
+func TestTheDNSRefusalComesBeforeTheCarveout(t *testing.T) {
+	spec := aLock()
+	spec.PreventDNSLeaks = true
+	script := renderLock(t, spec)
+
+	dns := strings.Index(script, "udp dport 53 reject")
+	lan := strings.Index(script, "ip daddr 192.168.1.0/24 accept")
+	if dns < 0 || lan < 0 {
+		t.Fatalf("expected both rules:\n%s", script)
+	}
+	if dns > lan {
+		t.Errorf("the local network is permitted before DNS is refused, so DNS to the "+
+			"router is still allowed:\n%s", script)
+	}
+}
+
+// The tunnel first, or a device that prevented leaks would refuse its own resolver — the
+// one it is meant to be using.
+func TestDNSThroughTheTunnelIsStillAllowed(t *testing.T) {
+	spec := aLock()
+	spec.PreventDNSLeaks = true
+	script := renderLock(t, spec)
+
+	tunnel := strings.Index(script, `output oifname "meshp0" accept`)
+	dns := strings.Index(script, "udp dport 53 reject")
+	if tunnel < 0 || dns < 0 {
+		t.Fatalf("expected both rules:\n%s", script)
+	}
+	if tunnel > dns {
+		t.Error("DNS is refused before the tunnel is permitted, so the device cannot resolve at all")
+	}
+	if lo := strings.Index(script, "output oif lo accept"); lo > dns {
+		t.Error("DNS is refused before loopback, which breaks a local stub resolver")
+	}
+}
+
+// Off by default, because it is a policy the network states rather than something a device
+// decides for itself.
+func TestDNSIsNotRefusedUnlessAsked(t *testing.T) {
+	script := renderLock(t, aLock())
+
+	if strings.Contains(script, "dport 53") {
+		t.Errorf("DNS was refused without the network asking:\n%s", script)
+	}
+}

--- a/internal/peerset/dns_test.go
+++ b/internal/peerset/dns_test.go
@@ -1,0 +1,76 @@
+package peerset
+
+import (
+	"testing"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// StateDelta.dns was carried on the wire and dropped here, which is the same mistake that
+// killed relays: a field handled everywhere downstream and not in the fold. The package doc
+// lists the four places it has to appear, and these are the two that are silent when missed.
+func TestResolverConfigurationIsFolded(t *testing.T) {
+	s := New()
+	s.Apply(&meshpv1.StateDelta{
+		FromVersion: 0, ToVersion: 1,
+		Dns: &meshpv1.DnsConfig{Nameservers: []string{"100.90.0.1"}, PreventLeaks: true},
+	})
+
+	if !s.DNS().GetPreventLeaks() {
+		t.Fatal("prevent_leaks did not survive the fold, so the agent would never refuse a leak")
+	}
+
+	// Absent in a delta means unchanged, or a routine peer update would switch it off.
+	s.Apply(&meshpv1.StateDelta{FromVersion: 1, ToVersion: 2})
+	if !s.DNS().GetPreventLeaks() {
+		t.Error("a delta that said nothing about DNS switched leak prevention off")
+	}
+}
+
+// A snapshot is the whole truth, so one carrying no DNS means the network has none. Keeping
+// the last one would leave a device refusing queries its network has stopped asking it to.
+func TestASnapshotClearsResolverConfiguration(t *testing.T) {
+	s := New()
+	s.Apply(&meshpv1.StateDelta{
+		FromVersion: 0, ToVersion: 1,
+		Dns: &meshpv1.DnsConfig{PreventLeaks: true},
+	})
+	s.Apply(&meshpv1.StateDelta{FromVersion: 0, ToVersion: 2})
+
+	if s.DNS() != nil {
+		t.Errorf("a snapshot with no DNS left %+v behind", s.DNS())
+	}
+}
+
+// Clone has to copy it, or two sets share a pointer and Invariant 22 is gone.
+func TestCloneCopiesResolverConfiguration(t *testing.T) {
+	s := New()
+	s.Apply(&meshpv1.StateDelta{
+		FromVersion: 0, ToVersion: 1,
+		Dns: &meshpv1.DnsConfig{PreventLeaks: true},
+	})
+
+	clone := s.Clone()
+	if !clone.DNS().GetPreventLeaks() {
+		t.Fatal("the clone lost the resolver configuration")
+	}
+	clone.DNS().PreventLeaks = false
+	if !s.DNS().GetPreventLeaks() {
+		t.Error("the clone shares a pointer with the original")
+	}
+}
+
+// And Equal has to look at it, or a test that folds and compares passes without ever seeing
+// the field — which is how the last one of these went unnoticed.
+func TestEqualNoticesResolverConfiguration(t *testing.T) {
+	a, b := New(), New()
+	a.Apply(&meshpv1.StateDelta{
+		FromVersion: 0, ToVersion: 1,
+		Dns: &meshpv1.DnsConfig{PreventLeaks: true},
+	})
+	b.Apply(&meshpv1.StateDelta{FromVersion: 0, ToVersion: 1})
+
+	if a.Equal(b) {
+		t.Error("two sets differing only in DNS compared equal")
+	}
+}

--- a/internal/peerset/peerset.go
+++ b/internal/peerset/peerset.go
@@ -52,6 +52,7 @@ type Set struct {
 	tunnel  *meshpv1.TunnelConfig
 	relays  *meshpv1.RelayConfig
 	filter  *meshpv1.PacketFilter
+	dns     *meshpv1.DnsConfig
 
 	// routeGroups is keyed by id, because a delta names groups to upsert and groups to
 	// withdraw rather than replacing the set.
@@ -94,6 +95,9 @@ func (s *Set) Tunnel() *meshpv1.TunnelConfig { return s.tunnel }
 // a policy, so everything is permitted, while an empty filter with default_deny set means
 // a policy exists and permits nothing.
 func (s *Set) Filter() *meshpv1.PacketFilter { return s.filter }
+
+// DNS is the resolver configuration last received, or nil when this network sends none.
+func (s *Set) DNS() *meshpv1.DnsConfig { return s.dns }
 
 // RouteGroups are the carried prefixes this device has been assigned, ordered by id.
 //
@@ -165,6 +169,11 @@ func (s *Set) Apply(delta *meshpv1.StateDelta) {
 		// routing a prefix its network no longer asks it to.
 		s.routeGroups = make(map[string]*meshpv1.RouteGroupAssignment)
 		s.advertised = nil
+		// And the resolver configuration, for the filter's reason rather than the relays':
+		// prevent_leaks decides whether this device refuses DNS outside the tunnel, so an
+		// agent that kept the last one it saw would go on blocking queries its network has
+		// stopped asking it to block, or worse, stop blocking ones it should.
+		s.dns = nil
 	}
 
 	// Removals first. Within one delta a key that is both removed and upserted is a
@@ -186,6 +195,9 @@ func (s *Set) Apply(delta *meshpv1.StateDelta) {
 	}
 	if delta.GetFilter() != nil {
 		s.filter = proto.CloneOf(delta.GetFilter())
+	}
+	if delta.GetDns() != nil {
+		s.dns = proto.CloneOf(delta.GetDns())
 	}
 
 	// Withdrawals first, so a group both withdrawn and reassigned in one delta ends up
@@ -222,6 +234,9 @@ func (s *Set) Clone() *Set {
 	}
 	if s.filter != nil {
 		out.filter = proto.CloneOf(s.filter)
+	}
+	if s.dns != nil {
+		out.dns = proto.CloneOf(s.dns)
 	}
 	out.routeGroups = make(map[string]*meshpv1.RouteGroupAssignment, len(s.routeGroups))
 	for id, group := range s.routeGroups {
@@ -287,6 +302,9 @@ func (s *Set) Equal(other *Set) bool {
 		return false
 	}
 	if !proto.Equal(s.tunnel, other.tunnel) || !proto.Equal(s.relays, other.relays) {
+		return false
+	}
+	if !proto.Equal(s.dns, other.dns) {
 		return false
 	}
 	if !proto.Equal(s.filter, other.filter) {

--- a/internal/tunnel/egress.go
+++ b/internal/tunnel/egress.go
@@ -25,7 +25,7 @@ import (
 // Nothing here is best effort. If the carve-out cannot be computed the group is unhonoured
 // and no lock is installed, because a device that locks itself away from its control plane
 // is off the network for a reason nobody watching can see.
-func (r *Reconciler) applyEgress(ctx context.Context, iface string, want bool, failClosed bool, relays, excluded []string) []string {
+func (r *Reconciler) applyEgress(ctx context.Context, iface string, want bool, failClosed, preventDNSLeaks bool, relays, excluded []string) []string {
 	if !want {
 		r.releaseEgress(ctx)
 		return nil
@@ -64,7 +64,7 @@ func (r *Reconciler) applyEgress(ctx context.Context, iface string, want bool, f
 	}
 
 	if failClosed {
-		if err := r.filter.ApplyLock(ctx, iface, carve.Endpoints, carve.Prefixes); err != nil {
+		if err := r.filter.ApplyLock(ctx, iface, carve.Endpoints, carve.Prefixes, preventDNSLeaks); err != nil {
 			r.log.Error("cannot refuse egress outside the tunnel; not claiming a default route",
 				"error", logx.SafeError(err))
 			return []string{"egress"}
@@ -82,7 +82,7 @@ func (r *Reconciler) applyEgress(ctx context.Context, iface string, want bool, f
 
 	if !r.claimed {
 		r.log.Info("this device now sends everything through the tunnel",
-			"interface", iface, "fail_closed", failClosed,
+			"interface", iface, "fail_closed", failClosed, "dns_leaks_prevented", preventDNSLeaks,
 			"kept_direct", len(carve.Prefixes), "endpoints_kept", len(carve.Endpoints))
 		if !failClosed {
 			// Said plainly, because it is the difference between the product this claims to
@@ -110,7 +110,7 @@ func (r *Reconciler) releaseEgress(ctx context.Context) {
 	// nothing else failed first. Leaving a lock behind because a route would not release is
 	// how a device ends up refusing everything with no explanation.
 	if r.filter != nil {
-		if err := r.filter.ApplyLock(ctx, "", nil, nil); err != nil && failed == nil {
+		if err := r.filter.ApplyLock(ctx, "", nil, nil, false); err != nil && failed == nil {
 			failed = err
 		}
 	}
@@ -154,6 +154,7 @@ func wantsEgress(state routeGroupSource) (bool, []string) {
 type routeGroupSource interface {
 	RouteGroups() []*meshpv1.RouteGroupAssignment
 	Tunnel() *meshpv1.TunnelConfig
+	DNS() *meshpv1.DnsConfig
 }
 
 // relayEndpointsOf lists the relay addresses a claim must keep reachable.

--- a/internal/tunnel/egress_test.go
+++ b/internal/tunnel/egress_test.go
@@ -226,3 +226,51 @@ func TestAnExplicitOptOutClaimsWithoutALock(t *testing.T) {
 		t.Errorf("a lock was installed for a network that opted out: %v", filter.locks)
 	}
 }
+
+// The flag has to reach the lock, or the rule is rendered correctly and never asked for.
+// This is the edge ADR-0018 asks for: a value that travels from desired state, through the
+// reconciler, to the thing that acts on it.
+func TestPreventLeaksReachesTheLock(t *testing.T) {
+	router := &fakeEgress{}
+	filter := &fakeFilter{}
+	m := membership()
+	m.ControlURL = "https://198.51.100.10:8443"
+	r := New(newFakeLink(), m, nil, filter, nil)
+	r.egress = router
+
+	state := peerset.New()
+	state.Apply(&meshpv1.StateDelta{
+		FromVersion: 0, ToVersion: 1,
+		UpsertPeers: []*meshpv1.Peer{peer(bobKey, "100.90.0.2/32")},
+		Tunnel:      &meshpv1.TunnelConfig{Mtu: 1420},
+		Dns:         &meshpv1.DnsConfig{PreventLeaks: true},
+		RouteGroups: []*meshpv1.RouteGroupAssignment{
+			assignmentTo("exit", bobKey, "0.0.0.0/0", "::/0"),
+		},
+	})
+
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.dnsLocked) == 0 {
+		t.Fatal("no lock was installed")
+	}
+	if !filter.dnsLocked[0] {
+		t.Error("the network asked for leak prevention and the lock was not told")
+	}
+}
+
+// And a network that has not asked does not get it.
+func TestLeakPreventionIsNotAssumed(t *testing.T) {
+	r, filter, _, _ := withEgress(t)
+
+	if _, err := r.Apply(context.Background(), egressState(1)); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.dnsLocked) == 0 {
+		t.Fatal("no lock was installed")
+	}
+	if filter.dnsLocked[0] {
+		t.Error("DNS was refused for a network that never asked for it")
+	}
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -150,7 +150,7 @@ type Filter interface {
 	// ApplyLock makes the host refuse egress that does not go through the tunnel. An empty
 	// interface name removes it, which is the only way it comes off: these rules are system
 	// state and outlive the process on purpose (ADR-0011).
-	ApplyLock(ctx context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix) error
+	ApplyLock(ctx context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix, preventDNSLeaks bool) error
 }
 
 // Egress claims and releases a full tunnel's routing.
@@ -334,7 +334,7 @@ func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, e
 	// installs its own lock and the two must not fight over the order they load in.
 	wantEgress, excluded := wantsEgress(state)
 	if failed := r.applyEgress(ctx, want.Name, wantEgress, failClosedFor(state.Tunnel()),
-		relayEndpointsOf(state.Relays()), excluded); failed != nil {
+		state.DNS().GetPreventLeaks(), relayEndpointsOf(state.Relays()), excluded); failed != nil {
 		unapplied = append(unapplied, failed...)
 	}
 

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -841,6 +841,7 @@ type fakeFilter struct {
 	lockErr   error
 	endpoints [][]netip.AddrPort
 	excluded  [][]netip.Prefix
+	dnsLocked []bool
 
 	// order, when set, is shared with the egress fake. Separate slices per fake record what
 	// each of them did and cannot show which happened first, and "the lock before the route"
@@ -849,13 +850,14 @@ type fakeFilter struct {
 	order *[]string
 }
 
-func (f *fakeFilter) ApplyLock(_ context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix) error {
+func (f *fakeFilter) ApplyLock(_ context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix, preventDNSLeaks bool) error {
 	if f.lockErr != nil {
 		return f.lockErr
 	}
 	f.locks = append(f.locks, iface)
 	f.endpoints = append(f.endpoints, endpoints)
 	f.excluded = append(f.excluded, excluded)
+	f.dnsLocked = append(f.dnsLocked, preventDNSLeaks)
 	if f.order != nil {
 		if iface == "" {
 			*f.order = append(*f.order, "unlock")


### PR DESCRIPTION
Slice 6 — the last of ADR-0011. *"A tunnel that is up while queries leak to the local resolver discloses everything the user is doing to whoever runs that network."*

### The hole this closes is one the carve-out has to leave

The lock already refuses everything it does not name, so this is not about the wider internet. The **local network is permitted** so the device keeps its printer and its gateway — and the resolver lives on the local network.

So the refusal goes **before** the carve-out, and that ordering is the whole rule. After it, it refuses nothing.

After the tunnel and after loopback, though, or a device preventing leaks would refuse the resolver it is meant to be using, and the stub on `127.0.0.53` with it.

### Plaintext only, as the ADR says

- **DoT (853)** does not disclose the query to the network it crosses.
- **DoH** is indistinguishable from any other HTTPS — blocking it means blocking 443, taking the device off the internet to close a hole this rule cannot see anyway.
- **mDNS (5353)** never leaves the link, and refusing it costs the printer discovery the carve-out exists to keep.

### peerset was dropping `StateDelta.dns` entirely

The field was on the wire and nothing folded it. **That is the same mistake that killed relays** — and the doc comment listing the four places has been sitting at the top of that file since ADR-0018 was written.

Now handled in all four, with a test for each: the fold, the snapshot clear, `Clone`, and `Equal`.

### Mutation tested

| mutation | |
|---|---|
| DNS refused *after* the carve-out | caught |
| peerset drops `dns` from the fold | caught |
| a snapshot keeps stale `dns` | caught |
| the flag never reaches the lock | caught |

The first is the one that matters — it is the difference between a rule that reads correctly and one that does anything.

### ADR-0011 is complete

1. ✅ kill switch · 2. ✅ reclamation · 3. ✅ carve-out · 4a. ✅ routing · 4b. ✅ claim · 5. ✅ fail-closed policy · **6. ✅ this** · 7. ✅ e2e

Remaining from the ADR: `meshp doctor` explaining the situation in plain language on a machine with no internet access.