### PR TITLE
feat(release): an install path that is not "build it yourself"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,152 @@
+name: release
+
+# Two triggers on purpose.
+#
+# A tag publishes. A pull request builds exactly the same artifacts and throws them away,
+# which is the only way anyone finds out that release packaging still works before the day
+# they need it. A workflow that runs only on tags is discovered to be broken at the worst
+# possible moment, by someone who has already announced a release — and it is the same
+# mistake ADR-0018 is about, in a place where the "mechanism nothing reaches" is a job.
+on:
+  push:
+    tags: ["v*"]
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - "scripts/install.sh"
+      - "deploy/systemd/**"
+      - ".go-version"
+      - "Makefile"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build release artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Tags carry the version the binaries are stamped with, and a shallow clone that
+          # omitted them would stamp every build "dev".
+          fetch-depth: 0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: .go-version
+          cache: true
+
+      - name: build every published platform
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME}"
+          case "$version" in
+            v*) ;;
+            *) version="0.0.0-$(git rev-parse --short HEAD)" ;;
+          esac
+          commit="$(git rev-parse HEAD)"
+          mkdir -p dist
+
+          # The agent and the CLI for every platform a person runs; the server binaries for
+          # Linux only, because nobody is asked to run a control plane on a laptop.
+          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64; do
+            os="${target%/*}"; arch="${target#*/}"
+            ext=""; [ "$os" = "windows" ] && ext=".exe"
+
+            binaries="meshp meshpd"
+            [ "$os" = "linux" ] && binaries="meshp meshpd meshp-control meshp-relay"
+
+            stage="dist/meshp_${version}_${os}_${arch}"
+            mkdir -p "$stage"
+            for cmd in $binaries; do
+              CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build \
+                -ldflags "-s -w -X github.com/meshpnet/meshp/internal/version.version=${version} -X github.com/meshpnet/meshp/internal/version.commit=${commit}" \
+                -o "${stage}/${cmd}${ext}" "./cmd/${cmd}"
+            done
+
+            # What a person needs beside the binaries to actually run them. A tarball of
+            # bare executables leaves everyone writing their own unit file, which is the
+            # step this whole slice exists to remove.
+            cp LICENSE NOTICE README.md "$stage/"
+            [ "$os" = "linux" ] && cp -r deploy/systemd "$stage/"
+
+            if [ "$os" = "windows" ]; then
+              (cd dist && zip -qr "$(basename "$stage").zip" "$(basename "$stage")")
+            else
+              tar -C dist -czf "${stage}.tar.gz" "$(basename "$stage")"
+            fi
+            rm -rf "$stage"
+          done
+
+          # One file, so a verifier needs one download and one command.
+          (cd dist && sha256sum ./* > SHA256SUMS)
+          ls -la dist
+
+      - name: the archives contain what they claim to
+        run: |
+          set -euo pipefail
+          # Unpacked and inspected rather than trusted. An archive that is missing a binary,
+          # or carries one built for the wrong platform, is indistinguishable from a good one
+          # until somebody downloads it.
+          tmp="$(mktemp -d)"
+          tar -C "$tmp" -xzf dist/meshp_*_linux_amd64.tar.gz
+          dir="$(find "$tmp" -maxdepth 1 -type d -name 'meshp_*')"
+
+          for cmd in meshp meshpd meshp-control meshp-relay; do
+            test -x "$dir/$cmd" || { echo "$cmd is missing from the linux archive"; exit 1; }
+          done
+          test -f "$dir/systemd/meshpd.service" || { echo "the systemd units are missing"; exit 1; }
+          test -f "$dir/LICENSE" && test -f "$dir/NOTICE" \
+            || { echo "the licence and notice are missing"; exit 1; }
+
+          file "$dir/meshpd" | grep -q "ELF 64-bit LSB.*x86-64" \
+            || { file "$dir/meshpd"; echo "the linux/amd64 archive holds the wrong binary"; exit 1; }
+
+          # And it reports the version it was stamped with, which is the one thing a person
+          # checks first when a bug report names a release.
+          "$dir/meshp" --version
+          echo "archives verified"
+
+      - name: checksums verify
+        run: cd dist && sha256sum -c SHA256SUMS
+
+      # The install script, run rather than reviewed. It is the first thing anyone touches
+      # and the only piece of this repository that a stranger executes as root, so "it looks
+      # right" is not enough — this builds a release, serves it, installs from it, and then
+      # corrupts it and requires the install to be refused.
+      - name: the install path works, and refuses a tampered archive
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq python3 curl
+          sudo -E env "PATH=$PATH" ./scripts/install-test.sh
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
+  publish:
+    name: publish the release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist
+
+      - name: create the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            --verify-tag

--- a/Makefile
+++ b/Makefile
@@ -312,3 +312,16 @@ dev-down: ## Tear down the dev stack and its volumes
 protect: ## Apply branch and tag protection: make protect REPO=meshp
 	@test -n "$(REPO)" || { echo "usage: make protect REPO=meshp [ENFORCEMENT=active|disabled]"; exit 2; }
 	@./scripts/protect-repo.sh "$(REPO)" $(or $(ENFORCEMENT),active)
+
+.PHONY: install-check
+install-check: ## Run install.sh end to end against a locally built release, in a container
+	@# The install script is the only thing here a stranger runs as root, and reviewing it
+	@# is not the same as running it. This builds a release, serves it, installs from it,
+	@# and then corrupts it and requires the install to be refused.
+	docker run --rm \
+	  -v "$(CURDIR)":/src -w /src \
+	  -v "$$(go env GOMODCACHE)":/go/pkg/mod \
+	  golang:$(GO_IMAGE_VERSION) sh -c \
+	  'apt-get update -qq >/dev/null 2>&1 && \
+	   apt-get install -y -qq python3 curl >/dev/null 2>&1 && \
+	   ./scripts/install-test.sh'

--- a/README.md
+++ b/README.md
@@ -38,9 +38,15 @@ ignoring it.
 The control plane serves TLS, from a certificate you supply or one it obtains from
 Let's Encrypt, and agents refuse a plaintext control URL to anything but loopback.
 
-What does not, and matters: direct paths, DNS and internet egress are all
-unimplemented, and the data plane is Linux-only — elsewhere a device enrols, holds an
-address, and reports honestly that it has no tunnel and cannot filter.
+Full-tunnel egress works on Linux, and fails closed (ADR-0011). A device sending
+everything through the tunnel refuses traffic that would leave any other way, so a dropped
+tunnel cannot quietly put a real address back on the wire — and those rules are firewall
+state, so they survive the agent being killed. `meshp doctor` explains that to whoever
+finds the machine, without needing a network to do it.
+
+What does not, and matters: direct paths and DNS are unimplemented, and the data plane is
+Linux-only — elsewhere a device enrols, holds an address, and reports honestly that it has
+no tunnel and cannot filter.
 
 It is public from the first commit because the design decisions are the
 interesting part and we would rather be argued with early.
@@ -89,9 +95,34 @@ If you need something that works this afternoon, use one of the other three. We
 mean that. The two rows in bold are where we are years behind, and no amount of
 architecture makes up for it yet.
 
-## Quick start
+## Install
 
-Requires Go 1.25+, Docker and Node 20+.
+On a device that is joining a network, there is no need to build anything:
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/meshpnet/meshp/main/scripts/install.sh
+less install.sh && sudo sh install.sh
+```
+
+It checks the download against the release's checksums, installs `meshp` and `meshpd`,
+and installs the agent's systemd unit without starting it — joining a network needs a
+token, so it stops before making that decision for you.
+
+```bash
+sudo systemctl enable --now meshpd
+sudo meshp join <token>
+```
+
+If anything ever refuses to connect on a device running meshp, `meshp doctor` says what is
+being blocked and why, and works on a machine with no internet access at all.
+
+The control plane and the relay are deliberately not installed by that script: they need a
+database, a certificate, and decisions about who may reach them. Their unit files ship in
+the same archive, under `systemd/`.
+
+## Building it yourself
+
+Requires Go 1.26+, Docker and Node 20+.
 
 ```bash
 git clone https://github.com/meshpnet/meshp.git

--- a/deploy/systemd/meshp-control.service
+++ b/deploy/systemd/meshp-control.service
@@ -1,0 +1,48 @@
+# The control plane.
+#
+# Unprivileged: it talks to Postgres and serves HTTPS, and does nothing to this host's
+# network. A control plane that needed root would be a much worse thing to expose.
+
+[Unit]
+Description=meshp control plane
+Documentation=https://github.com/meshpnet/meshp
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+# exec rather than notify: nothing here implements sd_notify, and a notify unit waits for a
+# readiness message that would never arrive. exec is the honest answer — systemd considers
+# the service started once the binary is running, which is what it actually knows.
+Type=exec
+ExecStart=/usr/local/bin/meshp-control
+Restart=always
+RestartSec=2s
+
+# Configuration lives in the environment, and the file holds a database URL, a secret key
+# and an administrative token — so it is owner-only and read by systemd rather than by the
+# process, which keeps the secrets out of the unit file and out of `systemctl show`.
+User=meshp
+Group=meshp
+EnvironmentFile=/etc/meshp/control.env
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictSUIDSGID=yes
+RestrictRealtime=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+
+# Binding 443 without root. The alternative is a reverse proxy, which is a fine choice and
+# not one this unit should force.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/meshp-relay.service
+++ b/deploy/systemd/meshp-relay.service
@@ -1,0 +1,41 @@
+# The relay.
+#
+# Unprivileged and deliberately dull: it forwards opaque frames between devices that cannot
+# reach each other directly (ADR-0002) and can decrypt none of them. It holds one public key
+# to verify the credentials the control plane issues (ADR-0017), and no other secret.
+
+[Unit]
+Description=meshp relay
+Documentation=https://github.com/meshpnet/meshp
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# exec rather than notify: nothing here implements sd_notify, and a notify unit waits for a
+# readiness message that would never arrive. exec is the honest answer — systemd considers
+# the service started once the binary is running, which is what it actually knows.
+Type=exec
+ExecStart=/usr/local/bin/meshp-relay
+Restart=always
+RestartSec=2s
+
+User=meshp
+Group=meshp
+EnvironmentFile=/etc/meshp/relay.env
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictSUIDSGID=yes
+RestrictRealtime=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/meshpd.service
+++ b/deploy/systemd/meshpd.service
@@ -1,0 +1,51 @@
+# The agent, on a device that joins a network.
+#
+# Runs as root because the whole job is privileged: creating a WireGuard interface,
+# writing routing rules, loading nftables. There is no useful smaller set — a
+# CAP_NET_ADMIN-only build was considered and dropped, because reclaiming a lock left by a
+# previous life (ADR-0011) needs the same access as installing one, and a daemon that could
+# install but not remove is the failure mode that ADR is written against.
+
+[Unit]
+Description=meshp agent
+Documentation=https://github.com/meshpnet/meshp
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# exec rather than notify: nothing here implements sd_notify, and a notify unit waits for a
+# readiness message that would never arrive. exec is the honest answer — systemd considers
+# the service started once the binary is running, which is what it actually knows.
+Type=exec
+ExecStart=/usr/local/bin/meshpd --state-dir /var/lib/meshp --socket /run/meshp/meshpd.sock
+Restart=always
+RestartSec=2s
+
+# The state directory holds this device's identity and its per-membership WireGuard keys
+# (Invariant 19), so it is owner-only. systemd creates both with these modes, which means a
+# fresh install does not depend on the daemon getting them right on first run.
+StateDirectory=meshp
+StateDirectoryMode=0700
+RuntimeDirectory=meshp
+RuntimeDirectoryMode=0755
+
+# Hardening that does not get in the way of what this has to do. NET_ADMIN for interfaces
+# and routing, NET_RAW for the packet filter. Everything else is dropped, which is most of
+# what a root process would otherwise carry.
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+RestrictRealtime=yes
+LockPersonality=yes
+
+# Not PrivateNetwork, obviously, and not ProtectKernelModules: loading the wireguard module
+# is exactly what a first start may have to do.
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Run install.sh end to end against a release built here.
+#
+# An install path nobody has executed is the one that fails on the first person who tries
+# it, so this builds the same archive the release workflow builds, serves it, installs from
+# it, and checks that a tampered archive is refused. It runs in a container because it
+# writes to /usr/local/bin and /etc/systemd/system.
+set -euo pipefail
+
+VERSION="v0.0.0-test"
+# This machine's architecture, not a fixed one: the script under test picks the archive by
+# what it finds, so a test that built something else would only ever prove it says no.
+ARCH="$(go env GOARCH)"
+# Laid out the way a real release is — artifacts under the tag — so the URL the script
+# builds is the shape it will build in production.
+REL="/tmp/rel/${VERSION}"
+STAGE="${REL}/meshp_${VERSION}_linux_${ARCH}"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+mkdir -p "$STAGE"
+for cmd in meshp meshpd meshp-control meshp-relay; do
+  CGO_ENABLED=0 GOOS=linux GOARCH="$ARCH" go build -o "${STAGE}/${cmd}" "./cmd/${cmd}"
+done
+cp LICENSE NOTICE README.md "$STAGE/"
+cp -r deploy/systemd "$STAGE/"
+tar -C "$REL" -czf "${STAGE}.tar.gz" "$(basename "$STAGE")"
+rm -rf "$STAGE"
+(cd "$REL" && sha256sum ./* > SHA256SUMS)
+
+(cd /tmp/rel && python3 -m http.server 871 >/dev/null 2>&1) &
+server=$!
+trap 'kill $server 2>/dev/null || true' EXIT
+for _ in $(seq 1 20); do curl -fsS "http://127.0.0.1:871/${VERSION}/SHA256SUMS" >/dev/null 2>&1 && break; sleep 0.5; done
+
+echo "installing from a locally built release"
+MESHP_DOWNLOAD_BASE="http://127.0.0.1:871" MESHP_VERSION="$VERSION" \
+  sh scripts/install.sh || fail "the install script failed"
+
+for cmd in meshp meshpd meshp-control meshp-relay; do
+  [ -x "/usr/local/bin/${cmd}" ] || fail "${cmd} was not installed"
+done
+[ -f /etc/systemd/system/meshpd.service ] || fail "the agent's unit was not installed"
+/usr/local/bin/meshp --version >/dev/null || fail "the installed binary does not run"
+echo "  binaries and unit installed, and the binary runs"
+
+# The security-critical half. An archive that has been tampered with must not be installed,
+# and this is the only assertion here that anyone would miss if it silently stopped working.
+rm -f /usr/local/bin/meshp
+printf 'tampered' >> "${REL}/meshp_${VERSION}_linux_${ARCH}.tar.gz"
+if MESHP_DOWNLOAD_BASE="http://127.0.0.1:871" MESHP_VERSION="${VERSION}" sh scripts/install.sh >/dev/null 2>&1; then
+  fail "a tampered archive was installed"
+fi
+[ -x /usr/local/bin/meshp ] && fail "a tampered archive was installed despite the checksum"
+echo "  a tampered archive is refused"
+
+echo
+echo "the install path works, and refuses what it should"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Install meshp from a published release.
+#
+#   curl -fsSL https://raw.githubusercontent.com/meshpnet/meshp/main/scripts/install.sh | sudo sh
+#
+# Or, having read it first, which is the better habit and the reason this stays short enough
+# to read:
+#
+#   curl -fsSLO https://raw.githubusercontent.com/meshpnet/meshp/main/scripts/install.sh
+#   less install.sh && sudo sh install.sh
+#
+# What it does: works out this machine's platform, downloads that archive and the checksum
+# file, refuses to continue if they disagree, installs the binaries, and installs the agent's
+# systemd unit without starting it. Joining a network is a separate decision and needs a
+# token, so this stops before making it.
+#
+# What it deliberately does not do: install the control plane or the relay. Those need a
+# database, a certificate and an administrator's decisions about who may reach them, and a
+# script that guessed at any of it would be configuring a security boundary on somebody's
+# behalf. The server-side units ship in the archive and docs/deploying.md walks through them.
+set -eu
+
+REPO="${MESHP_REPO:-meshpnet/meshp}"
+# Overridable so this script can be run end to end against a locally built release rather
+# than only in production. An install path nobody has executed is the one that fails on the
+# first person who tries it.
+DOWNLOAD_BASE="${MESHP_DOWNLOAD_BASE:-https://github.com/${REPO}/releases/download}"
+API_BASE="${MESHP_API_BASE:-https://api.github.com/repos/${REPO}}"
+VERSION="${MESHP_VERSION:-latest}"
+PREFIX="${MESHP_PREFIX:-/usr/local/bin}"
+
+die() { echo "meshp install: $*" >&2; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || die "this needs $1, which is not installed"; }
+need curl
+need tar
+need install
+
+[ "$(id -u)" = "0" ] || die "run this with sudo: it writes to ${PREFIX} and /etc/systemd/system"
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$os" in
+  linux|darwin) ;;
+  *) die "no published build for ${os}; Windows and mobile ship as signed packages" ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64) arch="amd64" ;;
+  aarch64|arm64) arch="arm64" ;;
+  *) die "no published build for $(uname -m)" ;;
+esac
+
+# The tag, resolved before anything is downloaded, so the archive and the checksums are
+# certain to come from the same release. Asking twice for "latest" could straddle a
+# publication and produce a mismatch that looks like tampering.
+if [ "$VERSION" = "latest" ]; then
+  VERSION="$(curl -fsSL "${API_BASE}/releases/latest" \
+    | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)"
+  [ -n "$VERSION" ] || die "could not work out the latest version; set MESHP_VERSION"
+fi
+
+archive="meshp_${VERSION}_${os}_${arch}.tar.gz"
+base="${DOWNLOAD_BASE}/${VERSION}"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+echo "downloading ${archive} (${VERSION})"
+curl -fsSL "${base}/${archive}" -o "${work}/${archive}" \
+  || die "could not download ${archive}; check that ${VERSION} has a build for ${os}/${arch}"
+curl -fsSL "${base}/SHA256SUMS" -o "${work}/SHA256SUMS" \
+  || die "could not download the checksums"
+
+# Verified before anything is unpacked, which is the point: an archive that has been
+# tampered with must not get as far as being extracted, let alone executed.
+echo "verifying the checksum"
+if command -v sha256sum >/dev/null 2>&1; then
+  ( cd "$work" && grep " ./${archive}\$\|  ${archive}\$" SHA256SUMS | sed 's| \./| |' | sha256sum -c - ) \
+    || die "the checksum does not match; do not install this"
+elif command -v shasum >/dev/null 2>&1; then
+  want="$(grep "${archive}\$" "${work}/SHA256SUMS" | awk '{print $1}')"
+  got="$(shasum -a 256 "${work}/${archive}" | awk '{print $1}')"
+  [ -n "$want" ] && [ "$want" = "$got" ] || die "the checksum does not match; do not install this"
+else
+  die "this needs sha256sum or shasum to verify the download"
+fi
+
+tar -C "$work" -xzf "${work}/${archive}"
+dir="${work}/meshp_${VERSION}_${os}_${arch}"
+[ -d "$dir" ] || die "the archive did not contain what was expected"
+
+echo "installing to ${PREFIX}"
+for cmd in meshp meshpd meshp-control meshp-relay; do
+  [ -f "${dir}/${cmd}" ] || continue
+  install -m 0755 "${dir}/${cmd}" "${PREFIX}/${cmd}"
+done
+
+if [ "$os" = "linux" ] && [ -d /etc/systemd/system ] && [ -f "${dir}/systemd/meshpd.service" ]; then
+  install -m 0644 "${dir}/systemd/meshpd.service" /etc/systemd/system/meshpd.service
+  command -v systemctl >/dev/null 2>&1 && systemctl daemon-reload || true
+  echo
+  echo "installed. The agent is not running yet:"
+  echo
+  echo "    sudo systemctl enable --now meshpd"
+  echo "    sudo meshp join <token>"
+  echo
+  echo "Nothing joins a network without a token, so this stops here rather than"
+  echo "starting a daemon with nothing to do."
+else
+  echo
+  echo "installed ${PREFIX}/meshp and ${PREFIX}/meshpd."
+  echo "Start meshpd however this system starts services, then run 'meshp join <token>'."
+fi


### PR DESCRIPTION
The gap between something that works and something *someone else* can run. Until now the only way in was cloning the repo, installing a Go toolchain, and writing a unit file by hand — a reasonable ask of a contributor, an unreasonable one of anybody else.

### Systemd units, in the repo rather than on one host

The agent runs privileged because the whole job is: creating interfaces, writing routes, loading nftables. A `CAP_NET_ADMIN`-only build was considered and dropped — **reclaiming a lock left by a previous life needs the same access as installing one**, and a daemon that could install but not remove is the failure ADR-0011 is written against.

The control plane and relay are unprivileged; neither touches the host's network.

`Type=exec` rather than `notify`, because nothing here implements sd_notify and a notify unit waits for a readiness message that never arrives.

### A release workflow whose build job runs on PRs too

It publishes checksummed archives on a tag, carrying the binaries plus `LICENSE`, `NOTICE` and the unit files — a tarball of bare executables leaves everyone writing their own unit, which is the step this removes.

Its build job **also runs on pull requests that touch packaging**, and throws the artifacts away. That is the only way anyone learns release packaging still works before the day they need it. A workflow that runs only on tags is discovered broken by someone who has already announced a release — **ADR-0018 again, with a job as the mechanism nothing reaches.**

### An install script that stops before deciding things for you

Resolves the tag once (so the archive and checksums cannot straddle a publication), downloads, **verifies before unpacking anything**, installs the binaries and the agent's unit, and stops.

It does not start the daemon and does not join a network: joining needs a token. It deliberately does not install the control plane or relay either — those need a database, a certificate, and decisions about who may reach them, and configuring a security boundary on somebody's behalf is not a convenience.

### Run, not reviewed

`scripts/install-test.sh` builds the same archive the workflow builds, serves it, installs from it, checks the binaries and unit landed and that the installed binary runs — then **corrupts the archive and requires the install to be refused**.

That last assertion is the one that matters. This is the only thing in this repository a stranger executes as root.

```
  binaries and unit installed, and the binary runs
  a tampered archive is refused
```

### Two things found by running it

- The units named `Type=notify-reload`, which **would have failed to start on every machine.**
- The first version of the test built amd64 on an arm64 host, where the script correctly refused an archive that did not exist. The script was right; the test was wrong.

### Also

README gains an install section, and its status paragraph no longer claims internet egress is unimplemented.

### Not in this PR

Task #8 also covers a landing page at meshp.net and 5–10 `good first issue` entries. Both remain — this is the install path only, which is the piece the other two depend on.
