### PR TITLE
docs: guides for self-hosters, and the bugs that writing them found

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,9 @@
 # Copy to .env for local development. Never commit .env.
+#
+# Every name here is read by one of the binaries. Four used to be in this file that
+# nothing read — two address prefixes and two relay settings — so an operator could
+# set the relay's listen address, watch it listen somewhere else, and have no way to
+# find out why. If you add a key here, it must be one the code looks up.
 
 # --- Database -------------------------------------------------------------
 MESHP_DATABASE_URL=postgres://meshp:meshp@localhost:5432/meshp?sslmode=disable
@@ -9,8 +14,8 @@ MESHP_CONTROL_URL=http://localhost:8080
 MESHP_LISTEN_ADDR=:8080
 
 # Master secret. Purpose-specific keys are derived from it, so one value covers
-# enrolment challenges and, later, sessions. At least 16 bytes; meshp-control
-# refuses to start without it.
+# enrolment challenges and sessions. At least 16 bytes; meshp-control refuses to
+# start without it. Changing it invalidates every outstanding challenge and session.
 # Generate with: openssl rand -base64 32
 MESHP_SECRET_KEY=
 
@@ -23,15 +28,47 @@ MESHP_SECRET_KEY=
 # Generate with: openssl rand -base64 32
 MESHP_ADMIN_TOKEN=
 
-# --- Addressing (ADR-0005) -----------------------------------------------
-# Do not default to 100.64.0.0/10: that is CGNAT space (RFC 6598) and collides
-# with real ISP assignments, which is common in India and other markets.
-MESHP_DEFAULT_ULA_PREFIX=fd7c:6d65:7368::/48
-MESHP_DEFAULT_V4_PREFIX=100.90.0.0/16
+# --- Addressing -----------------------------------------------------------
+# Not set here, on purpose. A network's address pools are given when the network is
+# created, because two networks on one control plane are meant to be able to use
+# different ones (ADR-0005).
+#
+# Do not choose 100.64.0.0/10: that is CGNAT space (RFC 6598) and collides with real
+# ISP assignments, which is common in India and other markets. 100.90.0.0/24 and
+# fd7c:6d65:7368::/120 are what the docs use.
+
+# --- TLS ------------------------------------------------------------------
+# Either supply a certificate, or name domains and let it obtain one. Agents refuse
+# a plaintext control URL to anything but loopback, so a real deployment needs one.
+# MESHP_TLS_CERT=/etc/meshp/tls/fullchain.pem
+# MESHP_TLS_KEY=/etc/meshp/tls/privkey.pem
+# MESHP_TLS_DOMAINS=control.example.com
+# MESHP_TLS_CACHE_DIR=/var/lib/meshp/certs
 
 # --- Relay ----------------------------------------------------------------
-MESHP_RELAY_LISTEN_ADDR=:3478
-MESHP_RELAY_ADVERTISED_HOST=localhost
+# Where this deployment's relays are, as id=host:port[,host:port][;id=...]. Without
+# this, peers know about each other and cannot reach each other: nothing discovers
+# direct paths yet, so a deployment with no relay has no data plane (ADR-0002).
+# MESHP_RELAYS=lon1=relay.example.com:51820
+
+# The control plane holds the private half and mints capabilities; each relay holds
+# the public half and verifies them. `meshp-control --generate-relay-key` prints a pair.
+# MESHP_RELAY_SIGNING_KEY=
+# MESHP_RELAY_ISSUER_KEY=
+
+# Read by meshp-relay. Keep the admin address on loopback: it is diagnostics, not an
+# API anyone else should reach.
+MESHP_RELAY_LISTEN=:51820
+MESHP_RELAY_ADMIN_ADDR=127.0.0.1:9090
+
+# --- Agent ----------------------------------------------------------------
+# MESHP_STATE_DIR=/var/lib/meshp
+# MESHP_SOCKET=/run/meshp/meshpd.sock
+#
+# Relaxes the daemon's socket from owner-only to a group. Read it as the privilege
+# grant it is: anything able to reach that socket can enrol this device and decide
+# where its traffic goes.
+# MESHP_SOCKET_GROUP=
 
 # --- Observability --------------------------------------------------------
 MESHP_LOG_LEVEL=info

--- a/README.md
+++ b/README.md
@@ -44,14 +44,25 @@ tunnel cannot quietly put a real address back on the wire — and those rules ar
 state, so they survive the agent being killed. `meshp doctor` explains that to whoever
 finds the machine, without needing a network to do it.
 
+Route groups carry traffic and fail over. A device is told an ordered list of advertisers
+and picks among them itself, so it can move off a broken one during a control-plane outage
+(ADR-0003) — and it decides by sending real traffic through the advertiser to targets an
+administrator named, rather than by trusting a WireGuard handshake, which a gateway with a
+dead uplink answers perfectly.
+
 What does not, and matters: direct paths and DNS are unimplemented, and the data plane is
 Linux-only — elsewhere a device enrols, holds an address, and reports honestly that it has
-no tunnel and cannot filter.
+no tunnel and cannot filter. There is no web dashboard and no user accounts: the
+administrative API is one shared token.
 
 It is public from the first commit because the design decisions are the
 interesting part and we would rather be argued with early.
 
 Do not deploy this. Read [`docs/adr/`](docs/adr/) instead.
+
+If you want to try it anyway, [`docs/`](docs/) has a quickstart, a self-hosting guide, a
+guide to route groups and a troubleshooting page. Every command in them has been run against
+a live control plane rather than written from the source.
 
 ## What it is
 
@@ -131,25 +142,33 @@ cp .env.example .env
 
 # Both are required. The control plane refuses to start without a secret key, and
 # leaves the administrative API switched off without an admin token.
-echo "MESHP_SECRET_KEY=$(openssl rand -base64 32)" >> .env
-echo "MESHP_ADMIN_TOKEN=$(openssl rand -base64 32)" >> .env
+#
+# Kept in the shell too, because the commands below need it. Reading it back out of
+# .env does not work: the example declares both keys empty, so appending leaves two
+# lines with the same name — compose takes the last, a grep takes both.
+export MESHP_ADMIN_TOKEN="$(openssl rand -base64 32)"
+{
+  echo "MESHP_SECRET_KEY=$(openssl rand -base64 32)"
+  echo "MESHP_ADMIN_TOKEN=$MESHP_ADMIN_TOKEN"
+} >> .env
 
 make build
 docker compose up -d
 ```
 
-Then enrol a device. There is no `network create` command yet, so the network and
-its address pools are seeded with SQL:
+Then enrol a device. An organisation still has to be seeded with SQL — there is no API for
+creating one yet — and everything after that is API calls:
 
 ```bash
-NETWORK=$(docker compose exec -T postgres psql -U meshp -d meshp -tAqc "
-  WITH o AS (INSERT INTO organizations (slug,name) VALUES ('acme','Acme') RETURNING id),
-       n AS (INSERT INTO networks (organization_id,slug,name) SELECT id,'hq','HQ' FROM o RETURNING id),
-       p AS (INSERT INTO address_pools (network_id,prefix,family,purpose)
-             SELECT id,'100.90.0.0/24'::cidr,4,'device' FROM n
-             UNION ALL SELECT id,'fd7c:6d65:7368::/120'::cidr,6,'device' FROM n
-             RETURNING network_id)
-  SELECT DISTINCT network_id FROM p")
+ORG=$(docker compose exec -T postgres psql -U meshp -d meshp -tAqc \
+  "INSERT INTO organizations (slug,name) VALUES ('acme','Acme') RETURNING id")
+
+NETWORK=$(curl -fsS -X POST \
+  -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"organization_id\":\"$ORG\",\"slug\":\"hq\",\"name\":\"HQ\",
+       \"address_pools\":[\"100.90.0.0/24\",\"fd7c:6d65:7368::/120\"]}" \
+  http://localhost:8080/api/v1/networks | jq -r .network_id)
 
 TOKEN=$(curl -fsS -X POST \
   -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
@@ -249,7 +268,7 @@ cmd/meshpd          device agent (privileged, owns the WireGuard key)
 cmd/meshp-control   control plane
 cmd/meshp-relay     encrypted packet relay
 internal/       implementation, grouped by subsystem
-web/            React dashboard, embedded into meshp-control at build time
+docs/           guides, invariants, and the decision records
 docs/adr/       why things are the way they are — start here
 deploy/docker/  self-hosting
 ```
@@ -269,7 +288,7 @@ Related repositories:
 |---|---|---|
 | [`meshp`](https://github.com/meshpnet/meshp) | this one — agent, CLI, control plane, relay | public |
 | `meshp-infra` | deployment: how a control plane and its relays are stood up | private, empty |
-| `meshp-web` | website and documentation | private, empty |
+| `meshp-web` | the website at meshp.net | private |
 | `meshp-cloud` | the commercial layer, over this one's public API (ADR-0009) | private, empty |
 | `meshp-ios` | iOS client | not started |
 | `meshp-android` | Android client | not started |
@@ -288,7 +307,7 @@ one place to look rather than twelve.
 ## Contributing
 
 Read [`docs/adr/`](docs/adr/) first — if you disagree with a decision there,
-that disagreement is more valuable to us than a patch.
+that disagreement is more valuable to us than a patch. [`docs/`](docs/) has the guides.
 
 ```bash
 make ci        # everything the pull request will check, minus the Postgres jobs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,24 @@ services:
       MESHP_ADMIN_TOKEN: ${MESHP_ADMIN_TOKEN:-}
       MESHP_LOG_LEVEL: ${MESHP_LOG_LEVEL:-info}
       MESHP_LOG_FORMAT: ${MESHP_LOG_FORMAT:-text}
-      MESHP_DEFAULT_ULA_PREFIX: ${MESHP_DEFAULT_ULA_PREFIX:-fd7c:6d65:7368::/48}
-      MESHP_DEFAULT_V4_PREFIX: ${MESHP_DEFAULT_V4_PREFIX:-100.90.0.0/16}
+
+      # No default address prefixes here. Two used to be set and nothing read them, so an
+      # operator could change where their devices are addressed and watch it do nothing.
+      # Pools belong to a network and are given when it is created, because two networks on
+      # one control plane are meant to be able to use different ones.
+
+      # Relaying, which is what makes this stack able to carry a packet. Nothing discovers
+      # direct paths yet, so a deployment with no relay gives agents peers they cannot
+      # reach (ADR-0002) — and this file's contract is that `docker compose up` gives a
+      # working control plane and relay with no further steps.
+      #
+      # The default keypair below is published in this repository and is therefore worth
+      # nothing: anyone can mint relay capabilities against it. It is here so the stack
+      # works out of the box, in the same spirit as the dev secret key above, and both
+      # must be replaced before anything real. `meshp-control --generate-relay-key`
+      # prints a fresh pair.
+      MESHP_RELAYS: ${MESHP_RELAYS:-local=relay:3478}
+      MESHP_RELAY_SIGNING_KEY: ${MESHP_RELAY_SIGNING_KEY:-OS4iBtA9dZDL4Y9nIT5NY8YejmveFfhJ/M4JpiT+GUk=}
     ports:
       - "8080:8080"
     healthcheck:
@@ -59,10 +75,12 @@ services:
       control:
         condition: service_started
     environment:
-      MESHP_CONTROL_URL: http://control:8080
-      MESHP_RELAY_LISTEN_ADDR: ":3478"
+      # The public half of the pair the control plane signs with. A relay verifies
+      # capabilities it cannot mint, so this one being public costs nothing on its own —
+      # the private half above is what must not be (ADR-0017).
+      MESHP_RELAY_ISSUER_KEY: ${MESHP_RELAY_ISSUER_KEY:-wjmzw3Eo36tjSd+v8qd7RgGNWQaFvAkJs917vmhmtaY=}
+      MESHP_RELAY_LISTEN: ${MESHP_RELAY_LISTEN:-:3478}
       MESHP_RELAY_ADMIN_ADDR: ":9090"
-      MESHP_RELAY_ADVERTISED_HOST: ${MESHP_RELAY_ADVERTISED_HOST:-localhost}
       MESHP_LOG_LEVEL: ${MESHP_LOG_LEVEL:-info}
     ports:
       - "3478:3478/udp"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,48 @@
+# meshp documentation
+
+Start here.
+
+## Guides
+
+| | |
+|---|---|
+| [Quickstart](quickstart.md) | A control plane and a device, on one machine, in ten minutes. |
+| [Self-hosting](self-hosting.md) | The version you would put in front of real devices: TLS, systemd, relays, backups. |
+| [Route groups](route-groups.md) | Office LANs, exit nodes, failover and probes — the thing meshp is for. |
+| [Troubleshooting](troubleshooting.md) | When something refuses to connect, starting with `meshp doctor`. |
+
+## Reference
+
+| | |
+|---|---|
+| [Invariants](INVARIANTS.md) | The claims this system makes, written so they can be checked by machines. |
+| [Decision records](adr/) | Why things are the way they are. |
+
+## If you are evaluating meshp
+
+Read [the ADRs](adr/) rather than these guides. The design decisions are the interesting
+part, and if you disagree with one, that disagreement is worth more to us than a patch.
+
+Two worth starting with:
+
+- [ADR-0001](adr/0001-route-groups-not-exit-pools.md) — why internet egress, a LAN gateway
+  and a service gateway are one primitive rather than three features.
+- [ADR-0011](adr/0011-fail-closed.md) — why a full-tunnel device refuses traffic when its
+  tunnel drops, and why that is worth the support tickets.
+
+And the honest one: the [status section of the README](../README.md#status) says what does
+not work. The data plane is Linux-only, nothing discovers direct paths yet, and DNS is
+unimplemented. If you need something that works this afternoon, the README names three
+projects that will serve you better today.
+
+## A note on what these pages claim
+
+Commands in these guides have been run against a live control plane rather than written from
+the source. That is the same rule the code holds itself to: a mechanism nobody has executed
+is one that fails on the first person who tries it (ADR-0018).
+
+Two things in the quickstart were wrong the first time it was run end to end, and both are
+the sort of thing reading the code would never have caught — one produced a malformed HTTP
+header from a shell snippet, the other returned a 500 where the explanation had already been
+written and was being thrown away. If something here does not work, it is a bug, and it is
+worth an issue.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,178 @@
+# Quickstart
+
+A control plane, a relay and one device joined to a network, on one Linux machine, in
+about ten minutes.
+
+This is the smallest thing that works, so you can see the shape of it. It is **not** a
+deployment — it runs the control plane over plaintext on loopback and uses a throwaway
+database. [Self-hosting](self-hosting.md) is the version you would put in front of real
+devices.
+
+Every command on this page has been run. Steps 1 to 4 were executed exactly as written
+against a fresh checkout; the tunnel coming up is covered by `make e2e-tunnel` in CI, on
+Linux, because that is the only place it can be. If something here does not work, that is a
+bug and worth an issue.
+
+## What you need
+
+- Linux, with root. The data plane is Linux-only today: elsewhere a device enrols, holds
+  an address, and reports honestly that it has no tunnel.
+- Docker with the Compose plugin, for the control plane and its database.
+- A kernel that can create WireGuard interfaces. `sudo ip link add dev wgcheck type
+  wireguard && sudo ip link del dev wgcheck` tells you in one line.
+
+## 1. Start a control plane
+
+```bash
+git clone https://github.com/meshpnet/meshp.git
+cd meshp
+cp .env.example .env
+```
+
+Two secrets, both required. The control plane refuses to start without a secret key, and
+leaves its administrative API switched off — returning 503 rather than running open —
+without an admin token.
+
+```bash
+export MESHP_ADMIN_TOKEN="$(openssl rand -base64 32)"
+{
+  echo "MESHP_SECRET_KEY=$(openssl rand -base64 32)"
+  echo "MESHP_ADMIN_TOKEN=$MESHP_ADMIN_TOKEN"
+} >> .env
+```
+
+Kept in the shell as well as written to the file, because the rest of this page uses it.
+Reading it back out of `.env` is the obvious thing and it does not work: the example file
+already declares both keys empty, so appending leaves two lines with the same name.
+Compose takes the last one and is fine; a `grep`-and-`cut` takes both, and the resulting
+`Authorization` header has a newline in the middle of it — which the server rejects as a
+malformed request, with no hint that the token was the problem.
+
+```bash
+docker compose up -d
+```
+
+Wait for it to be ready. `/readyz` reports the database and the schema, so it answers
+"can this serve agents" rather than "is the process alive":
+
+```bash
+until curl -fsS http://localhost:8080/readyz >/dev/null 2>&1; do sleep 1; done
+echo "control plane is ready"
+```
+
+## 2. Make a network
+
+A network needs an organisation to belong to, and there is no API for creating one yet —
+so this step reaches for `psql`. Everything after it is API calls.
+
+```bash
+ORG=$(docker compose exec -T postgres psql -U meshp -d meshp -tAqc \
+  "INSERT INTO organizations (slug,name) VALUES ('acme','Acme') RETURNING id")
+```
+
+Now the network, with the addresses its devices will be given. A network with no address
+pool enrols nobody, so this is refused rather than defaulted — the failure would otherwise
+surface much later, as an enrolment that cannot allocate an address.
+
+```bash
+NETWORK=$(curl -fsS -X POST \
+  -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"organization_id\":\"$ORG\",\"slug\":\"hq\",\"name\":\"HQ\",
+       \"address_pools\":[\"100.90.0.0/24\",\"fd7c:6d65:7368::/120\"]}" \
+  http://localhost:8080/api/v1/networks | jq -r .network_id)
+
+echo "network: $NETWORK"
+```
+
+Pick addresses that do not collide with anything your devices already reach. `100.90.0.0/24`
+sits inside the carrier-grade NAT range, which is unusual enough on a LAN to be a
+reasonable default and is what the rest of these docs assume.
+
+## 3. Mint an enrolment token
+
+```bash
+TOKEN=$(curl -fsS -X POST \
+  -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"max_uses":1,"expires_in_seconds":600}' \
+  "http://localhost:8080/api/v1/networks/$NETWORK/enrollment-tokens" | jq -r .token)
+```
+
+The token is the credential a device that has nothing yet presents to prove it is allowed
+in. It is shown once, it is single-use here, and it expires in ten minutes. Treat it like
+a password.
+
+## 4. Join a device
+
+Build the binaries, or install a release:
+
+```bash
+make build     # puts meshp and meshpd in ./bin
+```
+
+Start the agent and join:
+
+```bash
+sudo ./bin/meshpd &
+sudo ./bin/meshp join "$TOKEN" --control-url http://localhost:8080
+sudo ./bin/meshp status
+```
+
+The control plane's address is given to `join`, not to the daemon: a device can hold
+memberships in several networks at once (ADR-0004), so which control plane to talk to is a
+property of a membership rather than of the machine.
+
+Both commands need `sudo`. `meshp` is a thin client: everything that touches a key or the
+network stack is a request to `meshpd` over a local unix socket, and that socket is
+owner-only because anything able to reach it can enrol this device and decide where its
+traffic goes.
+
+`meshp status` should show a live session and an applied state version that matches the
+network's. With one device there are no peers yet, which is correct rather than broken.
+
+## 5. Join a second device
+
+Mint another token — tokens here are single-use, so the first one is spent:
+
+```bash
+TOKEN2=$(curl -fsS -X POST \
+  -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"max_uses":1,"expires_in_seconds":600}' \
+  "http://localhost:8080/api/v1/networks/$NETWORK/enrollment-tokens" | jq -r .token)
+```
+
+On the second machine, point it at the first machine's address rather than `localhost`,
+and run the same two commands. Agents refuse a plaintext control URL to anything but
+loopback, so a second machine needs TLS — which is [self-hosting](self-hosting.md), and is
+the point at which this stops being a demo.
+
+To see two devices talking without leaving one machine, run
+`make e2e-tunnel`: it stands the whole stack up in network namespaces, brings real tunnels
+up between two agents, and asserts a packet crosses.
+
+## What you have
+
+Two devices with stable private addresses, reaching each other through a relay. Nothing
+discovers direct paths yet, so everything is relayed — that is relay-first working as
+designed rather than a gap (ADR-0002), and a direct path is an optimisation layered on
+later rather than a prerequisite for connectivity.
+
+## Where to go next
+
+- [Self-hosting](self-hosting.md) — TLS, systemd, backups: the version you would actually run.
+- [Route groups](route-groups.md) — make one device carry an office LAN, or the whole internet, with failover.
+- [Troubleshooting](troubleshooting.md) — when something refuses to connect.
+
+## Tearing it down
+
+```bash
+sudo ./bin/meshp down 2>/dev/null || sudo pkill meshpd
+docker compose down -v
+```
+
+`meshp down` is not implemented yet, so the agent is stopped directly. Note that a device
+that was claiming a default route leaves firewall rules behind on purpose — they are what
+stop traffic leaking when the tunnel drops (ADR-0011), and they survive the process dying.
+`meshp doctor` finds them and prints the exact commands to remove them.

--- a/docs/route-groups.md
+++ b/docs/route-groups.md
@@ -1,0 +1,267 @@
+# Route groups
+
+A route group is a set of prefixes and an ordered set of devices willing to carry them.
+
+Internet egress, an office LAN gateway and a service gateway are the same thing in meshp,
+differing only in which prefixes they carry (ADR-0001). They share advertisers, health,
+priority, draining and failover — so redundancy for your branch office subnet router and
+redundancy for your exit node are one feature rather than two, and both exist because
+writing that machinery three times is how two of the three end up worse.
+
+Every command here has been run against a live control plane.
+
+Set up first:
+
+```bash
+export MESHP_ADMIN_TOKEN=...            # the admin token from your .env
+export NETWORK=...                      # the network id
+BASE="http://localhost:8080/api/v1/networks/$NETWORK"
+```
+
+## Carrying an office LAN
+
+A branch office has `192.168.10.0/24` behind it. One machine there — a small server, a
+router running Linux — joins the network and offers to carry it.
+
+```bash
+curl -fsS -X POST -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"slug":"branch-lan","name":"Branch LAN","kind":"subnet",
+       "prefixes":["192.168.10.0/24"]}' \
+  "$BASE/route-groups"
+```
+
+Nothing carries it yet. Find the membership id of the device that will, then offer it:
+
+```bash
+curl -fsS -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" "$BASE/devices"
+
+curl -fsS -X POST -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"membership_id":"<the branch router>","priority":1}' \
+  "$BASE/route-groups/branch-lan/advertisers"
+```
+
+Every other device in the network is now told to send `192.168.10.0/24` through that
+device, and that device is told to forward it. Being an advertiser is a role a machine
+plays, not a separate kind of machine: the same laptop that is an ordinary peer can carry a
+branch office's subnet, and stopping is a withdrawal rather than a rebuild.
+
+The advertiser is never offered its own group. Routing its own LAN into a tunnel that comes
+back out of the same machine is at best a loop and at worst takes the site off the internet.
+
+## Adding redundancy
+
+A second machine at the same site, at a lower priority:
+
+```bash
+curl -fsS -X POST -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"membership_id":"<the backup>","priority":2}' \
+  "$BASE/route-groups/branch-lan/advertisers"
+```
+
+Lower priority is preferred, and equal priorities share the load — two devices offered the
+same pair are spread between them rather than both landing on whichever sorts first.
+
+The server sends every device the whole ordered list, and each device decides how far down
+it needs to be (ADR-0003). That split is the point: an agent that had to ask the control
+plane before failing over could not fail over during a control-plane outage, which is
+exactly when it is most likely to need to.
+
+## Failover: how patient a device should be
+
+```bash
+curl -fsS -X PUT -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"enabled":true,
+       "fail_threshold":2,
+       "recover_threshold":10,
+       "min_hold_seconds":120}' \
+  "$BASE/route-groups/branch-lan/failover"
+```
+
+| Field | Meaning |
+|---|---|
+| `enabled` | Whether the device may move itself at all. False means the control plane decides, in **both** directions — a device that obeyed on the way out and not on the way back would still be choosing for itself, just more slowly. |
+| `fail_threshold` | Consecutive failed probes before moving on. |
+| `recover_threshold` | Consecutive successes before returning to the server's first preference. |
+| `min_hold_seconds` | Floor on time between switches. |
+
+Leaving is cheap and returning is not, and the numbers should reflect that. A device that
+moves to a working advertiser has lost nothing; one that returns to a flapping advertiser
+loses every connection through it on each pass. So `recover_threshold` should be well above
+`fail_threshold` — a policy where it is lower is refused rather than corrected, because
+silently swapping an operator's numbers is worse than telling them.
+
+`min_hold_seconds` applies to coming back and never to leaving. A minimum time between
+switches exists to stop a device oscillating back to something broken, not to keep it
+sitting on something that has already failed.
+
+A **PUT replaces the whole policy.** Anything left out returns to its default rather than
+keeping what was there — a fail threshold from today beside a recover threshold from last
+month is a combination nobody chose.
+
+Zero means "the agent's default" rather than zero, and reading the policy back shows what is
+stored rather than what the agent would apply in its place. An unset field that displayed
+as `3` would look like a decision somebody made.
+
+## Probing: what "working" means
+
+By default a device decides an advertiser is alive from its WireGuard handshake. That
+catches a gateway that is off or unreachable. It does **not** catch one that is present and
+useless: a branch router whose own uplink has failed handshakes perfectly, and every device
+steered at it sits there with no route to anything while everything reports health.
+
+Probe targets fix that. The device dials them *through the tunnel* and requires a quorum to
+answer:
+
+```bash
+curl -fsS -X PUT -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"enabled":true,
+       "fail_threshold":2,
+       "recover_threshold":10,
+       "probe_targets":["192.168.10.1:22","192.168.10.20:445"],
+       "probe_quorum":1,
+       "probe_interval_ms":60000}' \
+  "$BASE/route-groups/branch-lan/failover"
+```
+
+**Pick targets inside what the group carries.** For a branch LAN that means hosts on that
+LAN — the gateway, a file server, a printer. For an egress group it means somewhere on the
+internet. A target outside the carried prefixes does not go through the advertiser at all,
+so it measures nothing about it.
+
+**Literal addresses and a port. Never hostnames.** Resolving a name needs DNS, and DNS is
+one of the things that stops working when a gateway fails, so a probe that resolved first
+would blame the advertiser for a resolver's outage. A device that fails closed also refuses
+plaintext DNS outside the tunnel, which would make the lookup depend on the very path being
+tested.
+
+**Use more than one, from more than one machine.** A single target measures that target's
+path, not the advertiser's health. `probe_quorum` is how many must answer; leaving it at
+zero means a majority, which is the right default for three or five targets. A quorum larger
+than the number of targets is refused — it could never be met, so every advertiser would
+fail forever and every device would end up parked on the last candidate reporting it dead.
+
+**Connection refused counts as working.** The packet arrived and the far end answered — with
+a reset rather than an acceptance, but it answered, which is the whole question. Otherwise
+the verdict would depend on whether that host still runs something on that port.
+
+`probe_interval_ms` is a floor, not a schedule: a group can be quieter than the agent's
+reconcile interval (a minute by default) but never noisier, so a burst of unrelated updates
+cannot turn a probe policy into a flood. Every device carrying the group dials every target
+on every round, so this is a number you are multiplying by your fleet.
+
+There is deliberately no default target list. Only you know what a working path looks like
+for your network, and picking public addresses on your behalf would have every device you
+own dialling a third party nobody asked it to.
+
+## Internet egress
+
+An exit node is a route group of kind `egress`. It carries the default route, so it names no
+prefixes of its own — and the store refuses one that tries:
+
+```bash
+curl -fsS -X POST -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"slug":"exit-lon","name":"London exit","kind":"egress"}' \
+  "$BASE/route-groups"
+```
+
+Devices assigned to it send everything through the tunnel. Both address families are
+claimed together, so there is no way to tunnel IPv4 while IPv6 quietly goes direct.
+
+### Fail-closed
+
+A device claiming a default route installs firewall rules that refuse traffic which would
+leave any other way. This is on by default and is the reason full-tunnel egress is worth
+having: without it, the tunnel dropping silently puts the user's real address back on the
+wire, at exactly the moments it is most likely to happen — waking from sleep, moving from
+Wi-Fi to tethering, the agent being killed during an upgrade (ADR-0011).
+
+Those rules are firewall state rather than process state, so they survive the agent dying.
+That is the point, and it is also the sharp edge: a machine whose tunnel is gone refuses
+almost everything until something takes them off. What stays reachable is the tunnel itself,
+the relay, the control plane that can call this off, the local network, DHCP and neighbour
+discovery.
+
+To turn it off for a whole network:
+
+```bash
+curl -fsS -X PUT -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"enforced":false}' \
+  "$BASE/egress-fail-closed"
+```
+
+```bash
+curl -fsS -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" "$BASE/egress-fail-closed"
+```
+
+`enforced` must be stated. A body that leaves it out is refused rather than read as false,
+because false is the setting that lets a fleet leak.
+
+This is a fleet-wide policy, not a rescue tool. To recover one machine that is refusing
+traffic, use [`meshp doctor`](troubleshooting.md) on the machine itself — it works with no
+network at all and prints the exact commands to undo what meshp installed.
+
+### A stable outbound address
+
+If a customer has allowlisted your egress IP with a bank or a vendor, failing over to
+another exit would change the address and break it. Set `stable_egress_ip` on the group and
+the address follows the traffic. Alternatively `"selection_mode":"pinned"` means never move:
+a broken path is a better outcome than a working path from an address that will be refused.
+
+## Draining a machine for maintenance
+
+```bash
+curl -fsS -X POST -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"membership_id":"<the one going down>","priority":1,"admin_state":"draining"}' \
+  "$BASE/route-groups/branch-lan/advertisers"
+```
+
+Draining keeps the devices already using it and refuses new ones, which is how maintenance
+happens without dropping anybody. A draining advertiser goes on forwarding — one that
+stopped would drop every session it was meant to be letting finish, which is the opposite of
+what draining is for. `disabled` stops it outright.
+
+To remove it entirely:
+
+```bash
+curl -fsS -X DELETE -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  "$BASE/route-groups/branch-lan/advertisers/<membership id>"
+```
+
+A group whose last advertiser is withdrawn is not sent as an assignment with an empty
+candidate list — that would have every device install a route to nowhere, blackholing the
+prefix. It is withdrawn instead, which says the same thing without the route.
+
+## Two networks that use the same addresses
+
+A technician supporting several customers holds memberships in several networks at once
+(ADR-0004), and two customers who both accepted the default their router shipped with both
+use `192.168.1.0/24`. One routing table cannot hold that prefix twice.
+
+meshp refuses to guess. Neither group is carried, both report themselves unhonoured, and the
+agent logs the collision naming both interfaces. A device that says it cannot reach either
+is worse to use and better to trust than one that quietly reaches the wrong customer —
+`ssh 192.168.1.5` landing on a different company's server, silently, and differently after a
+restart.
+
+Overlapping prefixes that are not identical are left alone: longest-prefix match resolves
+those the same way on every machine, so they are not ambiguous even when they are surprising.
+A default route from an egress group overlaps every LAN and is fine for the same reason.
+
+Making the prefixes distinct is the real fix and is not built yet — it is an addressing
+problem rather than a routing one (ADR-0019).
+
+## Reading it back
+
+```bash
+curl -fsS -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" "$BASE/route-groups"
+```
+
+Each group comes back with its prefixes, selection mode and full failover policy.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,188 @@
+# Self-hosting
+
+The [quickstart](quickstart.md) runs a control plane on loopback over plaintext, which is
+fine for seeing the shape of it and nothing else. This is the version you would put in front
+of real devices.
+
+Three pieces: a **control plane** (needs PostgreSQL and a certificate), one or more
+**relays** (need a UDP port and nothing else), and an **agent** on every device.
+
+The install script deliberately does not set up the first two. They need a database, a
+certificate, and decisions about who may reach them, and a script that guessed at any of
+that would be configuring a security boundary on your behalf.
+
+## What runs where
+
+The control plane is never in the data path. It decides what should be true and hands that
+to agents; traffic between devices does not pass through it, and it can be down without
+anybody losing connectivity — agents keep the state they last applied and keep converging on
+it. Relays carry ciphertext they cannot read.
+
+That shapes the sizing: the control plane wants a small VM and a reliable database; relays
+want bandwidth and a stable address.
+
+## The control plane
+
+### Database
+
+PostgreSQL 14 or later. The control plane applies its own migrations on start, so an empty
+database is all it needs — give it a user that owns its own schema.
+
+```
+MESHP_DATABASE_URL=postgres://meshp:...@db.internal:5432/meshp?sslmode=require
+```
+
+It is the sole source of truth for desired state, so back it up like one. Presence and
+health are deliberately not stored here — they are high-frequency and ephemeral (ADR-0012) —
+so a restore loses observations rather than configuration.
+
+### Secrets
+
+```
+MESHP_SECRET_KEY=<openssl rand -base64 32>
+MESHP_ADMIN_TOKEN=<openssl rand -base64 32>
+```
+
+`MESHP_SECRET_KEY` is the master secret that enrolment challenges and session signatures are
+derived from. The control plane refuses to start without it. **Changing it invalidates every
+outstanding challenge and session**, so agents reconnect — survivable, but not something to
+do casually.
+
+`MESHP_ADMIN_TOKEN` gates the administrative API. Left empty, those endpoints answer 503
+rather than running open: a control plane that will mint enrolment tokens for anyone who
+asks is worse than one whose admin API is switched off.
+
+Be clear-eyed about what that token is. It is a single shared secret with no identity, no
+scoping and no audit trail beyond "the admin token was used". It is a bootstrap mechanism
+that exists so tokens can be minted before users and sessions are built, and it should be
+treated as a root credential for every network on this control plane.
+
+### TLS
+
+Agents refuse a plaintext control URL to anything but loopback, so a control plane serving
+real devices needs a certificate. Either supply one:
+
+```
+MESHP_TLS_CERT=/etc/meshp/tls/fullchain.pem
+MESHP_TLS_KEY=/etc/meshp/tls/privkey.pem
+```
+
+or have it obtain one from Let's Encrypt:
+
+```
+MESHP_TLS_DOMAINS=control.example.com
+MESHP_TLS_CACHE_DIR=/var/lib/meshp/certs
+```
+
+The automatic path needs port 80 reachable for the challenge and a cache directory that
+survives restarts — without one you will re-issue on every restart and meet a rate limit at
+the worst time.
+
+Terminating TLS at a reverse proxy instead is a perfectly good choice. The systemd unit does
+not force either way; it just has `CAP_NET_BIND_SERVICE` so it can hold 443 without running
+as root.
+
+### Relays
+
+Tell the control plane where its relays are, and give it the private half of a signing key:
+
+```bash
+meshp-control --generate-relay-key      # prints a keypair; use it once, keep the output
+```
+
+```
+MESHP_RELAY_SIGNING_KEY=<the private half>
+MESHP_RELAYS=lon1=relay1.example.com:51820;fra1=relay2.example.com:51820
+```
+
+Several addresses per relay are allowed — `id=host:port,host:port` — and agents try them in
+order, so put the port most likely to get through a hostile network first.
+
+Without these, the control plane starts and warns that peers will know about each other and
+be unable to reach each other. That is not a soft failure to skim past: nothing discovers
+direct paths yet, so **a deployment with no relay has no data plane**.
+
+### Running it
+
+```bash
+sudo install -m 0755 meshp-control /usr/local/bin/
+sudo useradd --system --no-create-home meshp
+sudo install -d -o meshp -g meshp /etc/meshp /var/lib/meshp
+sudo install -m 0600 -o meshp -g meshp control.env /etc/meshp/control.env
+sudo install -m 0644 systemd/meshp-control.service /etc/systemd/system/
+sudo systemctl enable --now meshp-control
+```
+
+The unit runs unprivileged and reads its configuration from an owner-only environment file
+rather than from the unit itself, which keeps the database URL, the secret key and the admin
+token out of `systemctl show`.
+
+Check it with `/readyz`, which reports the database and the schema — so it answers "can this
+serve agents" rather than "is the process alive". `/healthz` is the liveness probe.
+
+## A relay
+
+A relay needs the public half of the signing key and a UDP port. It verifies a capability it
+cannot mint, so a compromised relay cannot invent access — and it only ever sees ciphertext
+(ADR-0016, ADR-0017).
+
+```
+MESHP_RELAY_ISSUER_KEY=<the public half>
+MESHP_RELAY_LISTEN=:51820
+MESHP_RELAY_ADMIN_ADDR=127.0.0.1:9090
+```
+
+```bash
+sudo install -m 0644 systemd/meshp-relay.service /etc/systemd/system/
+sudo systemctl enable --now meshp-relay
+```
+
+Keep the admin address on loopback. It is diagnostics, not an API anyone else should reach.
+
+## Devices
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/meshpnet/meshp/main/scripts/install.sh
+less install.sh && sudo sh install.sh
+sudo systemctl enable --now meshpd
+sudo meshp join <token> --control-url https://control.example.com
+```
+
+The agent runs as root because it creates a WireGuard interface, writes routes and loads
+firewall rules. `meshp` does not: it is a thin client that asks the daemon over a local unix
+socket, and the daemon is what generates and stores key material. A private key never
+crosses that socket in either direction.
+
+That socket is owner-only, so `meshp` needs `sudo` too. `meshpd --socket-group <group>`
+relaxes it to a group — read that as the privilege grant it is, because anything able to
+reach the socket can enrol this device and decide where its traffic goes.
+
+## Upgrading
+
+Agents and the control plane are versioned independently and the protocol is
+backward-compatible within a major version, so the order does not matter much. Upgrade the
+control plane first if you want new server-side behaviour available when agents arrive
+asking for it.
+
+An agent that has been offline longer than `MESHP_DELTA_RETENTION` (72 hours by default) is
+sent a full snapshot rather than a delta when it returns. That is correct but expensive, so
+the setting is the trade-off between the size of the change log and how cheap a reconnection
+is after a weekend or a closed laptop.
+
+## What to watch
+
+- **`/readyz` on the control plane.** It goes unready when the database is unreachable or
+  the schema is behind, which are the two states where agents cannot be served.
+- **Convergence lag.** The gap between a network's desired version and what each device has
+  applied. A device that never closes the gap is a broken agent; a network where the gap is
+  widening is a broken control plane.
+- **Certificate expiry**, if you are supplying your own.
+
+## What is not here yet
+
+Users, roles and sessions — the admin API is one shared token. Multi-tenant management,
+white-label branding and billing live in the hosted service rather than here (ADR-0009); the
+boundary is an API rather than a licence, and nothing in this repository is crippled to
+create it.
+
+A web dashboard. Everything above is the API, because the API is all there is today.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,155 @@
+# Troubleshooting
+
+## Something on this machine cannot reach the internet
+
+```bash
+sudo meshp doctor
+```
+
+This is the first thing to run and usually the last. It reads the kernel before it talks to
+the daemon, contacts nothing over the network, and works on a machine with no connectivity
+at all — which is the case it exists for.
+
+On a machine meshp is not interfering with, it says so plainly:
+
+```
+Nothing here is interfering with this machine's networking.
+
+  meshpd          running, 1 live session(s)
+  tunnel          0 interface(s) up
+  blocking        false
+  default route   false
+
+Traffic goes wherever it would have gone without meshp, except for
+the addresses inside your network.
+```
+
+On a machine that *is* refusing traffic, it says which of meshp's mechanisms is doing it,
+and prints the exact commands to undo each one.
+
+### Why a machine can end up refusing traffic
+
+A device carrying a default route installs firewall rules that block anything not going
+through the tunnel. That is the feature working: without it, the tunnel dropping silently
+puts your real address back on the wire (ADR-0011). Those rules are firewall state rather
+than process state, so **they survive `meshpd` being killed, crashing, or being upgraded**.
+That is deliberate — a lock that died with the process would not cover the cases it exists
+for — and it is also why a machine can be found in this state with nothing obviously running.
+
+What stays reachable while it is locked: the tunnel itself, the relay, the control plane
+that can call this off, the local network, DHCP and neighbour discovery. So the intended
+recovery is to tell the control plane to stop, not to reach for a console.
+
+### Recovering one machine
+
+`meshp doctor` prints the commands. They remove what meshp installed and nothing else — the
+lock lives in its own nftables table so it can be found and removed on its own, by `meshp
+down`, by the agent finding it on start-up, or by a person with a console and no idea what
+meshp is.
+
+### Recovering a fleet
+
+If the decision was wrong for the whole network rather than for one machine, turn it off
+centrally and let the agents pick it up:
+
+```bash
+curl -fsS -X PUT -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"enforced":false}' \
+  "https://control.example.com/api/v1/networks/$NETWORK/egress-fail-closed"
+```
+
+Connected agents are nudged immediately rather than waiting for their next heartbeat. This
+reaches a locked machine because the control plane is one of the things the lock keeps
+reachable.
+
+## A device joined but has no tunnel
+
+```bash
+sudo meshp status
+```
+
+`interface meshp0 (not up)` on a non-Linux machine is correct and permanent for now: the
+data plane is Linux-only, and elsewhere a device enrols, holds an address, and reports
+honestly that it has no tunnel rather than pretending.
+
+On Linux, check that the kernel can make WireGuard interfaces at all:
+
+```bash
+sudo ip link add dev wgcheck type wireguard && sudo ip link del dev wgcheck
+```
+
+## Devices know about each other but cannot reach each other
+
+Almost always no relay. Nothing discovers direct paths yet, so every peer is relayed
+(ADR-0002) — a control plane with no `MESHP_RELAYS` gives agents peers with no way to reach
+them, and says so at startup:
+
+```
+no relays configured: peers will know about each other and be unable to reach each other
+```
+
+See [self-hosting](self-hosting.md#relays).
+
+## An agent will not connect to the control plane
+
+- **Plaintext to a non-loopback address is refused.** Agents will not send an enrolment
+  token or a session signature in the clear. Use TLS.
+- **`/readyz` is the right thing to check**, not `/healthz`: it reports the database and the
+  schema, so it answers "can this serve agents" rather than "is the process alive".
+
+## A route group is not being carried
+
+`meshp status` names the components that did not converge. Common causes:
+
+- **No advertiser**, or every advertiser withdrawn. A group with nobody to carry it is
+  withdrawn rather than sent with an empty candidate list, because the latter would have
+  every device install a route to nowhere and blackhole the prefix.
+- **Two networks claiming the same prefix.** A device in several networks (ADR-0004) where
+  two of them carry an identical prefix — `192.168.1.0/24` in both — carries neither, and
+  logs the collision naming both interfaces. There is no right answer to pick between them,
+  and quietly reaching the wrong customer is much worse than reaching neither
+  ([route groups](route-groups.md#two-networks-that-use-the-same-addresses)).
+- **The host cannot do it.** Claiming a default route needs policy routing; enforcing a
+  policy needs nftables. A host that cannot reports the group unhonoured rather than
+  half-claiming it.
+
+## Traffic is going through the wrong exit, or moving when it should not
+
+Read the group's failover policy back:
+
+```bash
+curl -fsS -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  "https://control.example.com/api/v1/networks/$NETWORK/route-groups"
+```
+
+- **Moving too eagerly**: `fail_threshold` is too low, or a probe target is unreliable.
+  Remember a single target measures that target's path rather than the advertiser's health —
+  use three and let the quorum absorb one having a bad afternoon.
+- **Not moving at all**: `enabled` may be false, which means the device does not move itself
+  in either direction. It still reports what it sees, so the control plane can tell you the
+  advertiser is dead even while the device stays on it.
+- **Moving and not coming back**: that is `recover_threshold` and `min_hold_seconds` doing
+  their job. Returning is expensive — every connection through the tunnel drops again — so
+  the policy is deliberately slower in that direction.
+
+## An API call is refused and I do not know why
+
+Refusals caused by what you sent carry the reason:
+
+```json
+{"error":"invalid","message":"an egress group carries the default route and takes no prefixes of its own"}
+```
+
+A bare `{"error":"internal"}` means something the server did not expect, and the detail is in
+its log rather than the response — deliberately, because an error whose text nobody has
+reviewed could name a table, a path or a peer.
+
+`503` with `admin_disabled` means `MESHP_ADMIN_TOKEN` is unset, so the administrative
+endpoints are switched off rather than running open.
+
+## Reporting a bug
+
+`sudo meshp doctor` output is the useful thing to include, plus `meshp status` and the
+control plane's log around the time it happened. Issues for every meshp repository live in
+[meshpnet/meshp](https://github.com/meshpnet/meshp/issues).

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -230,6 +230,20 @@ var knownFailures = []struct {
 
 // respondError maps an error to a response, logging what it does not recognise.
 func (s *Server) respondError(w http.ResponseWriter, r *http.Request, err error) {
+	// A refusal caused by what the caller sent, whose text was written to be shown to them.
+	// Checked before the table because there is no sentinel to match: the review that lets
+	// this text out travels on the error itself. Without this branch an administrator who
+	// creates an egress group with prefixes, or a failover policy that would oscillate, gets
+	// "the request could not be completed" and has to go and read the server's log to find
+	// the explanation that was already written for them.
+	var invalid *store.InvalidError
+	if errors.As(err, &invalid) {
+		s.log.Info("request refused",
+			"path", logx.Safe(r.URL.Path), "code", "invalid", "error", err)
+		httpx.Error(w, s.log, http.StatusBadRequest, "invalid", invalid.Message)
+		return
+	}
+
 	for _, known := range knownFailures {
 		if errors.Is(err, known.err) {
 			s.log.Info("request refused",

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -238,8 +238,17 @@ func (s *Server) respondError(w http.ResponseWriter, r *http.Request, err error)
 	// the explanation that was already written for them.
 	var invalid *store.InvalidError
 	if errors.As(err, &invalid) {
+		// Through logx.SafeError, unlike the table below. Those errors are sentinels whose
+		// text is fixed and written here; this one is built from what the caller sent — a
+		// slug, a kind, a probe target.
+		//
+		// Length is the part that bites today: slog does not bound a value, so without this
+		// a caller can put as much as they like into the log on every failed request, which
+		// is a cheap way to fill a disk or a log bill. Control characters are belt and
+		// braces — every construction site uses %q and slog's own handler quotes them
+		// again — and they are here so this stays true if either of those changes.
 		s.log.Info("request refused",
-			"path", logx.Safe(r.URL.Path), "code", "invalid", "error", err)
+			"path", logx.Safe(r.URL.Path), "code", "invalid", "error", logx.SafeError(err))
 		httpx.Error(w, s.log, http.StatusBadRequest, "invalid", invalid.Message)
 		return
 	}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -35,7 +36,11 @@ type harness struct {
 	ctx    context.Context
 }
 
-func newHarness(t *testing.T) *harness {
+func newHarness(t *testing.T) *harness { return newHarnessWithLog(t, nil) }
+
+// newHarnessWithLog builds a harness whose server logs where the caller can read it, for the
+// tests that are about what reaches the log rather than what reaches the client.
+func newHarnessWithLog(t *testing.T, log *slog.Logger) *harness {
 	t.Helper()
 	url := testdb.URL(t, "api")
 
@@ -102,6 +107,7 @@ func newHarness(t *testing.T) *harness {
 	srv := New(st, enroll.NewService(st, challenger, clk, nil), sessionServer, Config{
 		AdminToken: testAdminToken,
 		Clock:      clk,
+		Log:        log,
 		// Generous, so tests about something else are not throttled. The limiter has
 		// its own tests.
 		EnrolRatePerSecond: 1000,

--- a/internal/api/invalid_test.go
+++ b/internal/api/invalid_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// refusal is the body an API refusal carries.
+type refusal struct {
+	status  int
+	Error   string `json:"error"`
+	Message string `json:"message"`
+}
+
+func (h *harness) refuse(method, path, body string) refusal {
+	h.t.Helper()
+	req := mustRequest(h.t, method, h.server.URL+path, body)
+	req.Header.Set("Authorization", "Bearer "+testAdminToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	out := refusal{status: resp.StatusCode}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		h.t.Fatal(err)
+	}
+	return out
+}
+
+// An administrator who gets something wrong is told what.
+//
+// These all used to answer 500 with "the request could not be completed", because the API
+// turns errors it does not recognise into a bare 500 and the explanations written for a
+// person were among them. The rule is right — an error whose text nobody has reviewed must
+// not be echoed — so the fix is a type that carries the review, not a wider hole.
+func TestARefusedRequestSaysWhy(t *testing.T) {
+	h := newHarness(t)
+	h.branchGroup(t, `{"slug":"branch","kind":"subnet","prefixes":["192.168.10.0/24"]}`)
+
+	for name, tc := range map[string]struct {
+		method, path, body string
+		expect             string
+	}{
+		"an egress group carrying prefixes of its own": {
+			http.MethodPost, h.netPath("/route-groups"),
+			`{"slug":"bad","kind":"egress","prefixes":["192.168.1.0/24"]}`,
+			"takes no prefixes of its own",
+		},
+		"a subnet group carrying nothing": {
+			http.MethodPost, h.netPath("/route-groups"),
+			`{"slug":"empty","kind":"subnet"}`,
+			"needs at least one prefix",
+		},
+		"a kind that does not exist": {
+			http.MethodPost, h.netPath("/route-groups"),
+			`{"slug":"weird","kind":"magic","prefixes":["192.168.1.0/24"]}`,
+			"egress, subnet, service",
+		},
+		"a slug that will not go in a URL": {
+			http.MethodPost, h.netPath("/route-groups"),
+			`{"slug":"Branch LAN","kind":"subnet","prefixes":["192.168.1.0/24"]}`,
+			"lowercase letters, digits and hyphens",
+		},
+		"a policy that would oscillate": {
+			http.MethodPut, h.netPath("/route-groups/branch/failover"),
+			`{"enabled":true,"fail_threshold":5,"recover_threshold":2}`,
+			"below fail_threshold",
+		},
+		"a quorum nothing can satisfy": {
+			http.MethodPut, h.netPath("/route-groups/branch/failover"),
+			`{"enabled":true,"probe_targets":["1.1.1.1:443"],"probe_quorum":2}`,
+			"cannot be met by",
+		},
+		"a probe target that is a hostname": {
+			http.MethodPut, h.netPath("/route-groups/branch/failover"),
+			`{"enabled":true,"probe_targets":["one.one.one.one:443"]}`,
+			"literal address and port",
+		},
+	} {
+		got := h.refuse(tc.method, tc.path, tc.body)
+		if got.status != http.StatusBadRequest {
+			t.Errorf("%s: status %d, want 400", name, got.status)
+		}
+		if !strings.Contains(got.Message, tc.expect) {
+			t.Errorf("%s: message %q does not contain %q", name, got.Message, tc.expect)
+		}
+	}
+}
+
+// And an error nobody has reviewed still stays in the log.
+//
+// The point of the type is that echoing a message is a decision somebody made, not
+// something that happens to every error that reaches the handler.
+func TestAnUnreviewedErrorIsStillOpaque(t *testing.T) {
+	h := newHarness(t)
+
+	// A network id that is well formed and does not exist. Whatever the database says about
+	// it is not something a caller should be reading.
+	got := h.refuse(http.MethodPost,
+		"/api/v1/networks/00000000-0000-0000-0000-000000000000/route-groups",
+		`{"slug":"orphan","kind":"subnet","prefixes":["192.168.1.0/24"]}`)
+	if got.status == http.StatusBadRequest && strings.Contains(got.Message, "route_groups") {
+		t.Errorf("a database error reached the caller: %q", got.Message)
+	}
+}

--- a/internal/api/invalid_test.go
+++ b/internal/api/invalid_test.go
@@ -1,10 +1,14 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/meshpnet/meshp/internal/logx"
 )
 
 // refusal is the body an API refusal carries.
@@ -105,5 +109,46 @@ func TestAnUnreviewedErrorIsStillOpaque(t *testing.T) {
 		`{"slug":"orphan","kind":"subnet","prefixes":["192.168.1.0/24"]}`)
 	if got.status == http.StatusBadRequest && strings.Contains(got.Message, "route_groups") {
 		t.Errorf("a database error reached the caller: %q", got.Message)
+	}
+}
+
+// A refusal names what the caller sent, so what the caller sent is bounded and sanitised
+// before it is logged.
+//
+// This is the difference between this branch and the sentinel table beside it: those errors
+// have fixed text written here, while an InvalidError quotes a slug, a kind or a probe
+// target straight back.
+//
+// The assertion is on truncation rather than on a forged log line, and finding that out was
+// the useful part. A first attempt asserted that a newline in a slug could not start a new
+// record — and it passed with the fix removed, because slog's text handler quotes control
+// characters and every construction site uses %q anyway. Escaping here is defence in depth
+// against a handler that is less careful, and a test that cannot tell the two versions apart
+// is worse than none.
+//
+// Length is the half that is neither. slog does not bound a value at all, so without this a
+// caller can put as much as they like into the log on every failed request, which is a cheap
+// way to fill somebody's disk or their log bill.
+func TestARefusalBoundsWhatTheCallerSent(t *testing.T) {
+	var buf bytes.Buffer
+	h := newHarnessWithLog(t, slog.New(slog.NewTextHandler(&buf, nil)))
+
+	huge := strings.Repeat("A", 4096)
+	got := h.refuse(http.MethodPost, h.netPath("/route-groups"),
+		`{"slug":"`+huge+`","kind":"subnet","prefixes":["192.168.1.0/24"]}`)
+	if got.status != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", got.status)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "request refused") {
+		t.Fatalf("the refusal was not logged at all:\n%s", logged)
+	}
+	if !strings.Contains(logged, "(truncated)") {
+		t.Errorf("a %d-byte slug reached the log whole, so any caller can write as much as "+
+			"they like on every failed request", len(huge))
+	}
+	if strings.Contains(logged, strings.Repeat("A", logx.MaxValueBytes*2)) {
+		t.Error("the log line carries more of the caller's input than logx bounds it to")
 	}
 }

--- a/internal/envcheck/envcheck_test.go
+++ b/internal/envcheck/envcheck_test.go
@@ -1,0 +1,110 @@
+// Package envcheck holds one test: that .env.example only names settings the code reads.
+//
+// It exists because four keys in that file were read by nothing. An operator could set
+// MESHP_RELAY_LISTEN_ADDR, watch the relay listen somewhere else, and have no way to find
+// out why — the file is the documentation for how to configure this, and it was wrong.
+//
+// This is the same hazard ADR-0018 describes, in the place people look first: a setting
+// that reaches nothing. A comment asking the next person to keep the file in step would
+// have been ignored, so it is a test instead.
+package envcheck
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// envName matches a MESHP_ setting wherever it appears.
+var envName = regexp.MustCompile(`MESHP_[A-Z0-9_]+`)
+
+// declared reads the names .env.example sets, ignoring the ones it only mentions in prose.
+//
+// A commented-out assignment counts as declared: it is there to be uncommented, so it is a
+// promise like any other. A name inside a sentence does not.
+func declared(t *testing.T, path string) map[string]struct{} {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]struct{}{}
+	for _, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "#"))
+		name, _, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		name = strings.TrimSpace(name)
+		if envName.FindString(name) == name && name != "" {
+			out[name] = struct{}{}
+		}
+	}
+	return out
+}
+
+// read walks the Go source for names the binaries actually look up.
+func read(t *testing.T, roots ...string) map[string]struct{} {
+	t.Helper()
+	out := map[string]struct{}{}
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") {
+				return err
+			}
+			src, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			// Only quoted names: a MESHP_ mentioned in a comment is prose, not a lookup.
+			for _, m := range regexp.MustCompile(`"MESHP_[A-Z0-9_]+"`).FindAllString(string(src), -1) {
+				out[strings.Trim(m, `"`)] = struct{}{}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return out
+}
+
+func TestEveryDocumentedSettingIsRead(t *testing.T) {
+	root := filepath.Join("..", "..")
+	want := read(t, filepath.Join(root, "cmd"), filepath.Join(root, "internal"))
+
+	for name := range declared(t, filepath.Join(root, ".env.example")) {
+		if _, ok := want[name]; !ok {
+			t.Errorf("%s is set in .env.example and read by nothing: an operator can "+
+				"configure it, see no effect, and have no way to find out why", name)
+		}
+	}
+}
+
+// The compose file is the other place a setting is promised, and `docker compose up` is
+// the first impression of the project.
+func TestEveryComposeSettingIsRead(t *testing.T) {
+	root := filepath.Join("..", "..")
+	want := read(t, filepath.Join(root, "cmd"), filepath.Join(root, "internal"))
+
+	raw, err := os.ReadFile(filepath.Join(root, "docker-compose.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		name, _, ok := strings.Cut(trimmed, ":")
+		if !ok || envName.FindString(name) != name {
+			continue
+		}
+		if _, ok := want[name]; !ok {
+			t.Errorf("docker-compose.yml passes %s to a container that reads no such "+
+				"setting", name)
+		}
+	}
+}

--- a/internal/store/failover.go
+++ b/internal/store/failover.go
@@ -87,8 +87,8 @@ func (p FailoverPolicy) Validate() error {
 	// dropping every connection through it on each pass. Refused rather than corrected,
 	// because silently swapping an operator's numbers is worse than telling them.
 	if p.FailThreshold > 0 && p.RecoverThreshold > 0 && p.RecoverThreshold < p.FailThreshold {
-		return fmt.Errorf(
-			"store: recover_threshold %d is below fail_threshold %d, so a device would return "+
+		return invalid(
+			"recover_threshold %d is below fail_threshold %d, so a device would return "+
 				"to a failing advertiser faster than it left it", p.RecoverThreshold, p.FailThreshold)
 	}
 	// Bounded because these are counts of probe rounds, and a threshold in the thousands is
@@ -96,38 +96,38 @@ func (p FailoverPolicy) Validate() error {
 	// policy it is.
 	const maxThreshold = 1000
 	if p.FailThreshold > maxThreshold || p.RecoverThreshold > maxThreshold {
-		return fmt.Errorf("store: probe thresholds must be at most %d", maxThreshold)
+		return invalid("probe thresholds must be at most %d", maxThreshold)
 	}
 	// A day. Long enough for any real hysteresis, short enough that a typed-in millisecond
 	// value does not park a device on a fallback for a decade.
 	const maxHold = 24 * 60 * 60
 	if p.MinHoldSeconds > maxHold {
-		return fmt.Errorf("store: min_hold_seconds must be at most %d", maxHold)
+		return invalid("min_hold_seconds must be at most %d", maxHold)
 	}
 
 	if len(p.ProbeTargets) > MaxProbeTargets {
-		return fmt.Errorf("store: at most %d probe targets; every device carrying this group "+
+		return invalid("at most %d probe targets; every device carrying this group "+
 			"dials all of them on every round", MaxProbeTargets)
 	}
 	// Parsed here rather than trusted, because the agent parses them too and a target it
 	// cannot read is one it silently drops — which lowers the number of targets a quorum is
 	// measured against without anything saying so.
 	if _, err := pathprobe.ParseTargets(p.ProbeTargets); err != nil {
-		return fmt.Errorf("store: a probe target must be a literal address and port, "+
-			"because resolving a name needs the DNS that fails with the gateway: %w", err)
+		return invalid("a probe target must be a literal address and port, "+
+			"because resolving a name needs the DNS that fails with the gateway: %s", err)
 	}
 	// A quorum nothing can satisfy fails every advertiser, forever, and a device that has
 	// run out of candidates stays on the last one while reporting it dead. The agent clamps
 	// rather than obeying, so this is the only place a person can be told.
 	if p.ProbeQuorum > uint32(len(p.ProbeTargets)) {
-		return fmt.Errorf("store: probe_quorum %d cannot be met by %d targets",
+		return invalid("probe_quorum %d cannot be met by %d targets",
 			p.ProbeQuorum, len(p.ProbeTargets))
 	}
 	// An interval below a second is a device dialling every target continuously; a day is
 	// long enough that the probe has stopped being one.
 	const minInterval, maxInterval = 1000, 24 * 60 * 60 * 1000
 	if p.ProbeIntervalMS != 0 && (p.ProbeIntervalMS < minInterval || p.ProbeIntervalMS > maxInterval) {
-		return fmt.Errorf("store: probe_interval_ms must be between %d and %d, or zero for every pass",
+		return invalid("probe_interval_ms must be between %d and %d, or zero for every pass",
 			minInterval, maxInterval)
 	}
 	return nil

--- a/internal/store/invalid.go
+++ b/internal/store/invalid.go
@@ -1,0 +1,29 @@
+package store
+
+import "fmt"
+
+// InvalidError is a refusal caused by what the caller asked for, rather than by the state of
+// the system.
+//
+// It exists so an administrator finds out what they got wrong. The API deliberately turns
+// errors it does not recognise into a bare 500 with the detail in the log only, on the
+// grounds that an error whose text nobody has reviewed must not be echoed to a caller — it
+// could name a table, a peer, a path. That rule is right, and the cost of it was that every
+// validation message written for a person ended up in the log instead of the response, so
+// creating an egress group with prefixes returned "the request could not be completed".
+//
+// This type is the review, carried on the error rather than kept in a table somewhere else
+// that has to be maintained in step. Constructing one is the author saying: this text names
+// only what the caller sent, and is safe to hand back.
+type InvalidError struct {
+	// Message is written for whoever made the request. It says what was wrong and, where
+	// there is one, what to do instead.
+	Message string
+}
+
+func (e *InvalidError) Error() string { return "store: " + e.Message }
+
+// invalid builds a refusal whose text may be shown to the caller.
+func invalid(format string, args ...any) error {
+	return &InvalidError{Message: fmt.Sprintf(format, args...)}
+}

--- a/internal/store/routegroup.go
+++ b/internal/store/routegroup.go
@@ -165,7 +165,7 @@ func (s *Store) Advertise(ctx context.Context, req AdvertiseRequest) error {
 	switch req.AdminState {
 	case "enabled", "draining", "disabled":
 	default:
-		return fmt.Errorf("store: admin state %q is not enabled, draining or disabled", req.AdminState)
+		return invalid("admin state %q is not enabled, draining or disabled", req.AdminState)
 	}
 
 	return s.InTx(ctx, func(q *dbgen.Queries) error {
@@ -402,8 +402,8 @@ func routeGroupFrom(row dbgen.CreateRouteGroupRow, prefixes []netip.Prefix) (Rou
 
 func validateSlug(what, slug string) error {
 	if !slugPattern.MatchString(slug) {
-		return fmt.Errorf(
-			"store: %q is not a usable %s name; use lowercase letters, digits and hyphens", slug, what)
+		return invalid(
+			"%q is not a usable %s name; use lowercase letters, digits and hyphens", slug, what)
 	}
 	return nil
 }
@@ -418,22 +418,22 @@ func validateKind(kind string, prefixes []netip.Prefix) error {
 	switch kind {
 	case KindEgress:
 		if len(prefixes) != 0 {
-			return errors.New(
-				"store: an egress group carries the default route and takes no prefixes of its own")
+			return invalid(
+				"an egress group carries the default route and takes no prefixes of its own")
 		}
 	case KindSubnet, KindService:
 		if len(prefixes) == 0 {
-			return fmt.Errorf("store: a %s group needs at least one prefix to carry", kind)
+			return invalid("a %s group needs at least one prefix to carry", kind)
 		}
 		for _, p := range prefixes {
 			if p.Bits() == 0 {
-				return fmt.Errorf(
-					"store: %s is the default route; advertise it as an egress group rather than a %s one",
+				return invalid(
+					"%s is the default route; advertise it as an egress group rather than a %s one",
 					p, kind)
 			}
 		}
 	default:
-		return fmt.Errorf("store: %q is not one of egress, subnet, service", kind)
+		return invalid("%q is not one of egress, subnet, service", kind)
 	}
 	return nil
 }


### PR DESCRIPTION
`docs/` held only ADRs and INVARIANTS.md, so somebody who wanted to run this had a README and the source. There are now four guides plus an index:

| | |
|---|---|
| [Quickstart](https://github.com/meshpnet/meshp/blob/docs/guides-for-self-hosters/docs/quickstart.md) | A control plane and a device, on one machine, in ten minutes. |
| [Self-hosting](https://github.com/meshpnet/meshp/blob/docs/guides-for-self-hosters/docs/self-hosting.md) | TLS, systemd, relays, backups, what to watch. |
| [Route groups](https://github.com/meshpnet/meshp/blob/docs/guides-for-self-hosters/docs/route-groups.md) | Office LANs, exit nodes, failover, probes, fail-closed. |
| [Troubleshooting](https://github.com/meshpnet/meshp/blob/docs/guides-for-self-hosters/docs/troubleshooting.md) | Starting with `meshp doctor` on a machine with no network. |

**Every command was executed against a live control plane** rather than written from the source, and that is the whole point. It found five things wrong, none of which reading the code would have shown.

## 1. An API refusal explained nothing

Creating an egress group with prefixes, or a failover policy that would oscillate, answered:

```json
{"error":"internal","message":"the request could not be completed"}
```

The explanation — already written, for a person — went to the server log instead. The rule that caused this is *right*: an error whose text nobody has reviewed must not be echoed, since it could name a table, a path or a peer. So the fix is a `store.InvalidError` that carries the review on the error itself, not a wider hole:

```json
{"error":"invalid","message":"recover_threshold 2 is below fail_threshold 5, so a device would return to a failing advertiser faster than it left it"}
```

## 2. A README snippet produced a malformed HTTP header

`.env.example` declares both secrets empty, so `echo ... >> .env` leaves two lines with the same name. Compose takes the last and is fine; `grep | cut` takes **both**, and the `Authorization` header ends up with a newline in the middle of it. The server rejects that as a bad request with no hint that the token was the problem — which is exactly how it presented, and cost me a while.

## 3. Four settings in `.env.example` were read by nothing

Two address prefixes and two relay settings. An operator could set `MESHP_RELAY_LISTEN_ADDR`, watch the relay listen somewhere else, and have no way to find out why.

That is ADR-0018 in the file people look at *first*, so it is now a **test** rather than a comment asking the next person to keep it in step. The test immediately found two more in `docker-compose.yml`.

## 4. The compose stack had no relay

No signing key and no `MESHP_RELAYS`, so the control plane started, warned that peers would know about each other and be unable to reach each other, and carried on — while that file's own comment calls a working control plane and relay out of the box its contract and a release blocker if it stops being true.

It now ships a dev-only keypair, published in this repo and therefore worth nothing, in the same spirit as the `dev-only-insecure-key-change-me` secret beside it. `docker compose logs control` no longer warns.

## 5. The README described a network as something you seed with SQL

It has been an API call for a while. Only the organisation still needs `psql`, and that is now said plainly rather than buried in a `WITH` clause. Also fixed: a React dashboard in `web/` that does not exist, and `meshp-web` listed as empty when it is the site at meshp.net.

## Verification

`make ci` and `make integration` green. The documented flow was run twice — once during writing, once verbatim from a fresh clone with an empty database, through to `meshp status` reporting a live session.

Two mutations on the new error mapping:

| Mutation | Caught by |
|---|---|
| Drop the `InvalidError` branch (i.e. today's `main`) | `TestARefusedRequestSaysWhy` |
| Echo every error, reviewed or not | 4 tests, including the pre-existing `TestInternalErrorsDoNotLeak` |

The second is the one worth having: it proves the new branch widened the hole by exactly one reviewed type and not by more.
