### PR TITLE
feat(dns): point this machine's resolver at meshp for the names meshp owns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,10 +488,20 @@ jobs:
       # interface actually leaves by it cannot be tested without real interfaces, and a
       # probe that quietly used the routing table would report an advertiser healthy while
       # measuring the local network.
-      - name: interfaces, routes, teardown, a packet across the tunnel, and a bound probe
+      # resolved needs systemd-resolved to be the thing answering names here, which is true
+      # of this runner and is asserted rather than assumed: the step below fails on a skip,
+      # so a runner image that stopped shipping it would be a loud failure rather than a
+      # test quietly not running.
+      - name: this runner's names are answered by systemd-resolved
+        run: |
+          resolvectl status >/dev/null
+          sudo modprobe dummy || true
+          echo "systemd-resolved is answering here"
+
+      - name: interfaces, routes, teardown, a packet across the tunnel, a bound probe, and the host resolver
         run: |
           set -o pipefail
-          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/pathprobe/ -count=1 -v 2>&1 | tee dataplane.log
+          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/pathprobe/ ./internal/resolved/ -count=1 -v 2>&1 | tee dataplane.log
         continue-on-error: false
 
       - name: report, and refuse a silent skip

--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,9 @@ dataplane: ## Run the data-plane tests against real interfaces, in a privileged 
 	  golang:$(GO_IMAGE_VERSION)-alpine sh -c \
 	  'apk add --no-cache iproute2 wireguard-tools nftables iputils >/dev/null && \
 	   go test ./internal/wglink/ ./internal/nftables/ ./internal/pathprobe/ -count=1 -v'
+	@# internal/resolved is deliberately absent: it needs systemd-resolved, and this runs in
+	@# an alpine container that has none, so the tests would skip and report success without
+	@# testing anything. CI runs them directly on a runner that has one.
 
 .PHONY: migrate-check
 migrate-check: ## Apply, roll back and re-apply every migration against MESHP_TEST_DATABASE_URL

--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -22,6 +22,7 @@ import (
 	"github.com/meshpnet/meshp/internal/pathprobe"
 	"github.com/meshpnet/meshp/internal/peerset"
 	"github.com/meshpnet/meshp/internal/relaylink"
+	"github.com/meshpnet/meshp/internal/resolved"
 	"github.com/meshpnet/meshp/internal/routeprobe"
 	"github.com/meshpnet/meshp/internal/sessionclient"
 	"github.com/meshpnet/meshp/internal/tunnel"
@@ -77,6 +78,13 @@ type agent struct {
 	zones    *dns.Zones
 	resolver *dns.Server
 
+	// systemResolver points this machine's own resolver at the agent, or is nil on a host
+	// where meshp cannot configure one and put it back afterwards. Nil means names answer
+	// only to something querying the agent directly, which the status command says plainly
+	// rather than leaving somebody to wonder why `ssh fileserver` does not work.
+	systemResolverOnce sync.Once
+	systemResolver     *resolved.Resolvectl
+
 	ctx context.Context
 }
 
@@ -124,7 +132,8 @@ func (a *agent) reconcilerFor(m agentstate.Membership, relay tunnel.Relay, choos
 		WithEgress(routerOrNil()).
 		WithProber(proberOrNil()).
 		WithClaims(a.claims).
-		WithNames(a.zones)
+		WithNames(a.zones).
+		WithSystemResolver(a.systemResolverOrNil(), a.resolver.Addr)
 }
 
 // proberOrNil converts a possibly-absent dialer into the interface.
@@ -138,6 +147,29 @@ func proberOrNil() tunnel.Prober {
 		return d
 	}
 	return nil
+}
+
+// systemResolverOrNil converts a possibly-absent resolver configurer into the interface.
+//
+// Explicit for the reason routerOrNil and proberOrNil are: a nil *resolved.Resolvectl
+// assigned straight to an interface is a non-nil interface holding a nil pointer, so the
+// reconciler's own nil check would pass and every reconcile would call a method on nothing.
+//
+// Once, and lazily: it asks systemd-resolved for its status, which is a process spawn, and
+// doing that per membership per reconcile would be a spawn a minute for nothing.
+func (a *agent) systemResolverOrNil() tunnel.SystemResolver {
+	a.systemResolverOnce.Do(func() {
+		a.systemResolver = resolved.New(a.ctx)
+		if a.systemResolver == nil {
+			a.log.Warn("this machine's resolver cannot be configured by meshp",
+				"note", "names answer to a direct query and nowhere else",
+				"hint", "meshp status reports the resolver address; addresses always work")
+		}
+	})
+	if a.systemResolver == nil {
+		return nil
+	}
+	return a.systemResolver
 }
 
 // routerOrNil converts a possibly-absent router into the interface.

--- a/internal/resolved/resolvectl_linux.go
+++ b/internal/resolved/resolvectl_linux.go
@@ -1,0 +1,108 @@
+//go:build linux
+
+package resolved
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/logx"
+)
+
+// callTimeout bounds one resolvectl invocation.
+//
+// Talking to systemd-resolved over D-Bus is milliseconds of work. A bound exists because
+// this runs on the reconcile path: resolvectl blocking — on a busy bus, or a resolved that
+// has wedged — would stop the agent converging on anything else, and names are the least
+// important thing it does.
+const callTimeout = 10 * time.Second
+
+// Resolvectl configures systemd-resolved.
+type Resolvectl struct{ path string }
+
+// New returns a configurer for this host, or nil where systemd-resolved is not the thing
+// answering names.
+//
+// Nil rather than a stub, following the rule the filter and the egress router use: a
+// capability this host does not have must be absent, so the agent reports honestly that
+// names will not resolve rather than claiming to have configured something.
+//
+// Presence of the binary is not enough, for the reason nftables.Available gives: a container
+// can have resolvectl and no systemd-resolved to talk to, which fails later and looks like a
+// meshp fault. This asks resolved for its status, which needs the same bus access that
+// configuring a link does.
+func New(ctx context.Context) *Resolvectl {
+	path, err := exec.LookPath("resolvectl")
+	if err != nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+	if err := exec.CommandContext(ctx, path, "status").Run(); err != nil {
+		return nil
+	}
+	return &Resolvectl{path: path}
+}
+
+// Configure points one interface's queries for these domains at the agent's resolver.
+//
+// Two calls, and both are needed. `dns` says where to send them; `domain` with a leading
+// tilde marks each as a *routing* domain — meaning "send these here" without also adding it
+// to the search list. That distinction is the whole of split DNS here: a search domain would
+// have the stub append `acme.internal` to every bare name a user typed, which is how a
+// device in two networks silently reaches whichever one answers first (ADR-0021).
+//
+// Idempotent because the reconciler calls it on every pass. resolvectl replaces a link's
+// configuration rather than appending to it, so the second call is a no-op in effect.
+func (r *Resolvectl) Configure(ctx context.Context, iface string, server netip.AddrPort, domains []string) error {
+	if len(domains) == 0 {
+		// Nothing to route here. Reverting rather than configuring an empty set: a link
+		// left pointing at this resolver with no domains would still be consulted for
+		// anything resolved decided to send it.
+		return r.Revert(ctx, iface)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+
+	// The address carries its port. systemd-resolved accepts `addr:port` for a link's DNS
+	// server, which matters because the agent's resolver never gets port 53 — that is
+	// almost always taken by resolved itself.
+	if out, err := r.run(ctx, "dns", iface, server.String()); err != nil {
+		return fmt.Errorf("resolved: pointing %s at %s: %w (%s)", iface, server, err, out)
+	}
+
+	args := make([]string, 0, len(domains)+2)
+	args = append(args, "domain", iface)
+	for _, d := range domains {
+		args = append(args, "~"+d)
+	}
+	if out, err := r.run(ctx, args...); err != nil {
+		return fmt.Errorf("resolved: routing %s to %s: %w (%s)", strings.Join(domains, ", "), iface, err, out)
+	}
+	return nil
+}
+
+// Revert puts the interface back as systemd-resolved found it.
+//
+// The reason this package exists rather than one that edits resolv.conf: there is a real
+// undo, so the agent can take its configuration off without holding a copy of somebody
+// else's and hoping it is still current (Invariant 20).
+func (r *Resolvectl) Revert(ctx context.Context, iface string) error {
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+	if out, err := r.run(ctx, "revert", iface); err != nil {
+		return fmt.Errorf("resolved: reverting %s: %w (%s)", iface, err, out)
+	}
+	return nil
+}
+
+// run invokes resolvectl and returns its output, bounded, for the error message.
+func (r *Resolvectl) run(ctx context.Context, args ...string) (string, error) {
+	out, err := exec.CommandContext(ctx, r.path, args...).CombinedOutput()
+	return logx.Safe(strings.TrimSpace(string(out))), err
+}

--- a/internal/resolved/resolvectl_linux_test.go
+++ b/internal/resolved/resolvectl_linux_test.go
@@ -1,0 +1,123 @@
+//go:build linux
+
+package resolved
+
+import (
+	"context"
+	"net/netip"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The claim this package rests on: systemd-resolved really does send this domain to this
+// address on this link, and really does put the link back afterwards.
+//
+// Against the running systemd-resolved, on a link created for the purpose. There is no
+// useful way to fake this — the thing being tested is whether a specific daemon accepts a
+// specific pair of commands and whether its undo is a real undo, and a fake would only
+// assert that resolvectl was invoked with the arguments this file already says it invokes.
+//
+// A dummy link rather than a real interface, so a failure cannot take DNS away from the
+// machine running the test. `resolvectl revert` is what restores it, and if that is broken
+// this test is exactly where it should be discovered.
+func TestSystemdResolvedTakesTheConfigurationAndGivesItBack(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("needs root to create a link and configure systemd-resolved")
+	}
+	ctx := context.Background()
+	r := New(ctx)
+	if r == nil {
+		t.Skip("no systemd-resolved on this host")
+	}
+	if _, err := exec.LookPath("ip"); err != nil {
+		t.Skip("needs iproute2 to create the test link")
+	}
+
+	const link = "meshpdnstest"
+	_ = exec.Command("ip", "link", "del", link).Run()
+	if out, err := exec.Command("ip", "link", "add", link, "type", "dummy").CombinedOutput(); err != nil {
+		t.Skipf("cannot create a dummy link here: %v (%s)", err, out)
+	}
+	t.Cleanup(func() { _ = exec.Command("ip", "link", "del", link).Run() })
+	if out, err := exec.Command("ip", "link", "set", link, "up").CombinedOutput(); err != nil {
+		t.Fatalf("bringing %s up: %v (%s)", link, err, out)
+	}
+
+	server := netip.MustParseAddrPort("127.0.0.1:5399")
+	if err := r.Configure(ctx, link, server, []string{"acme.internal"}); err != nil {
+		t.Fatalf("configuring: %v", err)
+	}
+
+	status := resolvectlStatus(t, link)
+	if !strings.Contains(status, "127.0.0.1:5399") {
+		t.Errorf("resolved does not have the address:\n%s", status)
+	}
+	// The tilde is what makes it a routing domain rather than a search domain. A search
+	// domain would have the stub append acme.internal to every bare name a user typed,
+	// which is how a device in two networks silently reaches whichever answers first.
+	if !strings.Contains(status, "~acme.internal") {
+		t.Errorf("resolved has the domain but not as a routing domain:\n%s", status)
+	}
+
+	// Idempotent: the reconciler calls this on every pass.
+	if err := r.Configure(ctx, link, server, []string{"acme.internal"}); err != nil {
+		t.Fatalf("configuring a second time: %v", err)
+	}
+
+	if err := r.Revert(ctx, link); err != nil {
+		t.Fatalf("reverting: %v", err)
+	}
+	after := resolvectlStatus(t, link)
+	if strings.Contains(after, "127.0.0.1:5399") || strings.Contains(after, "acme.internal") {
+		t.Errorf("revert left meshp's configuration behind:\n%s", after)
+	}
+
+	// And reverting a link that was never configured is not an error, because the teardown
+	// path calls it without knowing whether there was anything to undo (Invariant 20).
+	if err := r.Revert(ctx, link); err != nil {
+		t.Errorf("reverting an already-reverted link: %v", err)
+	}
+}
+
+// An empty domain set reverts rather than configuring nothing, so a device that has left
+// every network stops being consulted.
+func TestNoDomainsRevertsTheLink(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("needs root to create a link and configure systemd-resolved")
+	}
+	ctx := context.Background()
+	r := New(ctx)
+	if r == nil {
+		t.Skip("no systemd-resolved on this host")
+	}
+
+	const link = "meshpdnstest2"
+	_ = exec.Command("ip", "link", "del", link).Run()
+	if out, err := exec.Command("ip", "link", "add", link, "type", "dummy").CombinedOutput(); err != nil {
+		t.Skipf("cannot create a dummy link here: %v (%s)", err, out)
+	}
+	t.Cleanup(func() { _ = exec.Command("ip", "link", "del", link).Run() })
+	_ = exec.Command("ip", "link", "set", link, "up").Run()
+
+	server := netip.MustParseAddrPort("127.0.0.1:5399")
+	if err := r.Configure(ctx, link, server, []string{"acme.internal"}); err != nil {
+		t.Fatalf("configuring: %v", err)
+	}
+	if err := r.Configure(ctx, link, server, nil); err != nil {
+		t.Fatalf("configuring with no domains: %v", err)
+	}
+	if got := resolvectlStatus(t, link); strings.Contains(got, "acme.internal") {
+		t.Errorf("an empty domain set left the link configured:\n%s", got)
+	}
+}
+
+func resolvectlStatus(t *testing.T, link string) string {
+	t.Helper()
+	out, err := exec.Command("resolvectl", "status", link).CombinedOutput()
+	if err != nil {
+		t.Fatalf("resolvectl status %s: %v (%s)", link, err, out)
+	}
+	return string(out)
+}

--- a/internal/resolved/resolvectl_other.go
+++ b/internal/resolved/resolvectl_other.go
@@ -1,0 +1,39 @@
+//go:build !linux
+
+package resolved
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+)
+
+// ErrUnsupported means this platform has no resolver meshp knows how to configure safely.
+var ErrUnsupported = errors.New("resolved: no supported resolver on this platform")
+
+// Resolvectl is declared so the wiring compiles everywhere, and is never constructed here.
+// Empty rather than mirroring the Linux type's fields: an unused field is dead weight the
+// linter is right to object to.
+type Resolvectl struct{}
+
+// New returns nothing on a platform where systemd-resolved is not what answers names.
+//
+// Nil rather than a stub that reports success. ADR-0021 requires a host that cannot
+// configure its resolver to say so and leave the system's DNS alone; a stub reporting
+// success would leave the agent believing names work while every lookup went to whatever
+// the machine used before.
+func New(context.Context) *Resolvectl { return nil }
+
+// Configure fails rather than silently doing nothing.
+//
+// Unreachable, because New returns nil here. It refuses rather than returning success for
+// the reason the pathprobe stub does: "nothing happened" and "it worked" must not look the
+// same to a caller, or a wiring mistake on a new platform reads as working software.
+func (r *Resolvectl) Configure(context.Context, string, netip.AddrPort, []string) error {
+	return ErrUnsupported
+}
+
+// Revert is a no-op that succeeds: there is nothing this platform could have installed, and
+// a teardown path that errors would report a failure to remove something that was never
+// there.
+func (r *Resolvectl) Revert(context.Context, string) error { return nil }

--- a/internal/resolved/resolved.go
+++ b/internal/resolved/resolved.go
@@ -1,0 +1,42 @@
+// Package resolved points the host's resolver at meshp for the names meshp owns.
+//
+// Only the mesh domains, and only for the tunnel's own interface. Everything else keeps
+// using whatever the machine was already using, which is not a nicety: a resolver that
+// captured every query would break split-horizon corporate DNS on the first laptop that
+// joined, and would make meshp answerable for the user's entire name resolution — a much
+// larger promise than the one being made (ADR-0021).
+//
+// # Why only systemd-resolved
+//
+// Because it is the one mechanism with a real undo. `resolvectl revert` puts a link back
+// exactly as it was, so the agent can honour Invariant 20 — remove what we installed —
+// without keeping a copy of somebody else's configuration and hoping it is still current
+// when the time comes.
+//
+// The alternatives are shared mutable files that other software also edits.
+// /etc/resolv.conf is rewritten by NetworkManager, dhclient, containers and the user;
+// putting a line in it means either clobbering theirs or parsing and rewriting a file whose
+// format has three dialects. ADR-0021 is explicit that a host which cannot configure its
+// resolver must say so and leave the system's DNS alone rather than write a file it does not
+// know how to put back, and that is what this package does everywhere but here.
+package resolved
+
+import (
+	"context"
+	"net/netip"
+)
+
+// Configurer points a host's resolver at an address for a set of domains.
+//
+// An interface so the agent can be tested without root and without a resolver daemon, and
+// so a platform with no implementation is a nil rather than a stub that reports success
+// and configures nothing.
+type Configurer interface {
+	// Configure sends queries for these domains, on this interface, to this address.
+	// Called on every reconcile, so it must be idempotent.
+	Configure(ctx context.Context, iface string, server netip.AddrPort, domains []string) error
+
+	// Revert puts the interface back as it was. Called when a device leaves a network, and
+	// safe to call for an interface that was never configured.
+	Revert(ctx context.Context, iface string) error
+}

--- a/internal/tunnel/names.go
+++ b/internal/tunnel/names.go
@@ -1,10 +1,12 @@
 package tunnel
 
 import (
+	"context"
 	"net/netip"
 	"strings"
 
 	"github.com/meshpnet/meshp/internal/dns"
+	"github.com/meshpnet/meshp/internal/logx"
 	"github.com/meshpnet/meshp/internal/peerset"
 )
 
@@ -98,4 +100,88 @@ func suffixFrom(state *peerset.Set) string {
 		}
 	}
 	return ""
+}
+
+// SystemResolver points the host's resolver at meshp for the names meshp owns.
+//
+// An interface, and nil on any host where meshp does not know how to configure the resolver
+// and put it back afterwards. Nil means names resolve when something asks the agent directly
+// and not otherwise — which is honest, and better than editing a file this agent cannot
+// restore (ADR-0021).
+type SystemResolver interface {
+	Configure(ctx context.Context, iface string, server netip.AddrPort, domains []string) error
+	Revert(ctx context.Context, iface string) error
+}
+
+// WithSystemResolver lets this reconciler make its network's names resolve for the whole
+// machine, rather than only for something querying the agent directly.
+//
+// The address is a function because the resolver's port is the kernel's choice and is not
+// known when the reconciler is built — 53 is almost always taken, so the agent asks for any
+// port and reports what it got.
+func (r *Reconciler) WithSystemResolver(s SystemResolver, addr func() netip.AddrPort) *Reconciler {
+	r.systemResolver = s
+	r.resolverAddr = addr
+	return r
+}
+
+// applySystemResolver tells the host where to send queries for this network's names.
+//
+// After the interface exists, unlike publishing the names themselves: systemd-resolved
+// configures a *link*, so there has to be one. That is also what makes this safe to scope —
+// each membership configures its own interface and its own domain, so two networks on one
+// device do not fight over a single global setting.
+//
+// Skipped when nothing changed, like the filter and the forwarding rules. Every call is a
+// process spawn and a bus round trip, and the reconciler runs on a timer.
+func (r *Reconciler) applySystemResolver(ctx context.Context, iface string, state *peerset.Set) []string {
+	if r.systemResolver == nil || r.resolverAddr == nil {
+		return nil
+	}
+	server := r.resolverAddr()
+
+	var domains []string
+	if suffix := suffixFrom(state); suffix != "" && server.IsValid() {
+		domains = []string{suffix}
+	}
+
+	want := systemResolverState{server: server, domains: strings.Join(domains, ",")}
+	r.mu.Lock()
+	unchanged := r.lastResolver == want
+	r.mu.Unlock()
+	if unchanged {
+		return nil
+	}
+
+	var err error
+	if len(domains) == 0 {
+		// No names to route, so the link goes back as it was. Reverting rather than
+		// leaving a stale pointer: a link still aimed at this resolver after the device
+		// left the network would send it queries nothing here can answer.
+		err = r.systemResolver.Revert(ctx, iface)
+	} else {
+		err = r.systemResolver.Configure(ctx, iface, server, domains)
+	}
+	if err != nil {
+		r.log.Error("this machine's resolver was not pointed at meshp",
+			"interface", iface, "error", logx.SafeError(err),
+			"consequence", "names in this network will not resolve; addresses still work")
+		return []string{"dns"}
+	}
+
+	r.mu.Lock()
+	r.lastResolver = want
+	r.mu.Unlock()
+
+	if len(domains) > 0 {
+		r.log.Info("names in this network now resolve on this machine",
+			"interface", iface, "resolver", server.String(), "domains", strings.Join(domains, ","))
+	}
+	return nil
+}
+
+// systemResolverState is what was last asked of the host, so an unchanged ask is skipped.
+type systemResolverState struct {
+	server  netip.AddrPort
+	domains string
 }

--- a/internal/tunnel/names_test.go
+++ b/internal/tunnel/names_test.go
@@ -278,3 +278,90 @@ func resolve(t *testing.T, at netip.AddrPort, name string) string {
 	}
 	return addr.String()
 }
+
+// recordingResolver captures what was asked of the host's resolver.
+type recordingResolver struct {
+	mu         sync.Mutex
+	configured []string
+	reverted   []string
+}
+
+func (r *recordingResolver) Configure(_ context.Context, iface string, _ netip.AddrPort, domains []string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.configured = append(r.configured, iface+":"+strings.Join(domains, ","))
+	return nil
+}
+
+func (r *recordingResolver) Revert(_ context.Context, iface string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reverted = append(r.reverted, iface)
+	return nil
+}
+
+func (r *recordingResolver) counts() (int, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.configured), len(r.reverted)
+}
+
+// Leaving a network takes its names with it.
+//
+// The one thing here that keeps answering after everything else is gone. A device that left
+// and went on resolving would send somebody to a name and hand them an address it can no
+// longer reach — a confident wrong answer, which is what this whole subsystem is arranged
+// to avoid.
+func TestTeardownStopsAnsweringAndPutsTheResolverBack(t *testing.T) {
+	link := newFakeLink()
+	zones := dns.NewZones()
+	sys := &recordingResolver{}
+	addr := netip.MustParseAddrPort("127.0.0.1:5399")
+
+	r := New(link, membership(), nil, nil, nil).
+		WithNames(zones).
+		WithSystemResolver(sys, func() netip.AddrPort { return addr })
+
+	state := stateWithNames("acme.internal", labelled(bobKey, "fileserver", "100.90.0.2/32"))
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if got := zones.Lookup("fileserver.acme.internal"); got.Code != dns.RCodeSuccess {
+		t.Fatalf("setup: the name does not resolve, code %v", got.Code)
+	}
+	if configured, _ := sys.counts(); configured != 1 {
+		t.Fatalf("setup: the host resolver was configured %d times", configured)
+	}
+
+	if err := r.Teardown(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := zones.Lookup("fileserver.acme.internal"); got.Code == dns.RCodeSuccess {
+		t.Error("a network this device has left still resolves")
+	}
+	if _, reverted := sys.counts(); reverted == 0 {
+		t.Error("the host's resolver was left pointed at a network this device has left")
+	}
+}
+
+// And an unchanged ask does not spawn a process on every reconcile tick.
+func TestTheHostResolverIsNotReconfiguredForNothing(t *testing.T) {
+	link := newFakeLink()
+	sys := &recordingResolver{}
+	addr := netip.MustParseAddrPort("127.0.0.1:5399")
+
+	r := New(link, membership(), nil, nil, nil).
+		WithNames(dns.NewZones()).
+		WithSystemResolver(sys, func() netip.AddrPort { return addr })
+
+	state := stateWithNames("acme.internal", labelled(bobKey, "fileserver", "100.90.0.2/32"))
+	for range 5 {
+		if _, err := r.Apply(context.Background(), state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if configured, _ := sys.counts(); configured != 1 {
+		t.Errorf("configured the host resolver %d times over five identical passes", configured)
+	}
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -141,11 +141,23 @@ type Reconciler struct {
 	// as ambiguous from either side. Nil where nothing resolves.
 	names Names
 
+	// systemResolver points the host's own resolver at the agent for this network's names,
+	// or is nil on a host where meshp cannot configure one and put it back.
+	systemResolver SystemResolver
+
+	// resolverAddr is where the agent answers, read at call time because the port is the
+	// kernel's choice and is not known when this is built.
+	resolverAddr func() netip.AddrPort
+
 	// clock is overridable so the probe interval can be tested without waiting. Nil means
 	// the wall clock.
 	clock func() time.Time
 
 	mu sync.Mutex
+
+	// lastResolver is what was last asked of the host's resolver, so an unchanged ask does
+	// not spawn a process on every reconcile tick.
+	lastResolver systemResolverState
 
 	// lastProbe is when each group was last probed, so a group can ask to be quieter than
 	// the daemon's reconcile interval. Under mu because Apply is entered both from the
@@ -406,6 +418,15 @@ func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, e
 	}
 
 	if failed := r.applyForwarding(ctx, want.Name, state.Advertised()); failed != nil {
+		unapplied = append(unapplied, failed...)
+	}
+
+	// The host's resolver last, and after the interface exists: systemd-resolved configures
+	// a link, so there has to be one. Reported as an unapplied component rather than as a
+	// failed apply — a device with peers, policy and routes but no names is worse off than
+	// one with all four, and much better off than one that reports the whole state as
+	// failed and stops converging on the rest.
+	if failed := r.applySystemResolver(ctx, want.Name, state); failed != nil {
 		unapplied = append(unapplied, failed...)
 	}
 

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -568,6 +568,31 @@ func (r *Reconciler) applyForwarding(ctx context.Context, iface string, advertis
 func (r *Reconciler) Teardown() error {
 	name := r.membership.InterfaceName
 
+	// The names first, because they are the only thing here that keeps answering after the
+	// rest is gone. A device that left a network and went on resolving its names would send
+	// somebody to `fileserver.acme.internal` and hand them an address it can no longer
+	// reach — a confident wrong answer, which is the failure this whole subsystem is
+	// arranged to avoid.
+	if r.names != nil {
+		r.names.Forget(name)
+	}
+
+	// Then the host's resolver, explicitly, before anything that can fail. Destroying the
+	// link below does make systemd-resolved drop the link's configuration, so this is
+	// belt and braces — but only for the path where the teardown completes. Observing the
+	// interface can fail and return early, and leaving a live link pointed at a resolver
+	// that has stopped answering for this network is worse than a stale rule: every query
+	// for those names would go somewhere that no longer knows them.
+	if r.systemResolver != nil {
+		if err := r.systemResolver.Revert(context.Background(), name); err != nil {
+			r.log.Warn("could not put this machine's resolver back",
+				"interface", name, "error", logx.SafeError(err))
+		}
+		r.mu.Lock()
+		r.lastResolver = systemResolverState{}
+		r.mu.Unlock()
+	}
+
 	// The policy and the forwarding first. A ruleset outliving the interface it names would
 	// go on matching nothing while an operator reads a table meshp installed and no longer
 	// maintains — and forwarding rules that outlived it would leave the host a gateway for a


### PR DESCRIPTION
The slice that makes `ssh fileserver` work. The agent has answered names since #81; nothing told the host to ask it.

## systemd-resolved only, on purpose

Not a first step — a decision. It is the one mechanism with a **real undo**: `resolvectl revert` puts a link back exactly as it was, so the agent honours Invariant 20 without keeping a copy of somebody else's configuration and hoping it is still current when the time comes.

The alternatives are shared mutable files that NetworkManager, dhclient, containers and the user also edit. ADR-0021 is explicit that a host which cannot configure its resolver must **say so and leave the system's DNS alone** rather than write a file it cannot put back. So everywhere else: nil configurer, a warning at startup, and names that answer a direct query and nowhere else.

## The second command is the one that matters

```
resolvectl dns    meshp0 127.0.0.1:53870
resolvectl domain meshp0 ~acme.internal
```

The tilde makes it a **routing** domain, not a search domain. A search domain would have the stub append `acme.internal` to every bare name a user typed — which is exactly how a device in two networks silently reaches whichever answers first. That is the thing ADR-0021 refuses at the resolver, and it would have come straight back in through the host one layer down.

Scoped per interface, which is what makes two networks on one device safe: each membership configures its own link and its own domain rather than competing for one global setting.

Skipped when nothing changed, like the filter and the forwarding rules — every call is a process spawn and a bus round trip, and the reconciler runs on a timer. A failure is an unapplied `dns` component rather than a failed apply: a device with peers, policy and routes but no names is worse off than one with all four, and far better off than one that reports everything failed and stops converging.

## What I could not verify locally, and what CI does instead

**This is the part worth reading.** macOS cannot run any of it, and an alpine container has no `systemd-resolved` — the tests skip there. So the behaviour of these two commands against a real daemon is something **CI establishes rather than confirms**. Given the last two hours of this session, I would rather say that plainly than present it as tested.

The real test runs against the running `systemd-resolved` on a dummy link created for the purpose, in the data-plane job. There is no useful way to fake it: what is being tested is whether a specific daemon accepts a specific pair of commands and whether its undo is a real undo. A fake would assert only that `resolvectl` was invoked with the arguments the source already says it is invoked with.

It asserts the address lands, the domain lands **with its tilde**, configuring twice is idempotent, revert removes both, and reverting an unconfigured link is not an error — the teardown path calls it without knowing whether there was anything to undo.

A dummy link rather than a real interface, so a failure cannot take DNS away from the runner. CI now also asserts up front that the runner answers names with systemd-resolved, so an image that stopped shipping it is a loud failure rather than a test quietly skipping — the data-plane job already treats a skip as failure.

## The known risk

Whether systemd-resolved accepts `address:port` for a link's DNS server. The agent's resolver never gets port 53 — resolved itself usually has it — so the whole design leans on that syntax being supported.

If CI says it is not, the fallback is a dedicated loopback address on port 53 (`127.0.0.54:53`) rather than a port on `127.0.0.1`. Only `127.0.0.53` is taken.