### PR TITLE
feat(routes): the failover policy an administrator writes now reaches the agent

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -125,6 +125,7 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	mux.Handle("DELETE /api/v1/networks/{networkID}/route-groups/{slug}", s.adminOnly(s.handleDeleteRouteGroup))
 	mux.Handle("POST /api/v1/networks/{networkID}/route-groups/{slug}/advertisers", s.adminOnly(s.handleAdvertise))
 	mux.Handle("DELETE /api/v1/networks/{networkID}/route-groups/{slug}/advertisers/{membershipID}", s.adminOnly(s.handleWithdraw))
+	mux.Handle("PUT /api/v1/networks/{networkID}/route-groups/{slug}/failover", s.adminOnly(s.handleSetRouteGroupFailover))
 }
 
 // rateLimited wraps an unauthenticated handler.

--- a/internal/api/failover.go
+++ b/internal/api/failover.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/meshpnet/meshp/internal/httpx"
+	"github.com/meshpnet/meshp/internal/logx"
+	"github.com/meshpnet/meshp/internal/store"
+)
+
+// failoverPolicy is how an administrator writes a route group's local failover policy.
+//
+// Every field is a pointer, so "not mentioned" is told from "set to zero". It matters
+// differently for each: an absent `enabled` must mean the default rather than false, since
+// false is the setting that stops a device leaving a dead advertiser; and an absent threshold
+// must mean the agent's default rather than zero, since zero would be a device that moves
+// before it has probed anything.
+type failoverPolicy struct {
+	Enabled          *bool   `json:"enabled"`
+	FailThreshold    *uint32 `json:"fail_threshold"`
+	RecoverThreshold *uint32 `json:"recover_threshold"`
+	MinHoldSeconds   *uint32 `json:"min_hold_seconds"`
+}
+
+func (p failoverPolicy) toStore() store.FailoverPolicy {
+	out := store.DefaultFailoverPolicy()
+	if p.Enabled != nil {
+		enabled := *p.Enabled
+		out.Enabled = &enabled
+	}
+	if p.FailThreshold != nil {
+		out.FailThreshold = *p.FailThreshold
+	}
+	if p.RecoverThreshold != nil {
+		out.RecoverThreshold = *p.RecoverThreshold
+	}
+	if p.MinHoldSeconds != nil {
+		out.MinHoldSeconds = *p.MinHoldSeconds
+	}
+	return out
+}
+
+// renderFailover is what the API says a group's policy is.
+//
+// The stored numbers verbatim, zeros included, rather than the defaults the agent would
+// apply in their place. An operator reading this back needs to know what is written down: a
+// response that showed 3 where nothing is stored would make an unset field look like a
+// decision, and the next person to raise the agent's default would be surprised twice.
+func renderFailover(p store.FailoverPolicy) map[string]any {
+	return map[string]any{
+		"enabled":           p.MayMove(),
+		"fail_threshold":    p.FailThreshold,
+		"recover_threshold": p.RecoverThreshold,
+		"min_hold_seconds":  p.MinHoldSeconds,
+	}
+}
+
+// handleSetRouteGroupFailover replaces a group's local failover policy.
+//
+// A PUT of the whole policy rather than a PATCH of parts. The numbers only mean anything
+// together — a fail threshold of one beside a recover threshold left from a previous edit is
+// a device that moves on the first lost packet and takes ten successes to come back — so
+// anything not named here goes back to its default rather than keeping whatever was there.
+func (s *Server) handleSetRouteGroupFailover(w http.ResponseWriter, r *http.Request) {
+	networkID, ok := s.pathUUID(w, r, "networkID")
+	if !ok {
+		return
+	}
+	slug := r.PathValue("slug")
+
+	var body failoverPolicy
+	if err := decode(w, r, &body); err != nil {
+		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
+	group, err := s.store.SetRouteGroupFailover(r.Context(), networkID, slug, body.toStore())
+	if errors.Is(err, store.ErrNoSuchRouteGroup) {
+		httpx.Error(w, s.log, http.StatusNotFound, "not_found", "no such route group in this network")
+		return
+	}
+	if err != nil {
+		s.respondError(w, r, err)
+		return
+	}
+
+	// Through logx.Safe for the reason handleAdvertise gives: this slug names a group to look
+	// up rather than one to create, so nothing has checked its shape.
+	s.log.Info("failover policy recorded",
+		"network_id", networkID, "slug", logx.Safe(slug),
+		"enabled", group.Failover.MayMove(),
+		"fail_threshold", group.Failover.FailThreshold,
+		"recover_threshold", group.Failover.RecoverThreshold,
+		"min_hold_seconds", group.Failover.MinHoldSeconds)
+
+	// How patient a device is about moving is desired state for every device that carries
+	// this group, so everyone needs telling.
+	s.tellNetwork(networkID)
+	httpx.WriteJSON(w, s.log, http.StatusOK, renderGroup(group))
+}

--- a/internal/api/failover_test.go
+++ b/internal/api/failover_test.go
@@ -1,0 +1,214 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// groupFailover is a group's policy as the API reports it.
+type groupFailover struct {
+	status           int
+	Enabled          bool   `json:"enabled"`
+	FailThreshold    uint32 `json:"fail_threshold"`
+	RecoverThreshold uint32 `json:"recover_threshold"`
+	MinHoldSeconds   uint32 `json:"min_hold_seconds"`
+}
+
+// setFailover puts a policy and reports what came back.
+func (h *harness) setFailover(slug, body string) groupFailover {
+	h.t.Helper()
+	req := mustRequest(h.t, http.MethodPut,
+		h.server.URL+h.netPath("/route-groups/"+slug+"/failover"), body)
+	req.Header.Set("Authorization", "Bearer "+testAdminToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	out := groupFailover{status: resp.StatusCode}
+	if resp.StatusCode != http.StatusOK {
+		return out
+	}
+	var wrapper struct {
+		LocalFailover groupFailover `json:"local_failover"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&wrapper); err != nil {
+		h.t.Fatal(err)
+	}
+	wrapper.LocalFailover.status = resp.StatusCode
+	return wrapper.LocalFailover
+}
+
+// readFailover reads one group's policy back out of the list.
+func (h *harness) readFailover(slug string) groupFailover {
+	h.t.Helper()
+	req := mustRequest(h.t, http.MethodGet, h.server.URL+h.netPath("/route-groups"), "")
+	req.Header.Set("Authorization", "Bearer "+testAdminToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var out struct {
+		RouteGroups []struct {
+			Slug          string        `json:"slug"`
+			LocalFailover groupFailover `json:"local_failover"`
+		} `json:"route_groups"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		h.t.Fatal(err)
+	}
+	for _, g := range out.RouteGroups {
+		if g.Slug == slug {
+			g.LocalFailover.status = resp.StatusCode
+			return g.LocalFailover
+		}
+	}
+	h.t.Fatalf("no group %q in the listing", slug)
+	return groupFailover{}
+}
+
+func (h *harness) branchGroup(t *testing.T, body string) {
+	t.Helper()
+	resp := h.post(h.netPath("/route-groups"), body)
+	status := resp.StatusCode
+	_ = resp.Body.Close()
+	if status != http.StatusCreated {
+		t.Fatalf("creating the group returned %d", status)
+	}
+}
+
+// A group created without a policy may move itself, and says so when read back.
+func TestANewGroupMayMoveItself(t *testing.T) {
+	h := newHarness(t)
+	h.branchGroup(t, `{"slug":"branch","kind":"subnet","prefixes":["192.168.10.0/24"]}`)
+
+	got := h.readFailover("branch")
+	if !got.Enabled {
+		t.Error("a group nobody configured reports that its devices may not move themselves")
+	}
+	// Unset rather than the agent's defaults. An operator reading this needs to know what is
+	// written down; showing 3 where nothing is stored makes an unset field look chosen.
+	if got.FailThreshold != 0 || got.RecoverThreshold != 0 || got.MinHoldSeconds != 0 {
+		t.Errorf("an unconfigured group reports thresholds: %+v", got)
+	}
+}
+
+func TestSettingAPolicyOnCreation(t *testing.T) {
+	h := newHarness(t)
+	h.branchGroup(t, `{"slug":"branch","kind":"subnet","prefixes":["192.168.10.0/24"],
+		"local_failover":{"enabled":true,"fail_threshold":2,"recover_threshold":20,"min_hold_seconds":300}}`)
+
+	got := h.readFailover("branch")
+	if !got.Enabled || got.FailThreshold != 2 || got.RecoverThreshold != 20 || got.MinHoldSeconds != 300 {
+		t.Errorf("read back %+v", got)
+	}
+}
+
+func TestChangingAPolicyLater(t *testing.T) {
+	h := newHarness(t)
+	h.branchGroup(t, `{"slug":"branch","kind":"subnet","prefixes":["192.168.10.0/24"]}`)
+
+	got := h.setFailover("branch", `{"enabled":false,"fail_threshold":2,"recover_threshold":20}`)
+	if got.status != http.StatusOK {
+		t.Fatalf("returned %d", got.status)
+	}
+	if got.Enabled {
+		t.Error("the opt-out did not take")
+	}
+	if again := h.readFailover("branch"); again.Enabled || again.FailThreshold != 2 {
+		t.Errorf("read back %+v", again)
+	}
+}
+
+// A PUT replaces the whole policy. The numbers only mean anything together, so a field left
+// out goes back to its default rather than keeping whatever was there — otherwise an operator
+// ends up with a fail threshold from today beside a recover threshold from last month.
+func TestAPolicyIsReplacedWhole(t *testing.T) {
+	h := newHarness(t)
+	h.branchGroup(t, `{"slug":"branch","kind":"subnet","prefixes":["192.168.10.0/24"]}`)
+
+	h.setFailover("branch", `{"enabled":true,"fail_threshold":2,"recover_threshold":20,"min_hold_seconds":300}`)
+	h.setFailover("branch", `{"enabled":true,"fail_threshold":5}`)
+
+	got := h.readFailover("branch")
+	if got.FailThreshold != 5 {
+		t.Errorf("fail_threshold = %d, want 5", got.FailThreshold)
+	}
+	if got.RecoverThreshold != 0 || got.MinHoldSeconds != 0 {
+		t.Errorf("fields left out of the replacement survived it: %+v", got)
+	}
+}
+
+// Omitting `enabled` means the default rather than false. False is the setting that stops a
+// device leaving a dead advertiser, and a body that never mentioned it must not turn it on.
+func TestOmittingEnabledDoesNotDisableFailover(t *testing.T) {
+	h := newHarness(t)
+	h.branchGroup(t, `{"slug":"branch","kind":"subnet","prefixes":["192.168.10.0/24"]}`)
+
+	if got := h.setFailover("branch", `{"fail_threshold":2}`); !got.Enabled {
+		t.Error("a policy that did not mention enabled turned local failover off")
+	}
+	if got := h.readFailover("branch"); !got.Enabled {
+		t.Error("and it stuck")
+	}
+}
+
+// A policy that would make a device oscillate is refused, and refused before it is stored.
+func TestABackwardsPolicyIsRefusedByTheAPI(t *testing.T) {
+	h := newHarness(t)
+	h.branchGroup(t, `{"slug":"branch","kind":"subnet","prefixes":["192.168.10.0/24"]}`)
+
+	for _, body := range []string{
+		`{"enabled":true,"fail_threshold":5,"recover_threshold":2}`,
+		`{"enabled":true,"fail_threshold":9999}`,
+		`{"enabled":true,"min_hold_seconds":100000000}`,
+		`{"enabled":true,"fail_treshold":2}`, // a typo, refused rather than ignored
+	} {
+		if got := h.setFailover("branch", body); got.status == http.StatusOK {
+			t.Errorf("%s was accepted", body)
+		}
+	}
+	if got := h.readFailover("branch"); got.FailThreshold != 0 {
+		t.Errorf("a refused policy was stored anyway: %+v", got)
+	}
+}
+
+// A group that is not in this network is a 404, so a typo in a slug does not look like a
+// fleet that has been reconfigured.
+func TestSettingAPolicyOnAnUnknownGroupIsNotFound(t *testing.T) {
+	h := newHarness(t)
+
+	if got := h.setFailover("nope", `{"enabled":true}`); got.status != http.StatusNotFound {
+		t.Errorf("returned %d, want 404", got.status)
+	}
+}
+
+// How patient a device is about moving decides how long a customer's traffic is broken, so
+// it is not something an unauthenticated caller may change.
+func TestFailoverNeedsTheAdminToken(t *testing.T) {
+	h := newHarness(t)
+	h.branchGroup(t, `{"slug":"branch","kind":"subnet","prefixes":["192.168.10.0/24"]}`)
+
+	req, err := http.NewRequest(http.MethodPut,
+		h.server.URL+h.netPath("/route-groups/branch/failover"),
+		bytes.NewReader([]byte(`{"enabled":false}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := resp.StatusCode
+	_ = resp.Body.Close()
+	if status != http.StatusUnauthorized {
+		t.Errorf("an unauthenticated caller got %d", status)
+	}
+}

--- a/internal/api/routegroup.go
+++ b/internal/api/routegroup.go
@@ -24,14 +24,15 @@ func (s *Server) handleCreateRouteGroup(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var body struct {
-		Slug                 string   `json:"slug"`
-		Name                 string   `json:"name"`
-		Kind                 string   `json:"kind"`
-		Prefixes             []string `json:"prefixes"`
-		SelectionMode        string   `json:"selection_mode"`
-		AutoFailback         *bool    `json:"auto_failback"`
-		FailbackDelaySeconds int32    `json:"failback_delay_seconds"`
-		StableEgressIP       string   `json:"stable_egress_ip"`
+		Slug                 string          `json:"slug"`
+		Name                 string          `json:"name"`
+		Kind                 string          `json:"kind"`
+		Prefixes             []string        `json:"prefixes"`
+		SelectionMode        string          `json:"selection_mode"`
+		AutoFailback         *bool           `json:"auto_failback"`
+		FailbackDelaySeconds int32           `json:"failback_delay_seconds"`
+		StableEgressIP       string          `json:"stable_egress_ip"`
+		LocalFailover        *failoverPolicy `json:"local_failover"`
 	}
 	if err := decode(w, r, &body); err != nil {
 		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request", err.Error())
@@ -46,6 +47,14 @@ func (s *Server) handleCreateRouteGroup(w http.ResponseWriter, r *http.Request) 
 		SelectionMode:        body.SelectionMode,
 		AutoFailback:         body.AutoFailback == nil || *body.AutoFailback,
 		FailbackDelaySeconds: body.FailbackDelaySeconds,
+		// Stated rather than left zero. A zero FailoverPolicy behaves identically — Enabled
+		// is a pointer and nil already means "may move" — but the row it stores is `{}`,
+		// and somebody reading this table wants to see what the group's policy is without
+		// having to know which absences are which.
+		Failover: store.DefaultFailoverPolicy(),
+	}
+	if body.LocalFailover != nil {
+		req.Failover = body.LocalFailover.toStore()
 	}
 	for _, raw := range body.Prefixes {
 		prefix, err := netip.ParsePrefix(raw)
@@ -263,6 +272,7 @@ func renderGroup(g store.RouteGroup) map[string]any {
 		"selection_mode":         g.SelectionMode,
 		"auto_failback":          g.AutoFailback,
 		"failback_delay_seconds": g.FailbackDelaySeconds,
+		"local_failover":         renderFailover(g.Failover),
 	}
 	if g.StableEgressIP != nil {
 		out["stable_egress_ip"] = g.StableEgressIP.String()

--- a/internal/routeprobe/disabled_test.go
+++ b/internal/routeprobe/disabled_test.go
@@ -1,0 +1,95 @@
+package routeprobe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/clock"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// A group whose policy says not to move does not move, in either direction.
+//
+// This branch was unreachable until the server started sending the policy at all: every
+// assignment arrived with no LocalFailoverPolicy, so `enabled` was never anything. What was
+// here before moved away and never came back, which parks a device on a fallback after one
+// blip — a state nobody chose, arriving silently, since the group still reports itself as
+// honoured.
+func TestAPolicyThatSaysNotToMoveDoesNotMove(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	a.LocalFailover = &meshpv1.LocalFailoverPolicy{Enabled: false, FailThreshold: 2}
+	c.Current(a)
+
+	if d := fail(t, c, a, 20); d.Current != "primary" || d.Switched != "" {
+		t.Fatalf("a device moved under a policy that says not to: %+v", d)
+	}
+	if got := c.Current(a).GetAdvertiserId(); got != "primary" {
+		t.Errorf("the chooser now points at %q", got)
+	}
+}
+
+// And it will not come back either, because coming back is a move too — and a device that
+// obeyed the policy on the way out and ignored it on the way in would still be choosing for
+// itself, just more slowly.
+func TestAPolicyThatSaysNotToMoveDoesNotReturn(t *testing.T) {
+	clk := clock.NewFake()
+	c := New(clk)
+
+	// Move it first, under a policy that allows moving.
+	a := assignment("primary", "backup")
+	a.LocalFailover = &meshpv1.LocalFailoverPolicy{Enabled: true, FailThreshold: 1, RecoverThreshold: 1, MinHoldSeconds: 1}
+	c.Current(a)
+	if d := fail(t, c, a, 1); d.Current != "backup" {
+		t.Fatalf("setup: the device did not move: %+v", d)
+	}
+
+	// Now switch local failover off. It should stay on the fallback.
+	a.LocalFailover = &meshpv1.LocalFailoverPolicy{Enabled: false, FailThreshold: 1, RecoverThreshold: 1, MinHoldSeconds: 1}
+	clk.Advance(time.Hour)
+	if d := succeed(t, c, a, 20); d.Current != "backup" || d.Switched != "" {
+		t.Fatalf("a device returned under a policy that says not to move: %+v", d)
+	}
+}
+
+// The counters and the reports keep running, which is the point of not simply returning
+// early. The control plane cannot see a path this device cannot use, so a device told not
+// to act on a dead advertiser must still be the thing that says it is dead.
+func TestADeviceThatMayNotMoveStillSaysWhatItSees(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	a.LocalFailover = &meshpv1.LocalFailoverPolicy{Enabled: false, FailThreshold: 3}
+	c.Current(a)
+
+	d := fail(t, c, a, 3)
+	if d.ConsecutiveFailures != 3 {
+		t.Errorf("consecutive_failures = %d after three failures, want 3", d.ConsecutiveFailures)
+	}
+	if !d.Report {
+		t.Error("the pass that would have moved was not reported, so nobody is told the prefix is unreachable")
+	}
+	if d.Reason == "" {
+		t.Error("nothing explains why a failing advertiser is still in use")
+	}
+
+	// Once, not on every pass: a device behaving exactly as configured must not fill the log.
+	if next := c.Observe(a, Result{Reachable: false}); next.Report {
+		t.Error("every failing pass is reported, which buries the one that mattered")
+	}
+}
+
+// An assignment with no policy at all means the device may move.
+//
+// The case that has to be right is a control plane too old to send one: a device that could
+// not leave a dead advertiser without being told to could not leave one during the
+// control-plane outage most likely to have caused the problem (ADR-0003).
+func TestNoPolicyMeansTheDeviceMayMove(t *testing.T) {
+	c := New(clock.NewFake())
+	a := assignment("primary", "backup")
+	a.LocalFailover = nil
+	c.Current(a)
+
+	if d := fail(t, c, a, DefaultFailThreshold); d.Current != "backup" {
+		t.Fatalf("a device with no policy would not leave a dead advertiser: %+v", d)
+	}
+}

--- a/internal/routeprobe/routeprobe.go
+++ b/internal/routeprobe/routeprobe.go
@@ -198,6 +198,38 @@ func (c *Chooser) observeLocked(assignment *meshpv1.RouteGroupAssignment, result
 	first := state.consecutiveFail == 0 && state.consecutiveOK == 0
 	decision := Decision{Current: state.currentID, Report: first}
 
+	// A policy that says not to move means neither direction, and the counters still run.
+	//
+	// Both directions, because the field is called `enabled` and an operator who switched
+	// local failover off has said the control plane decides where this device points. Moving
+	// away but never coming back would park every device on a fallback after one blip, which
+	// is a state nobody chose — and it would arrive silently, since the group still reports
+	// itself as honoured.
+	//
+	// The counters and the report keep running, and that is the point of putting this here
+	// rather than returning early: the control plane cannot see a path this device cannot
+	// use, so a device that stopped saying "this advertiser is dead" the moment it was told
+	// not to act on that would take away the one signal that could get somebody to act
+	// instead.
+	if !mayMove(assignment) {
+		if result.Reachable {
+			state.consecutiveFail = 0
+			state.consecutiveOK++
+			return decision
+		}
+		state.consecutiveOK = 0
+		state.consecutiveFail++
+		decision.ConsecutiveFailures = state.consecutiveFail
+		if state.consecutiveFail == failThreshold {
+			// Said once, on the pass that would have moved. Every pass would fill the log of
+			// a device that is behaving exactly as configured; never saying it leaves an
+			// operator with an unreachable prefix and no explanation.
+			decision.Report = true
+			decision.Reason = "the advertiser in use stopped answering probes, and this group's policy says not to move"
+		}
+		return decision
+	}
+
 	if !result.Reachable {
 		state.consecutiveOK = 0
 		state.consecutiveFail++
@@ -225,11 +257,6 @@ func (c *Chooser) observeLocked(assignment *meshpv1.RouteGroupAssignment, result
 
 	// Already where the server would put us; nothing to return to.
 	if state.currentID == state.preferredID {
-		return decision
-	}
-	if !assignment.GetLocalFailover().GetEnabled() && policy != nil {
-		// Failover switched off means stay where you are once you have moved, rather than
-		// oscillate under a policy that says not to.
 		return decision
 	}
 	if state.consecutiveOK < recoverThreshold {
@@ -301,6 +328,22 @@ func (c *Chooser) Forget(assigned []*meshpv1.RouteGroupAssignment) {
 			delete(c.pending, id)
 		}
 	}
+}
+
+// mayMove reports whether this group's policy lets the device choose for itself.
+//
+// An absent policy means yes. A control plane that has never heard of local failover is the
+// case this has to get right, and a device that cannot leave a dead advertiser without being
+// told to cannot leave one during the control-plane outage that is most likely to have
+// caused the problem (ADR-0003). The server states `enabled` explicitly for exactly this
+// reason — proto3 cannot tell an absent bool from false — so the only way to arrive here
+// with no policy is from a server that does not send one at all.
+func mayMove(assignment *meshpv1.RouteGroupAssignment) bool {
+	policy := assignment.GetLocalFailover()
+	if policy == nil {
+		return true
+	}
+	return policy.GetEnabled()
 }
 
 func orDefault(v, fallback int) int {

--- a/internal/session/failover_test.go
+++ b/internal/session/failover_test.go
@@ -1,0 +1,140 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/meshpnet/meshp/internal/store"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// setFailover records a policy for one of the fixture's groups.
+func (f *fixture) setFailover(slug string, policy store.FailoverPolicy) {
+	f.t.Helper()
+	if _, err := f.store.SetRouteGroupFailover(f.ctx, f.netID, slug, policy); err != nil {
+		f.t.Fatalf("SetRouteGroupFailover(%s): %v", slug, err)
+	}
+}
+
+func yes() *bool { v := true; return &v }
+func no() *bool  { v := false; return &v }
+
+// The policy an administrator writes has to arrive. Every field on LocalFailoverPolicy has
+// been in the proto and in the database since the beginning and none of them were ever sent,
+// so every agent ran on the routeprobe package's own defaults and the column meant nothing.
+func TestTheFailoverPolicyReachesTheAgent(t *testing.T) {
+	f := newFixture(t)
+	laptop := f.enrolDevice("laptop")
+	router := f.enrolDevice("branch-router")
+	f.subnetGroup("branch-lan", "192.168.10.0/24")
+	f.advertise("branch-lan", router, 1)
+
+	f.setFailover("branch-lan", store.FailoverPolicy{
+		Enabled: yes(), FailThreshold: 2, RecoverThreshold: 20, MinHoldSeconds: 300,
+	})
+
+	got := f.assignments(laptop)
+	if len(got) != 1 {
+		t.Fatalf("%d assignments, want 1", len(got))
+	}
+	policy := got[0].GetLocalFailover()
+	if policy == nil {
+		t.Fatal("the assignment carries no failover policy, so the agent runs on its own defaults")
+	}
+	if !policy.GetEnabled() {
+		t.Error("enabled did not arrive")
+	}
+	if policy.GetFailThreshold() != 2 {
+		t.Errorf("fail_threshold = %d, want 2", policy.GetFailThreshold())
+	}
+	if policy.GetRecoverThreshold() != 20 {
+		t.Errorf("recover_threshold = %d, want 20", policy.GetRecoverThreshold())
+	}
+	if policy.GetMinHoldSeconds() != 300 {
+		t.Errorf("min_hold_seconds = %d, want 300", policy.GetMinHoldSeconds())
+	}
+}
+
+// A group nobody has configured still sends a policy, and it says the device may move.
+//
+// Proto3 cannot tell an absent bool from false, so an assignment that left `enabled` out
+// would reach the agent as "you may not move yourself" — the opposite of the column's
+// default, and a fleet that sits on dead advertisers waiting for a control plane that may
+// be the thing that failed.
+func TestAGroupNobodyConfiguredStillSaysTheDeviceMayMove(t *testing.T) {
+	f := newFixture(t)
+	laptop := f.enrolDevice("laptop")
+	router := f.enrolDevice("branch-router")
+	f.subnetGroup("branch-lan", "192.168.10.0/24")
+	f.advertise("branch-lan", router, 1)
+
+	policy := f.assignments(laptop)[0].GetLocalFailover()
+	if policy == nil {
+		t.Fatal("no policy at all")
+	}
+	if !policy.GetEnabled() {
+		t.Error("a group nobody configured tells devices they may not move themselves")
+	}
+	// And nothing else is claimed. Zero means the agent's default, which keeps one set of
+	// numbers rather than two that drift apart.
+	if policy.GetFailThreshold() != 0 || policy.GetRecoverThreshold() != 0 || policy.GetMinHoldSeconds() != 0 {
+		t.Errorf("an unconfigured group states thresholds: %+v", policy)
+	}
+}
+
+// The opt-out arrives as an opt-out.
+func TestOptingOutOfLocalFailoverReachesTheAgent(t *testing.T) {
+	f := newFixture(t)
+	laptop := f.enrolDevice("laptop")
+	router := f.enrolDevice("branch-router")
+	f.subnetGroup("branch-lan", "192.168.10.0/24")
+	f.advertise("branch-lan", router, 1)
+
+	f.setFailover("branch-lan", store.FailoverPolicy{Enabled: no()})
+
+	if f.assignments(laptop)[0].GetLocalFailover().GetEnabled() {
+		t.Error("a group that switched local failover off still tells devices they may move")
+	}
+}
+
+// Probe targets are deliberately not sent yet: nothing in the agent reads them, so an
+// administrator could write them, see them stored, and watch them do nothing (ADR-0018).
+// This is here so that whoever adds them has to delete a test that says why they were not
+// there, rather than wondering whether it was an oversight.
+func TestProbeTargetsAreNotSentYet(t *testing.T) {
+	f := newFixture(t)
+	laptop := f.enrolDevice("laptop")
+	router := f.enrolDevice("branch-router")
+	f.subnetGroup("branch-lan", "192.168.10.0/24")
+	f.advertise("branch-lan", router, 1)
+
+	policy := f.assignments(laptop)[0].GetLocalFailover()
+	if len(policy.GetProbeTargets()) != 0 || policy.GetProbeQuorum() != 0 || policy.GetProbeIntervalMs() != 0 {
+		t.Errorf("probe settings are on the wire before anything reads them: %+v", policy)
+	}
+}
+
+// Two groups, two policies. A network is not one failover policy: an exit pool that must not
+// flap and a branch LAN that must recover quickly are different decisions.
+func TestEachGroupCarriesItsOwnPolicy(t *testing.T) {
+	f := newFixture(t)
+	laptop := f.enrolDevice("laptop")
+	router := f.enrolDevice("branch-router")
+	f.subnetGroup("branch-lan", "192.168.10.0/24")
+	f.subnetGroup("dc-lan", "10.10.0.0/16")
+	f.advertise("branch-lan", router, 1)
+	f.advertise("dc-lan", router, 1)
+
+	f.setFailover("branch-lan", store.FailoverPolicy{Enabled: yes(), FailThreshold: 2})
+	f.setFailover("dc-lan", store.FailoverPolicy{Enabled: no()})
+
+	byName := map[string]*meshpv1.LocalFailoverPolicy{}
+	for _, a := range f.assignments(laptop) {
+		byName[a.GetName()] = a.GetLocalFailover()
+	}
+	if got := byName["branch-lan"]; got.GetFailThreshold() != 2 || !got.GetEnabled() {
+		t.Errorf("branch-lan = %+v", got)
+	}
+	if got := byName["dc-lan"]; got.GetEnabled() {
+		t.Error("one group's policy leaked into another's")
+	}
+}

--- a/internal/session/routes.go
+++ b/internal/session/routes.go
@@ -162,6 +162,21 @@ func assignmentFor(group store.RouteGroup, candidates []routes.Candidate) *meshp
 		RouteGroupId: group.ID.String(),
 		Name:         group.Name,
 		Mode:         modeOf(group.SelectionMode),
+		LocalFailover: &meshpv1.LocalFailoverPolicy{
+			// Enabled is stated rather than omitted. Proto3 cannot tell an absent bool from
+			// false, so a policy that left it out would reach the agent as "this device may
+			// not move itself" — the opposite of the column's default, and a fleet that sits
+			// on dead advertisers waiting for a control plane that may be the thing that
+			// failed.
+			Enabled:          group.Failover.MayMove(),
+			FailThreshold:    group.Failover.FailThreshold,
+			RecoverThreshold: group.Failover.RecoverThreshold,
+			MinHoldSeconds:   group.Failover.MinHoldSeconds,
+			// probe_targets, probe_quorum and probe_interval_ms are deliberately not sent
+			// yet. Nothing in the agent reads them: it derives reachability from handshake
+			// age, so targets on the wire would be a setting an administrator could write,
+			// see stored, and watch do nothing (ADR-0018). They arrive with the probe.
+		},
 	}
 
 	// An egress group carries the default route rather than prefixes of its own, which is

--- a/internal/store/failover.go
+++ b/internal/store/failover.go
@@ -1,0 +1,110 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// FailoverPolicy is what a route group tells its devices about moving between advertisers.
+//
+// The agent decides which candidate is alive; the server owns the set and the order
+// (ADR-0003). This is the third thing: how patient to be about it. A device that moves on
+// the first lost packet takes every connection through it down with each blip, and one that
+// waits five minutes has an outage instead.
+//
+// Stored as jsonb rather than as columns, and handed to agents close to verbatim, because
+// ADR-0001 makes failover one mechanism written once — a group is an exit pool, a subnet
+// router or a service gateway depending only on what it carries, and adding a column per
+// knob would mean this table growing every time the policy learns a new one.
+type FailoverPolicy struct {
+	// Enabled is whether the device may move itself at all.
+	//
+	// A pointer, so a row written before this field was read — or by hand — is told from one
+	// that says false. The column defaults to '{"enabled": true}', so an absent value means
+	// true, which is also the safe direction: a device that can leave a dead advertiser is a
+	// better failure than one that cannot.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// FailThreshold is how many consecutive failed probes move the device on. Zero means the
+	// agent's default.
+	FailThreshold uint32 `json:"fail_threshold,omitempty"`
+
+	// RecoverThreshold is how many consecutive successes bring it back to the server's first
+	// preference. Higher than FailThreshold on purpose in every sensible policy: leaving is
+	// cheap and returning costs every connection again.
+	RecoverThreshold uint32 `json:"recover_threshold,omitempty"`
+
+	// MinHoldSeconds is the floor on time between switches, applied to coming back and never
+	// to leaving.
+	MinHoldSeconds uint32 `json:"min_hold_seconds,omitempty"`
+}
+
+// DefaultFailoverPolicy is what a group gets when nobody says otherwise.
+//
+// Enabled and nothing else: the thresholds are left at zero so the agent's own defaults
+// apply, which keeps one set of numbers rather than two that can drift apart. A control
+// plane that stated them here would be answering a question it has not been asked, and the
+// agent would stop being able to tell "the administrator chose three" from "nobody chose".
+func DefaultFailoverPolicy() FailoverPolicy {
+	enabled := true
+	return FailoverPolicy{Enabled: &enabled}
+}
+
+// MayMove reports whether the device may move itself between advertisers.
+func (p FailoverPolicy) MayMove() bool { return p.Enabled == nil || *p.Enabled }
+
+// Validate refuses a policy that cannot behave.
+func (p FailoverPolicy) Validate() error {
+	// A recover threshold below the fail threshold is a device that leaves slowly and
+	// returns quickly, which is backwards: it will oscillate across a flapping advertiser,
+	// dropping every connection through it on each pass. Refused rather than corrected,
+	// because silently swapping an operator's numbers is worse than telling them.
+	if p.FailThreshold > 0 && p.RecoverThreshold > 0 && p.RecoverThreshold < p.FailThreshold {
+		return fmt.Errorf(
+			"store: recover_threshold %d is below fail_threshold %d, so a device would return "+
+				"to a failing advertiser faster than it left it", p.RecoverThreshold, p.FailThreshold)
+	}
+	// Bounded because these are counts of probe rounds, and a threshold in the thousands is
+	// a device that never moves — which reads as failover being broken rather than as the
+	// policy it is.
+	const maxThreshold = 1000
+	if p.FailThreshold > maxThreshold || p.RecoverThreshold > maxThreshold {
+		return fmt.Errorf("store: probe thresholds must be at most %d", maxThreshold)
+	}
+	// A day. Long enough for any real hysteresis, short enough that a typed-in millisecond
+	// value does not park a device on a fallback for a decade.
+	const maxHold = 24 * 60 * 60
+	if p.MinHoldSeconds > maxHold {
+		return fmt.Errorf("store: min_hold_seconds must be at most %d", maxHold)
+	}
+	return nil
+}
+
+// encodeFailover renders a policy for the column.
+func encodeFailover(p FailoverPolicy) ([]byte, error) {
+	raw, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("store: encoding the failover policy: %w", err)
+	}
+	return raw, nil
+}
+
+// decodeFailover reads what the column holds.
+//
+// A row that will not parse is an error rather than a default. The alternative is a device
+// quietly running on numbers nobody wrote, which is indistinguishable from the policy
+// working — and the whole point of this field is that an operator can predict how their
+// fleet behaves.
+func decodeFailover(raw []byte) (FailoverPolicy, error) {
+	if len(raw) == 0 {
+		// NOT NULL with a default, so this should not happen. If it does, the honest answer
+		// is the schema default rather than an error: refusing to build the assignment would
+		// take the whole route group away over a missing knob.
+		return DefaultFailoverPolicy(), nil
+	}
+	var p FailoverPolicy
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return FailoverPolicy{}, fmt.Errorf("store: reading the failover policy: %w", err)
+	}
+	return p, nil
+}

--- a/internal/store/failover_test.go
+++ b/internal/store/failover_test.go
@@ -1,0 +1,206 @@
+package store
+
+import (
+	"errors"
+	"testing"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+// The column defaults to '{"enabled": true}', and a policy that does not mention it must
+// read the same way. The safe direction for an absent value is the one that lets a device
+// leave a dead advertiser, because it cannot ask the control plane to move it during the
+// outage most likely to have caused the problem.
+func TestAnUnstatedPolicyLetsTheDeviceMove(t *testing.T) {
+	for name, p := range map[string]FailoverPolicy{
+		"nothing stated":  {},
+		"stated true":     {Enabled: boolPtr(true)},
+		"only thresholds": {FailThreshold: 2, RecoverThreshold: 5},
+	} {
+		if !p.MayMove() {
+			t.Errorf("%s: reports that the device may not move itself", name)
+		}
+	}
+	if (FailoverPolicy{Enabled: boolPtr(false)}).MayMove() {
+		t.Error("an explicit false still lets the device move itself")
+	}
+}
+
+// Round-tripping through the column has to preserve the difference between "false" and
+// "not mentioned", which is the whole reason Enabled is a pointer.
+func TestAPolicySurvivesTheColumn(t *testing.T) {
+	for name, want := range map[string]FailoverPolicy{
+		"an opt-out":      {Enabled: boolPtr(false)},
+		"stated defaults": {Enabled: boolPtr(true)},
+		"thresholds":      {Enabled: boolPtr(true), FailThreshold: 2, RecoverThreshold: 8, MinHoldSeconds: 120},
+	} {
+		raw, err := encodeFailover(want)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		got, err := decodeFailover(raw)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if got.MayMove() != want.MayMove() {
+			t.Errorf("%s: may_move %v, want %v", name, got.MayMove(), want.MayMove())
+		}
+		if got.FailThreshold != want.FailThreshold ||
+			got.RecoverThreshold != want.RecoverThreshold ||
+			got.MinHoldSeconds != want.MinHoldSeconds {
+			t.Errorf("%s: read back %+v, want %+v", name, got, want)
+		}
+	}
+}
+
+// A row that will not parse is an error rather than a default. A device quietly running on
+// numbers nobody wrote is indistinguishable from the policy working.
+func TestAPolicyThatWillNotParseIsRefused(t *testing.T) {
+	if _, err := decodeFailover([]byte(`{"enabled": "yes"`)); err == nil {
+		t.Error("malformed JSON was accepted")
+	}
+	// An empty column is the one case that gets the schema default, because refusing would
+	// take the whole route group away over a missing knob.
+	got, err := decodeFailover(nil)
+	if err != nil {
+		t.Fatalf("an empty column was refused: %v", err)
+	}
+	if !got.MayMove() {
+		t.Error("an empty column read as an opt-out")
+	}
+}
+
+// Leaving slowly and returning quickly is backwards: a device would oscillate across a
+// flapping advertiser, dropping every connection through it on each pass. Refused rather
+// than corrected — silently swapping an operator's numbers is worse than telling them.
+func TestABackwardsPolicyIsRefused(t *testing.T) {
+	for name, p := range map[string]FailoverPolicy{
+		"recovering faster than it fails": {FailThreshold: 5, RecoverThreshold: 2},
+		"a threshold nobody could reach":  {FailThreshold: 5000},
+		"a recover threshold as large":    {RecoverThreshold: 5000},
+		"a hold measured in years":        {MinHoldSeconds: 100_000_000},
+	} {
+		if err := p.Validate(); err == nil {
+			t.Errorf("%s was accepted", name)
+		}
+	}
+
+	for name, p := range map[string]FailoverPolicy{
+		"equal thresholds":  {FailThreshold: 3, RecoverThreshold: 3},
+		"the usual shape":   {FailThreshold: 3, RecoverThreshold: 10, MinHoldSeconds: 60},
+		"nothing stated":    {},
+		"only a fail count": {FailThreshold: 3},
+		// Unset is not "below": it means the agent's default, which is higher than any
+		// sensible fail threshold. Rejecting this would refuse the ordinary case of naming
+		// one number and leaving the other alone.
+		"a fail count with no recover count": {FailThreshold: 900},
+	} {
+		if err := p.Validate(); err != nil {
+			t.Errorf("%s was refused: %v", name, err)
+		}
+	}
+}
+
+// The policy has to survive the database, because the column is where it lives between an
+// administrator writing it and an agent being sent it.
+func TestTheStoredPolicyIsWhatComesBack(t *testing.T) {
+	s, _ := seedNetwork(t)
+	ctx := testContext(t)
+
+	group := subnetGroup(t, s, "branch")
+	if !group.Failover.MayMove() {
+		t.Error("a group created without a policy came back as an opt-out")
+	}
+
+	updated, err := s.SetRouteGroupFailover(ctx, s.netID, "branch", FailoverPolicy{
+		Enabled: boolPtr(false), FailThreshold: 2, RecoverThreshold: 20, MinHoldSeconds: 300,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Failover.MayMove() {
+		t.Error("the opt-out did not stick")
+	}
+	if updated.Failover.FailThreshold != 2 || updated.Failover.RecoverThreshold != 20 ||
+		updated.Failover.MinHoldSeconds != 300 {
+		t.Errorf("stored %+v", updated.Failover)
+	}
+	// And the prefixes came back with it, rather than the group losing them on an edit that
+	// had nothing to do with them.
+	if len(updated.Prefixes) != 1 {
+		t.Errorf("%d prefixes after setting the policy, want 1", len(updated.Prefixes))
+	}
+
+	groups, err := s.RouteGroupsFor(ctx, s.netID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(groups) != 1 || groups[0].Failover.MayMove() {
+		t.Errorf("read back %+v", groups)
+	}
+}
+
+// How patient a device is about moving is desired state, so a change has to be logged for
+// agents to collect rather than sitting in a column nothing sends.
+func TestSettingThePolicyTellsAgents(t *testing.T) {
+	s, _ := seedNetwork(t)
+	ctx := testContext(t)
+	subnetGroup(t, s, "branch")
+
+	var before int64
+	if err := s.pool.QueryRow(ctx,
+		`SELECT state_version FROM networks WHERE id = $1`, s.netID).Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.SetRouteGroupFailover(ctx, s.netID, "branch",
+		FailoverPolicy{Enabled: boolPtr(true), FailThreshold: 2}); err != nil {
+		t.Fatal(err)
+	}
+
+	var kind string
+	var version int64
+	if err := s.pool.QueryRow(ctx,
+		`SELECT kind, version FROM state_changes WHERE network_id = $1 ORDER BY id DESC LIMIT 1`,
+		s.netID).Scan(&kind, &version); err != nil {
+		t.Fatalf("no change was logged: %v", err)
+	}
+	if kind != "routes" {
+		t.Errorf("logged kind = %q, want routes", kind)
+	}
+	if version <= before {
+		t.Errorf("the change was logged at version %d, which is not past %d", version, before)
+	}
+}
+
+// A typo in a slug is told from a change, rather than reported as a success that stored
+// nothing.
+func TestSettingThePolicyOnAnUnknownGroupIsRefused(t *testing.T) {
+	s, _ := seedNetwork(t)
+
+	_, err := s.SetRouteGroupFailover(testContext(t), s.netID, "nope", DefaultFailoverPolicy())
+	if !errors.Is(err, ErrNoSuchRouteGroup) {
+		t.Errorf("err = %v, want ErrNoSuchRouteGroup", err)
+	}
+}
+
+// A policy that cannot behave is refused before it is stored, not after — otherwise the
+// group is left holding numbers the API has already said no to.
+func TestABackwardsPolicyIsNotStored(t *testing.T) {
+	s, _ := seedNetwork(t)
+	ctx := testContext(t)
+	subnetGroup(t, s, "branch")
+
+	if _, err := s.SetRouteGroupFailover(ctx, s.netID, "branch",
+		FailoverPolicy{FailThreshold: 5, RecoverThreshold: 2}); err == nil {
+		t.Fatal("a backwards policy was stored")
+	}
+
+	groups, err := s.RouteGroupsFor(ctx, s.netID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(groups) != 1 || groups[0].Failover.FailThreshold != 0 {
+		t.Errorf("the refused policy was stored anyway: %+v", groups[0].Failover)
+	}
+}

--- a/internal/store/gen/routegroups.sql.go
+++ b/internal/store/gen/routegroups.sql.go
@@ -111,10 +111,11 @@ func (q *Queries) CreateNetwork(ctx context.Context, arg CreateNetworkParams) (C
 const createRouteGroup = `-- name: CreateRouteGroup :one
 INSERT INTO route_groups (
     network_id, slug, name, kind, selection_mode,
-    auto_failback, failback_delay_seconds, stable_egress_ip
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    auto_failback, failback_delay_seconds, stable_egress_ip, local_failover
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING id, network_id, slug, name, kind, selection_mode,
-          auto_failback, failback_delay_seconds, stable_egress_ip, created_at
+          auto_failback, failback_delay_seconds, stable_egress_ip, local_failover,
+          created_at
 `
 
 type CreateRouteGroupParams struct {
@@ -126,6 +127,7 @@ type CreateRouteGroupParams struct {
 	AutoFailback         bool
 	FailbackDelaySeconds int32
 	StableEgressIp       *netip.Addr
+	LocalFailover        []byte
 }
 
 type CreateRouteGroupRow struct {
@@ -138,6 +140,7 @@ type CreateRouteGroupRow struct {
 	AutoFailback         bool
 	FailbackDelaySeconds int32
 	StableEgressIp       *netip.Addr
+	LocalFailover        []byte
 	CreatedAt            time.Time
 }
 
@@ -151,6 +154,7 @@ func (q *Queries) CreateRouteGroup(ctx context.Context, arg CreateRouteGroupPara
 		arg.AutoFailback,
 		arg.FailbackDelaySeconds,
 		arg.StableEgressIp,
+		arg.LocalFailover,
 	)
 	var i CreateRouteGroupRow
 	err := row.Scan(
@@ -163,6 +167,7 @@ func (q *Queries) CreateRouteGroup(ctx context.Context, arg CreateRouteGroupPara
 		&i.AutoFailback,
 		&i.FailbackDelaySeconds,
 		&i.StableEgressIp,
+		&i.LocalFailover,
 		&i.CreatedAt,
 	)
 	return i, err
@@ -267,7 +272,8 @@ func (q *Queries) GetAdvertiserHealth(ctx context.Context, advertiserID uuid.UUI
 
 const getRouteGroupBySlug = `-- name: GetRouteGroupBySlug :one
 SELECT id, network_id, slug, name, kind, selection_mode,
-       auto_failback, failback_delay_seconds, stable_egress_ip, created_at
+       auto_failback, failback_delay_seconds, stable_egress_ip, local_failover,
+       created_at
 FROM route_groups
 WHERE network_id = $1 AND slug = $2
 `
@@ -287,6 +293,7 @@ type GetRouteGroupBySlugRow struct {
 	AutoFailback         bool
 	FailbackDelaySeconds int32
 	StableEgressIp       *netip.Addr
+	LocalFailover        []byte
 	CreatedAt            time.Time
 }
 
@@ -303,6 +310,7 @@ func (q *Queries) GetRouteGroupBySlug(ctx context.Context, arg GetRouteGroupBySl
 		&i.AutoFailback,
 		&i.FailbackDelaySeconds,
 		&i.StableEgressIp,
+		&i.LocalFailover,
 		&i.CreatedAt,
 	)
 	return i, err
@@ -455,7 +463,8 @@ func (q *Queries) ListRouteGroupPrefixes(ctx context.Context, dollar_1 []uuid.UU
 
 const listRouteGroups = `-- name: ListRouteGroups :many
 SELECT id, network_id, slug, name, kind, selection_mode,
-       auto_failback, failback_delay_seconds, stable_egress_ip, created_at
+       auto_failback, failback_delay_seconds, stable_egress_ip, local_failover,
+       created_at
 FROM route_groups
 WHERE network_id = $1
 ORDER BY slug
@@ -471,6 +480,7 @@ type ListRouteGroupsRow struct {
 	AutoFailback         bool
 	FailbackDelaySeconds int32
 	StableEgressIp       *netip.Addr
+	LocalFailover        []byte
 	CreatedAt            time.Time
 }
 
@@ -493,6 +503,7 @@ func (q *Queries) ListRouteGroups(ctx context.Context, networkID uuid.UUID) ([]L
 			&i.AutoFailback,
 			&i.FailbackDelaySeconds,
 			&i.StableEgressIp,
+			&i.LocalFailover,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err
@@ -503,6 +514,65 @@ func (q *Queries) ListRouteGroups(ctx context.Context, networkID uuid.UUID) ([]L
 		return nil, err
 	}
 	return items, nil
+}
+
+const setRouteGroupFailover = `-- name: SetRouteGroupFailover :one
+UPDATE route_groups
+SET local_failover = $3,
+    updated_at = now()
+WHERE network_id = $1 AND slug = $2
+RETURNING id, network_id, slug, name, kind, selection_mode,
+          auto_failback, failback_delay_seconds, stable_egress_ip, local_failover,
+          created_at
+`
+
+type SetRouteGroupFailoverParams struct {
+	NetworkID     uuid.UUID
+	Slug          string
+	LocalFailover []byte
+}
+
+type SetRouteGroupFailoverRow struct {
+	ID                   uuid.UUID
+	NetworkID            uuid.UUID
+	Slug                 string
+	Name                 string
+	Kind                 string
+	SelectionMode        string
+	AutoFailback         bool
+	FailbackDelaySeconds int32
+	StableEgressIp       *netip.Addr
+	LocalFailover        []byte
+	CreatedAt            time.Time
+}
+
+// Replaces a group's local failover policy.
+//
+// Replaced whole rather than merged field by field. The policy is a set of numbers that
+// only make sense together — a fail threshold of one alongside a recover threshold left
+// from a previous edit is a device that moves on the first lost packet and takes ten
+// successes to come back — and a partial update is how an operator ends up with a
+// combination nobody chose.
+//
+// Returns the row so the caller can report what is now in force, and no row at all when
+// the group is not in this network, which is how a typo is told from a change.
+func (q *Queries) SetRouteGroupFailover(ctx context.Context, arg SetRouteGroupFailoverParams) (SetRouteGroupFailoverRow, error) {
+	row := q.db.QueryRow(ctx, setRouteGroupFailover, arg.NetworkID, arg.Slug, arg.LocalFailover)
+	var i SetRouteGroupFailoverRow
+	err := row.Scan(
+		&i.ID,
+		&i.NetworkID,
+		&i.Slug,
+		&i.Name,
+		&i.Kind,
+		&i.SelectionMode,
+		&i.AutoFailback,
+		&i.FailbackDelaySeconds,
+		&i.StableEgressIp,
+		&i.LocalFailover,
+		&i.CreatedAt,
+	)
+	return i, err
 }
 
 const upsertAdvertiserHealth = `-- name: UpsertAdvertiserHealth :exec

--- a/internal/store/routegroup.go
+++ b/internal/store/routegroup.go
@@ -48,6 +48,12 @@ type RouteGroup struct {
 	// change, which is the ordinary case.
 	StableEgressIP *netip.Addr
 
+	// Failover is how patient devices should be about moving between this group's
+	// advertisers. Handed to agents rather than acted on here: the agent is the only thing
+	// that can see whether a path works, and it has to keep deciding during a control-plane
+	// outage (ADR-0003).
+	Failover FailoverPolicy
+
 	Prefixes []netip.Prefix
 }
 
@@ -63,6 +69,7 @@ type CreateRouteGroupRequest struct {
 	AutoFailback         bool
 	FailbackDelaySeconds int32
 	StableEgressIP       *netip.Addr
+	Failover             FailoverPolicy
 }
 
 // CreateRouteGroup stores a group and its prefixes.
@@ -78,9 +85,16 @@ func (s *Store) CreateRouteGroup(ctx context.Context, req CreateRouteGroupReques
 	if err := validateKind(req.Kind, req.Prefixes); err != nil {
 		return RouteGroup{}, err
 	}
+	if err := req.Failover.Validate(); err != nil {
+		return RouteGroup{}, err
+	}
+	failover, err := encodeFailover(req.Failover)
+	if err != nil {
+		return RouteGroup{}, err
+	}
 
 	var out RouteGroup
-	err := s.InTx(ctx, func(q *dbgen.Queries) error {
+	err = s.InTx(ctx, func(q *dbgen.Queries) error {
 		mode := req.SelectionMode
 		if mode == "" {
 			mode = "failover"
@@ -94,6 +108,7 @@ func (s *Store) CreateRouteGroup(ctx context.Context, req CreateRouteGroupReques
 			AutoFailback:         req.AutoFailback,
 			FailbackDelaySeconds: req.FailbackDelaySeconds,
 			StableEgressIp:       req.StableEgressIP,
+			LocalFailover:        failover,
 		})
 		if err != nil {
 			return fmt.Errorf("store: creating the route group: %w", err)
@@ -112,8 +127,8 @@ func (s *Store) CreateRouteGroup(ctx context.Context, req CreateRouteGroupReques
 			return err
 		}
 
-		out = routeGroupFrom(row, req.Prefixes)
-		return nil
+		out, err = routeGroupFrom(row, req.Prefixes)
+		return err
 	})
 	if err != nil {
 		return RouteGroup{}, err
@@ -253,7 +268,72 @@ func (s *Store) RouteGroupsFor(ctx context.Context, networkID uuid.UUID) ([]Rout
 
 	out := make([]RouteGroup, 0, len(rows))
 	for _, row := range rows {
-		out = append(out, routeGroupFrom(dbgen.CreateRouteGroupRow(row), byGroup[row.ID]))
+		group, err := routeGroupFrom(dbgen.CreateRouteGroupRow(row), byGroup[row.ID])
+		if err != nil {
+			// Named, because the error itself says only that some JSON would not parse and
+			// an operator needs to know which group to go and look at.
+			return nil, fmt.Errorf("store: route group %s: %w", row.Slug, err)
+		}
+		out = append(out, group)
+	}
+	return out, nil
+}
+
+// SetRouteGroupFailover replaces a group's local failover policy.
+//
+// Whole rather than field by field: the numbers only mean anything together, and a partial
+// update is how an operator ends up with a combination nobody chose — a fail threshold of
+// one from today's edit beside a recover threshold left over from last month's.
+//
+// In one transaction with the version bump, like every other route mutation. How patient a
+// device is about moving is desired state for that device, so it has to be logged for agents
+// to collect rather than sitting in a column nothing sends.
+func (s *Store) SetRouteGroupFailover(ctx context.Context, networkID uuid.UUID, slug string, policy FailoverPolicy) (RouteGroup, error) {
+	if err := policy.Validate(); err != nil {
+		return RouteGroup{}, err
+	}
+	raw, err := encodeFailover(policy)
+	if err != nil {
+		return RouteGroup{}, err
+	}
+
+	var out RouteGroup
+	err = s.InTx(ctx, func(q *dbgen.Queries) error {
+		row, err := q.SetRouteGroupFailover(ctx, dbgen.SetRouteGroupFailoverParams{
+			NetworkID: networkID, Slug: slug, LocalFailover: raw,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNoSuchRouteGroup
+		}
+		if err != nil {
+			return fmt.Errorf("store: recording the failover policy: %w", err)
+		}
+
+		prefixes, err := q.ListRouteGroupPrefixes(ctx, []uuid.UUID{row.ID})
+		if err != nil {
+			return fmt.Errorf("store: listing route group prefixes: %w", err)
+		}
+		carried := make([]netip.Prefix, 0, len(prefixes))
+		for _, p := range prefixes {
+			carried = append(carried, p.Prefix)
+		}
+
+		out, err = routeGroupFrom(dbgen.CreateRouteGroupRow(row), carried)
+		if err != nil {
+			return err
+		}
+
+		// Written unconditionally, unlike the fail-closed opt-out, which skips the bump when
+		// nothing changed. Comparing two policies for equality means deciding whether an
+		// absent threshold equals an explicit default, and getting that wrong drops a real
+		// edit silently. A route policy is changed by hand and rarely; a redundant delta
+		// costs one reconcile per device, and the reconciler is idempotent by construction
+		// (Invariant 18), so it costs nothing else.
+		_, err = BumpVersion(ctx, q, networkID, RoutesChanged())
+		return err
+	})
+	if err != nil {
+		return RouteGroup{}, err
 	}
 	return out, nil
 }
@@ -304,15 +384,20 @@ func (s *Store) CreateNetwork(ctx context.Context, orgID uuid.UUID, slug, name s
 	return out, nil
 }
 
-func routeGroupFrom(row dbgen.CreateRouteGroupRow, prefixes []netip.Prefix) RouteGroup {
+func routeGroupFrom(row dbgen.CreateRouteGroupRow, prefixes []netip.Prefix) (RouteGroup, error) {
+	failover, err := decodeFailover(row.LocalFailover)
+	if err != nil {
+		return RouteGroup{}, err
+	}
 	return RouteGroup{
 		ID: row.ID, NetworkID: row.NetworkID, Slug: row.Slug, Name: row.Name, Kind: row.Kind,
 		SelectionMode:        row.SelectionMode,
 		AutoFailback:         row.AutoFailback,
 		FailbackDelaySeconds: row.FailbackDelaySeconds,
 		StableEgressIP:       row.StableEgressIp,
+		Failover:             failover,
 		Prefixes:             prefixes,
-	}
+	}, nil
 }
 
 func validateSlug(what, slug string) error {

--- a/queries/routegroups.sql
+++ b/queries/routegroups.sql
@@ -21,10 +21,11 @@ ORDER BY created_at;
 -- name: CreateRouteGroup :one
 INSERT INTO route_groups (
     network_id, slug, name, kind, selection_mode,
-    auto_failback, failback_delay_seconds, stable_egress_ip
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    auto_failback, failback_delay_seconds, stable_egress_ip, local_failover
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING id, network_id, slug, name, kind, selection_mode,
-          auto_failback, failback_delay_seconds, stable_egress_ip, created_at;
+          auto_failback, failback_delay_seconds, stable_egress_ip, local_failover,
+          created_at;
 
 -- name: AddRouteGroupPrefix :exec
 -- Idempotent, because publishing the same group twice must not be an error.
@@ -34,16 +35,37 @@ ON CONFLICT (route_group_id, prefix) DO NOTHING;
 
 -- name: GetRouteGroupBySlug :one
 SELECT id, network_id, slug, name, kind, selection_mode,
-       auto_failback, failback_delay_seconds, stable_egress_ip, created_at
+       auto_failback, failback_delay_seconds, stable_egress_ip, local_failover,
+       created_at
 FROM route_groups
 WHERE network_id = $1 AND slug = $2;
 
 -- name: ListRouteGroups :many
 SELECT id, network_id, slug, name, kind, selection_mode,
-       auto_failback, failback_delay_seconds, stable_egress_ip, created_at
+       auto_failback, failback_delay_seconds, stable_egress_ip, local_failover,
+       created_at
 FROM route_groups
 WHERE network_id = $1
 ORDER BY slug;
+
+-- name: SetRouteGroupFailover :one
+-- Replaces a group's local failover policy.
+--
+-- Replaced whole rather than merged field by field. The policy is a set of numbers that
+-- only make sense together — a fail threshold of one alongside a recover threshold left
+-- from a previous edit is a device that moves on the first lost packet and takes ten
+-- successes to come back — and a partial update is how an operator ends up with a
+-- combination nobody chose.
+--
+-- Returns the row so the caller can report what is now in force, and no row at all when
+-- the group is not in this network, which is how a typo is told from a change.
+UPDATE route_groups
+SET local_failover = sqlc.arg(local_failover),
+    updated_at = now()
+WHERE network_id = $1 AND slug = $2
+RETURNING id, network_id, slug, name, kind, selection_mode,
+          auto_failback, failback_delay_seconds, stable_egress_ip, local_failover,
+          created_at;
 
 -- name: ListRouteGroupPrefixes :many
 SELECT route_group_id, prefix


### PR DESCRIPTION
First half of #5 (probe through the advertiser). The probe needs targets, targets live on the local failover policy, and **the policy has never been sent.**

`route_groups.local_failover` has existed since `0001_init.sql` with a default of `{"enabled": true}`. `LocalFailoverPolicy` has been in the proto for just as long. `assignmentFor` never set it. So every agent in every deployment has run on the `routeprobe` package's own constants, and the column has meant nothing to anyone. ADR-0018 again.

## What now travels

`enabled`, `fail_threshold`, `recover_threshold`, `min_hold_seconds`.

```bash
curl -sX PUT -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
  -d '{"enabled":true,"fail_threshold":2,"recover_threshold":20,"min_hold_seconds":300}' \
  "$CONTROL/api/v1/networks/$NETWORK/route-groups/branch-lan/failover"
```

Also settable as `local_failover` on route-group creation, and reported by `GET /route-groups`.

## What deliberately does not travel

`probe_targets`, `probe_quorum`, `probe_interval_ms`. Nothing in the agent reads them — it still derives reachability from handshake age — so putting them on the wire now would be a setting an administrator could write, see stored, and watch do nothing. Exactly the bug this PR is fixing, in a new field.

There is a test asserting they are absent, so whoever adds them has to delete something that explains why they were not there rather than wonder if it was an oversight.

## Three things that would have been silently wrong

**`enabled` is stated on the wire, never omitted.** Proto3 cannot tell an absent bool from false. A policy that left it out would arrive as *"this device may not move itself"* — the opposite of the column's default, and a fleet parked on dead advertisers waiting for a control plane that may be the thing that failed. The agent treats a wholly absent policy the same way, so an older control plane cannot freeze a device in place.

**`enabled: false` now means neither direction.** That branch was unreachable, because no policy was ever sent. What it did was move away and never come back — which parks a device on a fallback after one blip, arriving silently since the group still reports itself as honoured. A field called `enabled` should mean the control plane decides, not "leave freely, return never".

The counters and the report keep running under it, which is why this sits mid-function rather than returning early: the control plane cannot see a path the device cannot use, so a device told not to *act* on a dead advertiser must still be the thing that *says* it is dead. It says so once, on the pass that would have moved — every pass would bury it, never saying it leaves an operator with an unreachable prefix and no explanation.

**A backwards policy is refused, not corrected.** `recover_threshold` below `fail_threshold` describes a device that leaves slowly and returns quickly, which oscillates across a flapping advertiser and drops every connection through it on each pass. Silently swapping an operator's numbers is worse than telling them.

## Verification

`make ci` and `make integration` green. No migration — the column was already there.

Nine mutations, eight caught:

| Mutation | Caught by |
|---|---|
| Stop sending the policy (i.e. today's `main`) | 3 session tests |
| Omit `enabled`, so proto3 sends false | 3 session tests |
| Nil policy means the device may *not* move | `TestNoPolicyMeansTheDeviceMayMove` |
| `enabled:false` blocks only the return (what it used to do) | 2 routeprobe tests |
| A device that may not move stops reporting | `TestADeviceThatMayNotMoveStillSaysWhatItSees` |
| An absent `enabled` in the request body reads as false | `TestOmittingEnabledDoesNotDisableFailover` |
| Drop the version bump when the policy changes | `TestSettingThePolicyTellsAgents` |
| Skip `Validate`, storing a backwards policy | 3 tests across store and api |
| Decode a malformed column as the default | `TestAPolicyThatWillNotParseIsRefused` |

The ninth — an omitted `local_failover` on create stored as a zero policy — is **equivalent**, not a gap: `Enabled` is a pointer and nil already means "may move", so the two differ only in the JSON written (`{}` vs `{"enabled":true}`). Left as the explicit form so the table reads honestly, with a comment saying why, since it otherwise looks like dead code.

## Next

The probe itself: dial diverse targets bound to the tunnel interface so a gateway whose own uplink has failed stops passing as healthy, with quorum and `failed_probe_targets` in the report.
