### PR TITLE
feat(cli): meshp doctor explains a machine that is refusing traffic

### DIFF
--- a/cmd/meshp/doctor.go
+++ b/cmd/meshp/doctor.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/agentapi"
+	"github.com/meshpnet/meshp/internal/nftables"
+	"github.com/meshpnet/meshp/internal/wglink"
+)
+
+// cmdDoctor explains what meshp is doing to this machine's network.
+//
+// ADR-0011 asks for it by name and adds the requirement that shapes everything here: it must
+// work "on a machine with no internet access". That is not a nice-to-have. The person
+// running this is at a console on a host that cannot reach anything, quite possibly because
+// meshp refused to let it — so this contacts nothing. It reads the kernel and the local
+// socket, and every one of those answers is available on a machine that is completely cut
+// off.
+//
+// The ADR also predicts the support ticket: "There will also be support tickets from users
+// whose network broke because a laptop lost its tunnel and correctly refused to leak. That
+// is the intended behaviour, and the error message is the product." This command is that
+// error message, so it says what is refusing traffic, why, and how to undo it by hand —
+// because someone who cannot reach the internet cannot look it up either.
+func cmdDoctor(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp doctor", flag.ContinueOnError)
+	socket := fs.String("socket", envOr("MESHP_SOCKET", agentapi.DefaultSocketPath),
+		"meshpd's local socket")
+	if _, err := parseFlags(fs, args); err != nil {
+		return err
+	}
+
+	f := findings{}
+
+	// The kernel first, and deliberately before the daemon. What is refusing this machine's
+	// traffic is in the kernel whether or not anything is running, and the case that brought
+	// someone here is usually the one where nothing is.
+	f.locked = nftables.LockHeld(ctx)
+	f.claimed, _ = wglink.EgressHeld()
+
+	// A short timeout: an unresponsive daemon should not make the one command that explains
+	// an outage hang for the length of an ordinary status call.
+	status, err := agentapi.NewClient(*socket, 3*time.Second).Status(ctx)
+	f.daemonUp = err == nil
+	if err == nil {
+		f.enrolled = status.Enrolled
+		for _, m := range status.Memberships {
+			if m.Connected {
+				f.sessions++
+			}
+			if m.TunnelUp {
+				f.interfaces++
+			}
+		}
+	}
+
+	report(f, *socket)
+	if f.strandedEgress() {
+		// Non-zero because something is refusing this machine's traffic and nothing is
+		// managing it. Anything else — including a healthy full tunnel, which also refuses
+		// traffic — is not a fault and must not be reported as one.
+		return errStranded
+	}
+	return nil
+}
+
+// errStranded is returned when the machine is refusing traffic with nothing to undo it.
+var errStranded = fmt.Errorf("meshp: egress is being refused and meshpd is not running")
+
+// findings is what could be established without reaching anything.
+type findings struct {
+	locked     bool // a fail-closed lock is installed
+	claimed    bool // a default route is claimed through the tunnel
+	daemonUp   bool
+	enrolled   bool
+	sessions   int
+	interfaces int
+}
+
+// strandedEgress is the situation this command exists for: the kernel is refusing traffic
+// and the thing that would undo it is not running.
+func (f findings) strandedEgress() bool { return (f.locked || f.claimed) && !f.daemonUp }
+
+func report(f findings, socket string) {
+	switch {
+	case f.strandedEgress():
+		fmt.Println("This machine is refusing network traffic, and meshpd is not running.")
+		fmt.Println()
+		fmt.Println("meshp was set up to send everything through its tunnel, and to block")
+		fmt.Println("traffic that would leave any other way rather than let it out in the")
+		fmt.Println("clear. That block is a firewall rule, so it survived meshpd stopping.")
+		fmt.Println("It is doing what it was asked to do; there is nothing to reach.")
+		fmt.Println()
+		fmt.Println("Starting meshpd again removes it:")
+		fmt.Println()
+		fmt.Println("    sudo systemctl start meshpd")
+		fmt.Println()
+		fmt.Println("If meshpd will not start, undo it by hand:")
+		fmt.Println()
+		if f.locked {
+			fmt.Printf("    sudo nft delete table inet %s\n", nftables.LockTableName)
+		}
+		if f.claimed {
+			fmt.Printf("    sudo ip rule del fwmark %#x\n", wglink.EgressMark)
+			fmt.Printf("    sudo ip route flush table %d\n", wglink.EgressTable)
+		}
+		fmt.Println()
+		fmt.Println("Starting meshpd and undoing it by hand both restore this machine's")
+		fmt.Println("ordinary networking, and every command above is safe to run more than")
+		fmt.Println("once. meshpd puts back whatever it needs when it next starts.")
+
+	case f.locked || f.claimed:
+		fmt.Println("This machine is sending everything through its tunnel.")
+		fmt.Println()
+		fmt.Println("Traffic that would leave any other way is refused on purpose, so a")
+		fmt.Println("dropped tunnel cannot quietly put your real address back on the wire.")
+		fmt.Println("If something cannot connect, that is the reason.")
+		fmt.Println()
+		fmt.Printf("  meshpd          running, %d live session(s)\n", f.sessions)
+		fmt.Printf("  tunnel          %d interface(s) up\n", f.interfaces)
+		fmt.Printf("  blocking        %v\n", f.locked)
+		fmt.Printf("  default route   %v\n", f.claimed)
+		if f.interfaces == 0 {
+			fmt.Println()
+			fmt.Println("No tunnel is up, so nothing can get out at all. meshpd is running")
+			fmt.Println("and will restore it when it can reach its control plane.")
+		}
+
+	case !f.daemonUp:
+		fmt.Println("meshpd is not running, and it is not blocking anything.")
+		fmt.Println()
+		fmt.Printf("  socket   %s\n", socket)
+		fmt.Println()
+		fmt.Println("Whatever is wrong with this machine's network, meshp is not the")
+		fmt.Println("cause. Start it with 'sudo systemctl start meshpd'.")
+
+	case !f.enrolled:
+		fmt.Println("meshpd is running and this device has not joined a network.")
+		fmt.Println()
+		fmt.Println("Nothing is being blocked or routed. Run 'meshp join <token>'.")
+
+	default:
+		fmt.Println("Nothing here is interfering with this machine's networking.")
+		fmt.Println()
+		fmt.Printf("  meshpd          running, %d live session(s)\n", f.sessions)
+		fmt.Printf("  tunnel          %d interface(s) up\n", f.interfaces)
+		fmt.Println("  blocking        false")
+		fmt.Println("  default route   false")
+		fmt.Println()
+		fmt.Println("Traffic goes wherever it would have gone without meshp, except for")
+		fmt.Println("the addresses inside your network.")
+	}
+}

--- a/cmd/meshp/doctor_test.go
+++ b/cmd/meshp/doctor_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/meshpnet/meshp/internal/nftables"
+	"github.com/meshpnet/meshp/internal/wglink"
+)
+
+// capture runs report and returns what a person would see.
+func capture(t *testing.T, f findings) string {
+	t.Helper()
+	original := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	report(f, "/run/meshp/meshpd.sock")
+	_ = w.Close()
+	os.Stdout = original
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("reading: %v", err)
+	}
+	return buf.String()
+}
+
+// The case this command exists for, and the one ADR-0011 predicts the support ticket about.
+// Whoever is reading this is at a console on a machine that cannot reach anything, so the
+// exact commands have to be on the screen — they cannot look them up.
+func TestAStrandedMachineIsToldHowToFixItByHand(t *testing.T) {
+	out := capture(t, findings{locked: true, claimed: true})
+
+	for _, want := range []struct{ text, why string }{
+		{"nft delete table inet " + nftables.LockTableName,
+			"the exact command, because there is no way to search for it"},
+		{"ip rule del fwmark", "the routing half, which the firewall command does not undo"},
+		{"systemctl start meshpd", "the thing to try first, which fixes it without root surgery"},
+	} {
+		if !strings.Contains(out, want.text) {
+			t.Errorf("missing %q\n  needed because: %s\n\n%s", want.text, want.why, out)
+		}
+	}
+
+	// And it says why, or it reads as a malfunction rather than the feature working.
+	if !strings.Contains(out, "meshpd is not running") {
+		t.Error("the output does not say what is missing")
+	}
+}
+
+// Only the parts that are actually installed. Telling someone to remove a table that is not
+// there teaches them the output is guesswork, and the next instruction gets ignored too.
+func TestOnlyTheRelevantUndoIsOffered(t *testing.T) {
+	lockOnly := capture(t, findings{locked: true})
+	if strings.Contains(lockOnly, "ip rule del") {
+		t.Errorf("offered to remove routing rules that are not installed:\n%s", lockOnly)
+	}
+
+	routeOnly := capture(t, findings{claimed: true})
+	if strings.Contains(routeOnly, "nft delete table") {
+		t.Errorf("offered to remove a firewall table that is not installed:\n%s", routeOnly)
+	}
+}
+
+// A working full tunnel also refuses traffic. Reporting that as a fault would train people
+// to ignore this command on exactly the machines where it matters.
+func TestAWorkingFullTunnelIsNotAFault(t *testing.T) {
+	f := findings{locked: true, claimed: true, daemonUp: true, enrolled: true,
+		sessions: 1, interfaces: 1}
+	if f.strandedEgress() {
+		t.Fatal("a healthy full tunnel was diagnosed as stranded")
+	}
+
+	out := capture(t, f)
+	if strings.Contains(out, "nft delete table") {
+		t.Errorf("a healthy machine was told to tear down its own protection:\n%s", out)
+	}
+	if !strings.Contains(out, "on purpose") {
+		t.Errorf("the output does not explain that the refusal is deliberate:\n%s", out)
+	}
+}
+
+// A device that is blocking and has no tunnel is a real situation and the worst one to be
+// silent about: nothing gets out at all, and the reason is not obvious from the outside.
+func TestALockedMachineWithNoTunnelSaysSo(t *testing.T) {
+	out := capture(t, findings{locked: true, claimed: true, daemonUp: true, enrolled: true})
+
+	if !strings.Contains(out, "No tunnel is up") {
+		t.Errorf("a device blocking with no tunnel did not say so:\n%s", out)
+	}
+}
+
+// meshp not being the problem is an answer worth giving plainly. Someone runs this because
+// their network is broken, and "it is not us" saves them looking here.
+func TestAnIdleMachineSaysMeshpIsNotTheCause(t *testing.T) {
+	out := capture(t, findings{})
+
+	if !strings.Contains(out, "not blocking anything") {
+		t.Errorf("a machine meshp is not touching was not told so:\n%s", out)
+	}
+	if strings.Contains(out, "nft delete") {
+		t.Errorf("offered surgery on a machine with nothing installed:\n%s", out)
+	}
+}
+
+// The stranded case is the only fault. Everything else is a description.
+func TestOnlyAStrandedMachineIsAFault(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		f    findings
+		want bool
+	}{
+		{"locked with no daemon", findings{locked: true}, true},
+		{"route claimed with no daemon", findings{claimed: true}, true},
+		{"healthy full tunnel", findings{locked: true, claimed: true, daemonUp: true}, false},
+		{"daemon down and nothing installed", findings{}, false},
+		{"running and idle", findings{daemonUp: true, enrolled: true}, false},
+	} {
+		if got := tc.f.strandedEgress(); got != tc.want {
+			t.Errorf("%s: strandedEgress = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// The mark has to be printed the way `ip` expects it, or the command on the screen does not
+// work when typed — which is the only thing this command is for.
+func TestTheMarkIsPrintedAsIpExpectsIt(t *testing.T) {
+	out := capture(t, findings{claimed: true})
+
+	if !strings.Contains(out, "fwmark 0x6d657368") {
+		t.Errorf("the mark is not in the hex form `ip rule` takes:\n%s", out)
+	}
+	if !strings.Contains(out, "flush table 1835365224") {
+		t.Errorf("the table is not in the decimal form `ip route` takes:\n%s", out)
+	}
+	// And the two agree, since one number is used for both by design.
+	if wglink.EgressMark != wglink.EgressTable {
+		t.Error("the mark and the table have drifted apart")
+	}
+}

--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -102,6 +102,9 @@ func main() {
 	case "status":
 		runOrDie(cmdStatus, args[1:])
 		return
+	case "doctor":
+		runOrDie(cmdDoctor, args[1:])
+		return
 	}
 
 	if contains(bareVerbs, args[0]) {

--- a/internal/wglink/egress.go
+++ b/internal/wglink/egress.go
@@ -1,0 +1,18 @@
+package wglink
+
+// EgressMark is the firewall mark WireGuard puts on its own outer packets when this device
+// sends everything through the tunnel, and EgressTable is the routing table holding that
+// tunnel's default route.
+//
+// The same number for both, as wg-quick does: one value to recognise, one to remove, and no
+// chance of the two drifting apart. It is high and arbitrary to stay clear of the marks
+// other software picks, which conventionally live in the low bits.
+//
+// Here rather than beside the Linux implementation because they are plain numbers with no
+// platform behaviour, and because `meshp doctor` has to be able to print them on any build:
+// the person reading that output is at a console on a machine with no network, and the exact
+// `ip rule del fwmark ...` they need is the whole value of the command.
+const (
+	EgressMark  uint32 = 0x6d657368 // "mesh"
+	EgressTable uint32 = 0x6d657368
+)

--- a/internal/wglink/policyroute_linux.go
+++ b/internal/wglink/policyroute_linux.go
@@ -46,19 +46,6 @@ import (
 // outer packets leave through.
 
 const (
-	// EgressMark is the firewall mark WireGuard puts on its own outer packets.
-	//
-	// The same number is used for the routing table, as wg-quick does: one value to
-	// recognise, one to remove, and no chance of the two drifting apart. It is high and
-	// arbitrary to stay clear of the marks other software picks, which conventionally live
-	// in the low bits.
-	EgressMark uint32 = 0x6d657368 // "mesh"
-
-	// EgressTable is the routing table holding the tunnel's default route.
-	EgressTable uint32 = 0x6d657368
-
-	// suppressPriority must be lower than markPriority: main's specific routes have to be
-	// consulted before anything is handed to the tunnel.
 	suppressPriority uint32 = 32764
 	markPriority     uint32 = 32765
 )


### PR DESCRIPTION
The last thing ADR-0011 asks for — and its requirement is what shapes the whole command: it must work **"on a machine with no internet access."**

That is not a nice-to-have. The person running this is at a console on a host that cannot reach anything, quite possibly *because meshp refused to let it*. So this contacts nothing. It reads the kernel and the local socket, and both answers are available on a machine that is completely cut off.

The kernel is read **before** the daemon, deliberately: what is refusing traffic is in the kernel whether or not anything is running, and the case that brings someone here is usually the one where nothing is.

### The ADR predicts the support ticket this answers

> There will also be support tickets from users whose network broke because a laptop lost its tunnel and correctly refused to leak. That is the intended behaviour, **and the error message is the product.**

So the output says what is refusing traffic, why it is doing that on purpose, and the exact commands to undo it — because someone with no internet cannot look them up:

```
This machine is refusing network traffic, and meshpd is not running.

meshp was set up to send everything through its tunnel, and to block
traffic that would leave any other way rather than let it out in the
clear. That block is a firewall rule, so it survived meshpd stopping.
It is doing what it was asked to do; there is nothing to reach.

Starting meshpd again removes it:

    sudo systemctl start meshpd

If meshpd will not start, undo it by hand:

    sudo nft delete table inet meshp_lock
    sudo ip rule del fwmark 0x6d657368
    sudo ip route flush table 1835365224
```

### Two judgements worth naming

**Only the parts actually installed are offered.** Telling someone to remove a table that is not there teaches them the output is guesswork, and the next instruction gets ignored too.

**A working full tunnel also refuses traffic, and is not a fault.** Reporting it as one would train people to ignore this command on exactly the machines where it matters. The only non-zero exit is the stranded case: something is refusing traffic and nothing is managing it.

### Also

`EgressMark` and `EgressTable` move out of the Linux-only file. They are plain numbers with no platform behaviour, and this command has to print them on any build — the exact `ip rule del fwmark ...` is the whole value of the output.

### Mutation tested

| mutation | |
|---|---|
| a healthy full tunnel reported as stranded | caught |
| the routing half of the undo missing | caught |
| undo offered for things not installed | caught |

The output was also read as a person would read it, not only asserted against — the wording changed once as a result.

**ADR-0011 is now complete in full.**
