### PR TITLE
fix(dns): a port free in one protocol is not free in the other

### DIFF
--- a/internal/dns/server.go
+++ b/internal/dns/server.go
@@ -32,6 +32,10 @@ type Server struct {
 	zones *Zones
 	log   *slog.Logger
 
+	// bindPair is a field so the retry below can be proved by a test rather than argued
+	// for. Nothing outside this package sets it.
+	bindPair func(netip.AddrPort) (*net.UDPConn, *net.TCPListener, error)
+
 	mu   sync.Mutex
 	addr netip.AddrPort
 	udp  *net.UDPConn
@@ -43,7 +47,7 @@ func NewServer(zones *Zones, log *slog.Logger) *Server {
 	if log == nil {
 		log = slog.New(slog.DiscardHandler)
 	}
-	return &Server{zones: zones, log: log}
+	return &Server{zones: zones, log: log, bindPair: bindPair}
 }
 
 // ErrNotLoopback means somebody asked this to listen where it must not.
@@ -57,28 +61,33 @@ var ErrNotLoopback = errors.New("dns: the resolver listens on loopback only")
 // that line ran before the sockets existed — so `meshp status` could truthfully report no
 // resolver on a device that was about to have one, and the end-to-end assertion guarding
 // this feature failed on a slower machine. Binding is fast and can fail; serving is neither.
-//
-// Both protocols, because DNS is both: a truncated UDP answer tells the client to retry over
-// TCP, and a client that cannot is stuck with whatever fitted in 512 bytes.
 func (s *Server) Bind(addr netip.AddrPort) error {
 	if !addr.Addr().IsLoopback() {
 		return ErrNotLoopback
 	}
 
-	udp, err := net.ListenUDP("udp", net.UDPAddrFromAddrPort(addr))
-	if err != nil {
-		return err
+	// Retried only when the kernel is the one choosing. A caller that named a port wants
+	// that port, and asking again for a port somebody else holds would fail the same way
+	// ten times and call it diligence.
+	attempts := 1
+	if addr.Port() == 0 {
+		attempts = bindAttempts
 	}
-	// The port is read back from the socket rather than from what was asked for, because
-	// a caller may ask for zero and let the kernel choose — and the chosen port is what
-	// has to be handed to the system resolver.
-	bound := udp.LocalAddr().(*net.UDPAddr).AddrPort()
 
-	tcp, err := net.ListenTCP("tcp", net.TCPAddrFromAddrPort(bound))
+	var udp *net.UDPConn
+	var tcp *net.TCPListener
+	var err error
+	for range attempts {
+		udp, tcp, err = s.bindPair(addr)
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
-		_ = udp.Close()
 		return err
 	}
+
+	bound := tcp.Addr().(*net.TCPAddr).AddrPort()
 
 	s.mu.Lock()
 	s.udp, s.tcp, s.addr = udp, tcp, bound
@@ -86,6 +95,46 @@ func (s *Server) Bind(addr netip.AddrPort) error {
 
 	s.log.Info("resolver listening", "addr", bound.String())
 	return nil
+}
+
+// bindAttempts bounds the search for a port that is free in both protocols.
+//
+// There is no call that reserves one. Asking for port zero has the kernel choose for the
+// protocol being bound, knowing nothing about the other, so the second bind can fail on the
+// number the first just succeeded with — and did: a CI run lost its resolver to `listen tcp
+// 127.0.0.1:41230: bind: address already in use` after UDP had been given 41230. Retrying is
+// the mechanism rather than a workaround, because a fresh draw is the only way to ask again.
+//
+// Ten because each attempt is two syscalls against a range of some 28,000 ports, so ten
+// consecutive collisions means the machine is out of ports and a resolver is not its problem.
+const bindAttempts = 10
+
+// bindPair takes the same port in both protocols, or neither.
+//
+// TCP chooses and UDP matches, which is the way round that makes a collision rare: every
+// outbound connection on the machine holds a TCP ephemeral port, while UDP's range is nearly
+// empty. Asking the crowded side to pick a port it knows is free, then asking the quiet side
+// for that number, is far likelier to succeed than the reverse — which is what this used to
+// do.
+//
+// Both protocols, because DNS is both: a truncated UDP answer tells the client to retry over
+// TCP, and a client that cannot is stuck with whatever fitted in 512 bytes.
+func bindPair(addr netip.AddrPort) (*net.UDPConn, *net.TCPListener, error) {
+	tcp, err := net.ListenTCP("tcp", net.TCPAddrFromAddrPort(addr))
+	if err != nil {
+		return nil, nil, err
+	}
+	// Read back from the socket rather than from what was asked for, because a caller may
+	// ask for zero and let the kernel choose — and the chosen port is both what UDP must
+	// now match and what gets handed to the system resolver.
+	bound := tcp.Addr().(*net.TCPAddr).AddrPort()
+
+	udp, err := net.ListenUDP("udp", net.UDPAddrFromAddrPort(bound))
+	if err != nil {
+		_ = tcp.Close()
+		return nil, nil, err
+	}
+	return udp, tcp, nil
 }
 
 // Serve answers queries until ctx is done, then gives the sockets back.

--- a/internal/dns/server_test.go
+++ b/internal/dns/server_test.go
@@ -316,6 +316,126 @@ func TestBindReturnsHavingBound(t *testing.T) {
 	cancel()
 }
 
+// The bug this retry exists for, reproduced from the outside.
+//
+// A port free in one protocol is not free in the other, so asking the kernel for any port
+// gets a number that the second bind can lose. CI hit it for real — `listen tcp
+// 127.0.0.1:41230: bind: address already in use` — and a device came up with no resolver
+// because of a coincidence in the ephemeral range. Losing names to that is not acceptable
+// when another draw costs two syscalls.
+func TestAPortTakenInOneProtocolCostsAnotherDrawNotTheResolver(t *testing.T) {
+	s := NewServer(twoCustomers(t), nil)
+	real := s.bindPair
+
+	collisions := 0
+	s.bindPair = func(addr netip.AddrPort) (*net.UDPConn, *net.TCPListener, error) {
+		if collisions < 3 {
+			collisions++
+			return nil, nil, errors.New("bind: address already in use")
+		}
+		return real(addr)
+	}
+
+	if err := s.Bind(netip.MustParseAddrPort("127.0.0.1:0")); err != nil {
+		t.Fatalf("three unlucky draws lost the resolver: %v", err)
+	}
+	if collisions != 3 {
+		t.Fatalf("collisions = %d, want 3 — the failures were not actually delivered", collisions)
+	}
+	if !s.Addr().IsValid() || s.Addr().Port() == 0 {
+		t.Fatal("Bind reported success without an address")
+	}
+
+	// And the socket that eventually took is a real one, in both protocols, on the port
+	// Bind reported — which is the whole point of binding them as a pair.
+	udp, err := net.Dial("udp", s.Addr().String())
+	if err != nil {
+		t.Fatalf("nothing is listening on UDP where Bind said: %v", err)
+	}
+	_ = udp.Close()
+	tcp, err := net.Dial("tcp", s.Addr().String())
+	if err != nil {
+		t.Fatalf("nothing is listening on TCP where Bind said: %v", err)
+	}
+	_ = tcp.Close()
+}
+
+// Retrying stops rather than going on forever, so a host that will not let this process bind
+// at all reports that instead of hanging.
+func TestBindGivesUp(t *testing.T) {
+	s := NewServer(twoCustomers(t), nil)
+	attempts := 0
+	wont := errors.New("operation not permitted")
+	s.bindPair = func(netip.AddrPort) (*net.UDPConn, *net.TCPListener, error) {
+		attempts++
+		return nil, nil, wont
+	}
+
+	err := s.Bind(netip.MustParseAddrPort("127.0.0.1:0"))
+	if !errors.Is(err, wont) {
+		t.Fatalf("err = %v, want the failure that actually happened", err)
+	}
+	if attempts != bindAttempts {
+		t.Errorf("attempts = %d, want %d", attempts, bindAttempts)
+	}
+	if s.Addr().IsValid() {
+		t.Error("a server that never bound reports an address")
+	}
+}
+
+// A named port is asked for once. Retrying there would be ten identical failures dressed up
+// as effort: the caller wants that port, and a fresh draw is not on offer.
+func TestANamedPortIsAskedForOnce(t *testing.T) {
+	// A real listener, so the port is genuinely taken rather than faked taken.
+	busy, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = busy.Close() }()
+	taken := busy.Addr().(*net.TCPAddr).AddrPort()
+
+	s := NewServer(twoCustomers(t), nil)
+	real := s.bindPair
+	attempts := 0
+	s.bindPair = func(addr netip.AddrPort) (*net.UDPConn, *net.TCPListener, error) {
+		attempts++
+		return real(addr)
+	}
+
+	if err := s.Bind(taken); err == nil {
+		t.Fatal("Bind claimed a port another listener holds")
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 — a named port was retried", attempts)
+	}
+}
+
+// Neither socket is left behind when the other cannot be had. A leaked listener would hold a
+// port for the life of the daemon and be invisible, since nothing has a handle on it.
+func TestAHalfBoundPairIsClosed(t *testing.T) {
+	busyUDP, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = busyUDP.Close() }()
+	port := busyUDP.LocalAddr().(*net.UDPAddr).AddrPort()
+
+	// TCP on that number is free, so bindPair takes it and then cannot have the UDP half.
+	udp, tcp, err := bindPair(port)
+	if err == nil {
+		_ = udp.Close()
+		_ = tcp.Close()
+		t.Fatal("bindPair succeeded on a port already held for UDP")
+	}
+
+	// If the TCP half had been leaked, this could not take the same port.
+	again, err := net.Listen("tcp", port.String())
+	if err != nil {
+		t.Fatalf("the TCP half was left behind: %v", err)
+	}
+	_ = again.Close()
+}
+
 // Serve on a server that never bound returns rather than blocking, so a caller that ignored
 // a Bind failure does not wait forever on a resolver it does not have.
 func TestServeWithoutBindReturns(t *testing.T) {


### PR DESCRIPTION
`main` went red at c364a00, in the integration job:

```
level=ERROR msg="no name resolution on this device"
  error="listen tcp 127.0.0.1:41230: bind: address already in use" addr=127.0.0.1:0
```

## What happened

`Bind` asked for `127.0.0.1:0`, the kernel handed out UDP port 41230, and then it *demanded* 41230 for TCP. The two ephemeral ranges are allocated independently — a port free for UDP says nothing about TCP — so the second bind can lose a number the first just won. Something on the runner already held 41230 for TCP, and the daemon came up with no resolver.

Worse, it was the wrong way round. Every outbound connection on a machine holds a TCP ephemeral port; UDP's range is nearly empty. We were asking the quiet side to choose and the crowded side to match.

This is not new to #84 — it has been there since #81. It only surfaced now because #84's e2e assertion (`grep -q '  resolver  127\.'`) is the first thing that fails when the resolver is missing. The mechanism was already broken; nothing had reached it.

## The fix

**Retry, bounded at ten.** There is no call that reserves a port in both protocols, so a fresh draw is the only way to ask again — the retry is the mechanism, not a workaround. Ten consecutive collisions across ~28,000 ports means the machine is out of ports, and a resolver is not its problem then.

**Only when the caller asked for port zero.** A named port is wanted specifically; retrying it would be ten identical failures dressed up as effort.

**TCP chooses, UDP matches.** This makes a collision rare rather than merely survivable. It is a probability improvement, though — the retry is what makes it correct.

## Verification

Four mutations, each caught:

| mutation | test that fails |
|---|---|
| retry removed | `TestAPortTakenInOneProtocolCostsAnotherDrawNotTheResolver` |
| a named port retried too | `TestANamedPortIsAskedForOnce` |
| TCP half leaked when UDP cannot be had | `TestAHalfBoundPairIsClosed` |
| `bindAttempts = 1` | `TestAPortTaken…`, `TestBindGivesUp` |

Reversing the bind order is **deliberately not covered**: it changes the odds, not the behaviour, and a test that claimed otherwise would be lying.

The binder is a `Server` field so the retry is provable rather than argued for. `TestAHalfBoundPairIsClosed` and `TestANamedPortIsAskedForOnce` use real listeners holding real ports, so the collision they test is a genuine one.