### PR TITLE
docs: stop pointing at a deployment guide that does not exist

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,7 +18,7 @@
 # What it deliberately does not do: install the control plane or the relay. Those need a
 # database, a certificate and an administrator's decisions about who may reach them, and a
 # script that guessed at any of it would be configuring a security boundary on somebody's
-# behalf. The server-side units ship in the archive and docs/deploying.md walks through them.
+# behalf. The server-side units ship in the archive, under systemd/.
 set -eu
 
 REPO="${MESHP_REPO:-meshpnet/meshp}"


### PR DESCRIPTION
While writing the good-first-issues I checked the references in `scripts/install.sh` and found one that does not resolve:

> The server-side units ship in the archive and `docs/deploying.md` walks through them.

There is no `docs/deploying.md`. I wrote that line in #61.

This is the one script in the repository a stranger runs as root, and a confident pointer to something that is not there is worse than saying less — it is the first thing that suggests the rest of the file may be equally approximate.

The units genuinely do ship in the archive under `systemd/`, so the honest sentence is the shorter one. Writing the deployment guide is worth doing and is tracked separately.