### PR TITLE
feat(dns): a device resolves its networks' names, from state it already holds

### DIFF
--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -225,12 +225,17 @@ func cmdStatus(ctx context.Context, args []string) error {
 	if !status.Enrolled {
 		fmt.Println("not enrolled")
 		fmt.Println("  run 'meshp join <token>' to join a network")
+		// The resolver here too. It comes up before any membership does, so a device
+		// that has not joined anything still has one — and somebody checking whether it
+		// bound should not have to enrol first to find out.
+		printResolver(status)
 		return nil
 	}
 
 	fmt.Printf("enrolled  %d network(s)\n", len(status.Memberships))
 	fmt.Printf("  identity  %s\n", truncate(status.IdentityPublicKey, 20))
 	fmt.Printf("  daemon    %s, up since %s\n", status.Version, status.StartedAt.Format(time.RFC3339))
+	printResolver(status)
 
 	for _, m := range status.Memberships {
 		fmt.Println()
@@ -336,6 +341,25 @@ func describeDaemonError(err error, socket string) error {
 
 // truncate shortens a key for display. Public keys are not secret, but a terminal
 // full of base64 is unreadable.
+// printResolver says where names are answered, or that they are not.
+//
+// The negative case is stated rather than omitted: a device that resolves no names looks
+// identical to one whose resolver failed to bind, and telling those apart is the whole
+// reason somebody is reading this line.
+func printResolver(status agentapi.Status) {
+	if status.Resolver == "" {
+		fmt.Println("  resolver  not running; names will not resolve, addresses still work")
+		return
+	}
+	fmt.Printf("  resolver  %s", status.Resolver)
+	if len(status.ResolverSuffixes) > 0 {
+		fmt.Printf(" for %s", strings.Join(status.ResolverSuffixes, ", "))
+	} else {
+		fmt.Print(" (no names yet)")
+	}
+	fmt.Println()
+}
+
 func truncate(s string, n int) string {
 	if len(s) <= n {
 		return s

--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -15,6 +15,7 @@ import (
 	"github.com/meshpnet/meshp/internal/agentapi"
 	"github.com/meshpnet/meshp/internal/agentstate"
 	"github.com/meshpnet/meshp/internal/controlurl"
+	"github.com/meshpnet/meshp/internal/dns"
 	"github.com/meshpnet/meshp/internal/enrollclient"
 	"github.com/meshpnet/meshp/internal/keys"
 	"github.com/meshpnet/meshp/internal/nftables"
@@ -69,6 +70,13 @@ type agent struct {
 	// router's default both carry 192.168.1.0/24.
 	claims *tunnel.Claims
 
+	// zones is every name this device can answer for, across every network it is in, and
+	// resolver is what answers from them. Shared for the reason claims is: a bare name
+	// that exists in two of this device's networks is ambiguous, and only something that
+	// sees both can say so (ADR-0021).
+	zones    *dns.Zones
+	resolver *dns.Server
+
 	ctx context.Context
 }
 
@@ -115,7 +123,8 @@ func (a *agent) reconcilerFor(m agentstate.Membership, relay tunnel.Relay, choos
 		WithChooser(chooser).
 		WithEgress(routerOrNil()).
 		WithProber(proberOrNil()).
-		WithClaims(a.claims)
+		WithClaims(a.claims).
+		WithNames(a.zones)
 }
 
 // proberOrNil converts a possibly-absent dialer into the interface.
@@ -305,6 +314,7 @@ func relayStatus(l *relaylink.Link) *agentapi.RelayStatus {
 }
 
 func newAgent(ctx context.Context, log *slog.Logger, stateDir string, reconcileEvery time.Duration) *agent {
+	zones := dns.NewZones()
 	return &agent{
 		log:            log,
 		stateDir:       stateDir,
@@ -312,6 +322,8 @@ func newAgent(ctx context.Context, log *slog.Logger, stateDir string, reconcileE
 		reconcileEvery: reconcileEvery,
 		running:        make(map[uuid.UUID]*sessionHandle),
 		claims:         tunnel.NewClaims(),
+		zones:          zones,
+		resolver:       dns.NewServer(zones, log),
 		ctx:            ctx,
 	}
 }
@@ -529,6 +541,13 @@ func (a *agent) Status(_ context.Context) (agentapi.Status, error) {
 		Version:   version.Version(),
 		StartedAt: a.startedAt,
 		Enrolled:  a.state != nil,
+	}
+	// Before the enrolment check, because a resolver that is up on a device with no
+	// memberships is still a fact worth reporting — and its absence on a device that has
+	// them is the thing somebody will be looking for.
+	if addr := a.resolver.Addr(); addr.IsValid() {
+		status.Resolver = addr.String()
+		status.ResolverSuffixes = a.zones.Suffixes()
 	}
 	if a.state == nil {
 		return status, nil

--- a/cmd/meshpd/main.go
+++ b/cmd/meshpd/main.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"net/netip"
 	"os"
 	"os/signal"
 	"runtime"
@@ -81,6 +82,15 @@ func main() {
 	log.Info("meshpd stopped cleanly")
 }
 
+// dnsListenAddr is where the resolver listens.
+//
+// Loopback, because the kill switch permits loopback unconditionally and a resolver anybody
+// on the café Wi-Fi could query would tell them what machines are in your customers'
+// networks. Port zero: the kernel picks, and what it picked is read back and reported,
+// because 53 is almost always already taken by whatever the machine was using before and
+// fighting it would break the host's existing DNS to install ours.
+var dnsListenAddr = netip.MustParseAddrPort("127.0.0.1:0")
+
 func run(ctx context.Context, log *slog.Logger, stateDir, socketPath, socketGroup string, reconcileEvery time.Duration) error {
 	agent := newAgent(ctx, log, stateDir, reconcileEvery)
 
@@ -107,6 +117,22 @@ func run(ctx context.Context, log *slog.Logger, stateDir, socketPath, socketGrou
 	if err := server.Listen(); err != nil {
 		return err
 	}
+
+	// The resolver, before the sessions that fill it. Binding early means a device whose
+	// zones are still empty answers NXDOMAIN rather than nothing at all — a name that does
+	// not resolve yet is a better failure than a resolver that is not there, because the
+	// second one makes every query wait for a timeout.
+	//
+	// Its failure is not fatal. A port already taken, or a host that will not let this
+	// process bind, costs names and nothing else: the tunnel, the policy and the routes
+	// are all unaffected, and exiting here would take them down over a convenience.
+	go func() {
+		if err := agent.resolver.Listen(ctx, dnsListenAddr); err != nil && ctx.Err() == nil {
+			log.Error("no name resolution on this device",
+				"error", err, "addr", dnsListenAddr.String(),
+				"hint", "meshp status reports the resolver; addresses still work")
+		}
+	}()
 
 	agent.startAll()
 

--- a/docs/adr/0021-names-resolve-on-the-device.md
+++ b/docs/adr/0021-names-resolve-on-the-device.md
@@ -93,8 +93,20 @@ Fully-qualified names always resolve, and are the answer when a bare one will no
 ### 5. `device_name` stops being display-only
 
 A resolvable name is load-bearing. It gets a syntax (an LDH label), uniqueness within
-a network, and a rename path. Names that exist today and do not satisfy it must be
-reported rather than silently mangled into something that resolves.
+a network, and a rename path.
+
+**A collision is resolved by suffixing, never by refusing.** A device asking to join as
+`fileserver` when one exists becomes `fileserver-2`, and `meshp join` prints the name it
+was actually given. Refusing would mean a fleet imaged with one hostname produces one
+enrolment and forty-nine failures, for a reason the person running the installer can
+neither see nor fix — which is a worse product than having no names at all.
+
+The same rule applies to the migration that introduces the constraint: existing
+duplicates are renamed and the change is reported, rather than the migration refusing
+to apply. That is safe **only because names are not yet addresses** — nothing routes,
+authorises or resolves by `device_name` today, so a rename costs nothing. It is the
+reason to do this before the resolver ships rather than after: once a name is an
+address, it is in somebody's shell history and a rename is a breaking change forever.
 
 ## Consequences
 
@@ -111,11 +123,21 @@ admin ones are not — so reconciliation has the discriminator it needs.
 this it invalidates a name other people have in their shell history and their scripts,
 so it needs to be deliberate, logged, and probably rate-limited.
 
-**Uniqueness has to be enforced on names that already exist.** `devices.name` has no
-constraint today, so a deployment may already hold two machines called `laptop` in one
-network. The migration cannot silently rename one. It has to refuse, or quarantine,
-and an operator has to choose — which is a worse upgrade experience than doing nothing
-and the reason to do it before there are deployments rather than after.
+**Existing duplicates get renamed by the migration**, and it must say which. `devices.name`
+has no constraint today, so a deployment may already hold two machines called `laptop`
+in one network.
+
+An earlier draft of this ADR said the migration had to refuse rather than rename, and
+that was wrong. It blocks the upgrade to protect a name nothing depends on: `device_name`
+is display-only today, so a rename breaks no route, no policy and no lookup. The window
+in which that is true closes when the resolver ships, which is what makes the ordering
+here load-bearing rather than merely tidy.
+
+**Names stop being free text.** `Dave's laptop (spare)` is not an LDH label and will not
+survive. That is a real loss and the unavoidable price of a name being an address. It
+buys something back: once a name resolves it is security-relevant, and validation closes
+off control characters and homoglyphs — a device named to impersonate another is a
+phishing surface inside the mesh.
 
 **The agent now listens on a port.** Loopback only, but it is a new thing that can
 fail to bind, a new thing to report in `meshp status`, and a new thing `meshp doctor`

--- a/internal/agentapi/agentapi.go
+++ b/internal/agentapi/agentapi.go
@@ -38,6 +38,18 @@ type Status struct {
 	// (ADR-0006). Public, so safe to report.
 	IdentityPublicKey string `json:"identity_public_key,omitempty"`
 
+	// Resolver is where this device answers names, or empty when it is not answering.
+	//
+	// Reported because the port is the kernel's choice — 53 is almost always taken — so
+	// this is the only way anybody finds it, whether that is a person running `dig` or
+	// the code that will configure the system resolver.
+	Resolver string `json:"resolver,omitempty"`
+
+	// ResolverSuffixes are the domains it can answer for, across every network. Worth
+	// showing beside the address: a name that will not resolve is usually a name under a
+	// suffix that is not in this list.
+	ResolverSuffixes []string `json:"resolver_suffixes,omitempty"`
+
 	Memberships []MembershipStatus `json:"memberships"`
 }
 

--- a/internal/dns/fuzz_test.go
+++ b/internal/dns/fuzz_test.go
@@ -1,0 +1,69 @@
+package dns
+
+import (
+	"encoding/binary"
+	"net/netip"
+	"testing"
+)
+
+// A parser of packets off a socket, without a fuzz target, is a bad trade whatever the
+// dependency count it saved. This is the argument in the package comment, honoured.
+//
+// The properties are the ones that matter for a responder: never panic, never allocate on
+// somebody else's say-so, and never answer with something other than what was asked.
+func FuzzParseQuery(f *testing.F) {
+	f.Add(query(1, "fileserver.acme.internal", TypeA))
+	f.Add(query(0, "", TypeA))
+	f.Add(query(0xFFFF, "a.b.c.d.e.f.g", TypeAAAA))
+	f.Add([]byte{})
+	f.Add(make([]byte, headerLen))
+	// A compression pointer in the question, which is refused rather than followed.
+	f.Add([]byte{0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0xC0, 0x0C, 0, 1, 0, 1})
+	// A label length that runs past the end of the buffer.
+	f.Add([]byte{0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0x40, 'a'})
+
+	zones := NewZones()
+	zones.Replace("meshp0", Zone{Suffix: "acme.internal", Hosts: []Host{
+		{Name: "fileserver", Addrs: []netip.Addr{netip.MustParseAddr("100.90.0.5")}},
+	}})
+
+	f.Fuzz(func(t *testing.T, in []byte) {
+		q, err := ParseQuery(in)
+		if err != nil {
+			return
+		}
+
+		// A name that parsed must be renderable, or a response cannot echo the question
+		// and every client drops the reply as not matching what it sent.
+		if len(encodeName(q.Name)) > maxName+2 {
+			t.Fatalf("accepted a name that renders to %d bytes: %q", len(encodeName(q.Name)), q.Name)
+		}
+
+		// Answering must never produce something a client would refuse to read, and must
+		// never exceed what a datagram can carry.
+		res := zones.Lookup(q.Name)
+		answers := make([]Answer, 0, len(res.Addrs))
+		for _, addr := range res.Addrs {
+			answers = append(answers, Answer{Addr: addr, TTL: DefaultTTL})
+		}
+		reply := BuildResponse(q, res.Code, answers)
+
+		if len(reply) > MaxMessage {
+			t.Fatalf("built a %d-byte reply to a %d-byte query", len(reply), len(in))
+		}
+		if len(reply) < headerLen {
+			t.Fatalf("built a %d-byte reply, which is shorter than a header", len(reply))
+		}
+		if binary.BigEndian.Uint16(reply[0:2]) != q.ID {
+			t.Fatal("the reply does not carry the query's id")
+		}
+		if binary.BigEndian.Uint16(reply[2:4])&0x8000 == 0 {
+			t.Fatal("the reply is not marked as a response, so two resolvers would loop")
+		}
+		// The reply must be parseable as far as its own question, or a client cannot
+		// match it to what it sent.
+		if _, _, err := parseName(reply, headerLen); err != nil {
+			t.Fatalf("built a reply whose question will not parse: %v", err)
+		}
+	})
+}

--- a/internal/dns/message.go
+++ b/internal/dns/message.go
@@ -1,0 +1,296 @@
+// Package dns answers name queries for the networks a device is in, from the desired state
+// the device has already applied (ADR-0021).
+//
+// It resolves rather than forwards: the peer list the agent uses to configure WireGuard is
+// the same data that answers an A query, so a name keeps working when the control plane does
+// not — which is when somebody is most likely to be typing one.
+//
+// # Why the wire format is hand-written
+//
+// This is a responder for a handful of names on loopback, not a resolver. It answers A and
+// AAAA for names it owns and refuses everything else, which is a small enough subset that a
+// dependency would be mostly code this never executes. The parser is deliberately strict —
+// anything it does not fully understand is refused rather than guessed at — and it has a
+// fuzz target, because a hand-written parser of attacker-shaped input without one is a bad
+// trade whatever the dependency count.
+package dns
+
+import (
+	"encoding/binary"
+	"errors"
+	"net/netip"
+	"strings"
+)
+
+// Wire constants, named rather than spelled inline at the call sites.
+const (
+	// MaxMessage is the largest datagram this will send or accept over UDP.
+	//
+	// 512 is the pre-EDNS0 limit and this does not implement EDNS0, so it is also the
+	// real one: a response that does not fit is truncated and the client is told to
+	// retry over TCP. For a handful of addresses that will not happen, and pretending
+	// to a larger buffer we cannot negotiate would produce answers that get dropped by
+	// something in the middle.
+	MaxMessage = 512
+
+	// maxName is the longest name this will parse, per RFC 1035.
+	maxName = 255
+	// maxLabel is the longest single label.
+	maxLabel = 63
+
+	headerLen = 12
+)
+
+// Type is a DNS record type, limited to what this answers.
+type Type uint16
+
+const (
+	TypeA    Type = 1
+	TypeAAAA Type = 28
+)
+
+// Class is a DNS class. Only the internet class is answered.
+type Class uint16
+
+const ClassIN Class = 1
+
+// RCode is the answer's disposition.
+type RCode uint16
+
+const (
+	RCodeSuccess  RCode = 0
+	RCodeFormErr  RCode = 1
+	RCodeServFail RCode = 2
+
+	// RCodeNXDomain says the name does not exist here.
+	RCodeNXDomain RCode = 3
+
+	// RCodeRefused says this resolver will not answer, which is different from saying
+	// the name is not there. It is what an ambiguous bare name gets: the name exists in
+	// more than one of this device's networks, and choosing between them is precisely
+	// what must not happen (ADR-0021).
+	RCodeRefused RCode = 5
+)
+
+// ErrMalformed means a query could not be understood well enough to answer it.
+var ErrMalformed = errors.New("dns: malformed query")
+
+// Query is the part of a request this cares about.
+type Query struct {
+	ID uint16
+
+	// RecursionDesired is echoed back. This never recurses, but a stub resolver that sent
+	// RD and got a reply without it will often treat the answer as suspect.
+	RecursionDesired bool
+
+	// Name is the queried name, lowercased and without a trailing dot.
+	Name string
+
+	Type  Type
+	Class Class
+}
+
+// ParseQuery reads a single-question query.
+//
+// Strict on purpose. A query with no question, more than one question, a class this does not
+// serve, or trailing bytes it cannot account for is refused rather than partially honoured:
+// this listens on a socket, and a parser that guesses at the ambiguous cases is how a
+// responder ends up answering something other than what was asked.
+func ParseQuery(buf []byte) (Query, error) {
+	if len(buf) < headerLen {
+		return Query{}, ErrMalformed
+	}
+
+	var q Query
+	q.ID = binary.BigEndian.Uint16(buf[0:2])
+	flags := binary.BigEndian.Uint16(buf[2:4])
+	qdCount := binary.BigEndian.Uint16(buf[4:6])
+
+	// QR set means this is a response, not a question. Answering one would make two
+	// resolvers pointed at each other into a packet loop.
+	if flags&0x8000 != 0 {
+		return Query{}, ErrMalformed
+	}
+	// Opcode must be QUERY. Anything else — notably UPDATE — is not something to guess at.
+	if (flags>>11)&0xF != 0 {
+		return Query{}, ErrMalformed
+	}
+	q.RecursionDesired = flags&0x0100 != 0
+
+	if qdCount != 1 {
+		return Query{}, ErrMalformed
+	}
+
+	name, off, err := parseName(buf, headerLen)
+	if err != nil {
+		return Query{}, err
+	}
+	if off+4 > len(buf) {
+		return Query{}, ErrMalformed
+	}
+	q.Name = name
+	q.Type = Type(binary.BigEndian.Uint16(buf[off : off+2]))
+	q.Class = Class(binary.BigEndian.Uint16(buf[off+2 : off+4]))
+
+	return q, nil
+}
+
+// parseName reads a name and returns it lowercased, without a trailing dot.
+//
+// Compression pointers are refused rather than followed. A question section is the first
+// thing in a message, so there is nothing before it for a pointer to point at — a pointer
+// here is either a broken client or someone probing for a parser that will follow it into a
+// loop.
+func parseName(buf []byte, off int) (string, int, error) {
+	var out strings.Builder
+	total := 0
+
+	for {
+		if off >= len(buf) {
+			return "", 0, ErrMalformed
+		}
+		n := int(buf[off])
+		off++
+
+		if n == 0 {
+			return out.String(), off, nil
+		}
+		// A compression pointer. Refused rather than followed: a question section is the
+		// first thing in a message, so there is nothing before it to point at, and a
+		// parser that follows one can be walked into a loop.
+		//
+		// Redundant with the length bound below, and said so because a mutation proved
+		// it — every byte with these bits set is at least 64, which maxLabel already
+		// rejects. It stays because "pointers are not followed" and "labels are at most
+		// 63 bytes" are separate rules, and a reader looking for the first should find it
+		// rather than deduce it from the second.
+		if n&0xC0 != 0 {
+			return "", 0, ErrMalformed
+		}
+		if n > maxLabel {
+			return "", 0, ErrMalformed
+		}
+		total += n + 1
+		if total > maxName {
+			return "", 0, ErrMalformed
+		}
+		if off+n > len(buf) {
+			return "", 0, ErrMalformed
+		}
+
+		if out.Len() > 0 {
+			out.WriteByte('.')
+		}
+		// Lowercased here rather than at every comparison. DNS names are case-insensitive
+		// and a client may send any mixture; doing it once means the rest of this package
+		// can compare with ==.
+		for _, c := range buf[off : off+n] {
+			if c >= 'A' && c <= 'Z' {
+				c += 'a' - 'A'
+			}
+			out.WriteByte(c)
+		}
+		off += n
+	}
+}
+
+// Answer is one record in a response.
+type Answer struct {
+	Addr netip.Addr
+	TTL  uint32
+}
+
+// BuildResponse renders a reply to q.
+//
+// Records that do not match the question's type are dropped rather than sent: a client
+// asking for A and handed AAAA has been given something it did not ask for, and some stubs
+// treat that as a poisoned answer.
+func BuildResponse(q Query, code RCode, answers []Answer) []byte {
+	out := make([]byte, headerLen, MaxMessage)
+
+	binary.BigEndian.PutUint16(out[0:2], q.ID)
+
+	// QR, AA. Authoritative because for the names this owns, it is: the answer comes from
+	// desired state rather than from a cache of somebody else's zone.
+	flags := uint16(0x8000 | 0x0400)
+	if q.RecursionDesired {
+		// RD echoed, RA clear. This never recurses and says so; a stub that wanted
+		// recursion learns it will not get it rather than being told it did.
+		flags |= 0x0100
+	}
+	flags |= uint16(code) & 0xF
+	binary.BigEndian.PutUint16(out[2:4], flags)
+	binary.BigEndian.PutUint16(out[4:6], 1) // the question, echoed below
+
+	question := encodeName(q.Name)
+	out = append(out, question...)
+	out = binary.BigEndian.AppendUint16(out, uint16(q.Type))
+	out = binary.BigEndian.AppendUint16(out, uint16(q.Class))
+
+	written := 0
+	truncated := false
+	for _, a := range answers {
+		if !matches(q.Type, a.Addr) {
+			continue
+		}
+		record := encodeAnswer(q.Name, q.Type, a)
+		if len(out)+len(record) > MaxMessage {
+			// The client is told to ask again over TCP rather than handed a short list
+			// it cannot tell is short. A silently truncated answer set is how a device
+			// ends up talking to whichever half of a service fitted in the datagram.
+			truncated = true
+			break
+		}
+		out = append(out, record...)
+		written++
+	}
+
+	binary.BigEndian.PutUint16(out[6:8], uint16(written))
+	if truncated {
+		binary.BigEndian.PutUint16(out[2:4], binary.BigEndian.Uint16(out[2:4])|0x0200)
+	}
+	return out
+}
+
+// matches reports whether an address answers this question type.
+func matches(t Type, addr netip.Addr) bool {
+	switch t {
+	case TypeA:
+		return addr.Is4()
+	case TypeAAAA:
+		return addr.Is6() && !addr.Is4In6()
+	default:
+		return false
+	}
+}
+
+func encodeAnswer(name string, t Type, a Answer) []byte {
+	out := encodeName(name)
+	out = binary.BigEndian.AppendUint16(out, uint16(t))
+	out = binary.BigEndian.AppendUint16(out, uint16(ClassIN))
+	out = binary.BigEndian.AppendUint32(out, a.TTL)
+
+	addr := a.Addr.Unmap()
+	raw := addr.AsSlice()
+	out = binary.BigEndian.AppendUint16(out, uint16(len(raw)))
+	return append(out, raw...)
+}
+
+// encodeName writes a name in wire form. Uncompressed: the saving is a few bytes on a
+// message that is already small, and a compression pointer is a class of bug this does not
+// need to be able to have.
+func encodeName(name string) []byte {
+	out := make([]byte, 0, len(name)+2)
+	if name != "" {
+		for label := range strings.SplitSeq(name, ".") {
+			if len(label) == 0 || len(label) > maxLabel {
+				// Unreachable for names this package produced, and if it ever is reached
+				// an empty name is a better answer than a corrupt message.
+				return []byte{0}
+			}
+			out = append(out, byte(len(label)))
+			out = append(out, label...)
+		}
+	}
+	return append(out, 0)
+}

--- a/internal/dns/server.go
+++ b/internal/dns/server.go
@@ -1,0 +1,222 @@
+package dns
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/netip"
+	"sync"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/logx"
+)
+
+// readTimeout bounds a single TCP exchange.
+//
+// A DNS client over TCP sends a length and a message and expects an answer; anything that
+// opens a connection and then waits is either broken or holding a file descriptor on
+// purpose. Five seconds is far longer than a loopback exchange needs.
+const readTimeout = 5 * time.Second
+
+// Server answers queries for the zones a device holds.
+//
+// Loopback only, and that is a decision rather than a default. The egress kill switch
+// permits loopback unconditionally — its comment names "a local resolver" among the things
+// it must not break — so a device that has locked itself down can still resolve. A resolver
+// reachable from the network would also be one anybody on the café Wi-Fi could ask what
+// machines are in your customers' networks.
+type Server struct {
+	zones *Zones
+	log   *slog.Logger
+
+	mu   sync.Mutex
+	addr netip.AddrPort
+	udp  *net.UDPConn
+	tcp  *net.TCPListener
+}
+
+// NewServer returns a resolver serving these zones.
+func NewServer(zones *Zones, log *slog.Logger) *Server {
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	return &Server{zones: zones, log: log}
+}
+
+// ErrNotLoopback means somebody asked this to listen where it must not.
+var ErrNotLoopback = errors.New("dns: the resolver listens on loopback only")
+
+// Listen binds UDP and TCP and serves until ctx is done.
+//
+// Both, because DNS is both: a truncated UDP answer tells the client to retry over TCP, and
+// a client that cannot is stuck with whatever fitted in 512 bytes.
+func (s *Server) Listen(ctx context.Context, addr netip.AddrPort) error {
+	if !addr.Addr().IsLoopback() {
+		return ErrNotLoopback
+	}
+
+	udp, err := net.ListenUDP("udp", net.UDPAddrFromAddrPort(addr))
+	if err != nil {
+		return err
+	}
+	// The port is read back from the socket rather than from what was asked for, because
+	// a caller may ask for zero and let the kernel choose — and the chosen port is what
+	// has to be handed to the system resolver.
+	bound := udp.LocalAddr().(*net.UDPAddr).AddrPort()
+
+	tcp, err := net.ListenTCP("tcp", net.TCPAddrFromAddrPort(bound))
+	if err != nil {
+		_ = udp.Close()
+		return err
+	}
+
+	s.mu.Lock()
+	s.udp, s.tcp, s.addr = udp, tcp, bound
+	s.mu.Unlock()
+
+	s.log.Info("resolver listening", "addr", bound.String())
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); s.serveUDP(udp) }()
+	go func() { defer wg.Done(); s.serveTCP(tcp) }()
+
+	<-ctx.Done()
+	_ = udp.Close()
+	_ = tcp.Close()
+	wg.Wait()
+
+	s.mu.Lock()
+	s.udp, s.tcp, s.addr = nil, nil, netip.AddrPort{}
+	s.mu.Unlock()
+	return nil
+}
+
+// Addr is where the resolver is listening, or the zero value when it is not.
+//
+// Read rather than assumed, for the same reason the tunnel's listen port is: asking for any
+// port means the kernel chose, and its choice is the thing the rest of the system needs.
+func (s *Server) Addr() netip.AddrPort {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.addr
+}
+
+func (s *Server) serveUDP(conn *net.UDPConn) {
+	buf := make([]byte, MaxMessage)
+	for {
+		n, from, err := conn.ReadFromUDPAddrPort(buf)
+		if err != nil {
+			return // the listener was closed
+		}
+		reply := s.answer(buf[:n])
+		if reply == nil {
+			// Unparseable beyond the point of having an id to reply to. Dropped rather
+			// than answered: there is nothing truthful to say, and replying to a forged
+			// source would make this a reflector.
+			continue
+		}
+		if _, err := conn.WriteToUDPAddrPort(reply, from); err != nil {
+			s.log.Debug("could not send a reply", "error", logx.SafeError(err))
+		}
+	}
+}
+
+func (s *Server) serveTCP(listener *net.TCPListener) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		go s.serveConn(conn)
+	}
+}
+
+// serveConn handles one TCP client. A single exchange per connection: this is not a
+// high-traffic resolver, and keeping connections alive is state to get wrong for no gain.
+func (s *Server) serveConn(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(readTimeout))
+
+	var length [2]byte
+	if _, err := io.ReadFull(conn, length[:]); err != nil {
+		return
+	}
+	n := binary.BigEndian.Uint16(length[:])
+	if n == 0 || int(n) > MaxMessage {
+		// Bounded even over TCP, where the protocol would allow 65535. Nothing this
+		// answers needs more, and an unbounded allocation driven by two bytes from a
+		// client is a way to be made to hold memory.
+		return
+	}
+
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		return
+	}
+	reply := s.answer(buf)
+	if reply == nil {
+		return
+	}
+
+	out := make([]byte, 2, 2+len(reply))
+	binary.BigEndian.PutUint16(out, uint16(len(reply)))
+	if _, err := conn.Write(append(out, reply...)); err != nil {
+		s.log.Debug("could not send a reply", "error", logx.SafeError(err))
+	}
+}
+
+// answer turns a query into a response, or nil when there is nothing truthful to send.
+func (s *Server) answer(raw []byte) []byte {
+	q, err := ParseQuery(raw)
+	if err != nil {
+		// An id is the one thing worth recovering from a malformed query: a client that
+		// gets FORMERR learns it sent nonsense, where silence looks like packet loss and
+		// makes it retry. Below the header there is not even that.
+		if len(raw) >= 2 {
+			return BuildResponse(Query{ID: binary.BigEndian.Uint16(raw[0:2])}, RCodeFormErr, nil)
+		}
+		return nil
+	}
+
+	if q.Class != ClassIN {
+		return BuildResponse(q, RCodeRefused, nil)
+	}
+	switch q.Type {
+	case TypeA, TypeAAAA:
+	default:
+		// Everything else — MX, TXT, ANY — is refused rather than answered empty. An
+		// empty success says "this name has no such record", which is a claim about a
+		// zone this does not own.
+		return BuildResponse(q, RCodeRefused, nil)
+	}
+
+	res := s.zones.Lookup(q.Name)
+	if len(res.Ambiguous) > 0 {
+		// Logged, because the error a person sees is a bare REFUSED and this is the only
+		// place that can say why. Through logx.Safe: the name came off a socket.
+		s.log.Warn("refusing an ambiguous name rather than choosing a network",
+			"name", logx.Safe(q.Name), "matches", len(res.Ambiguous),
+			"alternatives", logx.Safe(joinNames(res.Ambiguous)))
+	}
+
+	answers := make([]Answer, 0, len(res.Addrs))
+	for _, addr := range res.Addrs {
+		answers = append(answers, Answer{Addr: addr, TTL: DefaultTTL})
+	}
+	return BuildResponse(q, res.Code, answers)
+}
+
+func joinNames(names []string) string {
+	out := ""
+	for i, n := range names {
+		if i > 0 {
+			out += ", "
+		}
+		out += n
+	}
+	return out
+}

--- a/internal/dns/server_test.go
+++ b/internal/dns/server_test.go
@@ -1,0 +1,289 @@
+package dns
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"net"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+)
+
+// serve starts a resolver on a loopback port the kernel picks, and returns where it is.
+func serve(t *testing.T, z *Zones) netip.AddrPort {
+	t.Helper()
+	s := NewServer(z, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	done := make(chan error, 1)
+	go func() { done <- s.Listen(ctx, netip.MustParseAddrPort("127.0.0.1:0")) }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for s.Addr().Port() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("the resolver never bound")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	addr := s.Addr()
+
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("Listen: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("the resolver did not stop when its context was cancelled")
+		}
+	})
+	return addr
+}
+
+// ask sends a real query over a real socket and returns the raw reply.
+func ask(t *testing.T, addr netip.AddrPort, name string, qtype Type) []byte {
+	t.Helper()
+	conn, err := net.Dial("udp", addr.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	if _, err := conn.Write(query(0x1234, name, qtype)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, MaxMessage)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return buf[:n]
+}
+
+// query builds a wire-format question, by hand, so the tests do not verify the encoder
+// against itself.
+func query(id uint16, name string, qtype Type) []byte {
+	out := make([]byte, headerLen)
+	binary.BigEndian.PutUint16(out[0:2], id)
+	binary.BigEndian.PutUint16(out[2:4], 0x0100) // RD
+	binary.BigEndian.PutUint16(out[4:6], 1)
+
+	if name != "" {
+		for _, label := range strings.Split(strings.TrimSuffix(name, "."), ".") {
+			out = append(out, byte(len(label)))
+			out = append(out, label...)
+		}
+	}
+	out = append(out, 0)
+	out = binary.BigEndian.AppendUint16(out, uint16(qtype))
+	return binary.BigEndian.AppendUint16(out, uint16(ClassIN))
+}
+
+func rcode(reply []byte) RCode { return RCode(binary.BigEndian.Uint16(reply[2:4]) & 0xF) }
+func ancount(reply []byte) int { return int(binary.BigEndian.Uint16(reply[6:8])) }
+
+// addrs pulls the answer records out of a reply, so the assertions are about what a client
+// would actually receive rather than about internal state.
+func addrs(t *testing.T, reply []byte) []netip.Addr {
+	t.Helper()
+	_, off, err := parseName(reply, headerLen)
+	if err != nil {
+		t.Fatalf("reply question is malformed: %v", err)
+	}
+	off += 4 // qtype, qclass
+
+	var out []netip.Addr
+	for range ancount(reply) {
+		_, next, err := parseName(reply, off)
+		if err != nil {
+			t.Fatalf("answer name is malformed: %v", err)
+		}
+		off = next
+		if off+10 > len(reply) {
+			t.Fatal("answer record is truncated")
+		}
+		length := int(binary.BigEndian.Uint16(reply[off+8 : off+10]))
+		off += 10
+		if off+length > len(reply) {
+			t.Fatal("answer data is truncated")
+		}
+		addr, ok := netip.AddrFromSlice(reply[off : off+length])
+		if !ok {
+			t.Fatalf("answer holds %d bytes, which is not an address", length)
+		}
+		out = append(out, addr)
+		off += length
+	}
+	return out
+}
+
+// The whole thing, over a socket: a query goes in, an address comes back.
+func TestARealQueryGetsARealAnswer(t *testing.T) {
+	addr := serve(t, twoCustomers(t))
+
+	reply := ask(t, addr, "fileserver.acme.internal", TypeA)
+	if got := rcode(reply); got != RCodeSuccess {
+		t.Fatalf("rcode = %v", got)
+	}
+	if binary.BigEndian.Uint16(reply[0:2]) != 0x1234 {
+		t.Error("the reply does not carry the query's id, so a client cannot match it")
+	}
+	got := addrs(t, reply)
+	if len(got) != 1 || got[0] != netip.MustParseAddr("100.90.0.5") {
+		t.Errorf("answers = %v", got)
+	}
+}
+
+// A question for A must not be answered with AAAA. Some stubs treat a mismatched type as a
+// poisoned answer, and rightly.
+func TestOnlyTheAskedFamilyComesBack(t *testing.T) {
+	addr := serve(t, twoCustomers(t))
+
+	v4 := addrs(t, ask(t, addr, "fileserver.acme.internal", TypeA))
+	if len(v4) != 1 || !v4[0].Is4() {
+		t.Errorf("A query answered with %v", v4)
+	}
+	v6 := addrs(t, ask(t, addr, "fileserver.acme.internal", TypeAAAA))
+	if len(v6) != 1 || v6[0].Is4() {
+		t.Errorf("AAAA query answered with %v", v6)
+	}
+}
+
+// A device with no address of the asked family exists and has no such record. That is a
+// success with no answers, not NXDOMAIN — the difference tells a client whether to try the
+// other family or give up.
+func TestNoAddressOfThatFamilyIsNotAMissingName(t *testing.T) {
+	addr := serve(t, twoCustomers(t))
+
+	reply := ask(t, addr, "laptop.acme.internal", TypeAAAA)
+	if got := rcode(reply); got != RCodeSuccess {
+		t.Errorf("rcode = %v, want success with no answers", got)
+	}
+	if n := ancount(reply); n != 0 {
+		t.Errorf("%d answers, want 0", n)
+	}
+}
+
+// The ambiguity rule, over the wire.
+func TestAnAmbiguousNameIsRefusedOverTheWire(t *testing.T) {
+	addr := serve(t, twoCustomers(t))
+
+	reply := ask(t, addr, "fileserver", TypeA)
+	if got := rcode(reply); got != RCodeRefused {
+		t.Errorf("rcode = %v, want REFUSED", got)
+	}
+	if n := ancount(reply); n != 0 {
+		t.Errorf("a refused query carried %d answers", n)
+	}
+}
+
+// Record types this does not serve are refused rather than answered empty. An empty success
+// asserts "this name has no MX", which is a claim about a zone this does not own.
+func TestUnservedTypesAreRefused(t *testing.T) {
+	addr := serve(t, twoCustomers(t))
+
+	for _, qtype := range []Type{15 /*MX*/, 16 /*TXT*/, 255 /*ANY*/, 12 /*PTR*/} {
+		reply := ask(t, addr, "fileserver.acme.internal", qtype)
+		if got := rcode(reply); got != RCodeRefused {
+			t.Errorf("type %d got %v, want REFUSED", qtype, got)
+		}
+	}
+}
+
+// TCP is not optional: a truncated UDP answer tells the client to retry there, and a client
+// that cannot is stuck with whatever fitted in 512 bytes.
+func TestTCPAnswersToo(t *testing.T) {
+	addr := serve(t, twoCustomers(t))
+
+	conn, err := net.Dial("tcp", addr.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	q := query(0x4321, "fileserver.acme.internal", TypeA)
+	framed := binary.BigEndian.AppendUint16(nil, uint16(len(q)))
+	if _, err := conn.Write(append(framed, q...)); err != nil {
+		t.Fatal(err)
+	}
+
+	var length [2]byte
+	if _, err := conn.Read(length[:]); err != nil {
+		t.Fatal(err)
+	}
+	reply := make([]byte, binary.BigEndian.Uint16(length[:]))
+	if _, err := conn.Read(reply); err != nil {
+		t.Fatal(err)
+	}
+	if got := rcode(reply); got != RCodeSuccess {
+		t.Fatalf("rcode = %v", got)
+	}
+	if got := addrs(t, reply); len(got) != 1 || got[0] != netip.MustParseAddr("100.90.0.5") {
+		t.Errorf("answers = %v", got)
+	}
+}
+
+// A malformed query gets FORMERR when there is an id to reply to, so a client learns it sent
+// nonsense rather than seeing what looks like packet loss and retrying forever.
+func TestAMalformedQueryGetsFormErr(t *testing.T) {
+	addr := serve(t, twoCustomers(t))
+
+	conn, err := net.Dial("udp", addr.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	// A header claiming one question, and no question after it.
+	bad := make([]byte, headerLen)
+	binary.BigEndian.PutUint16(bad[0:2], 0xBEEF)
+	binary.BigEndian.PutUint16(bad[4:6], 1)
+	if _, err := conn.Write(bad); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, MaxMessage)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := rcode(buf[:n]); got != RCodeFormErr {
+		t.Errorf("rcode = %v, want FORMERR", got)
+	}
+	if binary.BigEndian.Uint16(buf[0:2]) != 0xBEEF {
+		t.Error("the FORMERR does not carry the query's id")
+	}
+}
+
+// Listening anywhere but loopback is refused. A resolver on a routable address is one
+// anybody on the café Wi-Fi can ask what machines are in your customers' networks.
+func TestItRefusesToListenOffLoopback(t *testing.T) {
+	s := NewServer(twoCustomers(t), nil)
+
+	// A context that ends, and a result read with a deadline. Listen blocks until its
+	// context is done, so a version of this that passed context.Background() would hang
+	// rather than fail if the guard were removed — which is exactly what happened when a
+	// mutation removed it. A test that hangs on the bug it is checking for is worse than
+	// no test: it stalls the suite instead of naming the problem.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- s.Listen(ctx, netip.MustParseAddrPort("0.0.0.0:0")) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrNotLoopback) {
+			t.Errorf("err = %v, want ErrNotLoopback", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Listen did not refuse a non-loopback address; it bound and started serving")
+	}
+}

--- a/internal/dns/zones.go
+++ b/internal/dns/zones.go
@@ -1,0 +1,197 @@
+package dns
+
+import (
+	"net/netip"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// DefaultTTL is how long an answer may be cached.
+//
+// Short, because the underlying fact changes without warning: a device gets a new address
+// when it re-enrols, and a peer that has been revoked should stop resolving quickly. Sixty
+// seconds is long enough that a shell loop does not re-query on every iteration and short
+// enough that a stale answer is a nuisance rather than an outage.
+const DefaultTTL = 60
+
+// Host is one name and the addresses it has in one network.
+type Host struct {
+	// Name is the device's label, without any suffix. Already lowercased.
+	Name string
+
+	Addrs []netip.Addr
+}
+
+// Zone is one membership's names.
+type Zone struct {
+	// Suffix is what this network's names end with, such as "acme.internal". Lowercased,
+	// no leading or trailing dot.
+	Suffix string
+
+	Hosts []Host
+}
+
+// Zones is every name this device can answer for, across every network it is in.
+//
+// Safe for concurrent use: the resolver reads it while each membership's reconciler
+// replaces its own zone from a state delta.
+type Zones struct {
+	mu sync.RWMutex
+
+	// byOwner is keyed by interface name, the same key the route-claim registry uses, so
+	// a membership replaces its own names and nobody else's.
+	byOwner map[string]Zone
+}
+
+func NewZones() *Zones { return &Zones{byOwner: make(map[string]Zone)} }
+
+// Replace sets one membership's names, dropping whatever it had before.
+//
+// Replace rather than merge, for the reason a snapshot replaces a peer set: a name that has
+// gone must stop resolving, and merging would leave a revoked device answering forever.
+func (z *Zones) Replace(owner string, zone Zone) {
+	if z == nil {
+		return
+	}
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	if zone.Suffix == "" || len(zone.Hosts) == 0 {
+		delete(z.byOwner, owner)
+		return
+	}
+	z.byOwner[owner] = zone
+}
+
+// Forget drops a membership's names, for a device that has left a network.
+func (z *Zones) Forget(owner string) {
+	if z == nil {
+		return
+	}
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	delete(z.byOwner, owner)
+}
+
+// Suffixes lists the domains this device can answer for, sorted.
+//
+// Used to tell the system resolver which names to send here, and to decide whether a bare
+// name can be offered as a search domain at all.
+func (z *Zones) Suffixes() []string {
+	if z == nil {
+		return nil
+	}
+	z.mu.RLock()
+	defer z.mu.RUnlock()
+
+	out := make([]string, 0, len(z.byOwner))
+	for _, zone := range z.byOwner {
+		out = append(out, zone.Suffix)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Resolution is what a lookup found.
+type Resolution struct {
+	Addrs []netip.Addr
+
+	// Code is the disposition. Success with no addresses means the name exists in this
+	// network and has no address of the requested family, which is a different answer
+	// from the name not existing.
+	Code RCode
+
+	// Ambiguous names the fully-qualified alternatives when a bare name matched more than
+	// one network. Non-empty only with RCodeRefused, and it is the whole point of
+	// refusing: the caller can be told what to type instead.
+	Ambiguous []string
+}
+
+// Lookup answers a name.
+//
+// Three cases, and the third is the one this package exists to get right.
+//
+// A name ending in one of this device's suffixes is answered from that network alone. There
+// is nothing to disambiguate — the network is in the name.
+//
+// A name ending in a suffix this device does not have is not ours. NXDOMAIN would be a lie
+// (the name may exist perfectly well elsewhere), so it is refused, and the system resolver
+// should not have sent it here in the first place.
+//
+// A bare single label is looked up across every network, and answered **only if exactly one
+// has it**. Two matches is refused, naming both alternatives. There is deliberately no
+// precedence between memberships: an order would turn an ambiguous question into a confident
+// wrong answer, sending a technician to whichever customer sorted first (ADR-0021). A
+// person who is told `fileserver` is ambiguous has lost a keystroke; one who reaches the
+// wrong company's file server has lost more than that.
+func (z *Zones) Lookup(name string) Resolution {
+	if z == nil {
+		return Resolution{Code: RCodeNXDomain}
+	}
+	name = strings.ToLower(strings.TrimSuffix(name, "."))
+	if name == "" {
+		return Resolution{Code: RCodeNXDomain}
+	}
+
+	z.mu.RLock()
+	defer z.mu.RUnlock()
+
+	if strings.Contains(name, ".") {
+		return z.qualifiedLocked(name)
+	}
+	return z.bareLocked(name)
+}
+
+// qualifiedLocked answers a name that already says which network it means.
+func (z *Zones) qualifiedLocked(name string) Resolution {
+	for _, zone := range z.byOwner {
+		label, ok := strings.CutSuffix(name, "."+zone.Suffix)
+		if !ok {
+			continue
+		}
+		// One label only. `a.b.acme.internal` is not a device in acme; answering it from
+		// the host called `a` would invent a name nobody configured.
+		if label == "" || strings.Contains(label, ".") {
+			return Resolution{Code: RCodeNXDomain}
+		}
+		for _, host := range zone.Hosts {
+			if host.Name == label {
+				return Resolution{Addrs: host.Addrs, Code: RCodeSuccess}
+			}
+		}
+		// The suffix is ours and the device is not in it. That is a real NXDOMAIN, and
+		// saying so stops a stub from trying the next search domain and finding a
+		// different customer's machine.
+		return Resolution{Code: RCodeNXDomain}
+	}
+	// Not a suffix this device serves.
+	return Resolution{Code: RCodeRefused}
+}
+
+// bareLocked answers a single label, or refuses to choose.
+func (z *Zones) bareLocked(label string) Resolution {
+	var found []netip.Addr
+	var qualified []string
+
+	for _, zone := range z.byOwner {
+		for _, host := range zone.Hosts {
+			if host.Name != label {
+				continue
+			}
+			qualified = append(qualified, label+"."+zone.Suffix)
+			found = host.Addrs
+		}
+	}
+
+	switch len(qualified) {
+	case 0:
+		return Resolution{Code: RCodeNXDomain}
+	case 1:
+		return Resolution{Addrs: found, Code: RCodeSuccess}
+	default:
+		// Sorted so the same ambiguity reads the same way every time, rather than
+		// changing order with map iteration and looking like a new problem each query.
+		sort.Strings(qualified)
+		return Resolution{Code: RCodeRefused, Ambiguous: qualified}
+	}
+}

--- a/internal/dns/zones_test.go
+++ b/internal/dns/zones_test.go
@@ -1,0 +1,207 @@
+package dns
+
+import (
+	"net/netip"
+	"slices"
+	"testing"
+)
+
+func host(name string, addrs ...string) Host {
+	h := Host{Name: name}
+	for _, a := range addrs {
+		h.Addrs = append(h.Addrs, netip.MustParseAddr(a))
+	}
+	return h
+}
+
+// twoCustomers is the shape ADR-0004 exists for and ADR-0021 has to survive: one device in
+// two networks, each with a machine called fileserver.
+func twoCustomers(t *testing.T) *Zones {
+	t.Helper()
+	z := NewZones()
+	z.Replace("meshp0", Zone{Suffix: "acme.internal", Hosts: []Host{
+		host("fileserver", "100.90.0.5", "fd7c::5"),
+		host("laptop", "100.90.0.9"),
+	}})
+	z.Replace("meshp1", Zone{Suffix: "globex.internal", Hosts: []Host{
+		host("fileserver", "100.91.0.5"),
+		host("printer", "100.91.0.7"),
+	}})
+	return z
+}
+
+// A fully-qualified name says which network it means, so there is nothing to disambiguate.
+func TestAQualifiedNameResolvesToItsOwnNetwork(t *testing.T) {
+	z := twoCustomers(t)
+
+	acme := z.Lookup("fileserver.acme.internal")
+	if acme.Code != RCodeSuccess {
+		t.Fatalf("code = %v", acme.Code)
+	}
+	if !slices.Contains(acme.Addrs, netip.MustParseAddr("100.90.0.5")) {
+		t.Errorf("acme's fileserver resolved to %v", acme.Addrs)
+	}
+
+	globex := z.Lookup("fileserver.globex.internal")
+	if !slices.Contains(globex.Addrs, netip.MustParseAddr("100.91.0.5")) {
+		t.Errorf("globex's fileserver resolved to %v", globex.Addrs)
+	}
+	if slices.Contains(globex.Addrs, netip.MustParseAddr("100.90.0.5")) {
+		t.Error("one customer's address answered for another customer's name")
+	}
+}
+
+// Case and a trailing dot are how a stub resolver actually sends a name.
+func TestNamesAreMatchedWithoutCaseOrTrailingDot(t *testing.T) {
+	z := twoCustomers(t)
+	for _, name := range []string{
+		"FileServer.Acme.Internal",
+		"fileserver.acme.internal.",
+		"FILESERVER.ACME.INTERNAL.",
+	} {
+		if got := z.Lookup(name); got.Code != RCodeSuccess {
+			t.Errorf("%q did not resolve: %v", name, got.Code)
+		}
+	}
+}
+
+// The decision this package exists for.
+//
+// A bare name matching two networks is refused rather than answered from whichever sorted
+// first. An order would send a technician to a customer chosen by something they cannot see.
+func TestAnAmbiguousBareNameIsRefused(t *testing.T) {
+	z := twoCustomers(t)
+
+	got := z.Lookup("fileserver")
+	if got.Code != RCodeRefused {
+		t.Fatalf("code = %v, want REFUSED — a bare name in two networks was answered", got.Code)
+	}
+	if len(got.Addrs) != 0 {
+		t.Errorf("a refused name still carried addresses: %v", got.Addrs)
+	}
+	want := []string{"fileserver.acme.internal", "fileserver.globex.internal"}
+	if !slices.Equal(got.Ambiguous, want) {
+		t.Errorf("alternatives = %v, want %v — the error has to say what to type instead", got.Ambiguous, want)
+	}
+}
+
+// And an unambiguous bare name works, or the rule would just be "bare names never resolve",
+// which is a different and worse product.
+func TestAnUnambiguousBareNameResolves(t *testing.T) {
+	z := twoCustomers(t)
+
+	got := z.Lookup("printer")
+	if got.Code != RCodeSuccess {
+		t.Fatalf("code = %v, want success — printer is only in one network", got.Code)
+	}
+	if !slices.Contains(got.Addrs, netip.MustParseAddr("100.91.0.7")) {
+		t.Errorf("addrs = %v", got.Addrs)
+	}
+}
+
+// A device in one network is the ordinary case, and every bare name must work there.
+func TestOneNetworkHasNoAmbiguity(t *testing.T) {
+	z := NewZones()
+	z.Replace("meshp0", Zone{Suffix: "acme.internal", Hosts: []Host{host("fileserver", "100.90.0.5")}})
+
+	if got := z.Lookup("fileserver"); got.Code != RCodeSuccess {
+		t.Errorf("code = %v in a single-network device", got.Code)
+	}
+}
+
+// A name under a suffix this device serves, for a device that is not there, does not exist.
+//
+// NXDOMAIN rather than REFUSED, and the difference matters: a stub that gets REFUSED may try
+// the next search domain and find a different customer's machine, which is the ambiguity
+// coming back through the side door.
+func TestAMissingDeviceInAKnownNetworkDoesNotExist(t *testing.T) {
+	z := twoCustomers(t)
+	if got := z.Lookup("nosuchbox.acme.internal"); got.Code != RCodeNXDomain {
+		t.Errorf("code = %v, want NXDOMAIN", got.Code)
+	}
+}
+
+// A suffix this device does not serve is not ours to answer for. NXDOMAIN would be a claim
+// about somebody else's zone.
+func TestAForeignSuffixIsRefused(t *testing.T) {
+	z := twoCustomers(t)
+	for _, name := range []string{"example.com", "fileserver.other.internal", "www.google.com"} {
+		if got := z.Lookup(name); got.Code != RCodeRefused {
+			t.Errorf("%q got %v, want REFUSED", name, got.Code)
+		}
+	}
+}
+
+// Sub-labels are not devices. Answering `a.b.acme.internal` from the host called `b` would
+// invent a name nobody configured.
+func TestASubLabelIsNotADevice(t *testing.T) {
+	z := twoCustomers(t)
+	if got := z.Lookup("extra.fileserver.acme.internal"); got.Code != RCodeNXDomain {
+		t.Errorf("code = %v, want NXDOMAIN", got.Code)
+	}
+}
+
+// Replacing a membership's zone drops what it had. A revoked device must stop resolving, and
+// merging would leave it answering forever.
+func TestReplacingAZoneDropsTheOldNames(t *testing.T) {
+	z := NewZones()
+	z.Replace("meshp0", Zone{Suffix: "acme.internal", Hosts: []Host{
+		host("old", "100.90.0.1"), host("kept", "100.90.0.2"),
+	}})
+	z.Replace("meshp0", Zone{Suffix: "acme.internal", Hosts: []Host{host("kept", "100.90.0.2")}})
+
+	if got := z.Lookup("old.acme.internal"); got.Code == RCodeSuccess {
+		t.Error("a name removed from the network still resolves")
+	}
+	if got := z.Lookup("kept.acme.internal"); got.Code != RCodeSuccess {
+		t.Error("replacing a zone dropped a name that is still there")
+	}
+}
+
+// Leaving a network takes its names with it, and un-shadows any bare name it was making
+// ambiguous.
+func TestForgettingANetworkResolvesTheAmbiguity(t *testing.T) {
+	z := twoCustomers(t)
+	if got := z.Lookup("fileserver"); got.Code != RCodeRefused {
+		t.Fatalf("setup: expected ambiguity, got %v", got.Code)
+	}
+
+	z.Forget("meshp1")
+
+	got := z.Lookup("fileserver")
+	if got.Code != RCodeSuccess {
+		t.Fatalf("code = %v after leaving the other network", got.Code)
+	}
+	if !slices.Contains(got.Addrs, netip.MustParseAddr("100.90.0.5")) {
+		t.Errorf("addrs = %v", got.Addrs)
+	}
+	if got := z.Lookup("printer.globex.internal"); got.Code == RCodeSuccess {
+		t.Error("a network this device has left still resolves")
+	}
+}
+
+// The suffix list is what tells the system resolver which names to send here, so it has to
+// be complete and stable.
+func TestSuffixesAreListedInAStableOrder(t *testing.T) {
+	z := twoCustomers(t)
+	want := []string{"acme.internal", "globex.internal"}
+	for range 5 {
+		if got := z.Suffixes(); !slices.Equal(got, want) {
+			t.Fatalf("suffixes = %v, want %v", got, want)
+		}
+	}
+}
+
+// A nil Zones answers rather than panicking. The agent builds one per daemon and a test or
+// an early code path may not have.
+func TestANilZonesIsSafe(t *testing.T) {
+	var z *Zones
+	if got := z.Lookup("anything"); got.Code != RCodeNXDomain {
+		t.Errorf("code = %v", got.Code)
+	}
+	z.Replace("meshp0", Zone{Suffix: "x.internal"})
+	z.Forget("meshp0")
+	if got := z.Suffixes(); got != nil {
+		t.Errorf("suffixes = %v", got)
+	}
+}

--- a/internal/session/failover_test.go
+++ b/internal/session/failover_test.go
@@ -168,3 +168,66 @@ func TestEachGroupCarriesItsOwnPolicy(t *testing.T) {
 		t.Error("one group's policy leaked into another's")
 	}
 }
+
+// The DNS suffix a device is told to use, which is what makes any of its names resolvable.
+//
+// DnsConfig has been on the wire since the beginning and nothing ever set it — the fourth
+// instance of that pattern in this repository. The agent read exactly one field from it,
+// prevent_leaks, and every other one was dead.
+func TestTheDNSSuffixReachesTheAgent(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+
+	got := f.stateFor(alice.membershipID, 0).GetDns()
+	if got == nil {
+		t.Fatal("no DNS configuration at all, so nothing this device holds is nameable")
+	}
+	if len(got.GetSearchDomains()) != 1 || got.GetSearchDomains()[0] != "hq.internal" {
+		t.Errorf("search_domains = %v, want the network's slug under .internal", got.GetSearchDomains())
+	}
+}
+
+// Split DNS, stated rather than implied. A resolver that captured every query would break
+// split-horizon corporate DNS on the first laptop that joined.
+func TestOnlyTheMeshSuffixIsRoutedToTheResolver(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+
+	routes := f.stateFor(alice.membershipID, 0).GetDns().GetRoutes()
+	if len(routes) != 1 || routes[0].GetDomain() != "hq.internal" {
+		t.Errorf("routes = %v, want just the mesh suffix", routes)
+	}
+}
+
+// Two networks, two suffixes — which is what makes a bare name ambiguous on a device in
+// both, and what ADR-0021's refusal rule is about.
+func TestEachNetworkHasItsOwnSuffix(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+	other := f.otherNetwork("globex")
+	stranger := f.enrolDeviceIn(other, "stranger")
+
+	if got := f.stateFor(alice.membershipID, 0).GetDns().GetSearchDomains(); got[0] != "hq.internal" {
+		t.Errorf("hq got %v", got)
+	}
+	if got := f.stateFor(stranger.membershipID, 0).GetDns().GetSearchDomains(); got[0] != "globex.internal" {
+		t.Errorf("globex got %v", got)
+	}
+}
+
+// It rides on every delta, not only snapshots, for the reason the tunnel configuration
+// does: an agent that missed the snapshot carrying it would have peers it cannot name.
+func TestTheSuffixRidesOnEveryDelta(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+	before := f.headVersion()
+	f.enrolDevice("bob")
+
+	got := f.stateFor(alice.membershipID, before)
+	if isSnapshot(got) {
+		t.Fatal("wanted a delta")
+	}
+	if len(got.GetDns().GetSearchDomains()) == 0 {
+		t.Error("a delta carried no DNS configuration")
+	}
+}

--- a/internal/session/state.go
+++ b/internal/session/state.go
@@ -146,6 +146,7 @@ func (b *StateBuilder) snapshotFromPeers(ctx context.Context, membership dbgen.G
 		ToVersion:   uint64(membership.StateVersion),
 		UpsertPeers: make([]*meshpv1.Peer, 0, len(peers)),
 		Tunnel:      b.tunnelConfig(membership),
+		Dns:         b.dnsConfig(membership),
 		Relays:      b.relays,
 	}
 	for _, p := range peers {
@@ -238,6 +239,10 @@ func (b *StateBuilder) delta(ctx context.Context, membership dbgen.GetMembership
 		// knows nothing about.
 		Relays: b.relays,
 		Tunnel: b.tunnelConfig(membership),
+		// Alongside the tunnel configuration and for the same reason: it is small, it
+		// changes rarely, and an agent that missed the snapshot carrying it would have
+		// peers it cannot name.
+		Dns: b.dnsConfig(membership),
 	}
 
 	for id := range upserts {
@@ -373,6 +378,34 @@ func failClosedPolicy(enforced bool) meshpv1.TunnelConfig_FailClosed {
 		return meshpv1.TunnelConfig_FAIL_CLOSED_UNSPECIFIED
 	}
 	return meshpv1.TunnelConfig_FAIL_CLOSED_DISABLED
+}
+
+// DefaultDNSSuffix is what a network's names end with when nobody has said otherwise.
+//
+// ICANN reserved `.internal` for private use, so unlike a squatted TLD it cannot be
+// delegated out from under a deployment, and unlike `.local` it does not belong to mDNS
+// (ADR-0021).
+const DefaultDNSSuffix = "internal"
+
+// dnsConfig tells a device what its names look like.
+//
+// Only the search domain today. `nameservers` is deliberately left empty: the resolver is
+// the agent's own, on a loopback port the kernel picks, so its address is something only
+// the device knows — the server naming one would be inventing an address it cannot see.
+//
+// No records either. Admin-entered records live in `dns_records` and reach the agent in a
+// `records` field this message does not have yet; adding it is a change to the proto and
+// belongs with the code that reads it, not ahead of it.
+func (b *StateBuilder) dnsConfig(membership dbgen.GetMembershipForSessionRow) *meshpv1.DnsConfig {
+	suffix := membership.NetworkSlug + "." + DefaultDNSSuffix
+	return &meshpv1.DnsConfig{
+		SearchDomains: []string{suffix},
+		// Split DNS, stated rather than implied: only this suffix goes to the mesh
+		// resolver and everything else keeps using whatever the machine already used. A
+		// resolver that captured every query would break split-horizon corporate DNS on
+		// the first laptop that joined.
+		Routes: []*meshpv1.DnsConfig_Route{{Domain: suffix}},
+	}
 }
 
 // allowedIPs renders a peer's addresses as single-host prefixes.

--- a/internal/store/gen/sessions.sql.go
+++ b/internal/store/gen/sessions.sql.go
@@ -33,7 +33,13 @@ SELECT
     -- session already has means there is no second query that could be skipped on
     -- the path where routes did not change — which is how a device still carrying
     -- a default route would be told to stop failing closed.
-    n.egress_fail_closed
+    n.egress_fail_closed,
+    -- The network's slug, which is what its DNS suffix is built from
+    -- (ADR-0021). Selected alongside the rest rather than looked up when a
+    -- delta needs it, for the reason egress_fail_closed is: DnsConfig rides on
+    -- every delta, so anything it needs must come from a row the session
+    -- already has.
+    n.slug            AS network_slug
 FROM device_network_memberships m
 JOIN devices d  ON d.id = m.device_id
 JOIN networks n ON n.id = m.network_id
@@ -55,6 +61,7 @@ type GetMembershipForSessionRow struct {
 	StateVersion      int64
 	OrganizationID    uuid.UUID
 	EgressFailClosed  bool
+	NetworkSlug       string
 }
 
 // Everything needed to authenticate a control-channel session, in one round trip.
@@ -81,6 +88,7 @@ func (q *Queries) GetMembershipForSession(ctx context.Context, id uuid.UUID) (Ge
 		&i.StateVersion,
 		&i.OrganizationID,
 		&i.EgressFailClosed,
+		&i.NetworkSlug,
 	)
 	return i, err
 }

--- a/internal/tunnel/names.go
+++ b/internal/tunnel/names.go
@@ -1,0 +1,123 @@
+package tunnel
+
+import (
+	"net/netip"
+	"strings"
+
+	"github.com/meshpnet/meshp/internal/dns"
+	"github.com/meshpnet/meshp/internal/peerset"
+)
+
+// Names is where this reconciler publishes the names its network can answer for.
+//
+// An interface rather than *dns.Zones so the tunnel package does not depend on a resolver
+// being present. Nil is the ordinary case for a build or a test with no resolver, and means
+// names are simply not published.
+type Names interface {
+	// Replace sets one membership's names, dropping whatever it had before.
+	Replace(owner string, zone dns.Zone)
+
+	// Forget drops them, for a device that has left a network.
+	Forget(owner string)
+}
+
+// WithNames lets this reconciler publish the names of the network it is in.
+func (r *Reconciler) WithNames(n Names) *Reconciler {
+	r.names = n
+	return r
+}
+
+// publishNames turns the peer set into resolvable names.
+//
+// The peer list the reconciler has just handed to WireGuard is the same data that answers an
+// A query, which is the whole of ADR-0021's first decision: no second source, no query to
+// the control plane, and the names keep working exactly as long as the tunnel configuration
+// does.
+//
+// Keyed by interface name, like the route-claim registry, so a membership replaces its own
+// names and nobody else's.
+func (r *Reconciler) publishNames(state *peerset.Set) {
+	if r.names == nil {
+		return
+	}
+
+	suffix := suffixFrom(state)
+	if suffix == "" {
+		// A control plane that sends no search domain has not been told what this
+		// network's names look like, so there are none. Publishing under a suffix
+		// invented here would resolve names the server never said existed.
+		r.names.Forget(r.membership.InterfaceName)
+		return
+	}
+
+	zone := dns.Zone{Suffix: suffix}
+	for _, peer := range state.Peers() {
+		label := hostLabel(peer.GetDeviceName())
+		if label == "" {
+			// A device whose name is not a usable label is left out rather than mangled
+			// into one that resolves. Until device names are validated at enrolment
+			// (ADR-0021), a deployment can hold anything at all here, and inventing a
+			// name for it would create an address nobody chose.
+			continue
+		}
+		var addrs []netip.Addr
+		for _, raw := range peer.GetAllowedIps() {
+			prefix, err := netip.ParsePrefix(raw)
+			if err != nil {
+				continue
+			}
+			// AllowedIPs are single-host prefixes for a peer's own addresses, so the
+			// address is the prefix's. A wider one would be a carried route rather than
+			// a device, and naming it would point a name at a whole network.
+			if prefix.Bits() != prefix.Addr().BitLen() {
+				continue
+			}
+			addrs = append(addrs, prefix.Addr())
+		}
+		if len(addrs) == 0 {
+			continue
+		}
+		zone.Hosts = append(zone.Hosts, dns.Host{Name: label, Addrs: addrs})
+	}
+
+	r.names.Replace(r.membership.InterfaceName, zone)
+}
+
+// suffixFrom reads the network's DNS suffix out of desired state.
+//
+// The first search domain. There is one today; if there are ever several, the first is the
+// network's own and the rest are additions, so taking the first stays correct.
+func suffixFrom(state *peerset.Set) string {
+	for _, d := range state.DNS().GetSearchDomains() {
+		if s := strings.ToLower(strings.Trim(d, ".")); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// hostLabel turns a device name into a DNS label, or reports that it cannot.
+//
+// Deliberately does not repair. Lowercasing is safe because DNS comparison is
+// case-insensitive, so it changes nothing about which name resolves; anything else —
+// stripping spaces, replacing punctuation — would invent a name the operator did not choose
+// and cannot predict. Two devices called `Dave's laptop` and `Daves laptop` would collide
+// into one, silently.
+//
+// Validation at enrolment is what will make this unnecessary, and until then leaving a
+// device unnamed is the honest failure.
+func hostLabel(deviceName string) string {
+	label := strings.ToLower(strings.TrimSpace(deviceName))
+	if label == "" || len(label) > 63 {
+		return ""
+	}
+	for i, c := range label {
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		case c == '-' && i != 0 && i != len(label)-1:
+		default:
+			return ""
+		}
+	}
+	return label
+}

--- a/internal/tunnel/names_test.go
+++ b/internal/tunnel/names_test.go
@@ -1,0 +1,222 @@
+package tunnel
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/dns"
+	"github.com/meshpnet/meshp/internal/peerset"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// recordingNames captures what a reconciler publishes.
+type recordingNames struct {
+	mu        sync.Mutex
+	zones     map[string]dns.Zone
+	forgotten []string
+}
+
+func newRecordingNames() *recordingNames {
+	return &recordingNames{zones: map[string]dns.Zone{}}
+}
+
+func (r *recordingNames) Replace(owner string, z dns.Zone) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.zones[owner] = z
+}
+
+func (r *recordingNames) Forget(owner string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.zones, owner)
+	r.forgotten = append(r.forgotten, owner)
+}
+
+func (r *recordingNames) zone(owner string) dns.Zone {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.zones[owner]
+}
+
+// namedPeer is a peer with a chosen device name, since the name is the subject here.
+func namedPeer(key, deviceName string, ips ...string) *meshpv1.Peer {
+	p := peer(key, ips...)
+	p.DeviceName = deviceName
+	return p
+}
+
+// stateWithNames is a peer set carrying a search domain, as the server now sends one.
+func stateWithNames(suffix string, peers ...*meshpv1.Peer) *peerset.Set {
+	s := peerset.New()
+	delta := &meshpv1.StateDelta{
+		FromVersion: 0, ToVersion: 1, UpsertPeers: peers,
+		Tunnel: &meshpv1.TunnelConfig{Mtu: 1420},
+	}
+	if suffix != "" {
+		delta.Dns = &meshpv1.DnsConfig{SearchDomains: []string{suffix}}
+	}
+	s.Apply(delta)
+	return s
+}
+
+// The peers handed to WireGuard are the same data that answers a query — no second source
+// and nothing fetched (ADR-0021).
+func TestPeersBecomeResolvableNames(t *testing.T) {
+	link := newFakeLink()
+	names := newRecordingNames()
+	r := New(link, membership(), nil, nil, nil).WithNames(names)
+
+	state := stateWithNames("acme.internal",
+		namedPeer(bobKey, "bob", "100.90.0.2/32", "fd7c::2/128"),
+		namedPeer(carolKey, "carol", "100.90.0.3/32"))
+
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+
+	got := names.zone(membership().InterfaceName)
+	if got.Suffix != "acme.internal" {
+		t.Fatalf("suffix = %q", got.Suffix)
+	}
+	var labels []string
+	for _, h := range got.Hosts {
+		labels = append(labels, h.Name)
+	}
+	slices.Sort(labels)
+	if !slices.Equal(labels, []string{"bob", "carol"}) {
+		t.Errorf("hosts = %v", labels)
+	}
+	for _, h := range got.Hosts {
+		if h.Name == "bob" && len(h.Addrs) != 2 {
+			t.Errorf("bob has %d addresses, want both families", len(h.Addrs))
+		}
+	}
+}
+
+// A control plane that sends no search domain has not said what this network's names are,
+// so there are none. Inventing a suffix here would resolve names the server never mentioned.
+func TestNoSearchDomainMeansNoNames(t *testing.T) {
+	link := newFakeLink()
+	names := newRecordingNames()
+	r := New(link, membership(), nil, nil, nil).WithNames(names)
+
+	state := stateWithNames("", namedPeer(bobKey, "bob", "100.90.0.2/32"))
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+
+	if z := names.zone(membership().InterfaceName); len(z.Hosts) != 0 {
+		t.Errorf("published %d names with no search domain", len(z.Hosts))
+	}
+	if !slices.Contains(names.forgotten, membership().InterfaceName) {
+		t.Error("the membership's names were not withdrawn")
+	}
+}
+
+// A device name that is not a usable label is left out rather than repaired. Repairing it
+// would collide two different machines into one name, silently.
+func TestUnusableDeviceNamesAreLeftOut(t *testing.T) {
+	for name, deviceName := range map[string]string{
+		"a space":        "daves laptop x",
+		"an apostrophe":  "dave's-laptop",
+		"a leading dash": "-laptop",
+		"empty":          "",
+		"underscores":    "file_server",
+	} {
+		if got := hostLabel(deviceName); got != "" {
+			t.Errorf("%s: hostLabel(%q) = %q, want it left out", name, deviceName, got)
+		}
+	}
+	// Case is safe to change: DNS comparison is case-insensitive, so it alters nothing
+	// about which name resolves.
+	if got := hostLabel("FileServer"); got != "fileserver" {
+		t.Errorf("hostLabel(FileServer) = %q", got)
+	}
+	if got := hostLabel("branch-router-2"); got != "branch-router-2" {
+		t.Errorf("hostLabel(branch-router-2) = %q", got)
+	}
+}
+
+// The whole chain, over a socket: desired state goes into a reconciler, and a real DNS
+// query to a real resolver comes back with the peer's address.
+//
+// End to end for everything this package controls. What it cannot cover is the platform
+// data plane — on a host with no WireGuard the reconciler is never constructed at all — so
+// the fake link stands in for the kernel and everything above it is the shipping code.
+func TestANameResolvesEndToEnd(t *testing.T) {
+	zones := dns.NewZones()
+	link := newFakeLink()
+	r := New(link, membership(), nil, nil, nil).WithNames(zones)
+
+	state := stateWithNames("acme.internal",
+		namedPeer(bobKey, "fileserver", "100.90.0.2/32"),
+		namedPeer(carolKey, "printer", "100.90.0.3/32"))
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+
+	server := dns.NewServer(zones, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- server.Listen(ctx, netip.MustParseAddrPort("127.0.0.1:0")) }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for server.Addr().Port() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("the resolver never bound")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	got := resolve(t, server.Addr(), "fileserver.acme.internal")
+	if got != "100.90.0.2" {
+		t.Errorf("fileserver.acme.internal resolved to %q, want 100.90.0.2", got)
+	}
+
+	// And a device that left stops resolving, which is what makes a revoked peer's name
+	// go away rather than linger.
+	shrunk := stateWithNames("acme.internal", namedPeer(carolKey, "printer", "100.90.0.3/32"))
+	if _, err := r.Apply(context.Background(), shrunk); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolve(t, server.Addr(), "fileserver.acme.internal"); got != "" {
+		t.Errorf("a peer that is gone still resolves, to %q", got)
+	}
+	if got := resolve(t, server.Addr(), "printer.acme.internal"); got != "100.90.0.3" {
+		t.Errorf("printer stopped resolving too: %q", got)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Error("the resolver did not stop")
+	}
+}
+
+// resolve asks the resolver for an A record and returns the address, or "" when there is
+// none. Uses Go's own resolver, so this is a real client rather than a hand-rolled one.
+func resolve(t *testing.T, at netip.AddrPort, name string) string {
+	t.Helper()
+	res := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "udp", at.String())
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	addrs, err := res.LookupHost(ctx, name)
+	if err != nil || len(addrs) == 0 {
+		return ""
+	}
+	return addrs[0]
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -136,6 +136,11 @@ type Reconciler struct {
 	// is the whole verdict, which is what every device did before this existed.
 	prober Prober
 
+	// names is where this membership publishes what its network can resolve, shared with
+	// every other membership on the device so a bare name matching two of them can be seen
+	// as ambiguous from either side. Nil where nothing resolves.
+	names Names
+
 	// clock is overridable so the probe interval can be tested without waiting. Nil means
 	// the wall clock.
 	clock func() time.Time
@@ -287,6 +292,16 @@ func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, e
 		r.fail(err)
 		return []string{"peers"}, err
 	}
+
+	// The names this network can answer for, before anything touches the kernel.
+	//
+	// Deliberately not after the interface converges. A name is desired state the agent
+	// already holds — the same peer list it is about to hand to WireGuard — so it does not
+	// depend on the kernel having accepted anything, and a host whose interface will not
+	// come up should still be able to say what `fileserver` means. Publishing after the
+	// convergence would have tied one to the other for no reason beyond where the line
+	// happened to sit.
+	r.publishNames(state)
 
 	observed, err := r.link.Observe(want.Name)
 	if err != nil {

--- a/queries/sessions.sql
+++ b/queries/sessions.sql
@@ -24,7 +24,13 @@ SELECT
     -- session already has means there is no second query that could be skipped on
     -- the path where routes did not change — which is how a device still carrying
     -- a default route would be told to stop failing closed.
-    n.egress_fail_closed
+    n.egress_fail_closed,
+    -- The network's slug, which is what its DNS suffix is built from
+    -- (ADR-0021). Selected alongside the rest rather than looked up when a
+    -- delta needs it, for the reason egress_fail_closed is: DnsConfig rides on
+    -- every delta, so anything it needs must come from a row the session
+    -- already has.
+    n.slug            AS network_slug
 FROM device_network_memberships m
 JOIN devices d  ON d.id = m.device_id
 JOIN networks n ON n.id = m.network_id

--- a/scripts/e2e-enrol.sh
+++ b/scripts/e2e-enrol.sh
@@ -159,6 +159,20 @@ grep -q 'not enrolled' "$WORK/status-before.out" \
   || fail "an unenrolled daemon did not say so: $(cat "$WORK/status-before.out")"
 echo "  socket answers: $(head -1 "$WORK/status-before.out")"
 
+# The resolver is listening, on a daemon that has joined nothing.
+#
+# Asserted here because nothing else can. The daemon constructs a resolver and starts it in
+# a goroutine, and deleting that goroutine compiles cleanly and passes every unit test in
+# the tree — the package would be built, wired, and never listening, which is the exact
+# shape ADR-0018 is about and the shape WithChooser was missing in for two releases.
+#
+# Before enrolment on purpose: the resolver comes up ahead of any membership, so a device
+# with no names still answers, and a device whose names are missing later is a different
+# problem from one whose resolver never bound.
+grep -q '  resolver  127\.' "$WORK/status-before.out" \
+  || fail "the daemon is not answering names: $(grep resolver "$WORK/status-before.out" || echo 'no resolver line at all')"
+echo "  resolver: $(grep '  resolver' "$WORK/status-before.out" | sed 's/^ *//')"
+
 # And the stale lock is gone. Asserted on a daemon that is not enrolled, which is the case
 # that matters most: a device whose membership was revoked, or whose state was wiped, still
 # has to get its network back. Nothing in desired state can rescue it, because it has none.


### PR DESCRIPTION
First slice of ADR-0021. `internal/dns` was an empty directory; `DnsConfig` had been on the wire since the beginning with **nothing setting it**, and the agent read exactly one field — `prevent_leaks`, for the kill switch. Fourth instance of that pattern found in this repository.

## What works now

```
$ meshp status
  resolver  127.0.0.1:53870 for acme.internal

$ dig @127.0.0.1 -p 53870 fileserver.acme.internal +short
100.90.0.2
```

The agent answers A and AAAA for the peers it already holds. **The peer list handed to WireGuard is the same data that answers a query** — no second source, nothing fetched, and names keep working exactly as long as the tunnel configuration does. That is ADR-0021's first decision in full. The server sends each network's suffix, `<slug>.internal`, as a search domain and a split-DNS route.

## The ambiguity rule, implemented as written

A bare name matching two of this device's networks is **REFUSED**, with both fully-qualified alternatives named in the log, rather than answered from whichever sorted first. An order would turn an ambiguous question into a confident wrong answer and send a technician to a customer chosen by something they cannot see — the same thing #70 refuses for prefixes.

An unambiguous bare name still resolves, or the rule would collapse to "bare names never work", which is a different and worse product.

## Hand-written wire format

Two record types, a handful of names, loopback only — a small enough subset that a library would be mostly code never executed, and the project has eight direct dependencies, all load-bearing.

Strict: compression pointers in a question are refused rather than followed, unserved types are REFUSED rather than answered empty, a query for A is never answered with AAAA. Plus a **fuzz target**, because a hand-written parser of socket input without one is a bad trade whatever the dependency count. 3.9M executions, no crashes.

## Two of my own tests were wrong

**One hung instead of failing.** `TestItRefusesToListenOffLoopback` used `context.Background()`, so removing the loopback guard made `Listen` bind and block forever. A test that stalls the suite on the bug it checks for is worse than no test. It now uses a deadline and fails in 2s.

**One did not exist, and needed to.** Deleting the goroutine that starts the resolver **compiles cleanly and passes every unit test in the tree** — the daemon would construct a resolver that never listens. That is precisely the shape ADR-0018 is about, and the shape `WithChooser` was missing in.

`scripts/e2e-enrol.sh` now asserts `meshp status` reports a resolver, *before* it joins anything. Verified against the mutation:

```
FAIL: the daemon is not answering names:   resolver  not running; names will not resolve, addresses still work
```

## Smaller decisions

**Names publish before the interface converges.** A name is state the agent already holds, so it should not depend on the kernel having accepted anything — a host whose interface will not come up should still be able to say what `fileserver` means.

**Unusable device names are left out, not repaired.** Repairing would collide `Dave's laptop` and `Daves laptop` into one name, silently. Validation at enrolment makes it unnecessary and is a later slice.

**Port zero.** 53 is almost always taken; fighting for it would break the host's existing DNS to install ours. The kernel picks and `meshp status` reports it, which is the only way anyone finds it.

## Also here: an ADR-0021 correction

The migration consequence said duplicates must make the migration *refuse*. That was wrong — it blocks an upgrade to protect a name nothing depends on. Collisions are now resolved by **suffixing**, at enrolment and in the migration alike: refusing would mean a fleet imaged with one hostname produces one enrolment and forty-nine failures, for a reason the installer cannot see or fix.

Renaming is safe *only because names are not yet addresses*, which is the real argument for doing this before the resolver ships rather than after.

## Deliberately not here

`DnsConfig.records` for admin-entered records (a proto change), per-platform system resolver configuration, and `device_name` validation with its migration. Each is expensive in its own way and wants its own review. **So `ssh fileserver` does not work yet** — the system resolver still knows nothing about this. `dig` at the reported address does.

## Verification

`make ci`, `make integration` green. Six mutations caught; one equivalent and documented — rejecting compression pointers is redundant with the label-length bound, and stays because "pointers are not followed" and "labels are at most 63 bytes" are separate rules a reader should find separately.

The end-to-end test drives a real reconciler into real `dns.Zones`, starts a real server, and resolves through **Go's own `net.Resolver`** rather than a hand-rolled client.
