### PR TITLE
feat(dns): a device gets a name that is unique in the network it answers from

### DIFF
--- a/internal/dns/label.go
+++ b/internal/dns/label.go
@@ -1,0 +1,78 @@
+package dns
+
+import (
+	"strconv"
+	"strings"
+)
+
+// MaxLabel is the longest a DNS label may be.
+const MaxLabel = maxLabel
+
+// ValidLabel reports whether s is a label DNS can carry: lowercase letters, digits and
+// hyphens, not starting or ending with one, at most 63 bytes.
+//
+// The same rule the database enforces, so a label that gets past one gets past the other.
+// Two expressions of one rule is a drift risk and the alternative — asking the database
+// every time — is a round trip to answer a question about a string.
+func ValidLabel(s string) bool {
+	if s == "" || len(s) > MaxLabel {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		case c == '-' && i != 0 && i != len(s)-1:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// Label turns a display name into a DNS label, or returns "" when nothing usable is left.
+//
+// Lowercase; anything that is not a letter or digit becomes a hyphen; runs collapse; leading
+// and trailing hyphens go. `Dave's laptop (spare)` becomes `dave-s-laptop-spare`, which is
+// guessable — and being guessable is the point, because somebody has to type it.
+//
+// This mangles where the agent's own check refuses, and the difference is deliberate. Here
+// the result is stored, shown to an operator and changeable; at query time it would be an
+// invisible rewrite of what somebody typed.
+func Label(display string) string {
+	var b strings.Builder
+	b.Grow(len(display))
+
+	lastHyphen := true // leading hyphens are dropped
+	for _, r := range strings.ToLower(display) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastHyphen = false
+		default:
+			if !lastHyphen {
+				b.WriteByte('-')
+				lastHyphen = true
+			}
+		}
+	}
+
+	out := strings.Trim(b.String(), "-")
+	if len(out) > MaxLabel {
+		out = strings.TrimRight(out[:MaxLabel], "-")
+	}
+	return out
+}
+
+// Suffixed returns base with n appended, kept inside the label limit.
+//
+// Truncating the base rather than letting the result overrun: a 63-byte name that collided
+// must still produce a valid label, and a label the database rejects would turn a rename
+// into a failed enrolment.
+func Suffixed(base string, n int) string {
+	suffix := "-" + strconv.Itoa(n)
+	if len(base)+len(suffix) <= MaxLabel {
+		return base + suffix
+	}
+	return strings.TrimRight(base[:MaxLabel-len(suffix)], "-") + suffix
+}

--- a/internal/dns/label_test.go
+++ b/internal/dns/label_test.go
@@ -1,0 +1,75 @@
+package dns
+
+import "testing"
+
+// The rule has to match the one the database enforces, because a label that gets past one
+// and not the other is an enrolment that fails for a reason nobody can see.
+func TestLabelsAreGuessable(t *testing.T) {
+	for display, want := range map[string]string{
+		"fileserver":            "fileserver",
+		"FileServer":            "fileserver",
+		"Dave's laptop (spare)": "dave-s-laptop-spare",
+		"branch-router-2":       "branch-router-2",
+		"  padded  ":            "padded",
+		"a.b.c":                 "a-b-c",
+		"---dashes---":          "dashes",
+		"under_score":           "under-score",
+		"héllo":                 "h-llo",
+		"!!!":                   "",
+		"":                      "",
+		"-":                     "",
+	} {
+		if got := Label(display); got != want {
+			t.Errorf("Label(%q) = %q, want %q", display, got, want)
+		}
+	}
+}
+
+// Whatever Label produces must be something DNS can carry, or the constraint rejects it and
+// the enrolment fails.
+func TestLabelAlwaysProducesAValidLabelOrNothing(t *testing.T) {
+	for _, display := range []string{
+		"fileserver", "Dave's laptop", "!!!", "", "----",
+		"averyveryveryveryveryveryveryveryveryveryveryverylongdevicenamethatgoeson",
+		"ends-with-punctuation!!!",
+		"a" + string(make([]byte, 200)),
+	} {
+		got := Label(display)
+		if got != "" && !ValidLabel(got) {
+			t.Errorf("Label(%q) = %q, which is not a valid label", display, got)
+		}
+	}
+}
+
+// A long name that collides must still produce something the database will take.
+func TestSuffixingStaysInsideTheLimit(t *testing.T) {
+	long := Label(string(make([]byte, 0)) + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if len(long) != MaxLabel {
+		t.Fatalf("setup: base is %d bytes, want %d", len(long), MaxLabel)
+	}
+	for _, n := range []int{2, 10, 100, 1000} {
+		got := Suffixed(long, n)
+		if !ValidLabel(got) {
+			t.Errorf("Suffixed(%d) = %q, which is not a valid label", n, got)
+		}
+	}
+	if got := Suffixed("short", 2); got != "short-2" {
+		t.Errorf("Suffixed(short, 2) = %q", got)
+	}
+}
+
+func TestValidLabelRejectsWhatDNSCannotCarry(t *testing.T) {
+	for _, bad := range []string{
+		"", "-leading", "trailing-", "Upper", "under_score", "has space", "dot.dot",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // 65
+	} {
+		if ValidLabel(bad) {
+			t.Errorf("ValidLabel(%q) = true", bad)
+		}
+	}
+	for _, good := range []string{"a", "a-b", "fileserver", "x9", "branch-router-2"} {
+		if !ValidLabel(good) {
+			t.Errorf("ValidLabel(%q) = false", good)
+		}
+	}
+}

--- a/internal/enroll/label_test.go
+++ b/internal/enroll/label_test.go
@@ -1,0 +1,124 @@
+package enroll
+
+import (
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/keys"
+)
+
+// joinNamed enrols a fresh device under a chosen display name.
+func (f *fixture) joinNamed(name string) string {
+	f.t.Helper()
+	tok, _ := f.mintToken(1, time.Hour)
+
+	identity, err := keys.NewIdentity()
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	wg, err := keys.NewWireGuardPair()
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	resp, err := f.svc.IssueChallenge(f.ctx, ChallengeRequest{
+		Token: tok.Plaintext, IdentityPublicKey: identity.Public,
+	})
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	challenge, err := ParseChallenge(resp.Challenge)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	if _, err := f.svc.Redeem(f.ctx, RedeemRequest{
+		Token:              tok.Plaintext,
+		IdentityPublicKey:  identity.Public,
+		Challenge:          challenge,
+		Signature:          identity.Sign(challenge),
+		WireGuardPublicKey: wg.Public.String(),
+		Name:               name,
+		OS:                 "linux",
+	}); err != nil {
+		f.t.Fatalf("joining as %q: %v", name, err)
+	}
+
+	var label string
+	if err := f.store.Pool().QueryRow(f.ctx,
+		`SELECT m.dns_label FROM device_network_memberships m
+		 JOIN devices d ON d.id = m.device_id
+		 WHERE d.name = $1 ORDER BY m.joined_at DESC LIMIT 1`, name).Scan(&label); err != nil {
+		f.t.Fatalf("reading the label for %q: %v", name, err)
+	}
+	return label
+}
+
+// The rule that decides whether this is a better product or a worse one.
+//
+// A fleet imaged with one hostname must all enrol. Refusing the second would produce one
+// success and forty-nine failures, for a reason the person running the installer can
+// neither see nor fix (ADR-0021).
+func TestACollidingNameIsSuffixedNotRefused(t *testing.T) {
+	f := newFixture(t)
+
+	first := f.joinNamed("fileserver")
+	second := f.joinNamed("fileserver")
+	third := f.joinNamed("fileserver")
+
+	if first != "fileserver" {
+		t.Errorf("the first device got %q, want the unsuffixed name", first)
+	}
+	if second != "fileserver-2" {
+		t.Errorf("the second got %q, want fileserver-2", second)
+	}
+	if third != "fileserver-3" {
+		t.Errorf("the third got %q, want fileserver-3", third)
+	}
+}
+
+// Case and punctuation are normalised, so two devices a person would call the same thing
+// do not both claim the plain label.
+func TestNamesAreNormalisedBeforeTheyCollide(t *testing.T) {
+	f := newFixture(t)
+
+	if got := f.joinNamed("FileServer"); got != "fileserver" {
+		t.Fatalf("got %q", got)
+	}
+	if got := f.joinNamed("file server"); got != "file-server" {
+		t.Errorf("got %q, want file-server", got)
+	}
+	if got := f.joinNamed("FILESERVER"); got != "fileserver-2" {
+		t.Errorf("got %q, want fileserver-2 — case must not dodge the collision", got)
+	}
+}
+
+// A display name with nothing usable in it still enrols. Every membership needs a label,
+// and an opaque one beats a device that cannot join.
+func TestAnUnusableNameStillEnrols(t *testing.T) {
+	f := newFixture(t)
+
+	got := f.joinNamed("!!!")
+	if got == "" {
+		t.Fatal("a device with an unusable name got no label")
+	}
+	if len(got) < len("device-") || got[:len("device-")] != "device-" {
+		t.Errorf("label = %q, want one derived from the device id", got)
+	}
+}
+
+// The display name is untouched. `Dave's laptop (spare)` survives for a person to read;
+// the label is a second, machine-shaped name beside it. ADR-0021 called this cost
+// unavoidable and it turned out not to be.
+func TestTheDisplayNameSurvives(t *testing.T) {
+	f := newFixture(t)
+
+	label := f.joinNamed("Dave's laptop (spare)")
+	if label != "dave-s-laptop-spare" {
+		t.Errorf("label = %q", label)
+	}
+
+	var stored string
+	if err := f.store.Pool().QueryRow(f.ctx,
+		`SELECT name FROM devices WHERE name = $1`, "Dave's laptop (spare)").Scan(&stored); err != nil {
+		t.Fatalf("the display name did not survive: %v", err)
+	}
+}

--- a/internal/enroll/service.go
+++ b/internal/enroll/service.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/meshpnet/meshp/internal/clock"
+	"github.com/meshpnet/meshp/internal/dns"
 	"github.com/meshpnet/meshp/internal/ipam"
 	"github.com/meshpnet/meshp/internal/keys"
 	"github.com/meshpnet/meshp/internal/store"
@@ -213,6 +215,11 @@ func (s *Service) Redeem(ctx context.Context, req RedeemRequest) (RedeemResult, 
 		}
 		v4, v6 := chosen.v4(), chosen.v6()
 
+		label, err := freeLabel(ctx, q, tok.NetworkID, device.Name, device.ID)
+		if err != nil {
+			return err
+		}
+
 		membership, err := q.CreateMembership(ctx, dbgen.CreateMembershipParams{
 			DeviceID:      device.ID,
 			NetworkID:     tok.NetworkID,
@@ -220,9 +227,18 @@ func (s *Service) Redeem(ctx context.Context, req RedeemRequest) (RedeemResult, 
 			AddressV4:     v4,
 			AddressV6:     v6,
 			Tags:          tok.PreassignedTags,
+			DnsLabel:      label,
 		})
 		if err != nil {
 			if store.IsUniqueViolation(err) {
+				// Two constraints on this table can be violated here and they mean
+				// opposite things. A device already in the network is the caller's
+				// answer; a label taken between choosing it and inserting it is a race
+				// this lost, and the caller should be told to try again rather than told
+				// they are already enrolled.
+				if store.ConstraintName(err) == "device_network_memberships_dns_label_key" {
+					return fmt.Errorf("enroll: the name %q was taken while enrolling; try again", label)
+				}
 				return ErrAlreadyInNetwork
 			}
 			return fmt.Errorf("enroll: creating membership: %w", err)
@@ -463,4 +479,48 @@ func validateIdentityKey(pub []byte) error {
 		return fmt.Errorf("enroll: identity public key is %d bytes, want %d", len(pub), ed25519PublicKeySize)
 	}
 	return nil
+}
+
+// freeLabel picks the name this device answers to inside a network.
+//
+// Suffixed on collision, never refused. A fleet imaged with one hostname would otherwise
+// produce one enrolment and forty-nine failures, for a reason the person running the
+// installer can neither see nor fix (ADR-0021). `fileserver` becomes `fileserver-2`, and
+// the caller is told which name it actually got.
+//
+// The database holds the real constraint. This picks a candidate that looks free, and if it
+// loses a race the unique index catches it — which is why the insert distinguishes that
+// violation rather than reporting it as an enrolment that already happened.
+func freeLabel(ctx context.Context, q *dbgen.Queries, networkID uuid.UUID, displayName string, deviceID uuid.UUID) (string, error) {
+	base := dns.Label(displayName)
+	if base == "" {
+		// Nothing usable in the name at all. Derived from the device's id rather than
+		// refused: every membership needs a label, and an opaque one beats no enrolment.
+		// The same fallback the migration uses, so a device that predates this and one
+		// that arrives after it are named the same way.
+		base = "device-" + strings.ReplaceAll(deviceID.String(), "-", "")[:8]
+	}
+
+	taken, err := q.TakenDNSLabels(ctx, dbgen.TakenDNSLabelsParams{NetworkID: networkID, Prefix: &base})
+	if err != nil {
+		return "", fmt.Errorf("enroll: reading the names already in use: %w", err)
+	}
+	used := make(map[string]struct{}, len(taken))
+	for _, t := range taken {
+		used[t] = struct{}{}
+	}
+
+	if _, clash := used[base]; !clash {
+		return base, nil
+	}
+	// Bounded. A network with this many devices sharing one name has a naming problem the
+	// enrolment path cannot fix, and an unbounded loop here would hold a transaction open
+	// while it counted.
+	for n := 2; n <= 1000; n++ {
+		candidate := dns.Suffixed(base, n)
+		if _, clash := used[candidate]; !clash {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("enroll: a thousand devices in this network are already called %q", base)
 }

--- a/internal/session/state.go
+++ b/internal/session/state.go
@@ -151,7 +151,7 @@ func (b *StateBuilder) snapshotFromPeers(ctx context.Context, membership dbgen.G
 	}
 	for _, p := range peers {
 		delta.UpsertPeers = append(delta.UpsertPeers, b.peerFrom(
-			p.WireguardPublicKey, p.DeviceName, p.Tags, p.AddressV4, p.AddressV6))
+			p.WireguardPublicKey, p.DeviceName, p.DnsLabel, p.Tags, p.AddressV4, p.AddressV6))
 	}
 
 	// A snapshot describes the whole world, so it carries the filter unconditionally. An
@@ -260,7 +260,7 @@ func (b *StateBuilder) delta(ctx context.Context, membership dbgen.GetMembership
 		// upsert is the newer fact, so it must not also be removed.
 		delete(removes, peer.WireguardPublicKey)
 		delta.UpsertPeers = append(delta.UpsertPeers, b.peerFrom(
-			peer.WireguardPublicKey, peer.DeviceName, peer.Tags, peer.AddressV4, peer.AddressV6))
+			peer.WireguardPublicKey, peer.DeviceName, peer.DnsLabel, peer.Tags, peer.AddressV4, peer.AddressV6))
 	}
 
 	if routesChanged {
@@ -300,12 +300,13 @@ func (b *StateBuilder) delta(ctx context.Context, membership dbgen.GetMembership
 	return delta, nil
 }
 
-func (b *StateBuilder) peerFrom(publicKey, deviceName string, tags []string, v4, v6 *netip.Addr) *meshpv1.Peer {
+func (b *StateBuilder) peerFrom(publicKey, deviceName, dnsLabel string, tags []string, v4, v6 *netip.Addr) *meshpv1.Peer {
 	peer := &meshpv1.Peer{
 		PublicKey:                  publicKey,
 		AllowedIps:                 allowedIPs(v4, v6),
 		PersistentKeepaliveSeconds: keepaliveSeconds,
 		DeviceName:                 deviceName,
+		DnsLabel:                   dnsLabel,
 		Tags:                       tags,
 		// No endpoints. Nothing discovers where a peer is yet, so every peer is reached
 		// through a relay — which is what relay-first means (ADR-0002) rather than a

--- a/internal/store/gen/devices.sql.go
+++ b/internal/store/gen/devices.sql.go
@@ -158,9 +158,9 @@ func (q *Queries) CreateDevice(ctx context.Context, arg CreateDeviceParams) (Dev
 
 const createMembership = `-- name: CreateMembership :one
 INSERT INTO device_network_memberships (
-    device_id, network_id, interface_name, address_v4, address_v6, tags
-) VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, device_id, network_id, interface_name, address_v4, address_v6, state, tags, joined_at, last_seen_at, revoked_at
+    device_id, network_id, interface_name, address_v4, address_v6, tags, dns_label
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
+RETURNING id, device_id, network_id, interface_name, address_v4, address_v6, state, tags, joined_at, last_seen_at, revoked_at, dns_label
 `
 
 type CreateMembershipParams struct {
@@ -170,6 +170,7 @@ type CreateMembershipParams struct {
 	AddressV4     *netip.Addr
 	AddressV6     *netip.Addr
 	Tags          []string
+	DnsLabel      string
 }
 
 func (q *Queries) CreateMembership(ctx context.Context, arg CreateMembershipParams) (DeviceNetworkMembership, error) {
@@ -180,6 +181,7 @@ func (q *Queries) CreateMembership(ctx context.Context, arg CreateMembershipPara
 		arg.AddressV4,
 		arg.AddressV6,
 		arg.Tags,
+		arg.DnsLabel,
 	)
 	var i DeviceNetworkMembership
 	err := row.Scan(
@@ -194,6 +196,7 @@ func (q *Queries) CreateMembership(ctx context.Context, arg CreateMembershipPara
 		&i.JoinedAt,
 		&i.LastSeenAt,
 		&i.RevokedAt,
+		&i.DnsLabel,
 	)
 	return i, err
 }
@@ -495,4 +498,39 @@ func (q *Queries) RevokeMembership(ctx context.Context, arg RevokeMembershipPara
 	var i RevokeMembershipRow
 	err := row.Scan(&i.MembershipID, &i.DeviceID, &i.WireguardPublicKey)
 	return i, err
+}
+
+const takenDNSLabels = `-- name: TakenDNSLabels :many
+SELECT dns_label FROM device_network_memberships
+WHERE network_id = $1 AND dns_label LIKE $2 || '%'
+`
+
+type TakenDNSLabelsParams struct {
+	NetworkID uuid.UUID
+	Prefix    *string
+}
+
+// The labels already used in a network, among those a candidate might collide with.
+//
+// Prefix-matched rather than fetching every label in the network: a network with ten
+// thousand devices has ten thousand labels and one of them is being enrolled, so the
+// interesting set is the handful that start with the same base.
+func (q *Queries) TakenDNSLabels(ctx context.Context, arg TakenDNSLabelsParams) ([]string, error) {
+	rows, err := q.db.Query(ctx, takenDNSLabels, arg.NetworkID, arg.Prefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var dns_label string
+		if err := rows.Scan(&dns_label); err != nil {
+			return nil, err
+		}
+		items = append(items, dns_label)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }

--- a/internal/store/gen/models.go
+++ b/internal/store/gen/models.go
@@ -103,6 +103,8 @@ type DeviceNetworkMembership struct {
 	JoinedAt      time.Time
 	LastSeenAt    *time.Time
 	RevokedAt     *time.Time
+	// The name this device answers to inside this network, as <dns_label>.<network slug>.<suffix>. Unique per network because that is the scope of the name. devices.name stays free text for display.
+	DnsLabel string
 }
 
 type DnsRecord struct {

--- a/internal/store/gen/networks.sql.go
+++ b/internal/store/gen/networks.sql.go
@@ -118,7 +118,7 @@ func (q *Queries) GetNetwork(ctx context.Context, id uuid.UUID) (Network, error)
 }
 
 const listActiveMemberships = `-- name: ListActiveMemberships :many
-SELECT m.id, m.device_id, m.network_id, m.interface_name, m.address_v4, m.address_v6, m.state, m.tags, m.joined_at, m.last_seen_at, m.revoked_at
+SELECT m.id, m.device_id, m.network_id, m.interface_name, m.address_v4, m.address_v6, m.state, m.tags, m.joined_at, m.last_seen_at, m.revoked_at, m.dns_label
 FROM device_network_memberships m
 JOIN devices d ON d.id = m.device_id
 WHERE m.network_id = $1
@@ -148,6 +148,7 @@ func (q *Queries) ListActiveMemberships(ctx context.Context, networkID uuid.UUID
 			&i.JoinedAt,
 			&i.LastSeenAt,
 			&i.RevokedAt,
+			&i.DnsLabel,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/gen/sessions.sql.go
+++ b/internal/store/gen/sessions.sql.go
@@ -118,7 +118,8 @@ SELECT
     m.address_v6,
     m.tags,
     k.public_key    AS wireguard_public_key,
-    d.name          AS device_name
+    d.name          AS device_name,
+    m.dns_label
 FROM device_network_memberships m
 JOIN wireguard_keys k ON k.membership_id = m.id AND k.state = 'current'
 JOIN devices d        ON d.id = m.device_id
@@ -141,6 +142,7 @@ type ListPeersForMembershipRow struct {
 	Tags               []string
 	WireguardPublicKey string
 	DeviceName         string
+	DnsLabel           string
 }
 
 // The other devices this one may reach.
@@ -169,6 +171,7 @@ func (q *Queries) ListPeersForMembership(ctx context.Context, arg ListPeersForMe
 			&i.Tags,
 			&i.WireguardPublicKey,
 			&i.DeviceName,
+			&i.DnsLabel,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/gen/state.sql.go
+++ b/internal/store/gen/state.sql.go
@@ -58,7 +58,8 @@ SELECT
     m.address_v6,
     m.tags,
     k.public_key    AS wireguard_public_key,
-    d.name          AS device_name
+    d.name          AS device_name,
+    m.dns_label
 FROM device_network_memberships m
 JOIN wireguard_keys k ON k.membership_id = m.id AND k.state = 'current'
 JOIN devices d        ON d.id = m.device_id
@@ -74,6 +75,7 @@ type GetPeerForMembershipRow struct {
 	Tags               []string
 	WireguardPublicKey string
 	DeviceName         string
+	DnsLabel           string
 }
 
 // One peer's current state, for a delta that names it.
@@ -87,6 +89,7 @@ func (q *Queries) GetPeerForMembership(ctx context.Context, id uuid.UUID) (GetPe
 		&i.Tags,
 		&i.WireguardPublicKey,
 		&i.DeviceName,
+		&i.DnsLabel,
 	)
 	return i, err
 }

--- a/internal/store/policy_test.go
+++ b/internal/store/policy_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"errors"
+	"fmt"
 	"net/netip"
 	"testing"
 
@@ -51,10 +52,10 @@ func seedNetwork(t *testing.T) (seeded, func() uuid.UUID) {
 		}
 		if err := s.pool.QueryRow(ctx,
 			`INSERT INTO device_network_memberships
-			   (device_id,network_id,interface_name,address_v4,tags)
-			 VALUES ($1,$2,'meshp0',$3,$4) RETURNING id`,
+			   (device_id,network_id,interface_name,address_v4,tags,dns_label)
+			 VALUES ($1,$2,'meshp0',$3,$4,$5) RETURNING id`,
 			deviceID, netID, netip.AddrFrom4([4]byte{100, 90, 0, byte(n)}).String(),
-			[]string{"laptop"}).Scan(&membershipID); err != nil {
+			[]string{"laptop"}, fmt.Sprintf("device-%d", n)).Scan(&membershipID); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := s.pool.Exec(ctx,

--- a/internal/tunnel/names.go
+++ b/internal/tunnel/names.go
@@ -52,12 +52,16 @@ func (r *Reconciler) publishNames(state *peerset.Set) {
 
 	zone := dns.Zone{Suffix: suffix}
 	for _, peer := range state.Peers() {
-		label := hostLabel(peer.GetDeviceName())
-		if label == "" {
-			// A device whose name is not a usable label is left out rather than mangled
-			// into one that resolves. Until device names are validated at enrolment
-			// (ADR-0021), a deployment can hold anything at all here, and inventing a
-			// name for it would create an address nobody chose.
+		// The label the server assigned, not something derived here from the display
+		// name. The server is the only party that can make it unique within the network,
+		// which is what makes it resolvable at all — a name computed on the device would
+		// be one guess among however many devices are guessing.
+		label := peer.GetDnsLabel()
+		if !dns.ValidLabel(label) {
+			// Absent from a control plane too old to send one, or malformed from one that
+			// should not have. Left out rather than repaired: repairing would name a
+			// device something the server does not think it is called, so the name would
+			// resolve here and nowhere else.
 			continue
 		}
 		var addrs []netip.Addr
@@ -94,30 +98,4 @@ func suffixFrom(state *peerset.Set) string {
 		}
 	}
 	return ""
-}
-
-// hostLabel turns a device name into a DNS label, or reports that it cannot.
-//
-// Deliberately does not repair. Lowercasing is safe because DNS comparison is
-// case-insensitive, so it changes nothing about which name resolves; anything else —
-// stripping spaces, replacing punctuation — would invent a name the operator did not choose
-// and cannot predict. Two devices called `Dave's laptop` and `Daves laptop` would collide
-// into one, silently.
-//
-// Validation at enrolment is what will make this unnecessary, and until then leaving a
-// device unnamed is the honest failure.
-func hostLabel(deviceName string) string {
-	label := strings.ToLower(strings.TrimSpace(deviceName))
-	if label == "" || len(label) > 63 {
-		return ""
-	}
-	for i, c := range label {
-		switch {
-		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
-		case c == '-' && i != 0 && i != len(label)-1:
-		default:
-			return ""
-		}
-	}
-	return label
 }

--- a/internal/tunnel/names_test.go
+++ b/internal/tunnel/names_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/netip"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -216,21 +217,69 @@ func TestANameResolvesEndToEnd(t *testing.T) {
 }
 
 // resolve asks the resolver for an A record and returns the address, or "" when there is
-// none. Uses Go's own resolver, so this is a real client rather than a hand-rolled one.
+// none.
+//
+// A hand-built query rather than net.Resolver, and that is the fix for a test I first wrote
+// the other way. net.Resolver reads the host's /etc/resolv.conf for ndots, attempts and
+// timeout even in pure-Go mode, so "a real client" turned out to mean "a client configured
+// by whatever machine this runs on" — it passed here and timed out in CI. A test of this
+// package must not depend on the resolver configuration of the machine running it.
 func resolve(t *testing.T, at netip.AddrPort, name string) string {
 	t.Helper()
-	res := &net.Resolver{
-		PreferGo: true,
-		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
-			return (&net.Dialer{}).DialContext(ctx, "udp", at.String())
-		},
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 
-	addrs, err := res.LookupHost(ctx, name)
-	if err != nil || len(addrs) == 0 {
+	conn, err := net.Dial("udp", at.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	// Header: one question, recursion desired.
+	q := []byte{0x2a, 0x2a, 0x01, 0x00, 0, 1, 0, 0, 0, 0, 0, 0}
+	for _, label := range strings.Split(name, ".") {
+		q = append(q, byte(len(label)))
+		q = append(q, label...)
+	}
+	q = append(q, 0, 0, 1, 0, 1) // root, QTYPE=A, QCLASS=IN
+
+	if _, err := conn.Write(q); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 512)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("no reply from the resolver: %v", err)
+	}
+	reply := buf[:n]
+	if n < 12 {
+		t.Fatalf("reply is %d bytes", n)
+	}
+	if answers := int(reply[6])<<8 | int(reply[7]); answers == 0 {
 		return ""
 	}
-	return addrs[0]
+
+	// Walk past the echoed question, then past the answer's name, to the record data. Both
+	// names are uncompressed, because this resolver does not compress.
+	off := 12
+	for off < len(reply) && reply[off] != 0 {
+		off += int(reply[off]) + 1
+	}
+	off += 5 // root label, qtype, qclass
+	for off < len(reply) && reply[off] != 0 {
+		off += int(reply[off]) + 1
+	}
+	off += 1 + 2 + 2 + 4 // root label, type, class, ttl
+	if off+2 > len(reply) {
+		t.Fatal("reply is truncated before the record length")
+	}
+	length := int(reply[off])<<8 | int(reply[off+1])
+	off += 2
+	if off+length > len(reply) {
+		t.Fatal("reply is truncated before the address")
+	}
+	addr, ok := netip.AddrFromSlice(reply[off : off+length])
+	if !ok {
+		t.Fatalf("record holds %d bytes, which is not an address", length)
+	}
+	return addr.String()
 }

--- a/internal/tunnel/names_test.go
+++ b/internal/tunnel/names_test.go
@@ -44,10 +44,17 @@ func (r *recordingNames) zone(owner string) dns.Zone {
 	return r.zones[owner]
 }
 
-// namedPeer is a peer with a chosen device name, since the name is the subject here.
+// namedPeer is a peer with a chosen display name.
 func namedPeer(key, deviceName string, ips ...string) *meshpv1.Peer {
 	p := peer(key, ips...)
 	p.DeviceName = deviceName
+	return p
+}
+
+// labelled is a peer the server has named, which is the ordinary case.
+func labelled(key, label string, ips ...string) *meshpv1.Peer {
+	p := namedPeer(key, label, ips...)
+	p.DnsLabel = label
 	return p
 }
 
@@ -73,8 +80,8 @@ func TestPeersBecomeResolvableNames(t *testing.T) {
 	r := New(link, membership(), nil, nil, nil).WithNames(names)
 
 	state := stateWithNames("acme.internal",
-		namedPeer(bobKey, "bob", "100.90.0.2/32", "fd7c::2/128"),
-		namedPeer(carolKey, "carol", "100.90.0.3/32"))
+		labelled(bobKey, "bob", "100.90.0.2/32", "fd7c::2/128"),
+		labelled(carolKey, "carol", "100.90.0.3/32"))
 
 	if _, err := r.Apply(context.Background(), state); err != nil {
 		t.Fatal(err)
@@ -106,7 +113,7 @@ func TestNoSearchDomainMeansNoNames(t *testing.T) {
 	names := newRecordingNames()
 	r := New(link, membership(), nil, nil, nil).WithNames(names)
 
-	state := stateWithNames("", namedPeer(bobKey, "bob", "100.90.0.2/32"))
+	state := stateWithNames("", labelled(bobKey, "bob", "100.90.0.2/32"))
 	if _, err := r.Apply(context.Background(), state); err != nil {
 		t.Fatal(err)
 	}
@@ -119,27 +126,34 @@ func TestNoSearchDomainMeansNoNames(t *testing.T) {
 	}
 }
 
-// A device name that is not a usable label is left out rather than repaired. Repairing it
-// would collide two different machines into one name, silently.
-func TestUnusableDeviceNamesAreLeftOut(t *testing.T) {
-	for name, deviceName := range map[string]string{
-		"a space":        "daves laptop x",
-		"an apostrophe":  "dave's-laptop",
-		"a leading dash": "-laptop",
-		"empty":          "",
-		"underscores":    "file_server",
-	} {
-		if got := hostLabel(deviceName); got != "" {
-			t.Errorf("%s: hostLabel(%q) = %q, want it left out", name, deviceName, got)
-		}
+// A peer whose label the server did not assign, or assigned badly, is left out rather than
+// repaired. Repairing would name a device something the server does not think it is called,
+// so the name would resolve here and nowhere else.
+func TestPeersWithoutAServerAssignedLabelAreLeftOut(t *testing.T) {
+	link := newFakeLink()
+	names := newRecordingNames()
+	r := New(link, membership(), nil, nil, nil).WithNames(names)
+
+	// One the server named, one whose label DNS cannot carry. A peer with no label at all
+	// is the same path — ValidLabel refuses the empty string — and is covered by
+	// TestValidLabelRejectsWhatDNSCannotCarry rather than duplicated here.
+	good := namedPeer(bobKey, "Dave's laptop (spare)", "100.90.0.2/32")
+	good.DnsLabel = "dave-s-laptop-spare"
+	malformed := namedPeer(carolKey, "printer", "100.90.0.3/32")
+	malformed.DnsLabel = "Not A Label"
+
+	state := stateWithNames("acme.internal", good, malformed)
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
 	}
-	// Case is safe to change: DNS comparison is case-insensitive, so it alters nothing
-	// about which name resolves.
-	if got := hostLabel("FileServer"); got != "fileserver" {
-		t.Errorf("hostLabel(FileServer) = %q", got)
+
+	z := names.zone(membership().InterfaceName)
+	if len(z.Hosts) != 1 {
+		t.Fatalf("%d hosts published, want only the one with a usable label: %+v", len(z.Hosts), z.Hosts)
 	}
-	if got := hostLabel("branch-router-2"); got != "branch-router-2" {
-		t.Errorf("hostLabel(branch-router-2) = %q", got)
+	// And the display name is not what resolves — the server's label is.
+	if z.Hosts[0].Name != "dave-s-laptop-spare" {
+		t.Errorf("published %q, want the server's label", z.Hosts[0].Name)
 	}
 }
 
@@ -155,8 +169,8 @@ func TestANameResolvesEndToEnd(t *testing.T) {
 	r := New(link, membership(), nil, nil, nil).WithNames(zones)
 
 	state := stateWithNames("acme.internal",
-		namedPeer(bobKey, "fileserver", "100.90.0.2/32"),
-		namedPeer(carolKey, "printer", "100.90.0.3/32"))
+		labelled(bobKey, "fileserver", "100.90.0.2/32"),
+		labelled(carolKey, "printer", "100.90.0.3/32"))
 	if _, err := r.Apply(context.Background(), state); err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +196,7 @@ func TestANameResolvesEndToEnd(t *testing.T) {
 
 	// And a device that left stops resolving, which is what makes a revoked peer's name
 	// go away rather than linger.
-	shrunk := stateWithNames("acme.internal", namedPeer(carolKey, "printer", "100.90.0.3/32"))
+	shrunk := stateWithNames("acme.internal", labelled(carolKey, "printer", "100.90.0.3/32"))
 	if _, err := r.Apply(context.Background(), shrunk); err != nil {
 		t.Fatal(err)
 	}

--- a/migrations/0006_membership_dns_labels.sql
+++ b/migrations/0006_membership_dns_labels.sql
@@ -1,0 +1,113 @@
+-- A name a device can be reached by, unique in the network it is reached from.
+--
+-- ADR-0021 makes names resolvable as <label>.<network>.<suffix>, which requires the label
+-- to be unique within a network and to be a thing DNS can carry. Neither is true today:
+-- devices.name is free text with no constraint at all.
+--
+-- On the membership rather than on the device, and that is the decision worth explaining.
+-- The scope of uniqueness is the network, because the network is the next part of the name
+-- — and a device belongs to many networks (ADR-0004), so a constraint on devices.name would
+-- either be too strict (unique per organisation, forbidding two customers from both having
+-- a `fileserver`) or unenforceable (unique per network, which is not a column on that
+-- table). `UNIQUE (network_id, dns_label)` is exactly the rule, and it is a real constraint
+-- rather than something the application promises to remember.
+--
+-- It also costs less than ADR-0021 assumed. That ADR said names would stop being free text
+-- and `Dave's laptop (spare)` would not survive. It does: devices.name stays exactly as it
+-- is, display-only and unconstrained, and this is a second, machine-shaped name beside it.
+--
+-- The backfill renames rather than refuses. An earlier draft of ADR-0021 had the migration
+-- refuse on duplicates and make an operator choose, which blocks an upgrade to protect a
+-- name nothing yet depends on: no route, no policy and no lookup uses devices.name today.
+-- That window closes when the resolver is wired to the system, which is why this goes
+-- first.
+
+-- +goose Up
+
+ALTER TABLE device_network_memberships ADD COLUMN dns_label text;
+
+-- Backfill, in one pass per network, oldest membership first.
+--
+-- Ordering by joined_at rather than by id so the result is explicable: the device that has
+-- been in the network longest keeps the unsuffixed name, and a newcomer is the one that
+-- becomes `fileserver-2`. Ordered by id as a tiebreak, so two memberships created in the
+-- same transaction do not depend on which row the planner reaches first.
+DO $$
+DECLARE
+    m record;
+    base text;
+    candidate text;
+    n integer;
+    renamed integer := 0;
+    total integer := 0;
+BEGIN
+    FOR m IN
+        SELECT mem.id, mem.network_id, d.name AS device_name, d.id AS device_id
+        FROM device_network_memberships mem
+        JOIN devices d ON d.id = mem.device_id
+        ORDER BY mem.network_id, mem.joined_at, mem.id
+    LOOP
+        -- Lowercase, anything that is not a letter, digit or hyphen becomes a hyphen,
+        -- runs of hyphens collapse, and leading and trailing hyphens go. `Dave's laptop`
+        -- becomes `dave-s-laptop`, which is guessable, which is the point.
+        base := regexp_replace(lower(m.device_name), '[^a-z0-9]+', '-', 'g');
+        base := regexp_replace(base, '(^-+)|(-+$)', '', 'g');
+        base := left(base, 63);
+        base := regexp_replace(base, '-+$', '', 'g');
+
+        -- A name with nothing usable in it at all — empty, or only punctuation — gets one
+        -- derived from the device's id. Opaque, and better than a device that cannot be
+        -- named at all: every membership needs a label for the constraint below.
+        IF base = '' THEN
+            base := 'device-' || left(replace(m.device_id::text, '-', ''), 8);
+        END IF;
+
+        candidate := base;
+        n := 1;
+        WHILE EXISTS (
+            SELECT 1 FROM device_network_memberships
+            WHERE network_id = m.network_id AND dns_label = candidate
+        ) LOOP
+            n := n + 1;
+            -- Truncated so the suffix always fits inside the 63-byte label limit, rather
+            -- than producing a label the CHECK below would reject.
+            candidate := left(base, 63 - length('-' || n::text)) || '-' || n::text;
+        END LOOP;
+
+        IF candidate <> base THEN
+            renamed := renamed + 1;
+        END IF;
+        total := total + 1;
+
+        UPDATE device_network_memberships SET dns_label = candidate WHERE id = m.id;
+    END LOOP;
+
+    -- Said out loud. An operator whose device was renamed has to be able to find out, and
+    -- this is the only moment anything knows it happened.
+    RAISE NOTICE 'meshp: assigned DNS labels to % membership(s); % renamed to avoid a collision within their network', total, renamed;
+END $$;
+
+ALTER TABLE device_network_memberships ALTER COLUMN dns_label SET NOT NULL;
+
+-- The syntax, enforced rather than assumed. A label that is not one of these cannot be
+-- carried by DNS, and finding that out at query time means a device that silently does not
+-- resolve.
+ALTER TABLE device_network_memberships
+    ADD CONSTRAINT device_network_memberships_dns_label_check
+    CHECK (dns_label ~ '^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$');
+
+-- The rule this table exists to hold.
+ALTER TABLE device_network_memberships
+    ADD CONSTRAINT device_network_memberships_dns_label_key
+    UNIQUE (network_id, dns_label);
+
+COMMENT ON COLUMN device_network_memberships.dns_label IS
+    'The name this device answers to inside this network, as <dns_label>.<network slug>.<suffix>. Unique per network because that is the scope of the name. devices.name stays free text for display.';
+
+-- +goose Down
+
+ALTER TABLE device_network_memberships
+    DROP CONSTRAINT IF EXISTS device_network_memberships_dns_label_key;
+ALTER TABLE device_network_memberships
+    DROP CONSTRAINT IF EXISTS device_network_memberships_dns_label_check;
+ALTER TABLE device_network_memberships DROP COLUMN IF EXISTS dns_label;

--- a/proto/gen/meshp/v1/control.pb.go
+++ b/proto/gen/meshp/v1/control.pb.go
@@ -1171,9 +1171,18 @@ type Peer struct {
 	// Relay to use until (or unless) a direct path is established. meshp is
 	// relay-first: connectivity never depends on hole punching succeeding
 	// (ADR-0002).
-	RelayId       string   `protobuf:"bytes,6,opt,name=relay_id,json=relayId,proto3" json:"relay_id,omitempty"`
-	DeviceName    string   `protobuf:"bytes,7,opt,name=device_name,json=deviceName,proto3" json:"device_name,omitempty"` // display only
-	Tags          []string `protobuf:"bytes,8,rep,name=tags,proto3" json:"tags,omitempty"`                               // display and ACL context only; never authoritative
+	RelayId    string   `protobuf:"bytes,6,opt,name=relay_id,json=relayId,proto3" json:"relay_id,omitempty"`
+	DeviceName string   `protobuf:"bytes,7,opt,name=device_name,json=deviceName,proto3" json:"device_name,omitempty"` // display only
+	Tags       []string `protobuf:"bytes,8,rep,name=tags,proto3" json:"tags,omitempty"`                               // display and ACL context only; never authoritative
+	// The name this peer answers to inside this network, as
+	// <dns_label>.<network>.<suffix> (ADR-0021). Unique within the network, which
+	// device_name is not and was never required to be.
+	//
+	// Separate from device_name rather than replacing it, so a person keeps
+	// "Dave's laptop (spare)" in a device list while DNS gets something it can
+	// carry. Empty from a control plane too old to send one, and a device that
+	// receives none simply has no resolvable name.
+	DnsLabel      string `protobuf:"bytes,9,opt,name=dns_label,json=dnsLabel,proto3" json:"dns_label,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1262,6 +1271,13 @@ func (x *Peer) GetTags() []string {
 		return x.Tags
 	}
 	return nil
+}
+
+func (x *Peer) GetDnsLabel() string {
+	if x != nil {
+		return x.DnsLabel
+	}
+	return ""
 }
 
 type TunnelConfig struct {
@@ -3338,7 +3354,7 @@ const file_meshp_v1_control_proto_rawDesc = "" +
 	"\bStateAck\x12'\n" +
 	"\x0fapplied_version\x18\x01 \x01(\x04R\x0eappliedVersion\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x121\n" +
-	"\x14unapplied_components\x18\x03 \x03(\tR\x13unappliedComponents\"\x9b\x02\n" +
+	"\x14unapplied_components\x18\x03 \x03(\tR\x13unappliedComponents\"\xb8\x02\n" +
 	"\x04Peer\x12\x1d\n" +
 	"\n" +
 	"public_key\x18\x01 \x01(\tR\tpublicKey\x12\x1f\n" +
@@ -3350,7 +3366,8 @@ const file_meshp_v1_control_proto_rawDesc = "" +
 	"\brelay_id\x18\x06 \x01(\tR\arelayId\x12\x1f\n" +
 	"\vdevice_name\x18\a \x01(\tR\n" +
 	"deviceName\x12\x12\n" +
-	"\x04tags\x18\b \x03(\tR\x04tags\"\xa2\x02\n" +
+	"\x04tags\x18\b \x03(\tR\x04tags\x12\x1b\n" +
+	"\tdns_label\x18\t \x01(\tR\bdnsLabel\"\xa2\x02\n" +
 	"\fTunnelConfig\x12\x10\n" +
 	"\x03mtu\x18\x01 \x01(\rR\x03mtu\x12+\n" +
 	"\x11excluded_prefixes\x18\x02 \x03(\tR\x10excludedPrefixes\x12#\n" +

--- a/proto/meshp/v1/control.proto
+++ b/proto/meshp/v1/control.proto
@@ -182,6 +182,16 @@ message Peer {
 
   string device_name = 7;   // display only
   repeated string tags = 8; // display and ACL context only; never authoritative
+
+  // The name this peer answers to inside this network, as
+  // <dns_label>.<network>.<suffix> (ADR-0021). Unique within the network, which
+  // device_name is not and was never required to be.
+  //
+  // Separate from device_name rather than replacing it, so a person keeps
+  // "Dave's laptop (spare)" in a device list while DNS gets something it can
+  // carry. Empty from a control plane too old to send one, and a device that
+  // receives none simply has no resolvable name.
+  string dns_label = 9;
 }
 
 message TunnelConfig {

--- a/queries/devices.sql
+++ b/queries/devices.sql
@@ -11,9 +11,18 @@ WHERE identity_public_key = $1;
 
 -- name: CreateMembership :one
 INSERT INTO device_network_memberships (
-    device_id, network_id, interface_name, address_v4, address_v6, tags
-) VALUES ($1, $2, $3, $4, $5, $6)
+    device_id, network_id, interface_name, address_v4, address_v6, tags, dns_label
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
 RETURNING *;
+
+-- name: TakenDNSLabels :many
+-- The labels already used in a network, among those a candidate might collide with.
+--
+-- Prefix-matched rather than fetching every label in the network: a network with ten
+-- thousand devices has ten thousand labels and one of them is being enrolled, so the
+-- interesting set is the handful that start with the same base.
+SELECT dns_label FROM device_network_memberships
+WHERE network_id = $1 AND dns_label LIKE sqlc.arg(prefix) || '%';
 
 -- name: CountMembershipsForDevice :one
 SELECT count(*) FROM device_network_memberships

--- a/queries/sessions.sql
+++ b/queries/sessions.sql
@@ -53,7 +53,8 @@ SELECT
     m.address_v6,
     m.tags,
     k.public_key    AS wireguard_public_key,
-    d.name          AS device_name
+    d.name          AS device_name,
+    m.dns_label
 FROM device_network_memberships m
 JOIN wireguard_keys k ON k.membership_id = m.id AND k.state = 'current'
 JOIN devices d        ON d.id = m.device_id

--- a/queries/state.sql
+++ b/queries/state.sql
@@ -32,7 +32,8 @@ SELECT
     m.address_v6,
     m.tags,
     k.public_key    AS wireguard_public_key,
-    d.name          AS device_name
+    d.name          AS device_name,
+    m.dns_label
 FROM device_network_memberships m
 JOIN wireguard_keys k ON k.membership_id = m.id AND k.state = 'current'
 JOIN devices d        ON d.id = m.device_id


### PR DESCRIPTION
ADR-0021 needs a resolvable name to be unique within its network, and `devices.name` is free text with no constraint at all. This adds the constraint — **before** the resolver is wired to the system, while a rename still costs nothing because no route, policy or lookup uses the name yet. That window does not reopen.

## The label goes on the membership, not the device

The scope of uniqueness is the *network*, because the network is the next part of the name. A device belongs to many networks (ADR-0004), so a constraint on `devices.name` is either:

- **too strict** — unique per organisation, forbidding two customers from both having a `fileserver`, or
- **unenforceable** — unique per network, which is not a column on that table.

`UNIQUE (network_id, dns_label)` is exactly the rule, and it is a real constraint rather than something the application promises to remember.

## It costs less than the ADR assumed

ADR-0021 said names would stop being free text and `Dave's laptop (spare)` would not survive.

**It does.** `devices.name` is untouched; the label is a second, machine-shaped name beside it. `Dave's laptop (spare)` displays as itself and resolves as `dave-s-laptop-spare`. The cost the ADR called unavoidable turned out to be avoidable — the sort of thing only writing the migration finds.

## Suffixed, never refused

At enrolment and in the backfill alike. A fleet imaged with one hostname must all enrol; refusing the second produces one success and forty-nine failures, for a reason the installer can neither see nor fix.

The oldest membership keeps the plain name and a newcomer becomes `fileserver-2` — ordered by `joined_at`, so the result is explicable rather than dependent on which row the planner reached first.

## The backfill, run against real awkward data

| `devices.name` | network | label |
|---|---|---|
| `fileserver` | hq | `fileserver` |
| `fileserver` | hq | `fileserver-2` |
| `FileServer` | hq | `fileserver-3` |
| `Dave's laptop (spare)` | hq | `dave-s-laptop-spare` |
| `!!!` | hq | `device-aaaaaaaa` |
| 80 × `x` | hq | truncated to 63 |
| `fileserver` | **br** | `fileserver` |

That last row is the proof the scope is right — the same device keeps the plain name in a second network. Case collides correctly (`FileServer` → `-3`, not a fresh `fileserver`). `migrate-check` applies, rolls back and re-applies cleanly, and the migration `RAISE NOTICE`s what it renamed, because that is the only moment anything knows.

## Wire and agent

`Peer` gains `dns_label` rather than reusing `device_name`, so a person keeps a display name while DNS gets something it can carry. Additive; the protocol-compatibility job checks it.

**The agent uses the server's label and refuses to derive its own.** Only the server can make a label unique within a network; a name computed on the device would be one guess among however many devices are guessing. A peer with no label, or one DNS cannot carry, is left out rather than repaired — repairing would name a device something the server does not think it is called, so it would resolve here and nowhere else.

## Verification

`make ci`, `make integration`, `make migrate-check` all green.

Three mutations caught:

| Mutation | Caught by |
|---|---|
| Refuse a collision instead of suffixing | 3 enrol tests |
| Skip normalisation, so case dodges the collision | `TestLabelsAreGuessable`, `TestNamesAreNormalisedBeforeTheyCollide` |
| Agent derives the label from the display name | `TestPeersWithoutAServerAssignedLabelAreLeftOut` |

One store fixture inserted memberships directly and hit the new NOT NULL. Fixed the fixture, not the constraint.

## Next

System resolver configuration — the slice that makes `ssh fileserver` work — and then `DnsConfig.records` for admin-entered records.
