### PR TITLE
feat(routes): refuse a prefix two customer networks both claim

### DIFF
--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -62,6 +62,12 @@ type agent struct {
 	filterOnce sync.Once
 	filter     *nftables.Filter
 
+	// claims is what every membership on this device says it carries, shared so that two
+	// networks asking for the same customer prefix can each see the other. One device can
+	// hold memberships in many networks (ADR-0004), and two customers who both took their
+	// router's default both carry 192.168.1.0/24.
+	claims *tunnel.Claims
+
 	ctx context.Context
 }
 
@@ -104,7 +110,10 @@ func (a *agent) reconcilerFor(m agentstate.Membership, relay tunnel.Relay, choos
 		AddressV6:     m.AddressV6,
 		ListenPort:    m.ListenPort,
 		ControlURL:    m.ControlURL,
-	}, relay, a.filterOrNil(), log).WithChooser(chooser).WithEgress(routerOrNil())
+	}, relay, a.filterOrNil(), log).
+		WithChooser(chooser).
+		WithEgress(routerOrNil()).
+		WithClaims(a.claims)
 }
 
 // routerOrNil converts a possibly-absent router into the interface.
@@ -287,6 +296,7 @@ func newAgent(ctx context.Context, log *slog.Logger, stateDir string, reconcileE
 		startedAt:      time.Now().UTC(),
 		reconcileEvery: reconcileEvery,
 		running:        make(map[uuid.UUID]*sessionHandle),
+		claims:         tunnel.NewClaims(),
 		ctx:            ctx,
 	}
 }

--- a/internal/tunnel/claims.go
+++ b/internal/tunnel/claims.go
@@ -1,0 +1,102 @@
+package tunnel
+
+import (
+	"net/netip"
+	"sort"
+	"sync"
+)
+
+// Claims is what every membership on this device says it carries.
+//
+// A device can hold memberships in many networks at once (ADR-0004), and two customers who
+// both accepted the default their router shipped with both carry 192.168.1.0/24. One
+// routing table cannot hold that prefix twice, so without this one membership's route wins
+// in whatever order the table happened to be written — and a technician typing
+// `ssh 192.168.1.5` reaches whichever customer that was, silently, and differently after a
+// restart.
+//
+// ADR-0019 settled what to do: the ambiguity cannot be resolved by routing, because the
+// information needed to resolve it is not in the packet. Until the prefixes are made
+// distinct by addressing, a collision is reported rather than picked between. A device that
+// says it cannot reach either is worse to use and better to trust than one that quietly
+// reaches the wrong customer.
+//
+// Shared by every reconciler on the device, so it is guarded: each membership reconciles on
+// its own timer and on its own state deltas.
+type Claims struct {
+	mu sync.Mutex
+	// byOwner is what each membership last said it wants to carry, keyed by interface name
+	// — which is the name a person sees in `ip route` and in the logs.
+	byOwner map[string][]netip.Prefix
+}
+
+// NewClaims returns a registry for one device.
+func NewClaims() *Claims {
+	return &Claims{byOwner: make(map[string][]netip.Prefix)}
+}
+
+// Declare records what a membership has been assigned.
+//
+// What it is assigned, deliberately, rather than what it ended up carrying. If a membership
+// withdrew its claim on finding a collision, the other side would stop seeing one and start
+// carrying, at which point the first would see no collision either — and the two would take
+// turns, each briefly routing a customer's network, which is the silent wrong answer this
+// exists to prevent wearing a different hat.
+func (c *Claims) Declare(owner string, prefixes []netip.Prefix) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(prefixes) == 0 {
+		delete(c.byOwner, owner)
+		return
+	}
+	c.byOwner[owner] = append([]netip.Prefix(nil), prefixes...)
+}
+
+// Forget drops a membership's claims, for a device that has left a network.
+func (c *Claims) Forget(owner string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.byOwner, owner)
+}
+
+// Contested reports the other memberships claiming exactly this prefix.
+//
+// Exactly, and not overlapping. Two memberships claiming 192.168.1.0/24 and 192.168.1.0/25
+// overlap, but longest-prefix match resolves them the same way every time and on every
+// machine: the /25 wins for the addresses it covers and the /24 keeps the rest. That is
+// probably not what anyone intended, and it is not ambiguous, so it is not this function's
+// business. An identical prefix in two networks has no answer at all.
+//
+// A default route is the same story. An egress group carries 0.0.0.0/0, which overlaps
+// every customer prefix on the device — and again longest match decides, so a full tunnel
+// alongside a LAN route is well defined rather than contested.
+func (c *Claims) Contested(owner string, prefix netip.Prefix) []string {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var others []string
+	for other, prefixes := range c.byOwner {
+		if other == owner {
+			continue
+		}
+		for _, p := range prefixes {
+			if p == prefix {
+				others = append(others, other)
+				break
+			}
+		}
+	}
+	// Sorted so the same collision reads the same way in every log line, rather than
+	// changing order with map iteration and looking like a new event each pass.
+	sort.Strings(others)
+	return others
+}

--- a/internal/tunnel/claims_test.go
+++ b/internal/tunnel/claims_test.go
@@ -1,0 +1,130 @@
+package tunnel
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+func p(s string) netip.Prefix { return netip.MustParsePrefix(s) }
+
+// The case ADR-0004 sells and ADR-0019 says must not be resolved silently: a technician
+// supporting two customers who both took their router's default.
+func TestTwoNetworksClaimingOneCustomerPrefixBothRefuse(t *testing.T) {
+	claims := NewClaims()
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch", bobKey, "192.168.1.0/24")},
+		peer(bobKey, "100.90.0.2/32"))
+
+	first := New(newFakeLink(), membership(), nil, nil, nil).WithClaims(claims)
+	if _, err := first.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+
+	// A second membership, on its own interface, carrying the same customer prefix.
+	second := membership()
+	second.InterfaceName = "meshp1"
+	other := New(newFakeLink(), second, nil, nil, nil).WithClaims(claims)
+
+	unapplied, err := other.Apply(context.Background(), state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slicesContain(unapplied, "route-groups") {
+		t.Errorf("the second network carried a contested prefix silently: %v", unapplied)
+	}
+
+	// And the first refuses too, on its next pass. Neither wins, because which one a packet
+	// reached would otherwise depend on the order the routing table was written.
+	unapplied, err = first.Apply(context.Background(), state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slicesContain(unapplied, "route-groups") {
+		t.Errorf("the first network kept carrying a contested prefix: %v", unapplied)
+	}
+}
+
+// One network on a device is the ordinary case and must be untouched.
+func TestOneNetworkCarriesItsPrefixes(t *testing.T) {
+	claims := NewClaims()
+	r := New(newFakeLink(), membership(), nil, nil, nil).WithClaims(claims)
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch", bobKey, "192.168.1.0/24")},
+		peer(bobKey, "100.90.0.2/32"))
+
+	unapplied, err := r.Apply(context.Background(), state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slicesContain(unapplied, "route-groups") {
+		t.Errorf("a network with nobody to contest it refused its own prefix: %v", unapplied)
+	}
+}
+
+// Longest match resolves these deterministically on every machine, so they are not
+// ambiguous and must not be refused.
+func TestOverlappingButUnequalPrefixesAreNotContested(t *testing.T) {
+	claims := NewClaims()
+	claims.Declare("meshp0", []netip.Prefix{p("192.168.1.0/24")})
+
+	for _, other := range []string{"192.168.1.0/25", "192.168.0.0/16", "0.0.0.0/0"} {
+		if got := claims.Contested("meshp1", p(other)); len(got) != 0 {
+			t.Errorf("%s was called contested against 192.168.1.0/24: %v", other, got)
+		}
+	}
+	if got := claims.Contested("meshp1", p("192.168.1.0/24")); len(got) != 1 {
+		t.Errorf("an identical prefix was not contested: %v", got)
+	}
+}
+
+// A full tunnel alongside a customer LAN is well defined, so an egress group must not
+// contest anything — otherwise turning on egress would take a technician's customers away.
+func TestAnEgressGroupContestsNothing(t *testing.T) {
+	claims := NewClaims()
+	claims.Declare("meshp0", []netip.Prefix{p("0.0.0.0/0"), p("::/0")})
+
+	if got := contestedPrefixes(claims, "meshp1", []netip.Prefix{p("192.168.1.0/24")}); len(got) != 0 {
+		t.Errorf("a customer prefix was contested by a default route: %v", got)
+	}
+	if got := contestedPrefixes(claims, "meshp1", []netip.Prefix{p("0.0.0.0/0")}); len(got) != 0 {
+		t.Errorf("a default route contested another default route: %v", got)
+	}
+}
+
+// A membership that has left every route group must stop contesting, or the network it used
+// to share a prefix with stays refused for a claim nobody holds.
+func TestLeavingEveryGroupReleasesTheClaim(t *testing.T) {
+	claims := NewClaims()
+	first := New(newFakeLink(), membership(), nil, nil, nil).WithClaims(claims)
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch", bobKey, "192.168.1.0/24")},
+		peer(bobKey, "100.90.0.2/32"))
+	if _, err := first.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if got := claims.Contested("meshp1", p("192.168.1.0/24")); len(got) != 1 {
+		t.Fatalf("the first membership never claimed it: %v", got)
+	}
+
+	// The control plane takes it out of every group.
+	if _, err := first.Apply(context.Background(),
+		stateWithRoutes(2, nil, peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if got := claims.Contested("meshp1", p("192.168.1.0/24")); len(got) != 0 {
+		t.Errorf("a membership that left every group still contests: %v", got)
+	}
+}
+
+// A nil registry is the single-network case and every existing caller.
+func TestANilRegistryContestsNothing(t *testing.T) {
+	var claims *Claims
+	claims.Declare("meshp0", []netip.Prefix{p("192.168.1.0/24")})
+	claims.Forget("meshp0")
+	if got := claims.Contested("meshp1", p("192.168.1.0/24")); got != nil {
+		t.Errorf("a nil registry reported a collision: %v", got)
+	}
+}

--- a/internal/tunnel/routegroups.go
+++ b/internal/tunnel/routegroups.go
@@ -27,7 +27,12 @@ import (
 // Returns the group names it could not honour, which the caller reports as unapplied rather
 // than swallowing: a device quietly not carrying a prefix it was assigned is indistinguishable
 // from one that is, right up until somebody tries to use it.
-func applyRouteGroups(iface *wgplan.Interface, assignments []*meshpv1.RouteGroupAssignment, chooser *routeprobe.Chooser, log *slog.Logger) []string {
+func applyRouteGroups(iface *wgplan.Interface, assignments []*meshpv1.RouteGroupAssignment, chooser *routeprobe.Chooser, claims *Claims, log *slog.Logger) []string {
+	// Declared before the early return, so a membership that has been taken out of every
+	// route group stops contesting prefixes it no longer carries. Leaving a stale claim
+	// behind would keep another membership refused for a network this one has left.
+	claims.Declare(iface.Name, declaredPrefixes(assignments))
+
 	if len(assignments) == 0 {
 		return nil
 	}
@@ -72,6 +77,20 @@ func applyRouteGroups(iface *wgplan.Interface, assignments []*meshpv1.RouteGroup
 			unhonoured = append(unhonoured, name)
 			continue
 		}
+		// Another membership on this device carrying the same prefix. Refused rather than
+		// picked between: which one a packet reaches would depend on the order the routing
+		// table was written, so the technician who types `ssh 192.168.1.5` would sometimes
+		// reach one customer and sometimes the other (ADR-0019).
+		if contested := contestedPrefixes(claims, iface.Name, prefixes); len(contested) > 0 {
+			log.Error("not carrying a route group whose prefixes another network also claims",
+				"group", logx.Safe(name),
+				"prefixes", contested,
+				"also_claimed_by", claims.Contested(iface.Name, contested[0]),
+				"why", "which network a packet reached would depend on the order the routing table was written")
+			unhonoured = append(unhonoured, name)
+			continue
+		}
+
 		index, ok := byKey[wgplan.Key(best.GetPeerPublicKey())]
 		if !ok {
 			// Assigned a carrier that is not in this device's peer list. Nothing can be
@@ -111,4 +130,38 @@ func groupPrefixes(assignment *meshpv1.RouteGroupAssignment) (prefixes []netip.P
 		return nil, false, fmt.Errorf("it carries no prefixes")
 	}
 	return prefixes, false, nil
+}
+
+// declaredPrefixes is every prefix these assignments ask this membership to carry.
+//
+// Unparseable ones are skipped rather than refused: a prefix this build cannot read is
+// already reported as an unhonoured group above, and it cannot contest anything because
+// nothing can route it either.
+func declaredPrefixes(assignments []*meshpv1.RouteGroupAssignment) []netip.Prefix {
+	var out []netip.Prefix
+	for _, assignment := range assignments {
+		for _, raw := range assignment.GetPrefixes() {
+			if prefix, err := netip.ParsePrefix(raw); err == nil {
+				out = append(out, prefix.Masked())
+			}
+		}
+	}
+	return out
+}
+
+// contestedPrefixes is those of these prefixes that another membership also claims.
+func contestedPrefixes(claims *Claims, owner string, prefixes []netip.Prefix) []netip.Prefix {
+	var out []netip.Prefix
+	for _, prefix := range prefixes {
+		// A default route overlaps everything and is resolved by longest match, so it is
+		// never the contested one — an egress group alongside a customer LAN is well
+		// defined rather than ambiguous.
+		if prefix.Bits() == 0 {
+			continue
+		}
+		if len(claims.Contested(owner, prefix)) > 0 {
+			out = append(out, prefix)
+		}
+	}
+	return out
 }

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -106,6 +106,11 @@ type Reconciler struct {
 	// counters an operator is reading.
 	lastFilter *meshpv1.PacketFilter
 
+	// claims is shared with every other membership on this device, so a prefix two
+	// networks both carry can be seen as contested from either side. Nil where nothing
+	// shares it, which is every test that builds one reconciler.
+	claims *Claims
+
 	// chooser decides which candidate carries each group. Nil where local failover is not
 	// wanted, in which case the server's order is taken verbatim — which is what this did
 	// before there was a chooser.
@@ -180,6 +185,15 @@ func New(link wglink.Link, m Membership, relay Relay, filter Filter, log *slog.L
 	}
 }
 
+// WithClaims lets this reconciler see what other memberships on the device carry.
+//
+// Nil is safe and means "nothing else is running here", which is true of a device in one
+// network and of every test that builds a single reconciler.
+func (r *Reconciler) WithClaims(c *Claims) *Reconciler {
+	r.claims = c
+	return r
+}
+
 // WithEgress gives the reconciler the ability to claim a default route.
 //
 // Nil is meaningful and is the ordinary case: most devices are not full-tunnel, and a host
@@ -229,7 +243,7 @@ func (r *Reconciler) Status() Status {
 // The returned components are the parts that did not converge, which the agent reports back
 // so the control plane knows this device is not where it says it is.
 func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, error) {
-	want, unhonoured, err := Desired(r.membership, state, r.relay, r.chooser, r.log)
+	want, unhonoured, err := Desired(r.membership, state, r.relay, r.chooser, r.claims, r.log)
 	if err != nil {
 		// A description the kernel would refuse, or one wgplan judged unsafe. Reported
 		// rather than approximated: applying part of a rejected configuration is how an
@@ -521,7 +535,7 @@ func (r *Reconciler) fail(err error) {
 // The second return names route groups this device was assigned and could not carry. It is
 // a translation result rather than part of the interface description, which is why it comes
 // back separately: wgplan plans kernel operations, and "what is missing" is not one.
-func Desired(m Membership, state *peerset.Set, relay Relay, chooser *routeprobe.Chooser, log *slog.Logger) (wgplan.Interface, []string, error) {
+func Desired(m Membership, state *peerset.Set, relay Relay, chooser *routeprobe.Chooser, claims *Claims, log *slog.Logger) (wgplan.Interface, []string, error) {
 	if log == nil {
 		log = slog.New(slog.DiscardHandler)
 	}
@@ -573,7 +587,7 @@ func Desired(m Membership, state *peerset.Set, relay Relay, chooser *routeprobe.
 	//
 	// Reported rather than fatal: one group this device cannot honour must not cost it the
 	// peers and prefixes it can.
-	unhonoured := applyRouteGroups(&iface, state.RouteGroups(), chooser, log)
+	unhonoured := applyRouteGroups(&iface, state.RouteGroups(), chooser, claims, log)
 	return iface, unhonoured, nil
 }
 

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -337,7 +337,7 @@ func TestDesiredRendersAddressesAsHostPrefixes(t *testing.T) {
 	m.AddressV4 = "100.90.0.1"
 	m.AddressV6 = "fd7c::1"
 
-	iface, _, err := Desired(m, stateWith(1), nil, nil, nil)
+	iface, _, err := Desired(m, stateWith(1), nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -359,7 +359,7 @@ func TestDesiredRefusesAnAddressThatIsNotOneHost(t *testing.T) {
 		m := membership()
 		m.AddressV4 = addr
 		m.AddressV6 = ""
-		if _, _, err := Desired(m, stateWith(1), nil, nil, nil); err == nil {
+		if _, _, err := Desired(m, stateWith(1), nil, nil, nil, nil); err == nil {
 			t.Errorf("%s was accepted", addr)
 		}
 	}
@@ -372,7 +372,7 @@ func TestDesiredAcceptsAnAddressThatAlreadyCarriesItsPrefix(t *testing.T) {
 	m.AddressV4 = "100.90.0.1/32"
 	m.AddressV6 = "fd7c::1/128"
 
-	iface, _, err := Desired(m, stateWith(1), nil, nil, nil)
+	iface, _, err := Desired(m, stateWith(1), nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Desired: %v", err)
 	}
@@ -385,14 +385,14 @@ func TestDesiredRefusesAMembershipWithNothingToWorkFrom(t *testing.T) {
 	t.Run("no private key", func(t *testing.T) {
 		m := membership()
 		m.PrivateKey = ""
-		if _, _, err := Desired(m, stateWith(1), nil, nil, nil); err == nil {
+		if _, _, err := Desired(m, stateWith(1), nil, nil, nil, nil); err == nil {
 			t.Error("a membership with no private key was accepted")
 		}
 	})
 	t.Run("no addresses", func(t *testing.T) {
 		m := membership()
 		m.AddressV4, m.AddressV6 = "", ""
-		if _, _, err := Desired(m, stateWith(1), nil, nil, nil); err == nil {
+		if _, _, err := Desired(m, stateWith(1), nil, nil, nil, nil); err == nil {
 			t.Error("a membership with no addresses was accepted")
 		}
 	})
@@ -407,7 +407,7 @@ func TestDesiredTakesTheMTUFromTheServer(t *testing.T) {
 		Tunnel: &meshpv1.TunnelConfig{Mtu: 1280},
 	})
 
-	iface, _, err := Desired(membership(), state, nil, nil, nil)
+	iface, _, err := Desired(membership(), state, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -422,7 +422,7 @@ func TestDesiredFallsBackToADefaultMTU(t *testing.T) {
 	state := peerset.New()
 	state.Apply(&meshpv1.StateDelta{FromVersion: 0, ToVersion: 1})
 
-	iface, _, err := Desired(membership(), state, nil, nil, nil)
+	iface, _, err := Desired(membership(), state, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -437,7 +437,7 @@ func TestDesiredFallsBackToADefaultMTU(t *testing.T) {
 // A peer with no endpoint is configured and unreachable, which is the honest state of every
 // peer today: nothing discovers endpoints yet.
 func TestAPeerWithNoEndpointIsStillConfigured(t *testing.T) {
-	iface, _, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -458,7 +458,7 @@ func TestTheFirstEndpointIsUsed(t *testing.T) {
 	p := peer(bobKey, "100.90.0.2/32")
 	p.Endpoints = []string{"203.0.113.2:51820", "198.51.100.2:51820"}
 
-	iface, _, err := Desired(membership(), stateWith(1, p), nil, nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, p), nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -470,7 +470,7 @@ func TestTheFirstEndpointIsUsed(t *testing.T) {
 // The key is carried through untouched. wgplan does not parse keys, so a translation that
 // mangled one would only fail at the kernel, on a real host, with a confusing message.
 func TestKeysArePassedThroughUnchanged(t *testing.T) {
-	iface, _, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -584,7 +584,7 @@ func TestARememberedPortIsAskedForAgain(t *testing.T) {
 	m := membership()
 	m.ListenPort = 51999
 
-	iface, _, err := Desired(m, stateWith(1), nil, nil, nil)
+	iface, _, err := Desired(m, stateWith(1), nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -595,7 +595,7 @@ func TestARememberedPortIsAskedForAgain(t *testing.T) {
 
 // A membership that has never come up asks for any port.
 func TestAMembershipWithNoPortAsksForAny(t *testing.T) {
-	iface, _, err := Desired(membership(), stateWith(1), nil, nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1), nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -654,8 +654,7 @@ func relayedPeer(key, relayID string, ips ...string) *meshpv1.Peer {
 func TestARelayedPeerIsGivenItsLoopbackEndpoint(t *testing.T) {
 	relay := newFakeRelay("relay1")
 
-	iface, _, err := Desired(membership(),
-		stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32")), relay, nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32")), relay, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -683,7 +682,7 @@ func TestADirectEndpointWinsOverARelay(t *testing.T) {
 	p := relayedPeer(bobKey, "relay1", "100.90.0.2/32")
 	p.Endpoints = []string{"203.0.113.2:51820"}
 
-	iface, _, err := Desired(membership(), stateWith(1, p), relay, nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, p), relay, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -706,7 +705,7 @@ func TestAPeerOnAnUnreachableRelayDoesNotBreakTheOthers(t *testing.T) {
 	iface, _, err := Desired(membership(), stateWith(1,
 		relayedPeer(bobKey, "relay1", "100.90.0.2/32"),
 		relayedPeer(carolKey, "relay2", "100.90.0.3/32"),
-	), relay, nil, nil)
+	), relay, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("one unreachable relay refused the whole interface: %v", err)
 	}
@@ -729,8 +728,7 @@ func TestAPeerOnAnUnreachableRelayDoesNotBreakTheOthers(t *testing.T) {
 // With no relay at all — no data plane, or a deployment that has not configured one — a
 // relayed peer is unreachable rather than refused.
 func TestNoRelayLeavesRelayedPeersWithoutEndpoints(t *testing.T) {
-	iface, _, err := Desired(membership(),
-		stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32")), nil, nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32")), nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1136,7 +1134,7 @@ func TestACarriedPrefixReachesTheCarrierAndTheRoutingTable(t *testing.T) {
 		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch-lan", bobKey, "192.168.10.0/24")},
 		peer(bobKey, "100.90.0.2/32"))
 
-	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil)
+	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1177,7 +1175,7 @@ func TestAnEgressGroupPutsTheDefaultInAllowedIPs(t *testing.T) {
 		[]*meshpv1.RouteGroupAssignment{assignmentTo("exit", bobKey, "0.0.0.0/0", "::/0")},
 		peer(bobKey, "100.90.0.2/32"))
 
-	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil)
+	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("an egress group made the whole description fail: %v", err)
 	}
@@ -1219,7 +1217,7 @@ func TestACarrierThatIsNotAPeerIsReported(t *testing.T) {
 		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch-lan", carolKey, "192.168.10.0/24")},
 		peer(bobKey, "100.90.0.2/32"))
 
-	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil)
+	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1238,7 +1236,7 @@ func TestAnUnparseablePrefixIsReportedRatherThanGuessed(t *testing.T) {
 		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch-lan", bobKey, "not-a-prefix")},
 		peer(bobKey, "100.90.0.2/32"))
 
-	_, unhonoured, err := Desired(membership(), state, nil, nil, nil)
+	_, unhonoured, err := Desired(membership(), state, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1256,7 +1254,7 @@ func TestAGroupWithNoCandidatesIsReported(t *testing.T) {
 	state := stateWithRoutes(1, []*meshpv1.RouteGroupAssignment{assignment},
 		peer(bobKey, "100.90.0.2/32"))
 
-	_, unhonoured, err := Desired(membership(), state, nil, nil, nil)
+	_, unhonoured, err := Desired(membership(), state, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1278,7 +1276,7 @@ func TestTheFirstCandidateCarriesIt(t *testing.T) {
 	state := stateWithRoutes(1, []*meshpv1.RouteGroupAssignment{assignment},
 		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
 
-	iface, _, err := Desired(membership(), state, nil, nil, nil)
+	iface, _, err := Desired(membership(), state, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1515,7 +1513,7 @@ func TestADeviceFailsOverFromASilentAdvertiser(t *testing.T) {
 	if _, err := r.Apply(context.Background(), state); err != nil {
 		t.Fatal(err)
 	}
-	iface, _, err := Desired(membership(), state, nil, nil, nil)
+	iface, _, err := Desired(membership(), state, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1543,7 +1541,7 @@ func TestADeviceFailsOverFromASilentAdvertiser(t *testing.T) {
 // currentInterface recomputes what the reconciler would configure now.
 func currentInterface(t *testing.T, r *Reconciler, state *peerset.Set) wgplan.Interface {
 	t.Helper()
-	iface, _, err := Desired(r.membership, state, r.relay, r.chooser, r.log)
+	iface, _, err := Desired(r.membership, state, r.relay, r.chooser, r.claims, r.log)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Required by ADR-0019, and what it prevents is specific.

A technician holds memberships in two customer networks that both use `192.168.1.0/24`. They type `ssh 192.168.1.5` and reach **whichever of them the routing table happened to be written for** — silently, and possibly a different one after a restart.

One routing table cannot hold that prefix twice, and no rule can pick between them, because the information needed to pick is not in the packet. So neither is carried and both groups are reported unhonoured.

> A device that says it cannot reach either is worse to use and better to trust than one that quietly reaches the wrong customer.

### What counts as a collision

**Only an identical prefix.** Overlapping ones — `192.168.1.0/24` against `192.168.1.0/25`, or against an egress group's `0.0.0.0/0` — are resolved by longest match, the same way on every machine. Probably not what anyone intended, but not *ambiguous*.

That distinction matters practically: refusing overlaps would mean **turning on a full tunnel took a technician's customers away.**

### Declaring what is assigned, not what is carried

If a membership withdrew its claim on finding a collision, the other side would stop seeing one and start carrying, at which point the first would see no collision either — and the two would take turns, each briefly routing a customer's network.

That is the silent wrong answer again, wearing a different hat.

### Mutation tested

| mutation | |
|---|---|
| a contested prefix is carried anyway | caught |
| a membership contests itself (nobody carries anything) | caught |
| a default route contests customer prefixes | caught |
| leaving every group keeps the claim | caught |

### Scope

Interim behaviour. The real fix is making the prefixes distinct by **addressing** rather than routing, which needs its own design — ADR-0019 settled that it is not a routing problem, and task #3 carries it.