### PR TITLE
feat(api): somewhere for an administrator to opt out of fail-closed

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -113,6 +113,13 @@ func (s *Server) Routes(mux *http.ServeMux) {
 
 	mux.Handle("POST /api/v1/networks", s.adminOnly(s.handleCreateNetwork))
 
+	// Its own sub-resource rather than a field on a general network update, because this
+	// is the one setting here that can decide whether a laptop leaks. A PUT that names it
+	// in the path cannot be made by accident, reads unambiguously in an access log, and
+	// leaves no room for a partial update that silently carries it along.
+	mux.Handle("GET /api/v1/networks/{networkID}/egress-fail-closed", s.adminOnly(s.handleGetEgressFailClosed))
+	mux.Handle("PUT /api/v1/networks/{networkID}/egress-fail-closed", s.adminOnly(s.handleSetEgressFailClosed))
+
 	mux.Handle("GET /api/v1/networks/{networkID}/route-groups", s.adminOnly(s.handleListRouteGroups))
 	mux.Handle("POST /api/v1/networks/{networkID}/route-groups", s.adminOnly(s.handleCreateRouteGroup))
 	mux.Handle("DELETE /api/v1/networks/{networkID}/route-groups/{slug}", s.adminOnly(s.handleDeleteRouteGroup))

--- a/internal/api/egress.go
+++ b/internal/api/egress.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/meshpnet/meshp/internal/httpx"
+	"github.com/meshpnet/meshp/internal/store"
+)
+
+// handleGetEgressFailClosed reports whether this network's devices refuse egress outside the
+// tunnel while they claim a default route.
+//
+// Readable on its own, because an administrator asking "is this fleet protected?" should not
+// have to infer the answer from what the agents happen to be doing.
+func (s *Server) handleGetEgressFailClosed(w http.ResponseWriter, r *http.Request) {
+	networkID, ok := s.pathUUID(w, r, "networkID")
+	if !ok {
+		return
+	}
+
+	enforced, err := s.store.EgressFailClosed(r.Context(), networkID)
+	if errors.Is(err, store.ErrNoSuchNetwork) {
+		httpx.Error(w, s.log, http.StatusNotFound, "not_found", "no such network")
+		return
+	}
+	if err != nil {
+		s.respondError(w, r, err)
+		return
+	}
+	httpx.WriteJSON(w, s.log, http.StatusOK, map[string]any{"enforced": enforced})
+}
+
+// handleSetEgressFailClosed records an administrator's decision under ADR-0011.
+//
+// The interesting part is what this refuses. `enforced` is a pointer and a body that omits it
+// is rejected, rather than being read as Go's zero value — which for a bool is false, which
+// here means "let every device in this network leak if its tunnel drops". A typo in a field
+// name, a client that sends `{}`, or a script whose variable was empty would all otherwise
+// turn off a safety property and get a 200 back. decode already refuses unknown fields, so
+// this closes the other half of the same hole: a field that is simply not there.
+func (s *Server) handleSetEgressFailClosed(w http.ResponseWriter, r *http.Request) {
+	networkID, ok := s.pathUUID(w, r, "networkID")
+	if !ok {
+		return
+	}
+
+	var body struct {
+		Enforced *bool `json:"enforced"`
+	}
+	if err := decode(w, r, &body); err != nil {
+		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if body.Enforced == nil {
+		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request",
+			"enforced must be true or false; leaving it out would read as false, "+
+				"which lets devices in this network send traffic in the clear if the tunnel drops")
+		return
+	}
+
+	changed, err := s.store.SetEgressFailClosed(r.Context(), networkID, *body.Enforced)
+	if errors.Is(err, store.ErrNoSuchNetwork) {
+		httpx.Error(w, s.log, http.StatusNotFound, "not_found", "no such network")
+		return
+	}
+	if err != nil {
+		s.respondError(w, r, err)
+		return
+	}
+
+	if changed {
+		if *body.Enforced {
+			s.log.Info("this network's devices will refuse egress outside the tunnel",
+				"network_id", networkID)
+		} else {
+			// Warn rather than Info, and said in full. Whoever turned this off should be able
+			// to find out from the log that they did, and whoever is reading the log a year
+			// later after an incident should not have to know what "fail_closed=false" meant.
+			s.log.Warn("this network's devices will no longer refuse egress outside the tunnel",
+				"network_id", networkID,
+				"consequence", "traffic leaves in the clear if a device's tunnel drops while it carries a default route")
+		}
+		// Only when something changed: agents were told nothing otherwise, and nudging them
+		// to fetch a state they already hold is work for every device in the network.
+		s.tellNetwork(networkID)
+	}
+
+	httpx.WriteJSON(w, s.log, http.StatusOK, map[string]any{
+		"enforced": *body.Enforced,
+		"changed":  changed,
+	})
+}

--- a/internal/api/egress_test.go
+++ b/internal/api/egress_test.go
@@ -1,0 +1,258 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/meshpnet/meshp/internal/enrollclient"
+	"github.com/meshpnet/meshp/internal/sessionclient"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// answer is what both of these endpoints say.
+type answer struct {
+	status   int
+	Enforced bool `json:"enforced"`
+	Changed  bool `json:"changed"`
+}
+
+// readFailClosed asks what this network's policy is.
+func (h *harness) readFailClosed(path string) answer {
+	h.t.Helper()
+	return h.failClosed(http.MethodGet, path, "")
+}
+
+// writeFailClosed records one, and returns whatever came back — including the refusals,
+// since what this endpoint refuses is most of what is worth testing about it.
+func (h *harness) writeFailClosed(path, body string) answer {
+	h.t.Helper()
+	return h.failClosed(http.MethodPut, path, body)
+}
+
+// failClosed does the round trip and consumes the response, so a test that only looks at a
+// status code does not leak a connection.
+func (h *harness) failClosed(method, path, body string) answer {
+	h.t.Helper()
+	req := mustRequest(h.t, method, h.server.URL+path, body)
+	req.Header.Set("Authorization", "Bearer "+testAdminToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	out := answer{status: resp.StatusCode}
+	if resp.StatusCode != http.StatusOK {
+		return out
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		h.t.Fatal(err)
+	}
+	return out
+}
+
+// A network nobody has configured is enforcing, which is what ADR-0011 asks for and what
+// every agent is already doing. The point of reading it back is that an administrator should
+// not have to infer a fleet's safety from what its devices happen to be up to.
+func TestANewNetworkIsEnforcing(t *testing.T) {
+	h := newHarness(t)
+
+	got := h.readFailClosed(h.netPath("/egress-fail-closed"))
+	if got.status != http.StatusOK {
+		t.Fatalf("returned %d", got.status)
+	}
+	if !got.Enforced {
+		t.Error("a network nobody has configured reports that its devices may fail open")
+	}
+}
+
+func TestOptingOutAndBackIn(t *testing.T) {
+	h := newHarness(t)
+	path := h.netPath("/egress-fail-closed")
+
+	out := h.writeFailClosed(path, `{"enforced":false}`)
+	if out.status != http.StatusOK {
+		t.Fatalf("opting out returned %d", out.status)
+	}
+	if out.Enforced || !out.Changed {
+		t.Errorf("opting out reported enforced=%v changed=%v", out.Enforced, out.Changed)
+	}
+	if h.readFailClosed(path).Enforced {
+		t.Error("the opt-out did not stick")
+	}
+
+	back := h.writeFailClosed(path, `{"enforced":true}`)
+	if !back.Enforced || !back.Changed {
+		t.Errorf("turning it back on reported enforced=%v changed=%v", back.Enforced, back.Changed)
+	}
+	if !h.readFailClosed(path).Enforced {
+		t.Error("turning it back on did not stick")
+	}
+}
+
+// The guard worth having.
+//
+// `enforced` is a pointer precisely so a body that leaves it out is refused rather than read
+// as Go's zero value — which for a bool is false, which here means every device in the
+// network may send traffic in the clear when its tunnel drops. A body of `{}`, an explicit
+// null, or a script whose variable was empty would each otherwise turn off a safety property
+// and be answered with a 200.
+//
+// The misspelling is the other half of the same hole, closed by decode refusing unknown
+// fields: `{"enforce":false}` accepted and ignored would report success and change nothing,
+// leaving an administrator believing the fleet had been reconfigured.
+func TestTurningItOffHasToBeSaidOutLoud(t *testing.T) {
+	h := newHarness(t)
+	path := h.netPath("/egress-fail-closed")
+
+	for _, body := range []string{
+		`{}`,
+		`{"enforced":null}`,
+		`{"enforce":false}`,
+	} {
+		if got := h.writeFailClosed(path, body); got.status != http.StatusBadRequest {
+			t.Errorf("%s returned %d, want 400", body, got.status)
+		}
+	}
+
+	// And nothing was changed on the way past.
+	if !h.readFailClosed(path).Enforced {
+		t.Error("a refused request still turned fail-closed off")
+	}
+}
+
+// Writing the same answer twice reports that it changed nothing, so an operator running this
+// from a configuration loop can tell a no-op from a reconfiguration.
+func TestWritingTheSameAnswerReportsNoChange(t *testing.T) {
+	h := newHarness(t)
+	path := h.netPath("/egress-fail-closed")
+
+	if !h.writeFailClosed(path, `{"enforced":false}`).Changed {
+		t.Fatal("the first write reported no change")
+	}
+	second := h.writeFailClosed(path, `{"enforced":false}`)
+	if second.Changed || second.Enforced {
+		t.Errorf("the second write reported enforced=%v changed=%v", second.Enforced, second.Changed)
+	}
+}
+
+// A network that does not exist is a 404 rather than a 500 or a silent success, so a typo in
+// a script does not look like a fleet that has been reconfigured.
+func TestAnUnknownNetworkIsNotFound(t *testing.T) {
+	h := newHarness(t)
+	missing := "/api/v1/networks/" + uuid.New().String() + "/egress-fail-closed"
+
+	if got := h.readFailClosed(missing); got.status != http.StatusNotFound {
+		t.Errorf("reading returned %d, want 404", got.status)
+	}
+	if got := h.writeFailClosed(missing, `{"enforced":false}`); got.status != http.StatusNotFound {
+		t.Errorf("writing returned %d, want 404", got.status)
+	}
+}
+
+// This is a fleet's safety property, so it is not something an unauthenticated caller may
+// read or change.
+func TestFailClosedNeedsTheAdminToken(t *testing.T) {
+	h := newHarness(t)
+	path := h.server.URL + h.netPath("/egress-fail-closed")
+
+	for _, req := range []*http.Request{
+		mustRequest(t, http.MethodGet, path, ""),
+		mustRequest(t, http.MethodPut, path, `{"enforced":false}`),
+	} {
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		status := resp.StatusCode
+		_ = resp.Body.Close()
+		if status != http.StatusUnauthorized {
+			t.Errorf("%s answered an unauthenticated caller with %d", req.Method, status)
+		}
+	}
+}
+
+// The mechanism has to be reachable from where an administrator actually stands: a request
+// to the admin API, and a connected agent that changes what it enforces because of it
+// (ADR-0018). Everything else in this file tests a piece.
+//
+// Well inside the 25-second heartbeat, so this can only pass if the change was pushed. A
+// test that allowed longer could not tell a working push from a missing one — which is
+// precisely how the push came to be absent from every mutation path while the unit tests
+// passed.
+func TestOptingOutReachesAConnectedAgent(t *testing.T) {
+	h := newHarness(t)
+
+	identity, wg := newDevice(t)
+	joined, err := enrollclient.New(h.server.URL, nil).Join(h.ctx, enrollclient.JoinRequest{
+		Token: h.mintToken(1, time.Hour), Identity: identity, WireGuard: wg,
+		Name: "laptop", OS: "linux", AgentVersion: "test",
+	})
+	if err != nil {
+		t.Fatalf("the device could not join: %v", err)
+	}
+
+	rec := newRecorder()
+	agentCtx, stopAgent := context.WithCancel(h.ctx)
+	defer stopAgent()
+	client := sessionclient.New(sessionclient.Options{
+		ControlURL:   h.server.URL,
+		Identity:     identity,
+		MembershipID: joined.MembershipID,
+		AgentVersion: "test",
+	})
+	go func() { _ = client.Run(agentCtx, rec) }()
+
+	// It starts out enforcing, because that is what a network nobody has configured means.
+	first := rec.waitForTunnel(t, func(c *meshpv1.TunnelConfig) bool { return c != nil }, 10*time.Second)
+	if first.GetFailClosedPolicy() == meshpv1.TunnelConfig_FAIL_CLOSED_DISABLED {
+		t.Fatal("a device in a network nobody has configured was told it may fail open")
+	}
+
+	if got := h.writeFailClosed(h.netPath("/egress-fail-closed"), `{"enforced":false}`); got.status != http.StatusOK {
+		t.Fatalf("opting out returned %d", got.status)
+	}
+
+	rec.waitForTunnel(t, func(c *meshpv1.TunnelConfig) bool {
+		return c.GetFailClosedPolicy() == meshpv1.TunnelConfig_FAIL_CLOSED_DISABLED
+	}, 5*time.Second)
+}
+
+// waitForTunnel blocks until the agent holds a tunnel configuration that satisfies want.
+func (r *recorder) waitForTunnel(t *testing.T, want func(*meshpv1.TunnelConfig) bool, within time.Duration) *meshpv1.TunnelConfig {
+	t.Helper()
+	deadline := time.After(within)
+	for {
+		r.mu.Lock()
+		var last *meshpv1.TunnelConfig
+		if len(r.applied) > 0 {
+			last = r.applied[len(r.applied)-1].Tunnel()
+		}
+		r.mu.Unlock()
+		if want(last) {
+			return last
+		}
+		select {
+		case <-r.changed:
+		case <-deadline:
+			t.Fatalf("the agent still holds %v after %s", last, within)
+			return nil
+		}
+	}
+}
+
+func mustRequest(t *testing.T, method, url, body string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, url, bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
+}

--- a/internal/session/egress_test.go
+++ b/internal/session/egress_test.go
@@ -1,0 +1,190 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// otherNetwork stands up a second network in the same organization, with its own pools so
+// devices enrolled into it get addresses.
+func (f *fixture) otherNetwork(slug string) uuid.UUID {
+	f.t.Helper()
+	var id uuid.UUID
+	if err := f.store.Pool().QueryRow(f.ctx,
+		`INSERT INTO networks (organization_id,slug,name) VALUES ($1,$2,$2) RETURNING id`,
+		f.orgID, slug).Scan(&id); err != nil {
+		f.t.Fatal(err)
+	}
+	if _, err := f.store.Pool().Exec(f.ctx,
+		`INSERT INTO address_pools (network_id,prefix,family,purpose)
+		 VALUES ($1,'100.91.0.0/24'::cidr,4,'device'), ($1,'fd7d::/120'::cidr,6,'device')`,
+		id); err != nil {
+		f.t.Fatal(err)
+	}
+	return id
+}
+
+// setFailClosed records an administrator's answer for the fixture's network.
+func (f *fixture) setFailClosed(enforced bool) {
+	f.t.Helper()
+	if _, err := f.store.SetEgressFailClosed(f.ctx, f.netID, enforced); err != nil {
+		f.t.Fatalf("SetEgressFailClosed(%v): %v", enforced, err)
+	}
+}
+
+// A network nobody has said anything about sends no opinion, and the agent reads that as
+// closed. Sending ENFORCED instead would report a decision an administrator never made.
+func TestANetworkWithNoOpinionSendsNone(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+
+	got := f.stateFor(alice.membershipID, 0).GetTunnel().GetFailClosedPolicy()
+	if got != meshpv1.TunnelConfig_FAIL_CLOSED_UNSPECIFIED {
+		t.Errorf("fail_closed_policy = %v, want UNSPECIFIED for a network nobody has configured", got)
+	}
+}
+
+// And the opt-out is stated, because unset would be read as closed and the device would go
+// on refusing egress its administrator has said it need not refuse.
+func TestOptingOutReachesTheAgent(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+	f.setFailClosed(false)
+
+	got := f.stateFor(alice.membershipID, 0).GetTunnel().GetFailClosedPolicy()
+	if got != meshpv1.TunnelConfig_FAIL_CLOSED_DISABLED {
+		t.Errorf("fail_closed_policy = %v, want DISABLED after an administrator opted out", got)
+	}
+}
+
+// Turning it back on returns the network to saying nothing, which is the same thing the
+// agent enforces. The value that matters is what the device does, and it must go back to
+// refusing egress outside the tunnel.
+func TestTurningItBackOnStopsSayingDisabled(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+	f.setFailClosed(false)
+	f.setFailClosed(true)
+
+	got := f.stateFor(alice.membershipID, 0).GetTunnel().GetFailClosedPolicy()
+	if got == meshpv1.TunnelConfig_FAIL_CLOSED_DISABLED {
+		t.Error("the network still tells devices to fail open after being told to enforce")
+	}
+}
+
+// The hazard this whole design is arranged around.
+//
+// TunnelConfig rides on every delta, while route group assignments are only recomputed when
+// routes changed. A fail-closed answer derived from the assignments would be right on the
+// deltas that mention routes and wrong on the ones that do not — and wrong here means an
+// unrelated device joining the network tells a machine that is still carrying a default
+// route to stop refusing egress outside it.
+//
+// So: opt out, then move the version with something that has nothing to do with routes, and
+// require the delta to still carry the answer.
+func TestAnUnrelatedPeerChangeCarriesTheSameAnswer(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+	f.setFailClosed(false)
+	before := f.headVersion()
+
+	// A peer change and nothing else.
+	f.enrolDevice("bob")
+
+	got := f.stateFor(alice.membershipID, before)
+	if isSnapshot(got) {
+		t.Fatal("wanted a delta; a snapshot would not exercise the path this is about")
+	}
+	if len(got.GetRouteGroups()) != 0 {
+		t.Fatal("this delta recomputed route groups, so it is not the path this is about")
+	}
+	if policy := got.GetTunnel().GetFailClosedPolicy(); policy != meshpv1.TunnelConfig_FAIL_CLOSED_DISABLED {
+		t.Errorf("fail_closed_policy = %v on a delta that only added a peer, want DISABLED; "+
+			"a device carrying a default route would have been told to stop failing open", policy)
+	}
+}
+
+// The change has to reach agents by itself, not wait for something else to move the version.
+//
+// A version bumped with nothing logged produces a delta carrying a number and no contents:
+// the builder short-circuits on "nothing in this window changed", every agent acknowledges
+// the new version, and every one of them goes on enforcing the old answer while the
+// convergence metric calls them current.
+func TestOptingOutIsADeltaOnItsOwn(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+	before := f.headVersion()
+
+	f.setFailClosed(false)
+
+	if after := f.headVersion(); after == before {
+		t.Fatal("opting out did not move the state version, so no agent will ever be told")
+	}
+	got := f.stateFor(alice.membershipID, before)
+	if got.GetTunnel() == nil {
+		t.Fatal("the delta announcing the change carries no tunnel configuration")
+	}
+	if policy := got.GetTunnel().GetFailClosedPolicy(); policy != meshpv1.TunnelConfig_FAIL_CLOSED_DISABLED {
+		t.Errorf("fail_closed_policy = %v, want DISABLED", policy)
+	}
+}
+
+// Writing the value a network already holds tells nobody. Every agent would otherwise be
+// handed a delta for a reconfiguration that did not happen, which in a log is
+// indistinguishable from one that did.
+func TestWritingTheSameAnswerChangesNothing(t *testing.T) {
+	f := newFixture(t)
+	f.enrolDevice("alice")
+
+	f.setFailClosed(false)
+	before := f.headVersion()
+
+	changed, err := f.store.SetEgressFailClosed(f.ctx, f.netID, false)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	if changed {
+		t.Error("writing the same answer reported a change")
+	}
+	if after := f.headVersion(); after != before {
+		t.Errorf("state version moved from %d to %d for a write that changed nothing", before, after)
+	}
+}
+
+// A device reconnecting is sent a snapshot, which must carry the answer as well. An agent
+// that reconnected after an opt-out and got a snapshot with no opinion in it would go back
+// to enforcing, and the administrator's decision would last until the next restart.
+func TestASnapshotCarriesTheAnswer(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+	f.setFailClosed(false)
+
+	snapshot, err := NewStateBuilder(f.store).Snapshot(f.ctx, alice.membershipID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if policy := snapshot.GetTunnel().GetFailClosedPolicy(); policy != meshpv1.TunnelConfig_FAIL_CLOSED_DISABLED {
+		t.Errorf("fail_closed_policy = %v in a snapshot, want DISABLED", policy)
+	}
+}
+
+// Two networks, two answers. A control plane serving several tenants must not let one
+// administrator's opt-out reach anybody else's devices.
+func TestTheAnswerIsPerNetwork(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+	f.setFailClosed(false)
+
+	other := f.otherNetwork("second")
+	stranger := f.enrolDeviceIn(other, "stranger")
+
+	if policy := f.stateFor(alice.membershipID, 0).GetTunnel().GetFailClosedPolicy(); policy != meshpv1.TunnelConfig_FAIL_CLOSED_DISABLED {
+		t.Errorf("the network that opted out sends %v", policy)
+	}
+	if policy := f.stateFor(stranger.membershipID, 0).GetTunnel().GetFailClosedPolicy(); policy == meshpv1.TunnelConfig_FAIL_CLOSED_DISABLED {
+		t.Error("one network's opt-out told another network's devices to fail open")
+	}
+}

--- a/internal/session/server_test.go
+++ b/internal/session/server_test.go
@@ -175,8 +175,14 @@ type device struct {
 	addressV4    string
 }
 
-// enrolDevice puts a device in the network the way `meshp join` does.
+// enrolDevice puts a device in the fixture's network the way `meshp join` does.
 func (f *fixture) enrolDevice(name string) device {
+	f.t.Helper()
+	return f.enrolDeviceIn(f.netID, name)
+}
+
+// enrolDeviceIn puts a device in a named network, for the tests that need more than one.
+func (f *fixture) enrolDeviceIn(networkID uuid.UUID, name string) device {
 	f.t.Helper()
 
 	tok, err := enroll.NewToken()
@@ -184,7 +190,7 @@ func (f *fixture) enrolDevice(name string) device {
 		f.t.Fatal(err)
 	}
 	if _, err := f.store.Queries().CreateEnrollmentToken(f.ctx, dbgen.CreateEnrollmentTokenParams{
-		NetworkID: f.netID, OrganizationID: f.orgID, TokenHash: tok.Hash,
+		NetworkID: networkID, OrganizationID: f.orgID, TokenHash: tok.Hash,
 		PreassignedTags: []string{}, MaxUses: 1, ExpiresAt: f.clk.Now().Add(time.Hour),
 	}); err != nil {
 		f.t.Fatal(err)

--- a/internal/session/state.go
+++ b/internal/session/state.go
@@ -145,7 +145,7 @@ func (b *StateBuilder) snapshotFromPeers(ctx context.Context, membership dbgen.G
 		FromVersion: 0,
 		ToVersion:   uint64(membership.StateVersion),
 		UpsertPeers: make([]*meshpv1.Peer, 0, len(peers)),
-		Tunnel:      b.tunnelConfig(),
+		Tunnel:      b.tunnelConfig(membership),
 		Relays:      b.relays,
 	}
 	for _, p := range peers {
@@ -205,6 +205,14 @@ func (b *StateBuilder) delta(ctx context.Context, membership dbgen.GetMembership
 			// recomputes the assignments rather than touching peers.
 			routesChanged = true
 
+		case "tunnel":
+			// Nothing to set. TunnelConfig is attached to every delta below, so this row's
+			// only job is to exist: it is what stops the builder short-circuiting on "nothing
+			// in this window changed" and sending a version number with no contents. Handled
+			// explicitly rather than by falling through the switch, so that a reader looking
+			// for where 'tunnel' is dealt with finds this instead of concluding it was
+			// forgotten.
+
 		case "peer_upsert":
 			if change.MembershipID == nil {
 				continue // the membership was deleted; its removal is logged separately
@@ -229,7 +237,7 @@ func (b *StateBuilder) delta(ctx context.Context, membership dbgen.GetMembership
 		// agent that missed the snapshot carrying it would have peers naming a relay it
 		// knows nothing about.
 		Relays: b.relays,
-		Tunnel: b.tunnelConfig(),
+		Tunnel: b.tunnelConfig(membership),
 	}
 
 	for id := range upserts {
@@ -315,7 +323,17 @@ func (b *StateBuilder) preferredRelay() *meshpv1.RelayConfig_Relay {
 	return b.relays.GetRelays()[0]
 }
 
-func (b *StateBuilder) tunnelConfig() *meshpv1.TunnelConfig {
+// tunnelConfig is what every delta and every snapshot tells a device about its tunnel.
+//
+// Takes the membership rather than reading the network again, and that is the load-bearing
+// detail. TunnelConfig goes out with every delta, while route group assignments are only
+// recomputed when routes changed — so anything here that needed its own query would be a
+// query somebody could later decide to skip on the cheap path. The fail-closed answer would
+// then be right on the deltas that mention routes and wrong on the ones that do not, and
+// being wrong means telling a device that is still carrying a default route to stop
+// refusing egress outside it. The membership row is loaded before any of this runs and
+// already carries the column.
+func (b *StateBuilder) tunnelConfig(membership dbgen.GetMembershipForSessionRow) *meshpv1.TunnelConfig {
 	// 1420 leaves room for WireGuard's overhead inside a 1500-byte path.
 	mtu := uint32(1420)
 
@@ -333,16 +351,28 @@ func (b *StateBuilder) tunnelConfig() *meshpv1.TunnelConfig {
 	}
 
 	return &meshpv1.TunnelConfig{
-		Mtu: mtu,
-		// Left unset, which the agent reads as closed (ADR-0011). Sending an explicit false
-		// would be this control plane asking every device to leak if its tunnel drops, and
-		// nothing here has been told to want that — an administrator opting out is a
-		// decision that needs somewhere to be recorded first, and there is nowhere yet.
-		//
-		// Unset rather than an explicit true for the same reason: what is stored is what an
-		// operator chose, and nobody has chosen anything.
-		FailClosedPolicy: meshpv1.TunnelConfig_FAIL_CLOSED_UNSPECIFIED,
+		Mtu:              mtu,
+		FailClosedPolicy: failClosedPolicy(membership.EgressFailClosed),
 	}
+}
+
+// failClosedPolicy renders the stored answer onto the wire.
+//
+// Only the opt-out is ever stated. The column defaults to true, so a network holding true is
+// a network nobody has said anything about — and ENFORCED would report that as a decision an
+// administrator made. UNSPECIFIED is the honest word for it, and the agent reads it as closed
+// anyway (ADR-0011), so nothing about the device's behaviour turns on the difference. What
+// turns on it is whether the control plane is describing the world accurately, which is worth
+// more here than a symmetry between the two branches.
+//
+// DISABLED is stated explicitly, because there the difference does matter: the agent must be
+// able to tell an administrator who chose to fail open from a control plane too old to have
+// an opinion, and only one of those may take the lock off.
+func failClosedPolicy(enforced bool) meshpv1.TunnelConfig_FailClosed {
+	if enforced {
+		return meshpv1.TunnelConfig_FAIL_CLOSED_UNSPECIFIED
+	}
+	return meshpv1.TunnelConfig_FAIL_CLOSED_DISABLED
 }
 
 // allowedIPs renders a peer's addresses as single-host prefixes.

--- a/internal/store/egress.go
+++ b/internal/store/egress.go
@@ -1,0 +1,77 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	dbgen "github.com/meshpnet/meshp/internal/store/gen"
+)
+
+// ErrNoSuchNetwork means the network named does not exist, or has been deleted.
+var ErrNoSuchNetwork = errors.New("store: no such network")
+
+// EgressFailClosed reports whether devices in this network must refuse egress outside the
+// tunnel while they claim a default route.
+func (s *Store) EgressFailClosed(ctx context.Context, networkID uuid.UUID) (bool, error) {
+	network, err := s.Queries().GetNetwork(ctx, networkID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, ErrNoSuchNetwork
+	}
+	if err != nil {
+		return false, fmt.Errorf("store: loading the network: %w", err)
+	}
+	return network.EgressFailClosed, nil
+}
+
+// SetEgressFailClosed records an administrator's answer to ADR-0011 for one network.
+//
+// True is the default and means a device claiming a default route installs a firewall that
+// refuses everything not going through the tunnel. False means it does not, so traffic
+// leaves in the clear if the tunnel drops — which is a decision worth being able to make,
+// and worth being unable to make by accident.
+//
+// Reports whether anything changed. A write of the value the network already holds bumps
+// nothing and tells nobody: every agent would otherwise be handed a delta for a
+// reconfiguration that did not happen, and in a log that is indistinguishable from one that
+// did.
+//
+// The write and the version bump share a transaction, like every other mutation here. A
+// column changed without a logged change reaches no agent until something unrelated moves
+// the version — and for this column that means devices going on enforcing a policy their
+// administrator has already revoked, with the API reporting success.
+func (s *Store) SetEgressFailClosed(ctx context.Context, networkID uuid.UUID, enforced bool) (bool, error) {
+	changed := false
+	err := s.InTx(ctx, func(q *dbgen.Queries) error {
+		row, err := q.SetNetworkEgressFailClosed(ctx, dbgen.SetNetworkEgressFailClosedParams{
+			ID:               networkID,
+			EgressFailClosed: enforced,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNoSuchNetwork
+		}
+		if err != nil {
+			return fmt.Errorf("store: recording the fail-closed policy: %w", err)
+		}
+		if !row.Changed {
+			return nil
+		}
+
+		// TunnelChanged rather than RoutesChanged, though this is about egress. What
+		// changed is the tunnel configuration every device is sent, not who carries a
+		// prefix; logging it as a route change would make every agent in the network
+		// recompute and reinstall assignments that did not move.
+		if _, err := BumpVersion(ctx, q, networkID, TunnelChanged()); err != nil {
+			return err
+		}
+		changed = true
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return changed, nil
+}

--- a/internal/store/egress_test.go
+++ b/internal/store/egress_test.go
@@ -1,0 +1,130 @@
+package store
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// A tunnel change is about every device at once, so it names none — and it is exactly one
+// sort of thing, so a Change that claims to be two is refused rather than silently written
+// as whichever the switch happened to reach first.
+func TestTunnelChangeNamesNoPeer(t *testing.T) {
+	kind, err := TunnelChanged().kind()
+	if err != nil || kind != "tunnel" {
+		t.Fatalf("kind = %q, %v", kind, err)
+	}
+
+	id := uuid.New()
+	key := "a-key"
+	for name, change := range map[string]Change{
+		"a tunnel change naming a peer":         {Tunnel: true, MembershipID: &id},
+		"a tunnel change naming a removed key":  {Tunnel: true, PeerPublicKey: &key},
+		"both a tunnel and a policy change":     {Tunnel: true, Policy: true},
+		"both a tunnel and a route change":      {Tunnel: true, Routes: true},
+		"a change that says it is three things": {Tunnel: true, Routes: true, Policy: true},
+	} {
+		if _, err := change.kind(); err == nil {
+			t.Errorf("%s was accepted", name)
+		}
+	}
+}
+
+// The column exists so an administrator can answer ADR-0011, and the answer has to survive
+// being written and read back. A network nobody has configured enforces.
+func TestEgressFailClosedDefaultsToEnforcing(t *testing.T) {
+	s, _ := seedNetwork(t)
+
+	enforced, err := s.EgressFailClosed(testContext(t), s.netID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !enforced {
+		t.Error("a network nobody has configured does not enforce")
+	}
+}
+
+// The write and the version bump share a transaction, so a stored answer is always one that
+// has been logged for agents to collect. Checked through the log rather than through the
+// version alone: a bump with nothing logged produces a delta with a number and no contents,
+// which every agent acknowledges while continuing to enforce the old answer.
+func TestOptingOutLogsAChangeAgentsCanSee(t *testing.T) {
+	s, _ := seedNetwork(t)
+	ctx := testContext(t)
+
+	changed, err := s.SetEgressFailClosed(ctx, s.netID, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("the first write reported no change")
+	}
+
+	var kind string
+	var version int64
+	if err := s.pool.QueryRow(ctx,
+		`SELECT kind, version FROM state_changes WHERE network_id = $1 ORDER BY id DESC LIMIT 1`,
+		s.netID).Scan(&kind, &version); err != nil {
+		t.Fatalf("no change was logged: %v", err)
+	}
+	if kind != "tunnel" {
+		t.Errorf("logged kind = %q, want tunnel", kind)
+	}
+
+	var head int64
+	if err := s.pool.QueryRow(ctx,
+		`SELECT state_version FROM networks WHERE id = $1`, s.netID).Scan(&head); err != nil {
+		t.Fatal(err)
+	}
+	if version != head {
+		t.Errorf("the change was logged at version %d while the network is at %d", version, head)
+	}
+}
+
+// Writing the value a network already holds must not bump anything. Every agent would
+// otherwise be handed a delta for a reconfiguration that did not happen.
+func TestWritingTheSameAnswerLogsNothing(t *testing.T) {
+	s, _ := seedNetwork(t)
+	ctx := testContext(t)
+
+	if _, err := s.SetEgressFailClosed(ctx, s.netID, false); err != nil {
+		t.Fatal(err)
+	}
+	var before int64
+	if err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM state_changes WHERE network_id = $1`, s.netID).Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := s.SetEgressFailClosed(ctx, s.netID, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("writing the same answer reported a change")
+	}
+
+	var after int64
+	if err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM state_changes WHERE network_id = $1`, s.netID).Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if after != before {
+		t.Errorf("%d changes logged for a write that changed nothing", after-before)
+	}
+}
+
+// A network that is not there is told apart from one that is, rather than reported as a
+// success that stored nothing.
+func TestSettingItOnAnUnknownNetworkIsRefused(t *testing.T) {
+	s, _ := seedNetwork(t)
+	ctx := testContext(t)
+
+	if _, err := s.SetEgressFailClosed(ctx, uuid.New(), false); !errors.Is(err, ErrNoSuchNetwork) {
+		t.Errorf("err = %v, want ErrNoSuchNetwork", err)
+	}
+	if _, err := s.EgressFailClosed(ctx, uuid.New()); !errors.Is(err, ErrNoSuchNetwork) {
+		t.Errorf("reading gave err = %v, want ErrNoSuchNetwork", err)
+	}
+}

--- a/internal/store/gen/models.go
+++ b/internal/store/gen/models.go
@@ -178,6 +178,8 @@ type Network struct {
 	DeletedAt      *time.Time
 	// Deltas can be computed from this version onward; below it, agents are sent a snapshot.
 	OldestDeltaVersion int64
+	// False means devices claiming a default route in this network may let traffic leave outside the tunnel if it drops. True is the default and is sent as unspecified, because the column defaulting to true is not the same as an administrator choosing it.
+	EgressFailClosed bool
 }
 
 type Organization struct {

--- a/internal/store/gen/networks.sql.go
+++ b/internal/store/gen/networks.sql.go
@@ -90,7 +90,7 @@ func (q *Queries) GetConvergenceLag(ctx context.Context, networkID uuid.UUID) ([
 
 const getNetwork = `-- name: GetNetwork :one
 
-SELECT id, organization_id, slug, name, state_version, created_at, updated_at, deleted_at, oldest_delta_version FROM networks
+SELECT id, organization_id, slug, name, state_version, created_at, updated_at, deleted_at, oldest_delta_version, egress_fail_closed FROM networks
 WHERE id = $1 AND deleted_at IS NULL
 `
 
@@ -112,6 +112,7 @@ func (q *Queries) GetNetwork(ctx context.Context, id uuid.UUID) (Network, error)
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.OldestDeltaVersion,
+		&i.EgressFailClosed,
 	)
 	return i, err
 }
@@ -159,7 +160,7 @@ func (q *Queries) ListActiveMemberships(ctx context.Context, networkID uuid.UUID
 }
 
 const listNetworksForOrganization = `-- name: ListNetworksForOrganization :many
-SELECT id, organization_id, slug, name, state_version, created_at, updated_at, deleted_at, oldest_delta_version FROM networks
+SELECT id, organization_id, slug, name, state_version, created_at, updated_at, deleted_at, oldest_delta_version, egress_fail_closed FROM networks
 WHERE organization_id = $1 AND deleted_at IS NULL
 ORDER BY name
 `
@@ -183,6 +184,7 @@ func (q *Queries) ListNetworksForOrganization(ctx context.Context, organizationI
 			&i.UpdatedAt,
 			&i.DeletedAt,
 			&i.OldestDeltaVersion,
+			&i.EgressFailClosed,
 		); err != nil {
 			return nil, err
 		}
@@ -192,4 +194,57 @@ func (q *Queries) ListNetworksForOrganization(ctx context.Context, organizationI
 		return nil, err
 	}
 	return items, nil
+}
+
+const setNetworkEgressFailClosed = `-- name: SetNetworkEgressFailClosed :one
+WITH locked AS (
+    SELECT before.id, before.egress_fail_closed
+    FROM networks before
+    WHERE before.id = $1 AND before.deleted_at IS NULL
+    FOR UPDATE
+), updated AS (
+    UPDATE networks after
+    SET egress_fail_closed = $2::boolean,
+        updated_at = now()
+    FROM locked
+    WHERE after.id = locked.id
+    RETURNING after.egress_fail_closed
+)
+SELECT
+    updated.egress_fail_closed,
+    (updated.egress_fail_closed IS DISTINCT FROM locked.egress_fail_closed)::boolean AS changed
+FROM updated, locked
+`
+
+type SetNetworkEgressFailClosedParams struct {
+	ID               uuid.UUID
+	EgressFailClosed bool
+}
+
+type SetNetworkEgressFailClosedRow struct {
+	EgressFailClosed bool
+	Changed          bool
+}
+
+// Records whether devices in this network must refuse egress outside the tunnel
+// while they claim a default route (ADR-0011).
+//
+// Returns whether this actually changed anything, so the caller can decide
+// whether the network needs telling. Writing the same value again and bumping the
+// version regardless would send every agent in the network a delta describing a
+// change that did not happen, which is churn that looks exactly like a real
+// reconfiguration in the logs.
+//
+// Written as a CTE because RETURNING sees the row after the write, so an UPDATE
+// alone cannot say what the value used to be. The old row is read and locked
+// first, which also settles two administrators flipping this at once: the second
+// waits, re-reads, and reports honestly that it changed nothing.
+//
+// No row comes back for a network that does not exist or has been deleted, which
+// is how the caller tells that apart from a no-op write.
+func (q *Queries) SetNetworkEgressFailClosed(ctx context.Context, arg SetNetworkEgressFailClosedParams) (SetNetworkEgressFailClosedRow, error) {
+	row := q.db.QueryRow(ctx, setNetworkEgressFailClosed, arg.ID, arg.EgressFailClosed)
+	var i SetNetworkEgressFailClosedRow
+	err := row.Scan(&i.EgressFailClosed, &i.Changed)
+	return i, err
 }

--- a/internal/store/gen/sessions.sql.go
+++ b/internal/store/gen/sessions.sql.go
@@ -27,7 +27,13 @@ SELECT
     d.name            AS device_name,
     d.revoked_at      AS device_revoked_at,
     n.state_version,
-    n.organization_id
+    n.organization_id,
+    -- Selected here rather than fetched when a delta needs it, because a delta
+    -- always needs it: TunnelConfig rides on every one. Reading it from a row the
+    -- session already has means there is no second query that could be skipped on
+    -- the path where routes did not change — which is how a device still carrying
+    -- a default route would be told to stop failing closed.
+    n.egress_fail_closed
 FROM device_network_memberships m
 JOIN devices d  ON d.id = m.device_id
 JOIN networks n ON n.id = m.network_id
@@ -48,6 +54,7 @@ type GetMembershipForSessionRow struct {
 	DeviceRevokedAt   *time.Time
 	StateVersion      int64
 	OrganizationID    uuid.UUID
+	EgressFailClosed  bool
 }
 
 // Everything needed to authenticate a control-channel session, in one round trip.
@@ -73,6 +80,7 @@ func (q *Queries) GetMembershipForSession(ctx context.Context, id uuid.UUID) (Ge
 		&i.DeviceRevokedAt,
 		&i.StateVersion,
 		&i.OrganizationID,
+		&i.EgressFailClosed,
 	)
 	return i, err
 }

--- a/internal/store/statelog.go
+++ b/internal/store/statelog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -28,6 +29,10 @@ type Change struct {
 	// Routes marks a change to a route group or its advertisers, which names no peer for
 	// the same reason.
 	Routes bool
+
+	// Tunnel marks a change to the network's tunnel configuration — today, whether devices
+	// claiming a default route must fail closed. It names no peer for the same reason again.
+	Tunnel bool
 }
 
 // PeerUpserted records that a membership's peer state changed.
@@ -55,6 +60,15 @@ func RoutesChanged() Change { return Change{Routes: true} }
 // membership: a policy edit in a 500-device network would otherwise write 500 rows and
 // produce 500-entry deltas describing peers that did not change.
 func PolicyChanged() Change { return Change{Policy: true} }
+
+// TunnelChanged records that the network's tunnel configuration changed.
+//
+// A delta carries TunnelConfig whether or not this row is there, so it is tempting to think
+// the row is redundant. It is not: without something in the log, the builder sees no changes
+// in the window and returns a delta carrying a version number and nothing else. Every agent
+// would acknowledge the new version, the convergence metric would call them current, and
+// every one of them would still be enforcing the old answer.
+func TunnelChanged() Change { return Change{Tunnel: true} }
 
 // BumpVersion advances a network's state version and records what changed, together.
 //
@@ -94,25 +108,37 @@ func BumpVersion(ctx context.Context, q *dbgen.Queries, networkID uuid.UUID, cha
 }
 
 // kind reports which sort of change this is, refusing anything ambiguous.
+//
+// Written as a count rather than a chain of pairwise exclusions. Each new kind would
+// otherwise add a comparison against every existing one, and the entry that is easy to
+// forget is the one that makes two kinds mutually exclusive — which fails by writing a row
+// whose kind is only half of what the caller meant, silently. Here anything that is more
+// than one thing is refused by construction.
 func (c Change) kind() (string, error) {
-	switch {
-	case c.Policy && c.Routes:
-		return "", errors.New("a change is both a policy change and a route change; it must be one")
-	case c.Routes && (c.MembershipID != nil || c.PeerPublicKey != nil):
-		return "", errors.New("a route change also names a peer; it is about all of them")
-	case c.Routes:
-		return "routes", nil
-	case c.Policy && (c.MembershipID != nil || c.PeerPublicKey != nil):
-		return "", errors.New("a policy change also names a peer; it is about all of them")
-	case c.Policy:
-		return "policy", nil
-	case c.MembershipID != nil && c.PeerPublicKey != nil:
-		return "", errors.New("a change names both a membership and a key; it must be one or the other")
-	case c.MembershipID != nil:
-		return "peer_upsert", nil
-	case c.PeerPublicKey != nil:
-		return "peer_remove", nil
+	var kinds []string
+	if c.Policy {
+		kinds = append(kinds, "policy")
+	}
+	if c.Routes {
+		kinds = append(kinds, "routes")
+	}
+	if c.Tunnel {
+		kinds = append(kinds, "tunnel")
+	}
+	if c.MembershipID != nil {
+		kinds = append(kinds, "peer_upsert")
+	}
+	if c.PeerPublicKey != nil {
+		kinds = append(kinds, "peer_remove")
+	}
+
+	switch len(kinds) {
+	case 1:
+		return kinds[0], nil
+	case 0:
+		return "", errors.New("a change describes nothing; it must name a peer or say what else moved")
 	default:
-		return "", errors.New("a change names neither a membership nor a key")
+		return "", fmt.Errorf("a change is %s at once; it must be exactly one",
+			strings.Join(kinds, " and "))
 	}
 }

--- a/migrations/0005_egress_fail_closed.sql
+++ b/migrations/0005_egress_fail_closed.sql
@@ -1,0 +1,103 @@
+-- Somewhere for an administrator to say a network's devices may fail open.
+--
+-- ADR-0011 makes fail-closed the default for a device claiming a default route,
+-- and the agent already honours TunnelConfig.fail_closed_policy. What has been
+-- missing is anywhere for the decision to live, so the control plane has been
+-- sending UNSPECIFIED to everyone — which the agent reads as closed. A policy
+-- with no way to change it is a hard-coded behaviour wearing a policy's clothes
+-- (ADR-0018).
+--
+-- On the network rather than on the egress route group, which is the choice worth
+-- explaining, because ADR-0011 phrases the default in terms of groups.
+--
+-- TunnelConfig is sent with every delta, while route group assignments are only
+-- recomputed when routes changed — that is the whole point of the delta log. A
+-- setting on the group would have to be looked up on every delta anyway to be
+-- correct, and getting it wrong has a specific shape: an unrelated peer update
+-- would compute "no egress group, so nothing to enforce" and tear the lock off a
+-- machine that is still carrying a default route, in the one direction ADR-0011
+-- says must never happen by omission. Here it rides on the membership row the
+-- session already loads, so every delta and every snapshot carries the same
+-- answer without a second query to forget.
+--
+-- The other half is that a device claims at most one default route, so a
+-- per-group setting would need a rule for what happens when a device is assigned
+-- to two egress groups that disagree — a conflict with no honest resolution, for
+-- a distinction nobody has asked for.
+--
+-- Rescuing one bricked laptop is deliberately not what this is for: that is
+-- `meshp doctor` and a local teardown, which work on a machine with no network.
+-- This is the fleet-wide decision ADR-0011 describes.
+
+-- +goose Up
+
+ALTER TABLE networks
+    ADD COLUMN egress_fail_closed boolean NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN networks.egress_fail_closed IS
+    'False means devices claiming a default route in this network may let traffic leave outside the tunnel if it drops. True is the default and is sent as unspecified, because the column defaulting to true is not the same as an administrator choosing it.';
+
+-- A change to the tunnel configuration is a state change, like a policy change
+-- and a route change before it, and the delta log has to be able to say so.
+--
+-- Without a row here, flipping this column would bump the version and send every
+-- agent a delta with a new number and no contents: the builder short-circuits
+-- when nothing in the window changed, and the short-circuit does not carry a
+-- TunnelConfig. Agents would acknowledge the new version, the convergence metric
+-- would say they are current, and every one of them would still be enforcing the
+-- old answer. That is the failure BumpVersion's doc comment warns about, and it
+-- is silent.
+--
+-- It names no membership, for the reason 'policy' and 'routes' name none: it is
+-- about every device in the network at once.
+
+DO $$
+DECLARE c record;
+BEGIN
+    FOR c IN
+        SELECT conname FROM pg_constraint
+        WHERE conrelid = 'state_changes'::regclass AND contype = 'c'
+    LOOP
+        EXECUTE format('ALTER TABLE state_changes DROP CONSTRAINT %I', c.conname);
+    END LOOP;
+END $$;
+
+ALTER TABLE state_changes
+    ADD CONSTRAINT state_changes_kind_check
+    CHECK (kind IN ('peer_upsert', 'peer_remove', 'policy', 'routes', 'tunnel'));
+
+ALTER TABLE state_changes
+    ADD CONSTRAINT state_changes_identifier_check CHECK (
+        (kind = 'peer_upsert' AND membership_id IS NOT NULL) OR
+        (kind = 'peer_remove' AND peer_public_key IS NOT NULL) OR
+        (kind IN ('policy', 'routes', 'tunnel')
+            AND membership_id IS NULL AND peer_public_key IS NULL)
+    );
+
+-- +goose Down
+
+DO $$
+DECLARE c record;
+BEGIN
+    FOR c IN
+        SELECT conname FROM pg_constraint
+        WHERE conrelid = 'state_changes'::regclass AND contype = 'c'
+    LOOP
+        EXECUTE format('ALTER TABLE state_changes DROP CONSTRAINT %I', c.conname);
+    END LOOP;
+END $$;
+
+DELETE FROM state_changes WHERE kind = 'tunnel';
+
+ALTER TABLE state_changes
+    ADD CONSTRAINT state_changes_kind_check
+    CHECK (kind IN ('peer_upsert', 'peer_remove', 'policy', 'routes'));
+
+ALTER TABLE state_changes
+    ADD CONSTRAINT state_changes_identifier_check CHECK (
+        (kind = 'peer_upsert' AND membership_id IS NOT NULL) OR
+        (kind = 'peer_remove' AND peer_public_key IS NOT NULL) OR
+        (kind IN ('policy', 'routes') AND membership_id IS NULL AND peer_public_key IS NULL)
+    );
+
+ALTER TABLE networks DROP COLUMN IF EXISTS egress_fail_closed;

--- a/queries/networks.sql
+++ b/queries/networks.sql
@@ -13,6 +13,41 @@ SELECT * FROM networks
 WHERE organization_id = $1 AND deleted_at IS NULL
 ORDER BY name;
 
+-- name: SetNetworkEgressFailClosed :one
+-- Records whether devices in this network must refuse egress outside the tunnel
+-- while they claim a default route (ADR-0011).
+--
+-- Returns whether this actually changed anything, so the caller can decide
+-- whether the network needs telling. Writing the same value again and bumping the
+-- version regardless would send every agent in the network a delta describing a
+-- change that did not happen, which is churn that looks exactly like a real
+-- reconfiguration in the logs.
+--
+-- Written as a CTE because RETURNING sees the row after the write, so an UPDATE
+-- alone cannot say what the value used to be. The old row is read and locked
+-- first, which also settles two administrators flipping this at once: the second
+-- waits, re-reads, and reports honestly that it changed nothing.
+--
+-- No row comes back for a network that does not exist or has been deleted, which
+-- is how the caller tells that apart from a no-op write.
+WITH locked AS (
+    SELECT before.id, before.egress_fail_closed
+    FROM networks before
+    WHERE before.id = $1 AND before.deleted_at IS NULL
+    FOR UPDATE
+), updated AS (
+    UPDATE networks after
+    SET egress_fail_closed = sqlc.arg(egress_fail_closed)::boolean,
+        updated_at = now()
+    FROM locked
+    WHERE after.id = locked.id
+    RETURNING after.egress_fail_closed
+)
+SELECT
+    updated.egress_fail_closed,
+    (updated.egress_fail_closed IS DISTINCT FROM locked.egress_fail_closed)::boolean AS changed
+FROM updated, locked;
+
 -- name: BumpNetworkStateVersion :one
 -- Called exactly once per mutation that changes what any agent should do.
 -- Returns the new version so the caller can hand it to the delta computation.

--- a/queries/sessions.sql
+++ b/queries/sessions.sql
@@ -18,7 +18,13 @@ SELECT
     d.name            AS device_name,
     d.revoked_at      AS device_revoked_at,
     n.state_version,
-    n.organization_id
+    n.organization_id,
+    -- Selected here rather than fetched when a delta needs it, because a delta
+    -- always needs it: TunnelConfig rides on every one. Reading it from a row the
+    -- session already has means there is no second query that could be skipped on
+    -- the path where routes did not change — which is how a device still carrying
+    -- a default route would be told to stop failing closed.
+    n.egress_fail_closed
 FROM device_network_memberships m
 JOIN devices d  ON d.id = m.device_id
 JOIN networks n ON n.id = m.network_id


### PR DESCRIPTION
Closes the last loose end in the fail-closed work. The agent has honoured `TunnelConfig.fail_closed_policy` since #57; the control plane has been sending `UNSPECIFIED` to everyone because there was nowhere for an administrator to record a decision. A policy nobody can change is a hard-coded behaviour wearing a policy's clothes — ADR-0018's shape exactly.

## Using it

```bash
curl -sX PUT -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
  -d '{"enforced":false}' \
  "$CONTROL/api/v1/networks/$NETWORK/egress-fail-closed"
```

`GET` on the same path reads it back. Both are behind the admin token.

## Where the setting lives, and why

On the network, not on the egress route group — worth explaining, because ADR-0011 phrases the default in terms of groups.

`TunnelConfig` is sent with **every** delta, while route group assignments are only recomputed when routes changed. A setting on the group would have to be looked up on every delta anyway to be correct, and getting it wrong has a specific shape: an unrelated peer joining computes *"no egress group here, nothing to enforce"* and tears the lock off a machine that is still carrying a default route — leaking by omission, the one direction ADR-0011 says must never happen. Here it rides on the membership row the session already loads, so every delta and every snapshot carry the same answer and there is no second query anyone could later decide to skip.

The other half: a device claims at most one default route. A per-group setting would need a rule for what happens when a device is assigned to two egress groups that disagree — a conflict with no honest resolution, for a distinction nobody has asked for.

Rescuing one bricked laptop is deliberately not what this is for. That is `meshp doctor` and a local teardown, which work on a machine with no network. This is the fleet-wide decision ADR-0011 describes.

## Three things that would have been silently wrong

**Only the opt-out is stated.** The column defaults to true, so a network holding true is one nobody has said anything about. Sending `ENFORCED` would report a decision an administrator never made. `UNSPECIFIED` is the honest word, and the agent reads it as closed anyway — nothing about the device's behaviour turns on the difference, only whether the control plane is describing the world accurately.

**Flipping it logs a `tunnel` state change, not just a version bump.** Without a row in the log the builder short-circuits on "nothing in this window changed" and sends a version number with no contents. Every agent acknowledges it, the convergence metric calls them current, and every one of them goes on enforcing the old answer.

**`enforced` is a pointer, and a body that omits it is refused.** Go's zero value for a bool is false, which here means every device in the network may leak. `{}`, an explicit null, or a script whose variable was empty would each otherwise turn off a safety property and be answered with a 200. `decode` already refuses unknown fields, which closes the `{"enforce":false}` half.

## Verification

`make ci`, `make integration` and `make migrate-check` (apply → roll back → re-apply) all green.

Eleven mutations, all caught:

| Mutation | Caught by |
|---|---|
| Attach `TunnelConfig` only when routes changed | `TestAnUnrelatedPeerChangeCarriesTheSameAnswer` |
| Report `ENFORCED` for a default nobody chose | `TestANetworkWithNoOpinionSendsNone` |
| Send the same answer regardless of what is stored | 5 tests |
| Store the answer without logging a change | store + session |
| Bump the version but log nothing (the silent one) | `TestOptingOutIsADeltaOnItsOwn` |
| Log it as a `routes` change instead | `TestOptingOutLogsAChangeAgentsCanSee` |
| Bump on every write, changed or not | 2 tests |
| The naive `UPDATE ... RETURNING`, comparing the new value with itself | 4 tests |
| Always report a change | 3 tests |
| A plain `bool` in the request body | `TestTurningItOffHasToBeSaidOutLoud` |
| Drop the push to connected agents | `TestOptingOutReachesAConnectedAgent` |

That last one needed a new test to catch: a real agent over the shipping session client, an admin API request, and the agent's enforced policy changing well inside the 25-second heartbeat. A longer timeout could not tell a working push from a missing one.

## Also here

`Change.kind()` was a chain of pairwise exclusions, where each new kind adds a comparison against every existing one and the easy thing to forget is the entry that makes two kinds mutually exclusive — failing by writing a row whose kind is half of what the caller meant. Rewritten as a count, so anything that is more than one thing is refused by construction.

## Not in scope

No `meshp` CLI subcommand: there is no admin command group yet, and #64 (`meshp network create`) is open as a good-first-issue that would establish one.
