### PR TITLE
feat(routes): probe through the advertiser, not just its handshake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,10 +484,14 @@ jobs:
       # while testing nothing. A skip is therefore treated as a failure here. -E keeps the
       # Go environment across sudo, and -run is not narrowed: the point is that all of them
       # run somewhere.
-      - name: interfaces, routes, teardown and a packet across the tunnel
+      # pathprobe is here for the same reason wglink is: whether a socket bound to an
+      # interface actually leaves by it cannot be tested without real interfaces, and a
+      # probe that quietly used the routing table would report an advertiser healthy while
+      # measuring the local network.
+      - name: interfaces, routes, teardown, a packet across the tunnel, and a bound probe
         run: |
           set -o pipefail
-          sudo -E env "PATH=$PATH" go test ./internal/wglink/ -count=1 -v 2>&1 | tee dataplane.log
+          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/pathprobe/ -count=1 -v 2>&1 | tee dataplane.log
         continue-on-error: false
 
       - name: report, and refuse a silent skip
@@ -497,7 +501,7 @@ jobs:
             echo "### Data plane"
             echo
             echo '```'
-            grep -E '^(--- |ok|FAIL)|a packet crossed' dataplane.log || true
+            grep -E '^(--- |ok|FAIL)|a packet crossed|bound to' dataplane.log || true
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"
           if grep -q -- "--- SKIP" dataplane.log; then

--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ dataplane: ## Run the data-plane tests against real interfaces, in a privileged 
 	  -v "$$(go env GOMODCACHE)":/go/pkg/mod \
 	  golang:$(GO_IMAGE_VERSION)-alpine sh -c \
 	  'apk add --no-cache iproute2 wireguard-tools nftables iputils >/dev/null && \
-	   go test ./internal/wglink/ ./internal/nftables/ -count=1 -v'
+	   go test ./internal/wglink/ ./internal/nftables/ ./internal/pathprobe/ -count=1 -v'
 
 .PHONY: migrate-check
 migrate-check: ## Apply, roll back and re-apply every migration against MESHP_TEST_DATABASE_URL

--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/meshpnet/meshp/internal/enrollclient"
 	"github.com/meshpnet/meshp/internal/keys"
 	"github.com/meshpnet/meshp/internal/nftables"
+	"github.com/meshpnet/meshp/internal/pathprobe"
 	"github.com/meshpnet/meshp/internal/peerset"
 	"github.com/meshpnet/meshp/internal/relaylink"
 	"github.com/meshpnet/meshp/internal/routeprobe"
@@ -113,7 +114,21 @@ func (a *agent) reconcilerFor(m agentstate.Membership, relay tunnel.Relay, choos
 	}, relay, a.filterOrNil(), log).
 		WithChooser(chooser).
 		WithEgress(routerOrNil()).
+		WithProber(proberOrNil()).
 		WithClaims(a.claims)
+}
+
+// proberOrNil converts a possibly-absent dialer into the interface.
+//
+// Explicit for the reason routerOrNil is, and it has bitten this project already: a nil
+// *pathprobe.BoundDialer assigned straight to an interface is a non-nil interface holding a
+// nil pointer, so the reconciler's `r.prober == nil` check would pass and every probe would
+// panic on a platform that has no dialer.
+func proberOrNil() tunnel.Prober {
+	if d := pathprobe.NewDialer(); d != nil {
+		return d
+	}
+	return nil
 }
 
 // routerOrNil converts a possibly-absent router into the interface.

--- a/internal/api/failover.go
+++ b/internal/api/failover.go
@@ -21,6 +21,13 @@ type failoverPolicy struct {
 	FailThreshold    *uint32 `json:"fail_threshold"`
 	RecoverThreshold *uint32 `json:"recover_threshold"`
 	MinHoldSeconds   *uint32 `json:"min_hold_seconds"`
+
+	// ProbeTargets is a pointer to a slice so that an explicit empty list is told from an
+	// absent one. Both end up storing nothing, but only one of them is somebody deciding to
+	// stop probing, and the log line should be able to say which.
+	ProbeTargets    *[]string `json:"probe_targets"`
+	ProbeQuorum     *uint32   `json:"probe_quorum"`
+	ProbeIntervalMS *uint32   `json:"probe_interval_ms"`
 }
 
 func (p failoverPolicy) toStore() store.FailoverPolicy {
@@ -38,6 +45,15 @@ func (p failoverPolicy) toStore() store.FailoverPolicy {
 	if p.MinHoldSeconds != nil {
 		out.MinHoldSeconds = *p.MinHoldSeconds
 	}
+	if p.ProbeTargets != nil {
+		out.ProbeTargets = *p.ProbeTargets
+	}
+	if p.ProbeQuorum != nil {
+		out.ProbeQuorum = *p.ProbeQuorum
+	}
+	if p.ProbeIntervalMS != nil {
+		out.ProbeIntervalMS = *p.ProbeIntervalMS
+	}
 	return out
 }
 
@@ -48,11 +64,20 @@ func (p failoverPolicy) toStore() store.FailoverPolicy {
 // response that showed 3 where nothing is stored would make an unset field look like a
 // decision, and the next person to raise the agent's default would be surprised twice.
 func renderFailover(p store.FailoverPolicy) map[string]any {
+	targets := p.ProbeTargets
+	if targets == nil {
+		// An empty array rather than null, so a client can iterate what comes back without
+		// a special case for the group nobody has configured.
+		targets = []string{}
+	}
 	return map[string]any{
 		"enabled":           p.MayMove(),
 		"fail_threshold":    p.FailThreshold,
 		"recover_threshold": p.RecoverThreshold,
 		"min_hold_seconds":  p.MinHoldSeconds,
+		"probe_targets":     targets,
+		"probe_quorum":      p.ProbeQuorum,
+		"probe_interval_ms": p.ProbeIntervalMS,
 	}
 }
 
@@ -92,7 +117,8 @@ func (s *Server) handleSetRouteGroupFailover(w http.ResponseWriter, r *http.Requ
 		"enabled", group.Failover.MayMove(),
 		"fail_threshold", group.Failover.FailThreshold,
 		"recover_threshold", group.Failover.RecoverThreshold,
-		"min_hold_seconds", group.Failover.MinHoldSeconds)
+		"min_hold_seconds", group.Failover.MinHoldSeconds,
+		"probe_targets", len(group.Failover.ProbeTargets))
 
 	// How patient a device is about moving is desired state for every device that carries
 	// this group, so everyone needs telling.

--- a/internal/api/failover_test.go
+++ b/internal/api/failover_test.go
@@ -212,3 +212,93 @@ func TestFailoverNeedsTheAdminToken(t *testing.T) {
 		t.Errorf("an unauthenticated caller got %d", status)
 	}
 }
+
+// probeSettings is a group's probe configuration as the API reports it.
+type probeSettings struct {
+	status          int
+	ProbeTargets    []string `json:"probe_targets"`
+	ProbeQuorum     uint32   `json:"probe_quorum"`
+	ProbeIntervalMS uint32   `json:"probe_interval_ms"`
+}
+
+func (h *harness) readProbe(slug string) probeSettings {
+	h.t.Helper()
+	req := mustRequest(h.t, http.MethodGet, h.server.URL+h.netPath("/route-groups"), "")
+	req.Header.Set("Authorization", "Bearer "+testAdminToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var out struct {
+		RouteGroups []struct {
+			Slug          string        `json:"slug"`
+			LocalFailover probeSettings `json:"local_failover"`
+		} `json:"route_groups"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		h.t.Fatal(err)
+	}
+	for _, g := range out.RouteGroups {
+		if g.Slug == slug {
+			g.LocalFailover.status = resp.StatusCode
+			return g.LocalFailover
+		}
+	}
+	h.t.Fatalf("no group %q in the listing", slug)
+	return probeSettings{}
+}
+
+func TestSettingProbeTargets(t *testing.T) {
+	h := newHarness(t)
+	h.branchGroup(t, `{"slug":"branch","kind":"subnet","prefixes":["192.168.10.0/24"]}`)
+
+	if got := h.setFailover("branch", `{"enabled":true,
+		"probe_targets":["192.168.10.1:22","192.168.10.2:443"],
+		"probe_quorum":2,"probe_interval_ms":600000}`); got.status != http.StatusOK {
+		t.Fatalf("returned %d", got.status)
+	}
+
+	got := h.readProbe("branch")
+	if len(got.ProbeTargets) != 2 || got.ProbeTargets[0] != "192.168.10.1:22" {
+		t.Errorf("probe_targets = %v", got.ProbeTargets)
+	}
+	if got.ProbeQuorum != 2 || got.ProbeIntervalMS != 600000 {
+		t.Errorf("read back %+v", got)
+	}
+}
+
+// A group nobody has configured reports an empty array rather than null, so a client can
+// iterate what comes back without a special case for it.
+func TestAGroupWithNoProbeTargetsReportsAnEmptyList(t *testing.T) {
+	h := newHarness(t)
+	h.branchGroup(t, `{"slug":"branch","kind":"subnet","prefixes":["192.168.10.0/24"]}`)
+
+	if got := h.readProbe("branch"); got.ProbeTargets == nil {
+		t.Error("probe_targets came back as null rather than an empty list")
+	}
+}
+
+// The refusals: what an administrator writes here decides how much traffic a whole fleet
+// generates, and which failures it can see.
+func TestBadProbeSettingsAreRefused(t *testing.T) {
+	h := newHarness(t)
+	h.branchGroup(t, `{"slug":"branch","kind":"subnet","prefixes":["192.168.10.0/24"]}`)
+
+	for name, body := range map[string]string{
+		"a hostname, which needs the DNS that fails with the gateway": `{"enabled":true,"probe_targets":["one.one.one.one:443"]}`,
+		"a target with no port":                 `{"enabled":true,"probe_targets":["1.1.1.1"]}`,
+		"a quorum nothing can satisfy":          `{"enabled":true,"probe_targets":["1.1.1.1:443"],"probe_quorum":2}`,
+		"a quorum with no targets":              `{"enabled":true,"probe_quorum":1}`,
+		"more targets than a fleet should dial": `{"enabled":true,"probe_targets":["192.0.2.1:443","192.0.2.2:443","192.0.2.3:443","192.0.2.4:443","192.0.2.5:443","192.0.2.6:443","192.0.2.7:443","192.0.2.8:443","192.0.2.9:443"]}`,
+		"an interval below a second":            `{"enabled":true,"probe_interval_ms":100}`,
+	} {
+		if got := h.setFailover("branch", body); got.status == http.StatusOK {
+			t.Errorf("%s was accepted", name)
+		}
+	}
+	if got := h.readProbe("branch"); len(got.ProbeTargets) != 0 {
+		t.Errorf("a refused policy was stored anyway: %+v", got)
+	}
+}

--- a/internal/pathprobe/dial_linux.go
+++ b/internal/pathprobe/dial_linux.go
@@ -1,0 +1,132 @@
+//go:build linux
+
+package pathprobe
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// DefaultTimeout is how long one target has to answer.
+//
+// Three seconds is chosen against the reconcile interval rather than against any network:
+// every target is dialled at once, so a whole round costs this much at worst, and a minute
+// between rounds leaves the reconciler nothing to notice. Long enough for a satellite link
+// and a slow TLS-terminating middlebox; short enough that a black-holed target does not hold
+// a reconcile open while an operator waits to see the failover they are testing.
+const DefaultTimeout = 3 * time.Second
+
+// BoundDialer probes by opening TCP connections through a named interface.
+//
+// TCP rather than ICMP, which is the choice worth defending. A completed handshake proves a
+// bidirectional path all the way to a listening service — the thing a user is actually going
+// to do — while ICMP proves that something along the way was willing to answer a ping, and is
+// deprioritised or dropped outright by a large fraction of the internet. A probe whose
+// failures are mostly policy is worse than no probe, because a fleet learns to ignore it.
+//
+// SO_BINDTODEVICE rather than the routing table, which is the other one. A dial that consulted
+// the routing table would leave by the physical interface whenever the route through the
+// tunnel is missing — during the gap after a claim fails, or for a group that is not being
+// carried — and would then report the advertiser healthy while measuring the local network.
+// That is a false positive that pins a device to a dead gateway, and it is precisely the
+// failure this exists to remove. Binding to the interface means the packet either goes through
+// the tunnel or does not go at all.
+//
+// Once bound, WireGuard's own cryptokey routing decides which peer receives it: the target
+// falls inside the carried prefix, and the carried prefix is in exactly one peer's AllowedIPs
+// because wgplan refuses two peers claiming the same one. So "through the interface" and
+// "through the chosen advertiser" are the same thing, without this package having to know
+// which peer that is.
+type BoundDialer struct {
+	// Timeout bounds one target. Zero means DefaultTimeout.
+	Timeout time.Duration
+}
+
+// NewDialer returns a prober for this host, or nil where the platform cannot bind one.
+//
+// Nil rather than a stub, following the same rule as the egress router and the filter: a
+// capability this host does not have must be absent, so the caller falls back to the
+// handshake instead of trusting a measurement that did not go where it claims.
+func NewDialer() *BoundDialer { return &BoundDialer{} }
+
+// Probe dials every target at once and reports how each went.
+//
+// Concurrently, so a round costs one timeout rather than one per target. Sequential dials
+// would make a policy with four targets and a black hole among them hold the reconciler open
+// for twelve seconds, and the reconciler is what applies desired state.
+func (d *BoundDialer) Probe(ctx context.Context, iface string, targets []netip.AddrPort) []Outcome {
+	timeout := d.Timeout
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+
+	outcomes := make([]Outcome, len(targets))
+	var wg sync.WaitGroup
+	for i, target := range targets {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			outcomes[i] = d.dial(ctx, iface, target, timeout)
+		}()
+	}
+	wg.Wait()
+	return outcomes
+}
+
+func (d *BoundDialer) dial(ctx context.Context, iface string, target netip.AddrPort, timeout time.Duration) Outcome {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	dialer := &net.Dialer{
+		Control: func(_, _ string, c syscall.RawConn) error {
+			var bindErr error
+			if err := c.Control(func(fd uintptr) {
+				bindErr = unix.SetsockoptString(int(fd), unix.SOL_SOCKET, unix.SO_BINDTODEVICE, iface)
+			}); err != nil {
+				return err
+			}
+			return bindErr
+		},
+	}
+
+	started := time.Now()
+	conn, err := dialer.DialContext(ctx, "tcp", target.String())
+	if err != nil {
+		// A refused connection is not a failed path.
+		//
+		// The packet reached the target and the target answered — with a RST rather than a
+		// SYN-ACK, but it answered, which is everything this is asking. Counting it as a
+		// failure would make the verdict depend on whether that host happens to still run
+		// something on that port, so an administrator whose target closed port 443 would
+		// watch their whole fleet fail over for a reason nothing reports.
+		if isRefused(err) {
+			return Outcome{Target: target, RTT: time.Since(started)}
+		}
+		return Outcome{Target: target, Err: err}
+	}
+	rtt := time.Since(started)
+	// Closed immediately: nothing is sent, and holding it open would leave a connection per
+	// target per round on a device that probes forever.
+	_ = conn.Close()
+	return Outcome{Target: target, RTT: rtt}
+}
+
+// isRefused reports whether the far end answered by saying no.
+//
+// Here rather than in a shared file, even though it has nothing platform-specific in it: a
+// helper only the Linux build calls is dead code everywhere else, and the linter runs on
+// whatever the developer is sitting at.
+func isRefused(err error) bool {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+	return errno == unix.ECONNREFUSED || errno == unix.ECONNRESET
+}

--- a/internal/pathprobe/dial_linux_test.go
+++ b/internal/pathprobe/dial_linux_test.go
@@ -1,0 +1,309 @@
+//go:build linux
+
+package pathprobe
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// The claim this whole package rests on: a probe leaves by the interface it was bound to,
+// and not by whichever one the routing table prefers.
+//
+// It matters because the alternative is a false positive with teeth. If a dial could fall
+// back to the physical interface — during the gap after an egress claim fails, or for a
+// group whose route was never installed — it would report the advertiser healthy while
+// measuring the local network, and the device would sit on a dead gateway forever with
+// every check agreeing it was fine.
+//
+// Two namespaces joined by a veth pair stand in for a device and something on the far side
+// of a tunnel. There is no WireGuard here on purpose: what is being tested is the socket
+// option, and adding an encrypted tunnel underneath would only make a failure harder to
+// attribute. The interface that carries the route and the interface that does not are the
+// whole experiment.
+
+func privileged() bool { return os.Geteuid() == 0 }
+
+func run(t *testing.T, args ...string) {
+	t.Helper()
+	out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+// netnsRun runs fn inside a named network namespace.
+//
+// The thread is locked because a namespace is a property of a thread rather than a process:
+// without it the runtime could move the goroutine between two calls and open sockets in the
+// wrong place. Every socket fn uses must be opened inside fn for the same reason.
+func netnsRun(t *testing.T, name string, fn func()) {
+	t.Helper()
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	original, err := os.Open("/proc/thread-self/ns/net")
+	if err != nil {
+		t.Fatalf("opening this thread's namespace: %v", err)
+	}
+	defer func() { _ = original.Close() }()
+
+	target, err := os.Open("/var/run/netns/" + name)
+	if err != nil {
+		t.Fatalf("opening namespace %s: %v", name, err)
+	}
+	defer func() { _ = target.Close() }()
+
+	if err := unix.Setns(int(target.Fd()), unix.CLONE_NEWNET); err != nil {
+		t.Fatalf("entering namespace %s: %v", name, err)
+	}
+	defer func() {
+		if err := unix.Setns(int(original.Fd()), unix.CLONE_NEWNET); err != nil {
+			// Leaving the thread in the wrong namespace would corrupt every later test.
+			t.Fatalf("returning from namespace %s: %v", name, err)
+		}
+	}()
+
+	fn()
+}
+
+func TestAProbeLeavesByTheInterfaceItWasBoundTo(t *testing.T) {
+	if !privileged() {
+		t.Skip("needs root to create namespaces and interfaces")
+	}
+	if _, err := exec.LookPath("ip"); err != nil {
+		t.Skip("needs iproute2 to set up the namespaces")
+	}
+
+	const (
+		nsClient = "probeClient"
+		nsServer = "probeServer"
+		// The path that works.
+		clientAddr = "10.98.0.1"
+		serverAddr = "10.98.0.2"
+		// A second interface with no route to the server. Standing in for the physical
+		// interface a probe must never quietly fall back to.
+		decoyAddr = "10.98.1.1"
+		port      = 39443
+	)
+
+	cleanup := func() {
+		_ = exec.Command("ip", "netns", "del", nsClient).Run()
+		_ = exec.Command("ip", "netns", "del", nsServer).Run()
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	run(t, "ip", "netns", "add", nsClient)
+	run(t, "ip", "netns", "add", nsServer)
+
+	// The working path.
+	run(t, "ip", "link", "add", "tun0", "type", "veth", "peer", "name", "tun1")
+	run(t, "ip", "link", "set", "tun0", "netns", nsClient)
+	run(t, "ip", "link", "set", "tun1", "netns", nsServer)
+	run(t, "ip", "-n", nsClient, "addr", "add", clientAddr+"/24", "dev", "tun0")
+	run(t, "ip", "-n", nsServer, "addr", "add", serverAddr+"/24", "dev", "tun1")
+	run(t, "ip", "-n", nsClient, "link", "set", "tun0", "up")
+	run(t, "ip", "-n", nsServer, "link", "set", "tun1", "up")
+	run(t, "ip", "-n", nsClient, "link", "set", "lo", "up")
+	run(t, "ip", "-n", nsServer, "link", "set", "lo", "up")
+
+	// The decoy: up, addressed, and with no path to the server whatsoever. Its peer end
+	// stays in the client namespace and is left down, so anything sent through it is lost.
+	run(t, "ip", "-n", nsClient, "link", "add", "phys0", "type", "veth", "peer", "name", "phys1")
+	run(t, "ip", "-n", nsClient, "addr", "add", decoyAddr+"/24", "dev", "phys0")
+	run(t, "ip", "-n", nsClient, "link", "set", "phys0", "up")
+
+	// A listener the client can reach, but only one way.
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		netnsRun(t, nsServer, func() {
+			listener, err := net.Listen("tcp", serverAddr+":"+itoa(port))
+			if err != nil {
+				t.Errorf("listening in %s: %v", nsServer, err)
+				close(ready)
+				return
+			}
+			defer func() { _ = listener.Close() }()
+			close(ready)
+
+			// Two connections: one per successful dial the test expects. Accepting and
+			// closing immediately is enough — the probe only cares that the handshake
+			// completed.
+			_ = listener.(*net.TCPListener).SetDeadline(time.Now().Add(20 * time.Second))
+			for range 2 {
+				conn, err := listener.Accept()
+				if err != nil {
+					return
+				}
+				_ = conn.Close()
+			}
+		})
+	}()
+	<-ready
+
+	target := netip.MustParseAddrPort(serverAddr + ":" + itoa(port))
+	dialer := &BoundDialer{Timeout: 2 * time.Second}
+
+	// dial rather than Probe, and the reason is the whole hazard netnsRun exists for.
+	//
+	// A namespace belongs to a thread. netnsRun locks this goroutine to a thread it has moved
+	// into nsClient, so a socket opened here is opened there — but Probe fans out across
+	// goroutines, and those run on other threads, which are still in the root namespace. A
+	// test that called Probe would open its sockets in the wrong place and fail with "no
+	// such device" while the code under test was perfectly correct.
+	//
+	// So the binding is tested here, one dial at a time, and Probe's fan-out is tested over
+	// loopback below, where no namespace is involved.
+	netnsRun(t, nsClient, func() {
+		// Bound to the interface that carries the route: it works, and it reports a time.
+		got := dialer.dial(context.Background(), "tun0", target, 2*time.Second)
+		if got.Err != nil {
+			t.Fatalf("a probe bound to the interface that carries the route failed: %v", got.Err)
+		}
+		if got.RTT <= 0 {
+			t.Error("a successful probe reported no round trip time")
+		}
+
+		// The same target, bound to an interface with no path to it. This is the assertion
+		// the package exists for: the routing table would have sent this through tun0 and
+		// reported success, and binding is what stops it.
+		decoy := dialer.dial(context.Background(), "phys0", target, 2*time.Second)
+		if decoy.Err == nil {
+			t.Error("a probe bound to an interface with no route to the target succeeded, " +
+				"so the binding is not deciding where packets go and every verdict is about " +
+				"whatever path the kernel picked")
+		}
+
+		// And once more through the working interface, to prove the decoy did not break the
+		// dialer rather than the path.
+		if again := dialer.dial(context.Background(), "tun0", target, 2*time.Second); again.Err != nil {
+			t.Errorf("the working path stopped working after a bound failure: %v", again.Err)
+		}
+	})
+
+	<-done
+}
+
+// Probe dials every target at once and returns one outcome per target, in order.
+//
+// Over loopback rather than in a namespace, because the fan-out is the subject: Probe's
+// goroutines run on threads this test does not control, and a namespace belongs to a thread.
+// What is being checked here is that concurrency does not lose, reorder or duplicate an
+// answer — a round that dropped a target would silently lower the denominator the quorum is
+// measured against.
+func TestEveryTargetGetsAnAnswerInOrder(t *testing.T) {
+	if !privileged() {
+		t.Skip("needs root to bind a socket to an interface")
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = listener.Close() }()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	live := netip.MustParseAddrPort(listener.Addr().String())
+	// Reserved for documentation (RFC 5737) and routed nowhere, so it times out rather than
+	// reaching a stranger.
+	dead := netip.MustParseAddrPort("192.0.2.1:9")
+
+	dialer := &BoundDialer{Timeout: time.Second}
+	targets := []netip.AddrPort{live, dead, live, dead, live}
+	got := dialer.Probe(context.Background(), "lo", targets)
+
+	if len(got) != len(targets) {
+		t.Fatalf("%d outcomes for %d targets", len(got), len(targets))
+	}
+	for i, o := range got {
+		if o.Target != targets[i] {
+			t.Fatalf("outcome %d is about %s, want %s — the answers came back reordered",
+				i, o.Target, targets[i])
+		}
+		wantErr := targets[i] == dead
+		if (o.Err != nil) != wantErr {
+			t.Errorf("outcome %d for %s: err = %v, want error: %v", i, o.Target, o.Err, wantErr)
+		}
+	}
+}
+
+// A target that nothing is listening on, reached through an interface that works, is a
+// reachable path. The packet arrived and something answered — with a reset rather than an
+// acceptance, but it answered, which is the whole question. Counting it as failure would
+// make every verdict depend on whether the target still runs a service on that port.
+func TestARefusedConnectionIsStillAWorkingPath(t *testing.T) {
+	if !privileged() {
+		t.Skip("needs root to create namespaces and interfaces")
+	}
+	if _, err := exec.LookPath("ip"); err != nil {
+		t.Skip("needs iproute2 to set up the namespaces")
+	}
+
+	const (
+		nsClient = "refusedClient"
+		nsServer = "refusedServer"
+		client   = "10.97.0.1"
+		server   = "10.97.0.2"
+	)
+
+	cleanup := func() {
+		_ = exec.Command("ip", "netns", "del", nsClient).Run()
+		_ = exec.Command("ip", "netns", "del", nsServer).Run()
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	run(t, "ip", "netns", "add", nsClient)
+	run(t, "ip", "netns", "add", nsServer)
+	run(t, "ip", "link", "add", "rtun0", "type", "veth", "peer", "name", "rtun1")
+	run(t, "ip", "link", "set", "rtun0", "netns", nsClient)
+	run(t, "ip", "link", "set", "rtun1", "netns", nsServer)
+	run(t, "ip", "-n", nsClient, "addr", "add", client+"/24", "dev", "rtun0")
+	run(t, "ip", "-n", nsServer, "addr", "add", server+"/24", "dev", "rtun1")
+	run(t, "ip", "-n", nsClient, "link", "set", "rtun0", "up")
+	run(t, "ip", "-n", nsServer, "link", "set", "rtun1", "up")
+
+	dialer := &BoundDialer{Timeout: 2 * time.Second}
+	netnsRun(t, nsClient, func() {
+		// Nothing is listening there, and nothing is filtering either, so the kernel on the
+		// far side answers with a reset. dial rather than Probe for the threading reason
+		// given above.
+		got := dialer.dial(context.Background(), "rtun0",
+			netip.MustParseAddrPort(server+":39999"), 2*time.Second)
+		if got.Err != nil {
+			t.Errorf("a refused connection was counted as a broken path: %v", got.Err)
+		}
+	})
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/internal/pathprobe/dial_other.go
+++ b/internal/pathprobe/dial_other.go
@@ -1,0 +1,36 @@
+//go:build !linux
+
+package pathprobe
+
+import (
+	"context"
+	"net/netip"
+	"time"
+)
+
+// BoundDialer exists so the wiring compiles everywhere. It is never constructed on this
+// platform, because NewDialer returns nil.
+type BoundDialer struct{ Timeout time.Duration }
+
+// NewDialer returns nothing on a platform that cannot bind a socket to an interface.
+//
+// Nil rather than a dialer that would use the routing table. A probe that left by the
+// physical interface would report the advertiser healthy while measuring the local network,
+// which pins a device to a dead gateway — strictly worse than falling back to the handshake,
+// which at least measures something it can name.
+func NewDialer() *BoundDialer { return nil }
+
+// Probe fails every target rather than passing them.
+//
+// Unreachable: nothing constructs a BoundDialer here. It fails rather than returning nothing
+// because "nothing" reads as a group with no targets, which the reconciler treats as "the
+// probe did not run" and quietly falls back — so a wiring mistake on a new platform would
+// look exactly like working software. This way it shows up as an advertiser that will not
+// pass, which is wrong but visible.
+func (d *BoundDialer) Probe(_ context.Context, _ string, targets []netip.AddrPort) []Outcome {
+	out := make([]Outcome, 0, len(targets))
+	for _, t := range targets {
+		out = append(out, Outcome{Target: t, Err: ErrUnsupported})
+	}
+	return out
+}

--- a/internal/pathprobe/pathprobe.go
+++ b/internal/pathprobe/pathprobe.go
@@ -1,0 +1,167 @@
+// Package pathprobe measures whether traffic actually gets through an interface.
+//
+// It exists because a WireGuard handshake answers the wrong question. A handshake says the
+// advertiser is reachable; it says nothing about whether anything behind it is. A branch
+// router whose own uplink has failed handshakes perfectly, and every device steered at it
+// sits there with no internet while the control plane and the agent both report health.
+//
+// So this sends real traffic to targets an administrator named, through the tunnel, and
+// counts how many answered. The decision of what to do about the answer is not here — that
+// is routeprobe, which is deliberately free of I/O so its hysteresis can be tested against
+// a fake clock rather than a network that has to be broken on cue. This package is the
+// opposite half: the I/O, with the smallest possible amount of judgement attached.
+//
+// Two properties matter more than anything else here.
+//
+// **It must go through the tunnel, or it means nothing.** A probe that fell back to the
+// physical interface would report the advertiser healthy while measuring the local
+// connection — a false positive that keeps a device on a dead gateway, which is the exact
+// failure this package was written to remove. The dialer therefore binds to the interface
+// rather than trusting the routing table, and a platform that cannot do that has no prober
+// at all rather than a hopeful one.
+//
+// **One target is not a verdict.** A single target measures that target's path. Requiring a
+// quorum of diverse targets is what makes the difference between "the exit is down" and
+// "one operator is having a bad afternoon", and getting that wrong moves every device in a
+// fleet at once.
+package pathprobe
+
+import (
+	"errors"
+	"net/netip"
+	"sort"
+	"time"
+)
+
+// ErrUnsupported means this platform cannot probe through a named interface.
+//
+// Returned rather than silently probing anyway. A verdict that did not go through the
+// tunnel is worse than no verdict: no verdict leaves the handshake in charge, which is
+// honest about what it measures, while a wrong one fails a working advertiser or passes a
+// dead one.
+var ErrUnsupported = errors.New("pathprobe: this platform cannot bind a probe to an interface")
+
+// Outcome is what happened to one target.
+type Outcome struct {
+	Target netip.AddrPort
+
+	// RTT is how long the connection took to establish. Meaningless when Err is set.
+	RTT time.Duration
+
+	// Err is why the target did not answer, or nil.
+	Err error
+}
+
+// Result is the verdict across every target.
+type Result struct {
+	// Reachable is whether enough targets answered.
+	Reachable bool
+
+	// RTT is the median of the successful dials, or zero when none succeeded.
+	//
+	// The median rather than the fastest: the fastest is a lower bound on the path and
+	// flatters a link where most targets are slow, and this number ends up in front of
+	// somebody asking why their connection feels bad.
+	RTT time.Duration
+
+	// Failed names the targets that did not answer, in the order they were given.
+	//
+	// Reported onward so an operator can tell one target being down from the exit being
+	// down — which is the same distinction the quorum makes, except that the quorum only
+	// decides and this explains.
+	Failed []string
+
+	// Answered is how many targets came back, for the log line that says why a device did
+	// or did not move.
+	Answered int
+}
+
+// Quorum is how many targets must answer for a path to count as working.
+//
+// Zero means a majority, which is the honest default for an odd number of diverse targets
+// and rounds in the safe direction for an even one: two of two, two of four. Requiring more
+// than half is what stops one operator's outage moving a fleet; requiring all of them would
+// mean the least reliable target decides.
+//
+// A quorum larger than the number of targets can never be met, so it is clamped rather than
+// honoured. Refusing it belongs where a person can be told — the store validates it — and
+// by the time an assignment reaches a device the only choices left are to clamp or to fail
+// every advertiser forever.
+func Quorum(want int, targets int) int {
+	if targets <= 0 {
+		return 0
+	}
+	if want <= 0 {
+		return targets/2 + 1
+	}
+	if want > targets {
+		return targets
+	}
+	return want
+}
+
+// Verdict folds per-target outcomes into an answer.
+func Verdict(outcomes []Outcome, wantQuorum int) Result {
+	quorum := Quorum(wantQuorum, len(outcomes))
+
+	var rtts []time.Duration
+	result := Result{}
+	for _, o := range outcomes {
+		if o.Err != nil {
+			result.Failed = append(result.Failed, o.Target.String())
+			continue
+		}
+		result.Answered++
+		rtts = append(rtts, o.RTT)
+	}
+
+	// No targets is not a verdict of unreachable. A group with nothing to probe has to fall
+	// back to what the handshake says, and returning "unreachable" here would fail every
+	// advertiser in a network whose administrator never configured a target.
+	if len(outcomes) == 0 {
+		return Result{}
+	}
+
+	result.Reachable = result.Answered >= quorum
+	result.RTT = median(rtts)
+	return result
+}
+
+// median of the successful dials, or zero.
+func median(d []time.Duration) time.Duration {
+	if len(d) == 0 {
+		return 0
+	}
+	sorted := append([]time.Duration(nil), d...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[mid]
+	}
+	// The lower of the two middles rather than their mean. Averaging two durations invents
+	// a number neither target produced, and this is reported as an observation.
+	return sorted[mid-1]
+}
+
+// ParseTargets turns configured strings into addresses.
+//
+// Literal addresses only, never hostnames, and that is a decision rather than a
+// simplification. Resolving a name needs DNS, and DNS is one of the things that stops
+// working when a gateway fails — so a probe that had to resolve first would blame the
+// advertiser for a resolver's outage. Worse, a device that fails closed refuses plaintext
+// DNS outside the tunnel (ADR-0011), so the lookup would depend on the very path being
+// tested.
+func ParseTargets(raw []string) ([]netip.AddrPort, error) {
+	out := make([]netip.AddrPort, 0, len(raw))
+	for _, s := range raw {
+		target, err := netip.ParseAddrPort(s)
+		if err != nil {
+			return nil, err
+		}
+		if target.Port() == 0 {
+			return nil, errors.New("pathprobe: a probe target needs a port")
+		}
+		out = append(out, target)
+	}
+	return out, nil
+}

--- a/internal/pathprobe/pathprobe_test.go
+++ b/internal/pathprobe/pathprobe_test.go
@@ -1,0 +1,147 @@
+package pathprobe
+
+import (
+	"errors"
+	"net/netip"
+	"testing"
+	"time"
+)
+
+func target(s string) netip.AddrPort { return netip.MustParseAddrPort(s) }
+
+func ok(s string, rtt time.Duration) Outcome { return Outcome{Target: target(s), RTT: rtt} }
+func bad(s string) Outcome                   { return Outcome{Target: target(s), Err: errors.New("no")} }
+func outcomes(o ...Outcome) []Outcome        { return o }
+
+// A single target measures that target's path, not the advertiser's health. A majority of
+// diverse targets is what makes the difference between "the exit is down" and "one operator
+// is having a bad afternoon" — and getting it wrong moves a whole fleet at once.
+func TestAMajorityDecides(t *testing.T) {
+	for name, tc := range map[string]struct {
+		outcomes []Outcome
+		want     bool
+	}{
+		"all three answered":     {outcomes(ok("1.1.1.1:443", time.Millisecond), ok("8.8.8.8:443", time.Millisecond), ok("9.9.9.9:443", time.Millisecond)), true},
+		"one of three is down":   {outcomes(ok("1.1.1.1:443", time.Millisecond), bad("8.8.8.8:443"), ok("9.9.9.9:443", time.Millisecond)), true},
+		"two of three are down":  {outcomes(ok("1.1.1.1:443", time.Millisecond), bad("8.8.8.8:443"), bad("9.9.9.9:443")), false},
+		"none answered":          {outcomes(bad("1.1.1.1:443"), bad("8.8.8.8:443"), bad("9.9.9.9:443")), false},
+		"one of two is down":     {outcomes(ok("1.1.1.1:443", time.Millisecond), bad("8.8.8.8:443")), false},
+		"the only target is up":  {outcomes(ok("1.1.1.1:443", time.Millisecond)), true},
+		"the only target is out": {outcomes(bad("1.1.1.1:443")), false},
+	} {
+		if got := Verdict(tc.outcomes, 0); got.Reachable != tc.want {
+			t.Errorf("%s: reachable = %v, want %v", name, got.Reachable, tc.want)
+		}
+	}
+}
+
+// An even split fails rather than passes. Two of four is not a majority, and the safe
+// direction when half the internet says no is to believe it.
+func TestAnEvenSplitDoesNotPass(t *testing.T) {
+	got := Verdict(outcomes(
+		ok("1.1.1.1:443", time.Millisecond), ok("8.8.8.8:443", time.Millisecond),
+		bad("9.9.9.9:443"), bad("64.6.64.6:443")), 0)
+	if got.Reachable {
+		t.Error("two of four answered and the path was called healthy")
+	}
+}
+
+func TestAnExplicitQuorumIsHonoured(t *testing.T) {
+	three := outcomes(ok("1.1.1.1:443", time.Millisecond), bad("8.8.8.8:443"), bad("9.9.9.9:443"))
+	if !Verdict(three, 1).Reachable {
+		t.Error("a quorum of one was not met by one answer")
+	}
+	if Verdict(three, 2).Reachable {
+		t.Error("a quorum of two was met by one answer")
+	}
+}
+
+// A quorum larger than the number of targets can never be met, so it is clamped rather than
+// obeyed. Obeying it would fail every advertiser forever, and a device that has run out of
+// candidates stays on the last one while reporting it dead — a whole fleet unreachable
+// because of a number nobody could see was impossible.
+func TestAnImpossibleQuorumIsClamped(t *testing.T) {
+	all := outcomes(ok("1.1.1.1:443", time.Millisecond), ok("8.8.8.8:443", time.Millisecond))
+	if !Verdict(all, 9).Reachable {
+		t.Error("a quorum bigger than the target list failed a path where every target answered")
+	}
+	if Quorum(9, 2) != 2 {
+		t.Errorf("Quorum(9, 2) = %d, want 2", Quorum(9, 2))
+	}
+}
+
+// No targets is not a verdict of unreachable. A group with nothing to probe falls back to
+// what the handshake says, and answering "unreachable" here would fail every advertiser in a
+// network whose administrator never configured a target — which is every network today.
+func TestNoTargetsIsNotAFailure(t *testing.T) {
+	got := Verdict(nil, 0)
+	if got.Reachable {
+		t.Error("an empty probe reported a healthy path")
+	}
+	if len(got.Failed) != 0 || got.Answered != 0 || got.RTT != 0 {
+		t.Errorf("an empty probe invented a result: %+v", got)
+	}
+}
+
+// The failing targets are named, in the order they were given, so an operator can tell one
+// target being down from the exit being down.
+func TestFailingTargetsAreNamed(t *testing.T) {
+	got := Verdict(outcomes(
+		bad("1.1.1.1:443"), ok("8.8.8.8:443", time.Millisecond), bad("9.9.9.9:443")), 0)
+	if len(got.Failed) != 2 || got.Failed[0] != "1.1.1.1:443" || got.Failed[1] != "9.9.9.9:443" {
+		t.Errorf("failed = %v", got.Failed)
+	}
+	if got.Answered != 1 {
+		t.Errorf("answered = %d, want 1", got.Answered)
+	}
+}
+
+// The median of the successful dials, and only the successful ones. A failure has no round
+// trip time, so counting it as zero would report a path that is half broken as the fastest
+// one this device has ever seen.
+func TestTheRTTIsTheMedianOfWhatAnswered(t *testing.T) {
+	got := Verdict(outcomes(
+		ok("1.1.1.1:443", 10*time.Millisecond),
+		ok("8.8.8.8:443", 90*time.Millisecond),
+		ok("9.9.9.9:443", 50*time.Millisecond)), 0)
+	if got.RTT != 50*time.Millisecond {
+		t.Errorf("rtt = %v, want the median 50ms", got.RTT)
+	}
+
+	withFailure := Verdict(outcomes(
+		bad("1.1.1.1:443"), ok("8.8.8.8:443", 90*time.Millisecond)), 1)
+	if withFailure.RTT != 90*time.Millisecond {
+		t.Errorf("rtt = %v, want 90ms — the failure has no round trip to average in", withFailure.RTT)
+	}
+
+	if Verdict(outcomes(bad("1.1.1.1:443")), 0).RTT != 0 {
+		t.Error("a path where nothing answered reported a round trip time")
+	}
+}
+
+// Literal addresses only. Resolving a name needs DNS, and DNS is one of the things that
+// stops working when a gateway fails — so a probe that had to resolve first would blame the
+// advertiser for a resolver's outage. A device that fails closed refuses plaintext DNS
+// outside the tunnel, so the lookup would depend on the very path being tested.
+func TestTargetsMustBeLiteralAddresses(t *testing.T) {
+	for _, raw := range []string{
+		"one.one.one.one:443",
+		"1.1.1.1",
+		"1.1.1.1:0",
+		"",
+		"1.1.1.1:https",
+		"[2606:4700:4700::1111]",
+	} {
+		if _, err := ParseTargets([]string{raw}); err == nil {
+			t.Errorf("accepted %q", raw)
+		}
+	}
+
+	got, err := ParseTargets([]string{"1.1.1.1:443", "[2606:4700:4700::1111]:443"})
+	if err != nil {
+		t.Fatalf("refused a pair of literal addresses: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("parsed %d targets, want 2", len(got))
+	}
+}

--- a/internal/routeprobe/report.go
+++ b/internal/routeprobe/report.go
@@ -37,6 +37,7 @@ func (c *Chooser) recordLocked(groupID string, decision Decision, result Result)
 		Reachable:                result.Reachable,
 		RttMs:                    millis(result),
 		ConsecutiveFailures:      uint32(decision.ConsecutiveFailures),
+		FailedProbeTargets:       result.Failed,
 		SwitchedFromAdvertiserId: decision.Switched,
 		SwitchReason:             decision.Reason,
 	}

--- a/internal/routeprobe/routeprobe.go
+++ b/internal/routeprobe/routeprobe.go
@@ -140,6 +140,14 @@ type Result struct {
 
 	// RTT is informational and reported onward; nothing here branches on it.
 	RTT time.Duration
+
+	// Failed names the targets that did not answer, and is reported onward untouched.
+	//
+	// Nothing here branches on it either, and that is deliberate: the quorum has already
+	// turned these into a verdict, and a second rule that looked at *which* targets failed
+	// would be a policy the administrator did not write. It exists so an operator can tell
+	// one target being down from the exit being down, which the boolean cannot say.
+	Failed []string
 }
 
 // Decision is what a probe result led to.

--- a/internal/session/failover_test.go
+++ b/internal/session/failover_test.go
@@ -96,11 +96,41 @@ func TestOptingOutOfLocalFailoverReachesTheAgent(t *testing.T) {
 	}
 }
 
-// Probe targets are deliberately not sent yet: nothing in the agent reads them, so an
-// administrator could write them, see them stored, and watch them do nothing (ADR-0018).
-// This is here so that whoever adds them has to delete a test that says why they were not
-// there, rather than wondering whether it was an oversight.
-func TestProbeTargetsAreNotSentYet(t *testing.T) {
+// The targets an administrator named have to arrive, or the agent has nothing to dial and
+// falls back to the handshake — which is the whole thing this was supposed to replace.
+func TestProbeTargetsReachTheAgent(t *testing.T) {
+	f := newFixture(t)
+	laptop := f.enrolDevice("laptop")
+	router := f.enrolDevice("branch-router")
+	f.subnetGroup("branch-lan", "192.168.10.0/24")
+	f.advertise("branch-lan", router, 1)
+
+	f.setFailover("branch-lan", store.FailoverPolicy{
+		Enabled:      yes(),
+		ProbeTargets: []string{"192.168.10.1:22", "192.168.10.2:443"},
+		ProbeQuorum:  2, ProbeIntervalMS: 600_000,
+	})
+
+	policy := f.assignments(laptop)[0].GetLocalFailover()
+	if len(policy.GetProbeTargets()) != 2 {
+		t.Fatalf("probe_targets = %v", policy.GetProbeTargets())
+	}
+	if policy.GetProbeTargets()[0] != "192.168.10.1:22" {
+		t.Errorf("probe_targets = %v", policy.GetProbeTargets())
+	}
+	if policy.GetProbeQuorum() != 2 {
+		t.Errorf("probe_quorum = %d, want 2", policy.GetProbeQuorum())
+	}
+	if policy.GetProbeIntervalMs() != 600_000 {
+		t.Errorf("probe_interval_ms = %d, want 600000", policy.GetProbeIntervalMs())
+	}
+}
+
+// A group nobody has given targets sends none, which the agent reads as "fall back to the
+// handshake". There is deliberately no default: only an administrator knows what a working
+// path looks like for their network, and picking public addresses on their behalf would have
+// every device they own dialling a third party nobody asked it to.
+func TestAGroupWithNoTargetsSendsNone(t *testing.T) {
 	f := newFixture(t)
 	laptop := f.enrolDevice("laptop")
 	router := f.enrolDevice("branch-router")
@@ -108,8 +138,8 @@ func TestProbeTargetsAreNotSentYet(t *testing.T) {
 	f.advertise("branch-lan", router, 1)
 
 	policy := f.assignments(laptop)[0].GetLocalFailover()
-	if len(policy.GetProbeTargets()) != 0 || policy.GetProbeQuorum() != 0 || policy.GetProbeIntervalMs() != 0 {
-		t.Errorf("probe settings are on the wire before anything reads them: %+v", policy)
+	if len(policy.GetProbeTargets()) != 0 {
+		t.Errorf("a group nobody configured invented targets: %v", policy.GetProbeTargets())
 	}
 }
 

--- a/internal/session/routes.go
+++ b/internal/session/routes.go
@@ -172,10 +172,14 @@ func assignmentFor(group store.RouteGroup, candidates []routes.Candidate) *meshp
 			FailThreshold:    group.Failover.FailThreshold,
 			RecoverThreshold: group.Failover.RecoverThreshold,
 			MinHoldSeconds:   group.Failover.MinHoldSeconds,
-			// probe_targets, probe_quorum and probe_interval_ms are deliberately not sent
-			// yet. Nothing in the agent reads them: it derives reachability from handshake
-			// age, so targets on the wire would be a setting an administrator could write,
-			// see stored, and watch do nothing (ADR-0018). They arrive with the probe.
+
+			// What the device dials to find out whether the path through the advertiser
+			// works. Empty is the ordinary case and means the agent falls back to whether
+			// the advertiser's tunnel is up — which catches a gateway that is off, and not
+			// one whose own uplink has failed.
+			ProbeTargets:    group.Failover.ProbeTargets,
+			ProbeQuorum:     group.Failover.ProbeQuorum,
+			ProbeIntervalMs: group.Failover.ProbeIntervalMS,
 		},
 	}
 

--- a/internal/store/failover.go
+++ b/internal/store/failover.go
@@ -3,6 +3,8 @@ package store
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/meshpnet/meshp/internal/pathprobe"
 )
 
 // FailoverPolicy is what a route group tells its devices about moving between advertisers.
@@ -37,7 +39,32 @@ type FailoverPolicy struct {
 	// MinHoldSeconds is the floor on time between switches, applied to coming back and never
 	// to leaving.
 	MinHoldSeconds uint32 `json:"min_hold_seconds,omitempty"`
+
+	// ProbeTargets are addresses the device dials through the advertiser to decide whether
+	// the path works. Empty means the device falls back to whether the advertiser's tunnel
+	// is up, which catches a gateway that is off and not one whose own uplink has failed.
+	//
+	// There is deliberately no default. Only an administrator knows what a working path
+	// looks like for their network — for a branch LAN it is a host on that LAN, and nothing
+	// else will do — and picking public addresses on their behalf would have every device
+	// they own dialling a third party nobody asked it to.
+	ProbeTargets []string `json:"probe_targets,omitempty"`
+
+	// ProbeQuorum is how many targets must answer. Zero means a majority.
+	ProbeQuorum uint32 `json:"probe_quorum,omitempty"`
+
+	// ProbeIntervalMS is the floor on how often a device probes, so a group can be quieter
+	// than the daemon's reconcile interval. Zero means probe on every pass.
+	ProbeIntervalMS uint32 `json:"probe_interval_ms,omitempty"`
 }
+
+// MaxProbeTargets caps how many addresses one group may name.
+//
+// Every device carrying the group dials all of them on every round, so this is a number an
+// administrator multiplies by their fleet without meaning to. Eight is more than enough for
+// diversity — three or four is the useful range — and small enough that a policy cannot turn
+// a fleet into a load generator.
+const MaxProbeTargets = 8
 
 // DefaultFailoverPolicy is what a group gets when nobody says otherwise.
 //
@@ -76,6 +103,32 @@ func (p FailoverPolicy) Validate() error {
 	const maxHold = 24 * 60 * 60
 	if p.MinHoldSeconds > maxHold {
 		return fmt.Errorf("store: min_hold_seconds must be at most %d", maxHold)
+	}
+
+	if len(p.ProbeTargets) > MaxProbeTargets {
+		return fmt.Errorf("store: at most %d probe targets; every device carrying this group "+
+			"dials all of them on every round", MaxProbeTargets)
+	}
+	// Parsed here rather than trusted, because the agent parses them too and a target it
+	// cannot read is one it silently drops — which lowers the number of targets a quorum is
+	// measured against without anything saying so.
+	if _, err := pathprobe.ParseTargets(p.ProbeTargets); err != nil {
+		return fmt.Errorf("store: a probe target must be a literal address and port, "+
+			"because resolving a name needs the DNS that fails with the gateway: %w", err)
+	}
+	// A quorum nothing can satisfy fails every advertiser, forever, and a device that has
+	// run out of candidates stays on the last one while reporting it dead. The agent clamps
+	// rather than obeying, so this is the only place a person can be told.
+	if p.ProbeQuorum > uint32(len(p.ProbeTargets)) {
+		return fmt.Errorf("store: probe_quorum %d cannot be met by %d targets",
+			p.ProbeQuorum, len(p.ProbeTargets))
+	}
+	// An interval below a second is a device dialling every target continuously; a day is
+	// long enough that the probe has stopped being one.
+	const minInterval, maxInterval = 1000, 24 * 60 * 60 * 1000
+	if p.ProbeIntervalMS != 0 && (p.ProbeIntervalMS < minInterval || p.ProbeIntervalMS > maxInterval) {
+		return fmt.Errorf("store: probe_interval_ms must be between %d and %d, or zero for every pass",
+			minInterval, maxInterval)
 	}
 	return nil
 }

--- a/internal/store/failover_test.go
+++ b/internal/store/failover_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"errors"
+	"net/netip"
 	"testing"
 )
 
@@ -202,5 +203,101 @@ func TestABackwardsPolicyIsNotStored(t *testing.T) {
 	}
 	if len(groups) != 1 || groups[0].Failover.FailThreshold != 0 {
 		t.Errorf("the refused policy was stored anyway: %+v", groups[0].Failover)
+	}
+}
+
+// Probe targets have to be literal addresses. Resolving a name needs DNS, and DNS is one of
+// the things that stops working when a gateway fails — so a probe that had to resolve first
+// would blame the advertiser for a resolver's outage.
+func TestProbeTargetsMustBeAddresses(t *testing.T) {
+	for name, p := range map[string]FailoverPolicy{
+		"a hostname":         {ProbeTargets: []string{"one.one.one.one:443"}},
+		"no port":            {ProbeTargets: []string{"1.1.1.1"}},
+		"a named port":       {ProbeTargets: []string{"1.1.1.1:https"}},
+		"one bad among good": {ProbeTargets: []string{"1.1.1.1:443", "nonsense"}},
+	} {
+		if err := p.Validate(); err == nil {
+			t.Errorf("%s was accepted", name)
+		}
+	}
+	if err := (FailoverPolicy{ProbeTargets: []string{"1.1.1.1:443", "[2606:4700:4700::1111]:443"}}).Validate(); err != nil {
+		t.Errorf("literal addresses were refused: %v", err)
+	}
+}
+
+// A quorum nothing can satisfy fails every advertiser forever, and a device that has run out
+// of candidates stays on the last one while reporting it dead. The agent clamps rather than
+// obeying, so this is the only place a person can be told.
+func TestAnUnmeetableQuorumIsRefused(t *testing.T) {
+	if err := (FailoverPolicy{
+		ProbeTargets: []string{"1.1.1.1:443", "9.9.9.9:443"}, ProbeQuorum: 3,
+	}).Validate(); err == nil {
+		t.Error("a quorum of three across two targets was accepted")
+	}
+	if err := (FailoverPolicy{ProbeQuorum: 1}).Validate(); err == nil {
+		t.Error("a quorum with no targets at all was accepted")
+	}
+	if err := (FailoverPolicy{
+		ProbeTargets: []string{"1.1.1.1:443", "9.9.9.9:443"}, ProbeQuorum: 2,
+	}).Validate(); err != nil {
+		t.Errorf("a quorum equal to the target count was refused: %v", err)
+	}
+}
+
+// Every device carrying the group dials every target on every round, so this is a number an
+// administrator multiplies by their fleet without meaning to.
+func TestTheTargetListIsBounded(t *testing.T) {
+	var many []string
+	for i := range MaxProbeTargets + 1 {
+		many = append(many, netip.AddrPortFrom(
+			netip.AddrFrom4([4]byte{192, 0, 2, byte(i + 1)}), 443).String())
+	}
+	if err := (FailoverPolicy{ProbeTargets: many}).Validate(); err == nil {
+		t.Errorf("%d targets were accepted", len(many))
+	}
+	if err := (FailoverPolicy{ProbeTargets: many[:MaxProbeTargets]}).Validate(); err != nil {
+		t.Errorf("%d targets were refused: %v", MaxProbeTargets, err)
+	}
+}
+
+// An interval below a second is a device dialling continuously; a day is long enough that
+// the probe has stopped being one. Zero stays meaningful: probe on every pass.
+func TestTheProbeIntervalIsBounded(t *testing.T) {
+	for name, p := range map[string]FailoverPolicy{
+		"a hundred milliseconds": {ProbeIntervalMS: 100},
+		"a week":                 {ProbeIntervalMS: 7 * 24 * 60 * 60 * 1000},
+	} {
+		if err := p.Validate(); err == nil {
+			t.Errorf("%s was accepted", name)
+		}
+	}
+	for name, p := range map[string]FailoverPolicy{
+		"every pass":  {ProbeIntervalMS: 0},
+		"ten minutes": {ProbeIntervalMS: 600_000},
+	} {
+		if err := p.Validate(); err != nil {
+			t.Errorf("%s was refused: %v", name, err)
+		}
+	}
+}
+
+// The targets survive the column, because that is where they live between an administrator
+// writing them and an agent being sent them.
+func TestProbeTargetsSurviveTheStore(t *testing.T) {
+	s, _ := seedNetwork(t)
+	ctx := testContext(t)
+	subnetGroup(t, s, "branch")
+
+	updated, err := s.SetRouteGroupFailover(ctx, s.netID, "branch", FailoverPolicy{
+		Enabled:      boolPtr(true),
+		ProbeTargets: []string{"192.168.10.1:22", "192.168.10.2:443"},
+		ProbeQuorum:  2, ProbeIntervalMS: 600_000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(updated.Failover.ProbeTargets) != 2 || updated.Failover.ProbeQuorum != 2 ||
+		updated.Failover.ProbeIntervalMS != 600_000 {
+		t.Errorf("stored %+v", updated.Failover)
 	}
 }

--- a/internal/tunnel/probe.go
+++ b/internal/tunnel/probe.go
@@ -1,8 +1,12 @@
 package tunnel
 
 import (
+	"context"
+	"net/netip"
 	"time"
 
+	"github.com/meshpnet/meshp/internal/logx"
+	"github.com/meshpnet/meshp/internal/pathprobe"
 	"github.com/meshpnet/meshp/internal/routeprobe"
 	"github.com/meshpnet/meshp/internal/wgplan"
 	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
@@ -19,16 +23,24 @@ const livenessGrace = 3 * time.Minute
 
 // probeFromHandshake reads the observed interface for a verdict on one advertiser.
 //
-// An honest first probe rather than the intended one. What the failover policy asks for is
-// traffic sent *through* the advertiser to diverse targets, which measures what a user
-// experiences; this measures only whether the advertiser itself is reachable. The
-// difference matters — a gateway whose own uplink has failed still handshakes — so this
-// catches an advertiser that is off or unreachable and not one that is present and useless.
+// Half the answer, and the cheap half. It measures whether the advertiser itself is
+// reachable, which catches a gateway that is off or unplugged; it says nothing about whether
+// anything behind it is, because a branch router whose own uplink has failed handshakes
+// perfectly. The other half is probeThroughAdvertiser, which sends real traffic.
 //
-// It is worth having anyway because it costs nothing: the reconciler already reads this
-// from the kernel on every pass, so a device fails over from a dead gateway without a
-// single extra packet. Probing through the advertiser is the next slice, and this is the
-// subset that needs no new I/O to be true.
+// This stays in front of that one rather than being replaced by it, and the ordering is the
+// design. The two answer different questions and only one of them costs packets:
+//
+//   - No handshake at all is no verdict. A peer that was configured a moment ago has not had
+//     time, and a probe would fail for that reason and move a device before it ever tried.
+//   - A stale handshake is already a failure. The advertiser is unreachable, so there is
+//     nothing to be learned by dialling through it, and a device with a dead gateway should
+//     not also be generating traffic.
+//   - A fresh handshake is where this stops being enough, and where the probe takes over.
+//
+// So the probe only ever tightens a verdict this one has already passed. It cannot rescue an
+// advertiser the handshake says is gone, which is correct: the handshake is measuring the
+// tunnel the probe would have to travel through.
 func probeFromHandshake(observed wgplan.Observed, peerKey string) (routeprobe.Result, bool) {
 	for _, peer := range observed.Peers {
 		if string(peer.PublicKey) != peerKey {
@@ -72,4 +84,79 @@ func chosenCandidate(chooser *routeprobe.Chooser, assignment *meshpv1.RouteGroup
 		return nil
 	}
 	return chooser.Current(assignment)
+}
+
+// Prober measures whether traffic through an interface reaches somewhere.
+//
+// An interface so the reconciler can be tested without a network, and so a platform with no
+// implementation is a nil rather than a stub that dials out of the wrong interface and
+// reports a number about the wrong path.
+type Prober interface {
+	// Probe dials every target through iface and reports how each went. It does not decide
+	// anything: the quorum is the caller's, because the caller is the one holding the policy.
+	Probe(ctx context.Context, iface string, targets []netip.AddrPort) []pathprobe.Outcome
+}
+
+// probeThroughAdvertiser sends traffic to the group's targets and folds the answers into a
+// verdict, or reports that it did not run.
+//
+// The false is not a failure. A group with no targets, a host with no prober, or targets that
+// will not parse all mean "this device cannot answer the question that way", and the caller
+// keeps whatever the handshake said. Returning unreachable instead would fail every
+// advertiser in a network whose administrator never configured a target, which is every
+// network today.
+func (r *Reconciler) probeThroughAdvertiser(ctx context.Context, iface string, assignment *meshpv1.RouteGroupAssignment) (routeprobe.Result, []string, bool) {
+	if r.prober == nil {
+		return routeprobe.Result{}, nil, false
+	}
+	policy := assignment.GetLocalFailover()
+	raw := policy.GetProbeTargets()
+	if len(raw) == 0 {
+		return routeprobe.Result{}, nil, false
+	}
+
+	targets, err := pathprobe.ParseTargets(raw)
+	if err != nil {
+		// The store refuses these on the way in, so arriving here means a control plane that
+		// does not validate, or a policy written before it did. Logged rather than partially
+		// honoured: dropping the unparseable ones would quietly lower the number of targets
+		// the quorum is measured against, so a policy asking for two of three would become
+		// two of two and the group would fail on one target's bad afternoon.
+		r.log.Warn("ignoring this group's probe targets and falling back to the handshake",
+			"group", logx.Safe(assignment.GetName()), "error", logx.SafeError(err))
+		return routeprobe.Result{}, nil, false
+	}
+
+	if !r.dueToProbe(assignment.GetRouteGroupId(), policy.GetProbeIntervalMs()) {
+		return routeprobe.Result{}, nil, false
+	}
+
+	verdict := pathprobe.Verdict(r.prober.Probe(ctx, iface, targets), int(policy.GetProbeQuorum()))
+	return routeprobe.Result{Reachable: verdict.Reachable, RTT: verdict.RTT}, verdict.Failed, true
+}
+
+// dueToProbe reports whether enough time has passed, and records that it has.
+//
+// A floor rather than a schedule. The reconciler's own tick decides when this is asked, and
+// this only ever says "not yet" — so a group can be quieter than the daemon's reconcile
+// interval but never noisier, and a burst of unrelated state deltas cannot turn a probe
+// policy into a flood.
+//
+// An interval of zero means every pass, which is what a group that has not thought about it
+// gets: the reconcile interval is already a minute.
+func (r *Reconciler) dueToProbe(groupID string, intervalMS uint32) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := r.now()
+	if intervalMS == 0 {
+		r.lastProbe[groupID] = now
+		return true
+	}
+	last, seen := r.lastProbe[groupID]
+	if seen && now.Sub(last) < time.Duration(intervalMS)*time.Millisecond {
+		return false
+	}
+	r.lastProbe[groupID] = now
+	return true
 }

--- a/internal/tunnel/probe_test.go
+++ b/internal/tunnel/probe_test.go
@@ -1,0 +1,431 @@
+package tunnel
+
+import (
+	"context"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/clock"
+	"github.com/meshpnet/meshp/internal/pathprobe"
+	"github.com/meshpnet/meshp/internal/peerset"
+	"github.com/meshpnet/meshp/internal/routeprobe"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// fakeProber answers however a test says, and records what it was asked.
+type fakeProber struct {
+	mu sync.Mutex
+
+	// answer decides each target. Nil means every target answers.
+	answer func(netip.AddrPort) error
+
+	// calls records one entry per Probe, holding the interface it was told to use.
+	calls []probeCall
+}
+
+type probeCall struct {
+	iface   string
+	targets []netip.AddrPort
+}
+
+func (p *fakeProber) Probe(_ context.Context, iface string, targets []netip.AddrPort) []pathprobe.Outcome {
+	p.mu.Lock()
+	p.calls = append(p.calls, probeCall{iface: iface, targets: targets})
+	answer := p.answer
+	p.mu.Unlock()
+
+	out := make([]pathprobe.Outcome, 0, len(targets))
+	for _, t := range targets {
+		var err error
+		if answer != nil {
+			err = answer(t)
+		}
+		out = append(out, pathprobe.Outcome{Target: t, RTT: 5 * time.Millisecond, Err: err})
+	}
+	return out
+}
+
+func (p *fakeProber) count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.calls)
+}
+
+func (p *fakeProber) lastIface() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.calls) == 0 {
+		return ""
+	}
+	return p.calls[len(p.calls)-1].iface
+}
+
+// probedGroup is a group with two candidates and targets to dial through them.
+func probedGroup(first, second string, targets ...string) *meshpv1.RouteGroupAssignment {
+	return &meshpv1.RouteGroupAssignment{
+		RouteGroupId: "group-branch", Name: "branch", Prefixes: []string{"192.168.10.0/24"},
+		Candidates: []*meshpv1.RouteCandidate{
+			{PeerPublicKey: first, AdvertiserId: "adv-first", Priority: 1},
+			{PeerPublicKey: second, AdvertiserId: "adv-second", Priority: 2},
+		},
+		LocalFailover: &meshpv1.LocalFailoverPolicy{
+			Enabled: true, FailThreshold: 1, ProbeTargets: targets,
+		},
+	}
+}
+
+// handshaking marks every peer as freshly handshaking, which is the state the handshake
+// probe calls healthy.
+func handshaking(link *fakeLink) {
+	for i := range link.observed.Peers {
+		link.observed.Peers[i].HasHandshake = true
+		link.observed.Peers[i].HandshakeAge = time.Second
+	}
+}
+
+// warmUp applies once so the peers exist, then forgets that it happened.
+//
+// The first pass configures the interface from nothing, so there are no observed peers to
+// read a handshake from and nothing is probed — which is correct behaviour and not what any
+// of these tests are about. Doing it explicitly, and resetting the prober afterwards, keeps
+// every count below a statement about probing rather than about start-up.
+func warmUp(t *testing.T, r *Reconciler, link *fakeLink, state *peerset.Set, prober *fakeProber) {
+	t.Helper()
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	handshaking(link)
+	if prober != nil {
+		prober.reset()
+	}
+}
+
+func (p *fakeProber) reset() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = nil
+}
+
+// The failure this whole thing exists for.
+//
+// The advertiser is up, its handshake is fresh, and nothing gets through it — a branch
+// router whose own uplink has failed. Before this, every device steered at that router sat
+// there with no route to anything while the agent, the control plane and the handshake all
+// reported health.
+func TestADeviceLeavesAnAdvertiserThatIsUpButUseless(t *testing.T) {
+	clk := clock.NewFake()
+	link := newFakeLink()
+	prober := &fakeProber{answer: func(netip.AddrPort) error { return context.DeadlineExceeded }}
+	r := New(link, membership(), nil, nil, nil).
+		WithChooser(routeprobe.New(clk)).
+		WithProber(prober)
+
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{probedGroup(bobKey, carolKey, "1.1.1.1:443", "9.9.9.9:443")},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	handshaking(link)
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	handshaking(link)
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+
+	if prober.count() == 0 {
+		t.Fatal("nothing was probed, so the handshake is still the whole verdict")
+	}
+	if got := r.chooser.Current(state.RouteGroups()[0]).GetAdvertiserId(); got != "adv-second" {
+		t.Errorf("still using %q; the device stayed on an advertiser nothing gets through", got)
+	}
+}
+
+// And it stays put when the path works, or every device would move on the first probe.
+func TestAWorkingPathKeepsTheAdvertiser(t *testing.T) {
+	clk := clock.NewFake()
+	link := newFakeLink()
+	prober := &fakeProber{}
+	r := New(link, membership(), nil, nil, nil).
+		WithChooser(routeprobe.New(clk)).
+		WithProber(prober)
+
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{probedGroup(bobKey, carolKey, "1.1.1.1:443", "9.9.9.9:443")},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	for range 5 {
+		handshaking(link)
+		if _, err := r.Apply(context.Background(), state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := r.chooser.Current(state.RouteGroups()[0]).GetAdvertiserId(); got != "adv-first" {
+		t.Errorf("moved to %q while every target was answering", got)
+	}
+}
+
+// The probe is dialled through the tunnel, not through whatever the routing table prefers.
+// A probe on the wrong interface measures the local network and reports it as the
+// advertiser's health.
+func TestTheProbeGoesThroughTheTunnelInterface(t *testing.T) {
+	link := newFakeLink()
+	prober := &fakeProber{}
+	r := New(link, membership(), nil, nil, nil).
+		WithChooser(routeprobe.New(clock.NewFake())).
+		WithProber(prober)
+
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{probedGroup(bobKey, carolKey, "1.1.1.1:443")},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	warmUp(t, r, link, state, prober)
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if got := prober.lastIface(); got != membership().InterfaceName {
+		t.Errorf("probed through %q, want the tunnel %q", got, membership().InterfaceName)
+	}
+}
+
+// A group with no targets is not probed at all, and the handshake stays in charge. That is
+// every network that has not configured one, which today is all of them.
+func TestAGroupWithNoTargetsIsNotProbed(t *testing.T) {
+	link := newFakeLink()
+	prober := &fakeProber{answer: func(netip.AddrPort) error { return context.DeadlineExceeded }}
+	r := New(link, membership(), nil, nil, nil).
+		WithChooser(routeprobe.New(clock.NewFake())).
+		WithProber(prober)
+
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{probedGroup(bobKey, carolKey)},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	for range 5 {
+		handshaking(link)
+		if _, err := r.Apply(context.Background(), state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if prober.count() != 0 {
+		t.Errorf("a group with no targets was probed %d times", prober.count())
+	}
+	if got := r.chooser.Current(state.RouteGroups()[0]).GetAdvertiserId(); got != "adv-first" {
+		t.Errorf("moved to %q on a group nobody asked to be probed", got)
+	}
+}
+
+// An advertiser the handshake already says is gone is not dialled through.
+//
+// The tunnel the probe would have to travel through is the thing the handshake just reported
+// as dead, so the packets would be spent to reach an answer already in hand — and a device
+// whose gateway has failed should not also be generating traffic.
+func TestASilentAdvertiserIsNotProbed(t *testing.T) {
+	link := newFakeLink()
+	prober := &fakeProber{}
+	r := New(link, membership(), nil, nil, nil).
+		WithChooser(routeprobe.New(clock.NewFake())).
+		WithProber(prober)
+
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{probedGroup(bobKey, carolKey, "1.1.1.1:443")},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	// The warm-up puts the peers on the interface and hands them a fresh handshake, so that
+	// what follows is a statement about a stale one rather than about start-up. Without it
+	// there are no observed peers at all, nothing is probed for that reason, and this test
+	// passes whatever the code does — which is how it was written the first time, and what a
+	// mutation caught.
+	warmUp(t, r, link, state, prober)
+
+	// Now every peer's handshake goes stale.
+	for i := range link.observed.Peers {
+		link.observed.Peers[i].HasHandshake = true
+		link.observed.Peers[i].HandshakeAge = time.Hour
+	}
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if prober.count() != 0 {
+		t.Error("an advertiser whose handshake is stale was dialled through anyway")
+	}
+
+	// And a fresh one is probed, so the assertion above is about staleness and not about
+	// the prober being unreachable from here.
+	handshaking(link)
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if prober.count() == 0 {
+		t.Error("a fresh handshake was not probed either, so the check above proves nothing")
+	}
+}
+
+// A host with no prober keeps the handshake, rather than failing every advertiser because it
+// cannot answer the question.
+func TestAHostWithNoProberFallsBackToTheHandshake(t *testing.T) {
+	link := newFakeLink()
+	r := New(link, membership(), nil, nil, nil).
+		WithChooser(routeprobe.New(clock.NewFake()))
+
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{probedGroup(bobKey, carolKey, "1.1.1.1:443")},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	for range 5 {
+		handshaking(link)
+		if _, err := r.Apply(context.Background(), state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := r.chooser.Current(state.RouteGroups()[0]).GetAdvertiserId(); got != "adv-first" {
+		t.Errorf("a host that cannot probe moved to %q anyway", got)
+	}
+}
+
+// Targets the agent cannot parse mean the probe does not run, rather than running against
+// the ones it could read.
+//
+// Dropping the unparseable ones would quietly lower the number of targets a quorum is
+// measured against: a policy asking for two of three would silently become two of two, and
+// the group would fail on one target's bad afternoon.
+func TestUnreadableTargetsFallBackRatherThanShrinkTheQuorum(t *testing.T) {
+	link := newFakeLink()
+	prober := &fakeProber{}
+	r := New(link, membership(), nil, nil, nil).
+		WithChooser(routeprobe.New(clock.NewFake())).
+		WithProber(prober)
+
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{probedGroup(bobKey, carolKey, "1.1.1.1:443", "not-an-address")},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	warmUp(t, r, link, state, prober)
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if prober.count() != 0 {
+		t.Errorf("probed with %d targets when one of them could not be read; dropping the "+
+			"unreadable one turns a quorum of two-of-three into two-of-two", prober.count())
+	}
+
+	// The same group with every target readable is probed, so the check above is about the
+	// bad target rather than about nothing having reached the prober.
+	good := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{probedGroup(bobKey, carolKey, "1.1.1.1:443")},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+	handshaking(link)
+	if _, err := r.Apply(context.Background(), good); err != nil {
+		t.Fatal(err)
+	}
+	if prober.count() == 0 {
+		t.Error("a group whose targets all parse was not probed either, so the check above proves nothing")
+	}
+}
+
+// A group can be quieter than the daemon's reconcile interval. Without a floor, the probe
+// cadence would be a daemon-wide flag, and a burst of unrelated state deltas would turn a
+// probe policy into a flood.
+func TestTheProbeIntervalIsAFloor(t *testing.T) {
+	clk := clock.NewFake()
+	link := newFakeLink()
+	prober := &fakeProber{}
+	r := New(link, membership(), nil, nil, nil).
+		WithChooser(routeprobe.New(clk)).
+		WithProber(prober)
+	r.clock = clk.Now
+
+	group := probedGroup(bobKey, carolKey, "1.1.1.1:443")
+	group.LocalFailover.ProbeIntervalMs = 600_000 // ten minutes
+	state := stateWithRoutes(1, []*meshpv1.RouteGroupAssignment{group},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	warmUp(t, r, link, state, prober)
+	for range 5 {
+		handshaking(link)
+		if _, err := r.Apply(context.Background(), state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if prober.count() != 1 {
+		t.Fatalf("probed %d times in ten minutes with a ten-minute floor, want 1", prober.count())
+	}
+
+	clk.Advance(11 * time.Minute)
+	handshaking(link)
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if prober.count() != 2 {
+		t.Errorf("probed %d times after the interval elapsed, want 2", prober.count())
+	}
+}
+
+// An interval of zero means every pass, which is what a group that has not thought about it
+// gets — the reconcile interval is already a minute.
+func TestNoIntervalMeansEveryPass(t *testing.T) {
+	clk := clock.NewFake()
+	link := newFakeLink()
+	prober := &fakeProber{}
+	r := New(link, membership(), nil, nil, nil).
+		WithChooser(routeprobe.New(clk)).
+		WithProber(prober)
+	r.clock = clk.Now
+
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{probedGroup(bobKey, carolKey, "1.1.1.1:443")},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	warmUp(t, r, link, state, prober)
+	for range 3 {
+		handshaking(link)
+		if _, err := r.Apply(context.Background(), state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if prober.count() != 3 {
+		t.Errorf("probed %d times over three passes with no interval set, want 3", prober.count())
+	}
+}
+
+// The targets that failed reach the control plane, so an operator can tell one target being
+// down from the exit being down — which the boolean cannot say.
+func TestFailingTargetsAreReportedOnward(t *testing.T) {
+	clk := clock.NewFake()
+	link := newFakeLink()
+	dead := netip.MustParseAddrPort("9.9.9.9:443")
+	prober := &fakeProber{answer: func(t netip.AddrPort) error {
+		if t == dead {
+			return context.DeadlineExceeded
+		}
+		return nil
+	}}
+	chooser := routeprobe.New(clk)
+	r := New(link, membership(), nil, nil, nil).WithChooser(chooser).WithProber(prober)
+
+	state := stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{probedGroup(bobKey, carolKey, "1.1.1.1:443", "9.9.9.9:443", "8.8.8.8:443")},
+		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
+
+	warmUp(t, r, link, state, prober)
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+
+	reports := chooser.Pending()
+	if len(reports) != 1 {
+		t.Fatalf("%d reports, want 1", len(reports))
+	}
+	if !reports[0].GetReachable() {
+		t.Error("two of three targets answered and the path was called broken")
+	}
+	failed := reports[0].GetFailedProbeTargets()
+	if len(failed) != 1 || failed[0] != dead.String() {
+		t.Errorf("failed_probe_targets = %v, want just the dead one", failed)
+	}
+	if reports[0].GetRttMs() == 0 {
+		t.Error("the report carries no round trip time, so nothing measured the path")
+	}
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -16,6 +16,7 @@ import (
 	"net/netip"
 	"strings"
 	"sync"
+	"time"
 
 	"google.golang.org/protobuf/proto"
 
@@ -130,7 +131,22 @@ type Reconciler struct {
 	// in-flight masqueraded flows. An unchanged assignment is left alone.
 	lastAdvertised *meshpv1.AdvertisedRoutes
 
-	mu       sync.Mutex
+	// prober sends real traffic through the tunnel to decide whether a path works, or is
+	// nil where this platform cannot bind a socket to an interface. Nil means the handshake
+	// is the whole verdict, which is what every device did before this existed.
+	prober Prober
+
+	// clock is overridable so the probe interval can be tested without waiting. Nil means
+	// the wall clock.
+	clock func() time.Time
+
+	mu sync.Mutex
+
+	// lastProbe is when each group was last probed, so a group can ask to be quieter than
+	// the daemon's reconcile interval. Under mu because Apply is entered both from the
+	// session's applier and from the reconcile ticker.
+	lastProbe map[string]time.Time
+
 	kind     wglink.Kind
 	up       bool
 	lastErr  string
@@ -182,7 +198,16 @@ func New(link wglink.Link, m Membership, relay Relay, filter Filter, log *slog.L
 	return &Reconciler{
 		link: link, membership: m, relay: relay, filter: filter,
 		log: log, kind: wglink.KindUnknown,
+		lastProbe: make(map[string]time.Time),
 	}
+}
+
+// now is the reconciler's idea of the time.
+func (r *Reconciler) now() time.Time {
+	if r.clock == nil {
+		return time.Now()
+	}
+	return r.clock()
 }
 
 // WithClaims lets this reconciler see what other memberships on the device carry.
@@ -200,6 +225,17 @@ func (r *Reconciler) WithClaims(c *Claims) *Reconciler {
 // that cannot claim one reports the group unhonoured rather than half-claiming it.
 func (r *Reconciler) WithEgress(e Egress) *Reconciler {
 	r.egress = e
+	return r
+}
+
+// WithProber lets this reconciler send traffic through an advertiser to find out whether the
+// path works, rather than only asking whether the advertiser answered a handshake.
+//
+// Nil is meaningful and is the ordinary case on anything but Linux: a host that cannot bind a
+// socket to an interface has no way to guarantee the probe went through the tunnel, and a
+// measurement of the wrong path is worse than none.
+func (r *Reconciler) WithProber(p Prober) *Reconciler {
+	r.prober = p
 	return r
 }
 
@@ -277,10 +313,12 @@ func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, e
 			"operations", len(plan.Ops))
 	}
 
-	// Every probe this pass costs is a read the reconciler already did. A device whose
-	// gateway has gone silent therefore fails over on the next tick without sending a
-	// single extra packet.
-	r.observeAdvertisers(observed, state.RouteGroups())
+	// The handshake half of this costs nothing — the reconciler has already read it from the
+	// kernel — so a device whose gateway has gone silent fails over on the next tick without
+	// sending a packet. The probe half does send traffic, and only for groups whose
+	// administrator named targets, only when the handshake says the advertiser is up, and no
+	// more often than that group's probe interval allows.
+	r.observeAdvertisers(ctx, want.Name, observed, state.RouteGroups())
 
 	// Which implementation ended up behind it, read rather than assumed. ADR-0015 requires
 	// this to be reportable: a silent userspace fallback makes a tenfold difference in
@@ -406,7 +444,7 @@ func (r *Reconciler) applyFilter(ctx context.Context, iface string, want *meshpv
 // Decisions are not acted on here. The chooser records them, and the next Apply configures
 // whatever it now points at — which keeps "decide" and "converge" in the order the rest of
 // this package uses, rather than reconfiguring an interface half way through reading it.
-func (r *Reconciler) observeAdvertisers(observed wgplan.Observed, assignments []*meshpv1.RouteGroupAssignment) {
+func (r *Reconciler) observeAdvertisers(ctx context.Context, iface string, observed wgplan.Observed, assignments []*meshpv1.RouteGroupAssignment) {
 	if r.chooser == nil {
 		return
 	}
@@ -422,6 +460,26 @@ func (r *Reconciler) observeAdvertisers(observed wgplan.Observed, assignments []
 		if !ok {
 			continue
 		}
+
+		// The handshake first, and the probe only if it passed. A stale handshake already
+		// says the advertiser is unreachable, so dialling through it would spend packets to
+		// reach the same answer — and the tunnel the probe would travel through is the thing
+		// the handshake just reported as gone.
+		if result.Reachable {
+			if probed, failed, ran := r.probeThroughAdvertiser(ctx, iface, assignment); ran {
+				result = probed
+				result.Failed = failed
+				if !result.Reachable {
+					// Said plainly, because this is the case the handshake gets wrong and the
+					// reason this exists: the advertiser answered, and nothing behind it did.
+					r.log.Warn("this advertiser is up but nothing gets through it",
+						"group", logx.Safe(assignment.GetName()),
+						"advertiser", logx.Safe(current.GetAdvertiserId()),
+						"failed_targets", len(failed))
+				}
+			}
+		}
+
 		if decision := r.chooser.Observe(assignment, result); decision.Switched != "" {
 			r.log.Info("moving to another advertiser",
 				"group", logx.Safe(assignment.GetName()),


### PR DESCRIPTION
Closes #5. A WireGuard handshake says the advertiser is reachable; it says nothing about whether anything behind it is. A branch router whose own uplink has failed handshakes perfectly, and every device steered at it sits with no route to anything while the agent, the control plane and the handshake all report health. [PR #41](https://github.com/meshpnet/meshp/pull/41) documented that as an honest subset — this is the rest.

## Using it

```bash
curl -sX PUT -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
  -d '{"enabled":true,"probe_targets":["192.168.10.1:22","192.168.10.2:443"],"probe_quorum":1,"probe_interval_ms":600000}' \
  "$CONTROL/api/v1/networks/$NETWORK/route-groups/branch-lan/failover"
```

## The load-bearing decision

**`SO_BINDTODEVICE`, not the routing table.** A dial that consulted the routing table would leave by the physical interface whenever the route through the tunnel is missing — after a failed egress claim, or for a group not being carried — and would then report the advertiser healthy *while measuring the local connection*. That false positive pins a device to a dead gateway, which is the exact failure this removes.

Once bound, WireGuard's cryptokey routing picks the peer, and wgplan already refuses two peers claiming one prefix — so "through the interface" and "through the chosen advertiser" are the same thing without this package knowing which peer that is.

A host that cannot bind gets **no prober at all** rather than a hopeful one. A measurement of the wrong path is worse than none.

## Four more choices worth defending

**TCP, not ICMP.** A completed handshake proves a bidirectional path to a listening service — what a user is about to do. A ping proves something along the way was willing to answer one, and is deprioritised or dropped across much of the internet. A probe whose failures are mostly policy is worse than no probe, because a fleet learns to ignore it. A *refused* connection counts as working: the packet arrived and the far end answered, and counting it as failure would make every verdict depend on whether the target still runs something on that port.

**The handshake stays in front.** No handshake is no verdict; a stale one is already a failure and needs no packets to confirm; a fresh one is where the handshake stops being enough. The probe only ever tightens a verdict the handshake passed, and cannot rescue an advertiser it says is gone — correct, since the tunnel the probe would travel through is the thing reported dead.

**No default targets.** Only an administrator knows what a working path looks like for their network — for a branch LAN it is a host on that LAN and nothing else will do. Picking public addresses on their behalf would have every device they own dialling a third party nobody asked it to. A group with no targets falls back to the handshake, which is every network today.

**Literal addresses only.** Resolving a name needs DNS, and DNS is one of the things that stops working when a gateway fails — so a probe that resolved first would blame the advertiser for a resolver's outage. A device that fails closed refuses plaintext DNS outside the tunnel (ADR-0011), so the lookup would depend on the very path being tested. Unreadable targets mean the probe does not run *at all* rather than running against the rest: dropping them would silently turn a two-of-three quorum into two-of-two.

`probe_interval_ms` is a floor, not a schedule — a group can be quieter than the daemon's reconcile interval but never noisier, so a burst of unrelated deltas cannot turn a probe policy into a flood.

## Verification

`make ci`, `make integration`, and the data-plane tests under `--privileged` all green.

The binding is tested **against real interfaces**, two network namespaces, in the data-plane job — whether a socket leaves by the interface it was bound to cannot be tested any other way. The decoy interface has no route to the target: the routing table would have sent that dial through the working one and reported success.

That test dials one target at a time on purpose. A namespace belongs to a *thread*, and `Probe` fans out across goroutines running on threads the test does not control — a test that called `Probe` would open sockets in the root namespace and fail with "no such device" while the code was perfectly correct. The fan-out is covered separately over loopback.

Sixteen mutations, all caught:

| Mutation | Caught by |
|---|---|
| Drop `SO_BINDTODEVICE` | `TestAProbeLeavesByTheInterfaceItWasBoundTo` (real interfaces) |
| Never probe (i.e. today's `main`) | 5 tunnel tests |
| Probe even when the handshake says the advertiser is gone | `TestASilentAdvertiserIsNotProbed` |
| Probe the physical interface | `TestTheProbeGoesThroughTheTunnelInterface` |
| Quorum of all targets rather than a majority | 2 tests |
| Obey an impossible quorum instead of clamping | `TestAnImpossibleQuorumIsClamped` |
| No targets reads as unreachable | `TestNoTargetsIsNotAFailure` |
| Failed dials counted as zero-RTT in the median | `TestTheRTTIsTheMedianOfWhatAnswered` |
| Drop unreadable targets and probe the rest | `TestUnreadableTargetsFallBackRatherThanShrinkTheQuorum` |
| Ignore the probe interval | `TestTheProbeIntervalIsAFloor` |
| Failed targets not reported onward | `TestFailingTargetsAreReportedOnward` |
| Stop sending the targets | `TestProbeTargetsReachTheAgent` |
| Accept hostnames as targets | 2 tests |
| Store an unmeetable quorum | 2 tests |
| No cap on targets per group | 2 tests |
| A refused connection counts as broken | `TestARefusedConnectionIsStillAWorkingPath` (real interfaces) |

**Two of these first exposed tests that passed vacuously.** Both asserted "nothing was probed" on a warm-up pass that had no observed peers yet, so they would have passed whatever the code did. Fixed, and each now also proves the prober is reachable from where the test stands — otherwise the negative assertion means nothing.
