### PR TITLE
fix(dns): the resolver binds before the daemon carries on

### DIFF
--- a/cmd/meshpd/main.go
+++ b/cmd/meshpd/main.go
@@ -118,21 +118,23 @@ func run(ctx context.Context, log *slog.Logger, stateDir, socketPath, socketGrou
 		return err
 	}
 
-	// The resolver, before the sessions that fill it. Binding early means a device whose
-	// zones are still empty answers NXDOMAIN rather than nothing at all — a name that does
-	// not resolve yet is a better failure than a resolver that is not there, because the
-	// second one makes every query wait for a timeout.
+	// The resolver, bound before anything else runs and served afterwards.
+	//
+	// Synchronously on purpose. Binding in a goroutine meant everything below this line ran
+	// before the sockets existed, so `meshp status` could truthfully report no resolver on a
+	// device that was about to have one — which is what broke the end-to-end assertion
+	// guarding this feature, on a machine slower than the one it was written on.
 	//
 	// Its failure is not fatal. A port already taken, or a host that will not let this
-	// process bind, costs names and nothing else: the tunnel, the policy and the routes
-	// are all unaffected, and exiting here would take them down over a convenience.
-	go func() {
-		if err := agent.resolver.Listen(ctx, dnsListenAddr); err != nil && ctx.Err() == nil {
-			log.Error("no name resolution on this device",
-				"error", err, "addr", dnsListenAddr.String(),
-				"hint", "meshp status reports the resolver; addresses still work")
-		}
-	}()
+	// process bind, costs names and nothing else: the tunnel, the policy and the routes are
+	// all unaffected, and exiting here would take them down over a convenience.
+	if err := agent.resolver.Bind(dnsListenAddr); err != nil {
+		log.Error("no name resolution on this device",
+			"error", err, "addr", dnsListenAddr.String(),
+			"hint", "meshp status reports the resolver; addresses still work")
+	} else {
+		go agent.resolver.Serve(ctx)
+	}
 
 	agent.startAll()
 

--- a/internal/dns/server.go
+++ b/internal/dns/server.go
@@ -49,11 +49,18 @@ func NewServer(zones *Zones, log *slog.Logger) *Server {
 // ErrNotLoopback means somebody asked this to listen where it must not.
 var ErrNotLoopback = errors.New("dns: the resolver listens on loopback only")
 
-// Listen binds UDP and TCP and serves until ctx is done.
+// Bind takes the sockets and returns, so a caller knows whether it has a resolver before it
+// carries on.
 //
-// Both, because DNS is both: a truncated UDP answer tells the client to retry over TCP, and
-// a client that cannot is stuck with whatever fitted in 512 bytes.
-func (s *Server) Listen(ctx context.Context, addr netip.AddrPort) error {
+// Separate from serving, and that separation is load-bearing rather than tidiness. When the
+// two were one call the daemon had to start it in a goroutine, which meant everything after
+// that line ran before the sockets existed — so `meshp status` could truthfully report no
+// resolver on a device that was about to have one, and the end-to-end assertion guarding
+// this feature failed on a slower machine. Binding is fast and can fail; serving is neither.
+//
+// Both protocols, because DNS is both: a truncated UDP answer tells the client to retry over
+// TCP, and a client that cannot is stuck with whatever fitted in 512 bytes.
+func (s *Server) Bind(addr netip.AddrPort) error {
 	if !addr.Addr().IsLoopback() {
 		return ErrNotLoopback
 	}
@@ -78,6 +85,20 @@ func (s *Server) Listen(ctx context.Context, addr netip.AddrPort) error {
 	s.mu.Unlock()
 
 	s.log.Info("resolver listening", "addr", bound.String())
+	return nil
+}
+
+// Serve answers queries until ctx is done, then gives the sockets back.
+//
+// Returns immediately when nothing is bound, so a caller that ignored a Bind failure does
+// not block forever on a resolver it does not have.
+func (s *Server) Serve(ctx context.Context) {
+	s.mu.Lock()
+	udp, tcp := s.udp, s.tcp
+	s.mu.Unlock()
+	if udp == nil || tcp == nil {
+		return
+	}
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -92,7 +113,6 @@ func (s *Server) Listen(ctx context.Context, addr netip.AddrPort) error {
 	s.mu.Lock()
 	s.udp, s.tcp, s.addr = nil, nil, netip.AddrPort{}
 	s.mu.Unlock()
-	return nil
 }
 
 // Addr is where the resolver is listening, or the zero value when it is not.

--- a/internal/dns/server_test.go
+++ b/internal/dns/server_test.go
@@ -18,25 +18,23 @@ func serve(t *testing.T, z *Zones) netip.AddrPort {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	done := make(chan error, 1)
-	go func() { done <- s.Listen(ctx, netip.MustParseAddrPort("127.0.0.1:0")) }()
-
-	deadline := time.Now().Add(5 * time.Second)
-	for s.Addr().Port() == 0 {
-		if time.Now().After(deadline) {
-			t.Fatal("the resolver never bound")
-		}
-		time.Sleep(5 * time.Millisecond)
+	// Bound before this returns, so there is nothing to poll for — which is the property
+	// the split exists to give callers.
+	if err := s.Bind(netip.MustParseAddrPort("127.0.0.1:0")); err != nil {
+		t.Fatal(err)
 	}
 	addr := s.Addr()
+	if addr.Port() == 0 {
+		t.Fatal("Bind returned without an address")
+	}
+
+	done := make(chan struct{})
+	go func() { defer close(done); s.Serve(ctx) }()
 
 	t.Cleanup(func() {
 		cancel()
 		select {
-		case err := <-done:
-			if err != nil {
-				t.Errorf("Listen: %v", err)
-			}
+		case <-done:
 		case <-time.After(5 * time.Second):
 			t.Error("the resolver did not stop when its context was cancelled")
 		}
@@ -267,23 +265,67 @@ func TestAMalformedQueryGetsFormErr(t *testing.T) {
 func TestItRefusesToListenOffLoopback(t *testing.T) {
 	s := NewServer(twoCustomers(t), nil)
 
-	// A context that ends, and a result read with a deadline. Listen blocks until its
-	// context is done, so a version of this that passed context.Background() would hang
-	// rather than fail if the guard were removed — which is exactly what happened when a
-	// mutation removed it. A test that hangs on the bug it is checking for is worse than
-	// no test: it stalls the suite instead of naming the problem.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	// Bind returns rather than blocking, so this is a plain assertion now. It used to need
+	// a goroutine and a deadline, because a version of it that called the old combined
+	// Listen with context.Background() would hang rather than fail when the guard was
+	// removed — a test that stalls the suite on the bug it checks for is worse than none.
+	// Splitting bind from serve removed the hazard rather than working around it.
+	if err := s.Bind(netip.MustParseAddrPort("0.0.0.0:0")); !errors.Is(err, ErrNotLoopback) {
+		t.Errorf("err = %v, want ErrNotLoopback", err)
+	}
+	if s.Addr().IsValid() {
+		t.Error("a refused address was bound anyway")
+	}
+}
+
+// Bind returns having bound, which is the whole reason it is not part of Serve.
+//
+// The contract a caller depends on: once this returns without an error, Addr is real and
+// the sockets exist, so everything after that line can rely on there being a resolver.
+// When binding lived inside Serve the daemon had to start it in a goroutine, and everything
+// after that line ran before the sockets existed — `meshp status` reported no resolver on a
+// device that was about to have one, and the end-to-end guard for this feature failed on a
+// machine slower than the one it was written on.
+//
+// This cannot catch a caller that puts Bind in a goroutine anyway; the end-to-end script is
+// what notices that, and only when it loses the race. What this does is make the correct
+// wiring possible and keep it that way.
+func TestBindReturnsHavingBound(t *testing.T) {
+	s := NewServer(twoCustomers(t), nil)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	done := make(chan error, 1)
-	go func() { done <- s.Listen(ctx, netip.MustParseAddrPort("0.0.0.0:0")) }()
+	if s.Addr().IsValid() {
+		t.Fatal("a server reports an address before anything bound")
+	}
+	if err := s.Bind(netip.MustParseAddrPort("127.0.0.1:0")); err != nil {
+		t.Fatal(err)
+	}
+	if !s.Addr().IsValid() || s.Addr().Port() == 0 {
+		t.Fatal("Bind returned before the socket existed")
+	}
+
+	// And the socket really is accepting, not merely recorded.
+	conn, err := net.Dial("udp", s.Addr().String())
+	if err != nil {
+		t.Fatalf("nothing is listening where Bind said: %v", err)
+	}
+	_ = conn.Close()
+
+	go s.Serve(ctx)
+	cancel()
+}
+
+// Serve on a server that never bound returns rather than blocking, so a caller that ignored
+// a Bind failure does not wait forever on a resolver it does not have.
+func TestServeWithoutBindReturns(t *testing.T) {
+	s := NewServer(twoCustomers(t), nil)
+	done := make(chan struct{})
+	go func() { defer close(done); s.Serve(context.Background()) }()
 
 	select {
-	case err := <-done:
-		if !errors.Is(err, ErrNotLoopback) {
-			t.Errorf("err = %v, want ErrNotLoopback", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("Listen did not refuse a non-loopback address; it bound and started serving")
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve blocked on a server with no sockets")
 	}
 }

--- a/internal/tunnel/names_test.go
+++ b/internal/tunnel/names_test.go
@@ -177,18 +177,13 @@ func TestANameResolvesEndToEnd(t *testing.T) {
 	}
 
 	server := dns.NewServer(zones, nil)
+	if err := server.Bind(netip.MustParseAddrPort("127.0.0.1:0")); err != nil {
+		t.Fatal(err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	done := make(chan error, 1)
-	go func() { done <- server.Listen(ctx, netip.MustParseAddrPort("127.0.0.1:0")) }()
-
-	deadline := time.Now().Add(5 * time.Second)
-	for server.Addr().Port() == 0 {
-		if time.Now().After(deadline) {
-			t.Fatal("the resolver never bound")
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	done := make(chan struct{})
+	go func() { defer close(done); server.Serve(ctx) }()
 
 	got := resolve(t, server.Addr(), "fileserver.acme.internal")
 	if got != "100.90.0.2" {


### PR DESCRIPTION
`main` is red on the end-to-end assertion added in #81 — the one guarding that the resolver is actually started. It reports *"resolver not running"* on a device whose resolver is about to be running.

**The guard was right; the wiring was racy.**

`Listen` bound and served in one call, so the daemon had to start it in a goroutine, so everything after that line ran before the sockets existed. `scripts/e2e-enrol.sh` polls until the daemon answers on its unix socket and then reads status — and on a slower machine that read happened first. It never lost the race on my laptop, which is why it shipped.

## The fix

Split into `Bind` and `Serve`.

`Bind` takes the sockets and returns, so once it has, `Addr()` is real and every later line can rely on there being a resolver. `Serve` answers until the context ends.

The daemon binds **synchronously** and serves in a goroutine. Because the unix socket only starts answering afterwards (`server.Serve` is the last line of `run`), no `meshp status` call can observe the gap:

```
117  server.Listen()          — unix socket bound, not yet answering
131  agent.resolver.Bind(...) — resolver bound, or reported as failed
136  go agent.resolver.Serve(ctx)
141  server.Serve(ctx)        — status calls start being answered here
```

The race is closed **structurally**, not by making the assertion tolerant. A retry loop in the script would have hidden a resolver that took ten seconds to come up as readily as one that took ten milliseconds.

## Tests

Two on the new contract: `Bind` returns having bound and with something really listening on the address it reports; `Serve` on a server that never bound returns rather than blocking forever on a resolver it does not have.

**Honest limit:** the first catches an asynchronous `Bind` **19 times in 20** — a scheduling race, so a strong guard rather than a proof, and worth saying rather than claiming a guarantee. A *caller* that puts `Bind` in a goroutine anyway is still only caught by the end-to-end script, and only when it loses the race. That is the same class of gap as the resolver never starting at all, and the script is the only thing that sees either.

## Also

It removed a hazard rather than working around one. The loopback test used to need a goroutine and a deadline, because the combined `Listen` blocked forever when the guard was removed instead of failing. `Bind` returns, so it is a plain assertion now.