### PR TITLE
chore: ignore what an assistant derives from this repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,11 @@ CLAUDE.md
 .cursor/
 .aider*
 .continue/
+
+# Whatever an assistant derives from this repository, which is not the repository.
+# graphify writes a parsed copy of the tree — ASTs, chunk lists and a content-addressed
+# cache — and it runs to megabytes. Unanchored so it is ignored at any depth, because the
+# cache nests another graphify-out/ under .graphify/repos/<owner>/<repo>/.
+graphify-out/
+.graphify/
+.graphify_*


### PR DESCRIPTION
`graphify-out/` is 8.8M of parsed copy of this tree — ASTs, chunk lists and a content-addressed cache. It is not the project; it is derived from the project, regenerated on demand, and stale the moment anything changes.

Nothing graphify-related was ever committed, so this is prevention rather than cleanup — no `git rm --cached` needed.

Three patterns, all unanchored so they match at any depth:

| pattern | why |
|---|---|
| `graphify-out/` | the output directory |
| `.graphify/` | the skill's cache tree, which nests *another* `graphify-out/` under `.graphify/repos/<owner>/<repo>/` |
| `.graphify_*` | loose state files, for the case where one lands outside the output directory |

Verified with `git check-ignore -v` against the real 8.8M directory and against a synthesized nested cache tree, rather than trusting the patterns to be right:

```
.gitignore:44:graphify-out/   graphify-out/cache/ast/0049d862…json
.gitignore:45:.graphify/      .graphify/repos/meshpnet/meshp/graphify-out/.graphify_ast.json
.gitignore:46:.graphify_*     .graphify_stray.json
```

Placed beside `CLAUDE.md` and `.claude/`, because it is the same rule already stated there: what a particular assistant needs in order to work here is not something a contributor cloning this repository should receive.