### PR TITLE
docs: ADR-0021, names resolve on the device, from desired state

### DIFF
--- a/docs/adr/0020-colliding-prefixes-are-mapped-on-the-device.md
+++ b/docs/adr/0020-colliding-prefixes-are-mapped-on-the-device.md
@@ -1,0 +1,161 @@
+# ADR-0020: Colliding prefixes are mapped on the device that sees the collision
+
+- **Status:** proposed
+- **Date:** 2026-08-16
+
+## Context
+
+ADR-0019 settled that two customers both carrying `192.168.1.0/24` is an addressing
+problem rather than a routing one, and handed the rest forward: *"Each membership's
+colliding prefix gets its own mapped address range, and the name layer resolves to
+the mapped address rather than to the customer's own. What that mapping looks like is
+not settled here."*
+
+This settles it. There are two questions left — **who allocates a mapped range**, and
+**where the translation happens** — and the answers are not independent.
+
+Today a collision is detected and refused (PR #70). A device in two networks that
+both carry `192.168.1.0/24` carries neither and reports both route groups unhonoured.
+That is deliberate and it is not a resting place: the technician ADR-0004 exists for
+still cannot reach either customer.
+
+Three constraints make most of the obvious answers wrong.
+
+**ACLs are enforced at the destination (ADR-0007).** The authoritative check is
+inbound, on the machine being reached, against the identity of the device reaching
+it. Anything that rewrites the source address between the technician and the
+customer's server destroys the input that check runs on. The customer's file server
+would see one address for every technician in the MSP.
+
+**Failover must not drop connections.** Route groups exist so that when an advertiser
+fails, another one carries the prefix and traffic continues (ADR-0001, ADR-0003).
+Connection tracking state does not move between advertisers. Any design that puts
+per-connection state on the advertiser makes every failover an outage, which
+dismantles the feature this project leads with.
+
+**No single party can see both sides.** An MSP running one control plane can allocate
+across all its networks. A technician joined to forty *customers'* independently
+operated control planes cannot: those deployments do not know about each other and
+never will. The only thing that can see both memberships is the device holding them.
+
+## Decision
+
+**The device allocates the mapped range, and the device performs the translation, per
+membership, on its own interface.**
+
+Concretely, when a device holds two memberships whose route groups carry an identical
+prefix:
+
+1. **The device allocates a mapped range for each colliding membership**, from a
+   block reserved for this purpose inside its own address space. The allocation is
+   device-local state, like the collision registry in PR #70, and it is stable for the
+   life of the membership so a mapped address does not move under a running
+   connection.
+
+2. **Each membership already has its own interface.** `device_network_memberships`
+   carries `interface_name`, and the reconciler is constructed per membership. This
+   is what makes the rest work: after translation the destination is `192.168.1.5` on
+   both interfaces, and it is unambiguous because each interface has exactly one peer
+   holding that prefix in its allowed IPs.
+
+3. **The routing table carries the mapped ranges, not the customer's.**
+   `100.71.5.0/24` goes to `meshp0`, `100.71.6.0/24` to `meshp1`. The table holds two
+   distinct prefixes, so there is nothing to contest.
+
+4. **Translation happens on the way into the tunnel, after the interface is chosen.**
+   The destination is rewritten from the mapped address to the customer's real one as
+   the packet leaves for that membership's interface, and back on the reply. Source
+   addresses are never touched.
+
+5. **Names resolve to mapped addresses.** `fileserver.customer-a` resolves to
+   `100.71.5.5`. The mapped range is an implementation detail a person should never
+   have to type.
+
+The packet that crosses the tunnel is therefore an ordinary packet: real source, real
+destination. The advertiser forwards it without knowing any of this happened, and the
+customer's server sees the technician's own mesh address, which is what ADR-0007
+needs and what an audit log should show.
+
+## Consequences
+
+**The technician gets what ADR-0004 promised.** One agent, forty customers, and
+`ssh fileserver.customer-a` reaches customer A even though customer B uses the same
+addresses. That claim has been in ADR-0004 since the beginning and has never been
+true when prefixes collide.
+
+**This is not usable until DNS exists.** Without names, a technician has to know that
+customer A is `100.71.5.0/24` this week — which is worse than the current refusal,
+because it is the same cognitive load as remembering which customer is which *plus* a
+layer of indirection. The mechanism can be built and tested before DNS; it should not
+be presented to a user before it. That makes DNS a hard prerequisite for shipping this
+rather than a nice pairing, and it is the main cost of this decision.
+
+**It needs address translation on every platform that supports multi-network
+membership.** On Linux that is nftables, which is already a dependency for policy and
+for the egress kill switch. Elsewhere it is not written yet, and a host that cannot
+translate must report the colliding groups unhonoured exactly as it does today rather
+than carry one of them. The failure mode stays the honest one.
+
+**The mapped block is a new reservation in the device's address space**, and it must
+not collide with anything either — including the mesh addresses of the networks the
+device is in, and whatever the local LAN uses. Choosing it badly recreates this
+problem one level up.
+
+**Two devices will disagree about which range means which customer**, because each
+allocates its own. That is correct and worth stating plainly: a mapped address is
+meaningful only on the device that minted it, and it must never appear in a control
+plane, an audit log or a support ticket as though it identified something globally.
+Anything that renders one for a person has to say which device it is relative to.
+
+**Diagnostics get harder.** `meshp status` and `meshp doctor` will show addresses that
+appear nowhere in the customer's own network, and a packet capture on the advertiser
+will show the customer's real addresses rather than the ones the technician typed.
+Both commands have to explain the mapping rather than print it, or this becomes a
+feature that works and cannot be debugged.
+
+## Alternatives considered
+
+**Translate at the advertiser.** The branch router rewrites `100.71.5.0/24` into
+`192.168.1.0/24` on the way in and back on the way out. Attractive because the
+technician's device needs nothing special.
+
+Rejected on two counts, either of which is sufficient. It puts per-connection state on
+the advertiser, so failing over to a second advertiser drops every connection through
+it — undoing the feature route groups exist to provide. And the reply path requires
+the advertiser to source-NAT, so the customer's server sees the advertiser rather than
+the technician, which destroys the input ADR-0007's destination-side enforcement runs
+on and flattens every audit trail to one address.
+
+**Let the control plane allocate the mapped ranges.** Tidier: IPAM already exists,
+allocation is already a server-side concern, and the mapping could be sent as desired
+state. It works for a single MSP running one control plane over many customer
+networks — which is a real and important case.
+
+Rejected because it does not work for the other one, and the other one is ADR-0004's
+headline. A technician joined to forty customers' own control planes has forty parties
+that cannot coordinate, do not know each other exists, and have no reason to. A
+mechanism that works only when one organisation owns every network is a different
+product. The device-side allocation covers both cases; the server-side allocation
+covers one.
+
+If that constraint disappeared — if every network a device joined were always
+operated by the same control plane — server-side allocation would be the better
+answer, and the ranges would be visible to operators, which would remove the
+diagnostic cost above.
+
+**Rewrite the source instead, and route by it.** `ip rule from <mapped source> lookup
+<table>` disambiguates without touching the destination. Rejected for the reason
+ADR-0019 gives for the same shape: the kernel picks a source address by looking up the
+route, which is the question being asked. It works only if the application binds
+first, which is a workaround a person has to know rather than a product.
+
+**Ask the customer to renumber.** Free to build, and the honest reason it is here is
+that it is what every competitor implicitly requires. Rejected because it is not a
+decision an MSP can make: a technician cannot ask forty customers to renumber their
+LANs because of a tool the technician chose, and the customer whose network is
+`192.168.1.0/24` is the most common customer there is.
+
+**Leave it refused, as PR #70 does.** The current behaviour, and correct as an interim
+— a device that says it cannot reach either customer is better than one that quietly
+reaches the wrong one. Rejected as an end state: it means ADR-0004's central claim is
+false for exactly the users ADR-0004 was written for.

--- a/docs/adr/0021-names-resolve-on-the-device.md
+++ b/docs/adr/0021-names-resolve-on-the-device.md
@@ -1,0 +1,181 @@
+# ADR-0021: Names resolve on the device, from desired state
+
+- **Status:** proposed
+- **Date:** 2026-08-16
+
+## Context
+
+DNS is named in the first line of this project's own description and does not exist.
+`internal/dns` is an empty directory. What does exist is scattered and was designed
+by people who had not yet had to make it work together:
+
+- **On the wire**, `DnsConfig` carries `nameservers`, `search_domains`, per-domain
+  `routes` and `prevent_leaks`. Nothing server-side has ever set it. The agent folds
+  it into its peer set and reads exactly one field — `prevent_leaks`, for the egress
+  kill switch.
+- **In the schema**, `dns_zones` has an `is_split` flag ("queries for this zone go to
+  meshp, everything else falls through to the system resolver") and `dns_records`
+  holds A, AAAA and CNAME with a `managed_by` of `admin`, `device` or `service`. So
+  an administrator was always meant to be able to write records by hand, alongside
+  the ones derived from devices.
+- **`Peer.device_name` is marked "display only"** on the wire, and `devices.name` has
+  no uniqueness constraint and no validation.
+- **The egress kill switch already permits loopback unconditionally**, and its comment
+  names "a local resolver" among the things it must not break.
+
+Three things force the decisions below.
+
+**Resolution cannot depend on the control plane being up.** The moment somebody most
+needs `ssh fileserver` to work is the moment something is broken, and the control
+plane is a thing that can be broken. Every other part of this system is built so that
+an agent keeps working from the state it last applied (ADR-0008); a name service that
+queried the server would make DNS the one subsystem that fails when the server does.
+
+**A device is in many networks at once (ADR-0004).** Two customers both have a machine
+called `fileserver`. A bare `fileserver` typed by a technician is ambiguous, and it is
+ambiguous in exactly the way an overlapping `192.168.1.0/24` is — the information
+needed to resolve it is not in the query.
+
+**Administrators write records the device cannot derive.** A CNAME for `git`, an A
+record for something that is not a meshp device at all. Those are desired state; they
+cannot be synthesised from a peer list.
+
+## Decision
+
+### 1. The agent resolves, from state it already holds
+
+`meshpd` runs a resolver listening on loopback. It answers from the desired state it
+has already applied — the peer list it uses to configure WireGuard is the same data
+that answers an A query — and it keeps answering when the control plane is
+unreachable, the same way the tunnel keeps carrying traffic.
+
+`DnsConfig.nameservers` names that loopback address. The field is used for what it
+says; the resolver it points at happens to be local.
+
+### 2. Records are desired state, and travel with everything else
+
+Admin-entered and service records are sent to the agent in `DnsConfig`, in a new
+repeated `records` field, and are applied by the same reconciler that applies peers
+and route groups. They are versioned, delta-compressed and acknowledged like anything
+else (ADR-0008).
+
+This is a proto change to the message the repository calls the most expensive thing to
+change, and it is worth it: the alternative is a second, unversioned path by which
+configuration reaches a device.
+
+### 3. A name is `<device>.<network>.<suffix>`, and the suffix belongs to the operator
+
+The default suffix is `internal`, giving `fileserver.acme.internal`. ICANN reserved
+`.internal` for exactly this use, so it cannot be delegated out from under a
+deployment.
+
+An operator may set a domain they own instead. `.local` is not an option — RFC 6762
+gives it to mDNS, and taking it breaks printer discovery on every machine that joins.
+A `.meshp` TLD is not an option either: it is not ours, and squatting a namespace we
+do not control is how a product acquires a migration it cannot schedule.
+
+### 4. A bare name resolves only when it is unambiguous
+
+`fileserver` resolves if exactly one of this device's memberships has a `fileserver`.
+If two do, **it does not resolve**, and the error names both fully-qualified
+alternatives.
+
+There is deliberately no precedence order between memberships. An order would make the
+query succeed and reach one customer, chosen by something the person typing had no
+view of — which is the silent wrong answer PR #70 refuses for colliding prefixes, and
+it should not be reintroduced one layer up because the layer is called DNS. A
+technician who is told "`fileserver` is ambiguous: `fileserver.acme.internal` or
+`fileserver.globex.internal`" has lost a keystroke. One who reaches the wrong
+customer's file server has lost more than that.
+
+Fully-qualified names always resolve, and are the answer when a bare one will not.
+
+### 5. `device_name` stops being display-only
+
+A resolvable name is load-bearing. It gets a syntax (an LDH label), uniqueness within
+a network, and a rename path. Names that exist today and do not satisfy it must be
+reported rather than silently mangled into something that resolves.
+
+## Consequences
+
+**Names work during a control-plane outage**, which is when they are wanted. They also
+work on a device whose tunnel to the control plane is fine but whose route to it is
+not, because nothing is queried across the network to answer them.
+
+**The proto gains records, and the schema gains a reader.** `dns_zones` and
+`dns_records` have sat unread since the first migration; this is what reads them. The
+`managed_by` column was written for this — device-derived records are regenerated,
+admin ones are not — so reconciliation has the discriminator it needs.
+
+**Renaming a device becomes a user-visible event.** Today it is a label change. After
+this it invalidates a name other people have in their shell history and their scripts,
+so it needs to be deliberate, logged, and probably rate-limited.
+
+**Uniqueness has to be enforced on names that already exist.** `devices.name` has no
+constraint today, so a deployment may already hold two machines called `laptop` in one
+network. The migration cannot silently rename one. It has to refuse, or quarantine,
+and an operator has to choose — which is a worse upgrade experience than doing nothing
+and the reason to do it before there are deployments rather than after.
+
+**The agent now listens on a port.** Loopback only, but it is a new thing that can
+fail to bind, a new thing to report in `meshp status`, and a new thing `meshp doctor`
+has to explain when a machine can reach addresses but not names.
+
+**Resolver configuration is per-platform and unpleasant.** systemd-resolved, plain
+`/etc/resolv.conf`, `scutil` on macOS, the registry on Windows — each is a different
+mechanism with a different failure mode, and several of them are shared mutable state
+that other software also edits. A host that cannot configure its resolver must report
+that it cannot, and leave the system's DNS alone, rather than writing a file it does
+not know how to put back. This is where most of the work is, and it is the reason this
+ADR does not promise every platform at once.
+
+**Split DNS is not optional.** Only the mesh zones go to the mesh resolver; everything
+else keeps using whatever the machine was already using. A resolver that captured all
+queries would break split-horizon corporate DNS on the first laptop that joined, and
+would make meshp responsible for the user's entire name resolution — which is a much
+larger promise than the one being made.
+
+**Bare-name refusal will surprise people.** Somebody with one network will use bare
+names for months, join a second, and find that some of them stop working. The error
+has to be good enough that the surprise is survivable, and this should be said plainly
+in the documentation rather than discovered.
+
+## Alternatives considered
+
+**Serve DNS from the control plane over the tunnel.** `nameservers` points at a mesh
+address the server answers on. Simpler agent, one place to change records, and
+admin-entered records need no wire format at all.
+
+Rejected because it makes name resolution depend on the control plane at query time.
+That is the wrong dependency for this system specifically: ADR-0008 exists so agents
+converge and then keep working, and a control-plane outage would take out names
+everywhere at once — while somebody tries to `ssh` to the box that would let them fix
+it. It also puts the control plane in a request path it is otherwise never in.
+
+If that constraint disappeared — if the control plane were replicated to where it
+could be treated as always-up — this would be the better answer, and it would remove
+both the proto change and most of the reconciliation work.
+
+**mDNS, or `.local`.** No server involvement, no records to distribute, and it is
+what a small network would reach for. Rejected because RFC 6762 owns `.local` and
+taking it breaks existing mDNS on the machine, because multicast does not cross the
+tunnel, and because it answers only for hosts that are currently up — which is not
+what a name is for.
+
+**A precedence order for bare names**, by join time, or an administrator's ranking.
+It is what `search` in `resolv.conf` does, so it would surprise nobody. Rejected for
+the reason in Decision 4: it converts an ambiguous question into a confident wrong
+answer, and this project has already decided, for prefixes, that it would rather say
+it does not know. Doing the opposite here would mean the same collision behaves one
+way for an address and another way for a name.
+
+**One flat namespace with no network component** — `fileserver.internal` across every
+membership. Fewer keystrokes and no ambiguity rule needed, because there is nothing to
+disambiguate: the first network to claim a name owns it. Rejected because it makes two
+customers' devices compete for names in a namespace neither of them can see, and
+because the network component is what makes the fully-qualified escape hatch in
+Decision 4 exist at all.
+
+**Do nothing, and let people use addresses.** Which is today. Rejected because a mesh
+address is allocated by IPAM and is not a thing a person can be expected to hold in
+their head, and because every product this is compared against resolves names.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,6 +29,7 @@ deliberate act with a written reason rather than a drift nobody noticed.
 | [0018](0018-mechanisms-must-be-reachable.md) | A mechanism is not done until something running reaches it |
 | [0019](0019-egress-routing-overlap-addressing.md) | Egress is a routing problem; overlapping prefixes are an addressing one |
 | [0020](0020-colliding-prefixes-are-mapped-on-the-device.md) | Colliding prefixes are mapped on the device that sees the collision |
+| [0021](0021-names-resolve-on-the-device.md) | Names resolve on the device, from desired state |
 
 ## Format
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@ deliberate act with a written reason rather than a drift nobody noticed.
 | [0017](0017-relay-credentials-over-the-control-channel.md) | An agent asks for its relay credential; the server does not push it |
 | [0018](0018-mechanisms-must-be-reachable.md) | A mechanism is not done until something running reaches it |
 | [0019](0019-egress-routing-overlap-addressing.md) | Egress is a routing problem; overlapping prefixes are an addressing one |
+| [0020](0020-colliding-prefixes-are-mapped-on-the-device.md) | Colliding prefixes are mapped on the device that sees the collision |
 
 ## Format
 


### PR DESCRIPTION
DNS is in the first line of this project's description, and `internal/dns` is an empty directory. This settles the design before any of it gets written, because the parts that are hard to change later — the name shape and what a bare name does — are the parts a user builds muscle memory around.

**Marked `proposed`.** Companion to #78; the two are independent and you can accept either without the other.

## What already exists, scattered

- **On the wire:** `DnsConfig` carries `nameservers`, `search_domains`, `routes`, `prevent_leaks`. **Nothing server-side has ever set it.** The agent reads exactly one field — `prevent_leaks`, for the kill switch.
- **In the schema:** `dns_zones.is_split` and `dns_records` with A/AAAA/CNAME and a `managed_by` of `admin` / `device` / `service`. Unread since the first migration. Someone already decided administrators write records by hand alongside device-derived ones.
- **`Peer.device_name` is marked "display only"**, and `devices.name` has no uniqueness constraint.
- **The kill switch already permits loopback unconditionally**, and its comment names "a local resolver" among the things it must not break. The design was already pointing here.

## The three constraints, and what they decide

**Resolution cannot depend on the control plane.** The moment somebody most needs `ssh fileserver` is the moment something is broken — and the control plane is a thing that can be broken. Every other subsystem here keeps working from state it last applied (ADR-0008). A name service that queried the server would be the one that fails when the server does, while somebody tries to reach the box that would let them fix it.

→ **The agent resolves**, from the peer list it already uses to configure WireGuard. Records travel as desired state in a new `DnsConfig.records` field, versioned and acknowledged like everything else, rather than by a second unversioned path.

**A device is in many networks at once (ADR-0004).** Two customers both have a `fileserver`.

→ **A bare name resolves only when unambiguous.** No precedence order. An order would make the query succeed and reach one customer, chosen by something the person typing had no view of — the silent wrong answer #70 refuses for prefixes, and it must not come back one layer up because the layer is called DNS. The error names both FQDNs; a technician loses a keystroke instead of reaching the wrong company's file server.

**Administrators write records the device cannot derive.** A CNAME for `git`, an A record for something that is not a meshp device.

→ That is why records are on the wire rather than synthesised locally, and why `managed_by` earns its keep: device records are regenerated, admin records are not.

## Names

`fileserver.acme.internal` — `<device>.<network>.<suffix>`, suffix operator-settable, defaulting to `.internal` because ICANN reserved it for exactly this and it cannot be delegated out from under a deployment.

Not `.local` — RFC 6762 gives it to mDNS, and taking it breaks printer discovery on every machine that joins. Not `.meshp` — not ours to squat, and squatting is how a product acquires a migration it cannot schedule.

## Read this before agreeing

**`device_name` stops being display-only.** It needs syntax, per-network uniqueness and a rename path. `devices.name` has no constraint today, so a deployment may already hold two machines called `laptop` in one network — and the migration cannot silently rename one. It has to refuse or quarantine, and an operator has to choose. Much better done now than after there are deployments.

Also spelled out in the ADR: renaming a device becomes user-visible (it invalidates other people's shell history); the agent gains a listening port to bind, report and explain; split DNS is not optional, because a resolver that captured all queries would break split-horizon corporate DNS on the first laptop that joined; and resolver configuration is per-platform, unpleasant, shared mutable state — a host that cannot configure one must say so and leave the system's DNS alone rather than write a file it does not know how to put back.

## The alternative that would win if a constraint vanished

**Serving DNS from the control plane over the tunnel.** Simpler agent, one place to change records, no proto change at all. It loses only on the outage dependency — so if the control plane were replicated to where it could be treated as always-up, it would be the better answer.

Also rejected: mDNS (multicast does not cross the tunnel, and it only answers for hosts currently up), a precedence order (above), and one flat namespace (makes two customers compete for names in a namespace neither can see).
