### PR TITLE
test(dns): a name resolves on the machine holding it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,22 @@ jobs:
             || { echo "the end-to-end run never reported a kernel tunnel"; exit 1; }
           echo "the tunnel came up and was asserted"
 
+      - name: a name resolved on the machine holding it
+        run: |
+          # The one assertion that tests the feature rather than its parts. Everything else
+          # about DNS -- the wire format, the zones, resolvectl, the port -- is covered by
+          # tests that ask meshp directly, and all of them pass on a machine where no
+          # ordinary program can find these names. Silence here would mean the runner
+          # skipped it, which is how a feature ends up gated by nothing.
+          if grep -q "skipped-resolver" e2e.log; then
+            echo "the name assertions skipped, so the DNS feature gates nothing"
+            sed -n 's/.*skipped-resolver: /reason: /p' e2e.log
+            exit 1
+          fi
+          grep -q "through this host's own resolver" e2e.log \
+            || { echo "no name was resolved through the host resolver"; exit 1; }
+          sed -n 's/^  \(.* -> .*through this host.s own resolver\)/resolved: \1/p' e2e.log
+
       # Two agents at once, which the enrolment script cannot do: every device is handed
       # the interface name meshp0, so two daemons on one host fight over it. A namespace
       # each is what makes a real handshake — and therefore a real reachability report —

--- a/internal/tunnel/names.go
+++ b/internal/tunnel/names.go
@@ -132,8 +132,18 @@ func (r *Reconciler) WithSystemResolver(s SystemResolver, addr func() netip.Addr
 // each membership configures its own interface and its own domain, so two networks on one
 // device do not fight over a single global setting.
 //
-// Skipped when nothing changed, like the filter and the forwarding rules. Every call is a
-// process spawn and a bus round trip, and the reconciler runs on a timer.
+// Asked on every pass, not only when the ask changes, and that is the whole of why this
+// repairs itself. An earlier version remembered what it had already requested and skipped a
+// repeat, which made it a cache rather than a reconciler: systemd-resolved holds per-link
+// configuration in memory only, so `systemctl restart systemd-resolved` — an ordinary
+// package upgrade — drops it and nothing puts it back. Names stayed broken until the daemon
+// was restarted, while the interface, the routes and the filter all healed on this same
+// timer. Two process spawns a minute is a small price for the thing mending itself, and it
+// is what Invariant 18 asks of every other step here.
+//
+// Nothing read back: there is no cheap, stable way to ask systemd-resolved what a link is
+// currently set to, so this re-asserts rather than compares. The operation is declarative
+// and idempotent, which is what makes that safe.
 func (r *Reconciler) applySystemResolver(ctx context.Context, iface string, state *peerset.Set) []string {
 	if r.systemResolver == nil || r.resolverAddr == nil {
 		return nil
@@ -145,14 +155,6 @@ func (r *Reconciler) applySystemResolver(ctx context.Context, iface string, stat
 		domains = []string{suffix}
 	}
 
-	want := systemResolverState{server: server, domains: strings.Join(domains, ",")}
-	r.mu.Lock()
-	unchanged := r.lastResolver == want
-	r.mu.Unlock()
-	if unchanged {
-		return nil
-	}
-
 	var err error
 	if len(domains) == 0 {
 		// No names to route, so the link goes back as it was. Reverting rather than
@@ -162,26 +164,38 @@ func (r *Reconciler) applySystemResolver(ctx context.Context, iface string, stat
 	} else {
 		err = r.systemResolver.Configure(ctx, iface, server, domains)
 	}
+
+	// Said when it changes, though it is done every pass. The work is idempotent; a line a
+	// minute repeating that nothing has happened is not, and it would bury the line that
+	// matters. A failure that persists is carried by the unapplied component below, which
+	// is the channel built for a condition rather than an event.
+	got := systemResolverState{server: server, domains: strings.Join(domains, ","), failed: err != nil}
+	r.mu.Lock()
+	changed := r.announced != got
+	r.announced = got
+	r.mu.Unlock()
+
 	if err != nil {
-		r.log.Error("this machine's resolver was not pointed at meshp",
-			"interface", iface, "error", logx.SafeError(err),
-			"consequence", "names in this network will not resolve; addresses still work")
+		if changed {
+			r.log.Error("this machine's resolver was not pointed at meshp",
+				"interface", iface, "error", logx.SafeError(err),
+				"consequence", "names in this network will not resolve; addresses still work")
+		}
 		return []string{"dns"}
 	}
 
-	r.mu.Lock()
-	r.lastResolver = want
-	r.mu.Unlock()
-
-	if len(domains) > 0 {
+	if changed && len(domains) > 0 {
 		r.log.Info("names in this network now resolve on this machine",
 			"interface", iface, "resolver", server.String(), "domains", strings.Join(domains, ","))
 	}
 	return nil
 }
 
-// systemResolverState is what was last asked of the host, so an unchanged ask is skipped.
+// systemResolverState is what was last said about the host's resolver, so a line is written
+// when the situation changes and not on every pass. It records the failure as well as the
+// ask, so a recovery is announced rather than passing in silence.
 type systemResolverState struct {
 	server  netip.AddrPort
 	domains string
+	failed  bool
 }

--- a/internal/tunnel/names_test.go
+++ b/internal/tunnel/names_test.go
@@ -1,7 +1,10 @@
 package tunnel
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"log/slog"
 	"net"
 	"net/netip"
 	"slices"
@@ -284,20 +287,53 @@ type recordingResolver struct {
 	mu         sync.Mutex
 	configured []string
 	reverted   []string
+	err        error
+}
+
+// fail makes every later ask return this error, or none when nil. A host whose resolver is
+// not running is an ordinary state, not a broken test.
+func (r *recordingResolver) fail(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.err = err
 }
 
 func (r *recordingResolver) Configure(_ context.Context, iface string, _ netip.AddrPort, domains []string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.configured = append(r.configured, iface+":"+strings.Join(domains, ","))
-	return nil
+	return r.err
 }
 
 func (r *recordingResolver) Revert(_ context.Context, iface string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.reverted = append(r.reverted, iface)
-	return nil
+	return r.err
+}
+
+// recordingLogger returns a logger and a handle on what it was told, so a test can assert
+// that something was said once rather than on every pass.
+func recordingLogger() (*slog.Logger, *loggedLines) {
+	lines := &loggedLines{}
+	return slog.New(slog.NewTextHandler(lines, &slog.HandlerOptions{Level: slog.LevelDebug})), lines
+}
+
+type loggedLines struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (l *loggedLines) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.Write(p)
+}
+
+func (l *loggedLines) count(substr string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return strings.Count(l.buf.String(), substr)
 }
 
 func (r *recordingResolver) counts() (int, int) {
@@ -345,8 +381,18 @@ func TestTeardownStopsAnsweringAndPutsTheResolverBack(t *testing.T) {
 	}
 }
 
-// And an unchanged ask does not spawn a process on every reconcile tick.
-func TestTheHostResolverIsNotReconfiguredForNothing(t *testing.T) {
+// The host is asked again on every pass, because nothing here can tell when it stopped
+// listening.
+//
+// This replaces a test that asserted the opposite — that an unchanged ask was skipped — and
+// the reversal is the point. systemd-resolved keeps per-link configuration in memory only:
+// `systemctl restart systemd-resolved`, which happens on an ordinary systemd package
+// upgrade, drops it. A reconciler that remembers having asked never notices, so names stay
+// broken until the daemon restarts, while the interface, the routes and the filter all heal
+// on this same timer. There is no cheap, stable way to read back what a link is set to, so
+// re-asserting is the only mechanism available — and the operation is declarative, so it
+// costs two process spawns a minute and nothing else.
+func TestTheHostResolverIsAskedAgainOnEveryPass(t *testing.T) {
 	link := newFakeLink()
 	sys := &recordingResolver{}
 	addr := netip.MustParseAddrPort("127.0.0.1:5399")
@@ -361,7 +407,68 @@ func TestTheHostResolverIsNotReconfiguredForNothing(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if configured, _ := sys.counts(); configured != 1 {
-		t.Errorf("configured the host resolver %d times over five identical passes", configured)
+	if configured, _ := sys.counts(); configured != 5 {
+		t.Errorf("asked the host resolver %d times over five passes, want 5 — "+
+			"a pass that skips cannot repair a resolver that forgot", configured)
+	}
+}
+
+// And it does not say so five times. The work repeats; the announcement must not, or the one
+// line that matters is buried under a line a minute saying nothing happened.
+func TestASteadyResolverIsAnnouncedOnce(t *testing.T) {
+	link := newFakeLink()
+	sys := &recordingResolver{}
+	log, lines := recordingLogger()
+
+	r := New(link, membership(), nil, nil, log).
+		WithNames(dns.NewZones()).
+		WithSystemResolver(sys, func() netip.AddrPort { return netip.MustParseAddrPort("127.0.0.1:5399") })
+
+	state := stateWithNames("acme.internal", labelled(bobKey, "fileserver", "100.90.0.2/32"))
+	for range 5 {
+		if _, err := r.Apply(context.Background(), state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := lines.count("names in this network now resolve"); got != 1 {
+		t.Errorf("announced %d times over five identical passes, want 1", got)
+	}
+}
+
+// A failure that persists is logged once too, and the recovery is announced.
+//
+// The condition is carried continuously by the unapplied component instead, which is the
+// channel built for a state rather than an event. Logging it every minute would be the same
+// mistake in the other direction.
+func TestAResolverThatFailsThenRecoversSaysSoOnce(t *testing.T) {
+	link := newFakeLink()
+	sys := &recordingResolver{}
+	sys.fail(errors.New("resolved is not running"))
+	log, lines := recordingLogger()
+
+	r := New(link, membership(), nil, nil, log).
+		WithNames(dns.NewZones()).
+		WithSystemResolver(sys, func() netip.AddrPort { return netip.MustParseAddrPort("127.0.0.1:5399") })
+
+	state := stateWithNames("acme.internal", labelled(bobKey, "fileserver", "100.90.0.2/32"))
+	for range 3 {
+		unapplied, err := r.Apply(context.Background(), state)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !slices.Contains(unapplied, "dns") {
+			t.Fatal("a resolver that could not be configured was not reported as unapplied")
+		}
+	}
+	if got := lines.count("was not pointed at meshp"); got != 1 {
+		t.Errorf("logged the same failure %d times, want 1", got)
+	}
+
+	sys.fail(nil)
+	if _, err := r.Apply(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	if got := lines.count("names in this network now resolve"); got != 1 {
+		t.Errorf("a resolver that came good announced itself %d times, want 1", got)
 	}
 }

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -155,9 +155,10 @@ type Reconciler struct {
 
 	mu sync.Mutex
 
-	// lastResolver is what was last asked of the host's resolver, so an unchanged ask does
-	// not spawn a process on every reconcile tick.
-	lastResolver systemResolverState
+	// announced is what was last said about the host's resolver, so the log gets a line
+	// when that changes rather than one on every reconcile tick. The ask itself is made
+	// every pass — see applySystemResolver.
+	announced systemResolverState
 
 	// lastProbe is when each group was last probed, so a group can ask to be quieter than
 	// the daemon's reconcile interval. Under mu because Apply is entered both from the
@@ -589,7 +590,7 @@ func (r *Reconciler) Teardown() error {
 				"interface", name, "error", logx.SafeError(err))
 		}
 		r.mu.Lock()
-		r.lastResolver = systemResolverState{}
+		r.announced = systemResolverState{}
 		r.mu.Unlock()
 	}
 

--- a/scripts/e2e-enrol.sh
+++ b/scripts/e2e-enrol.sh
@@ -288,6 +288,15 @@ if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" = "0" ] && ip link add dev wgprob
   tunnel_possible=1
 fi
 
+# And whether this host has a resolver meshp knows how to configure and put back. Decided by
+# asking resolved to speak rather than by looking for the binary: a container can have
+# resolvectl installed with no daemon behind it, and the agent makes the same call for the
+# same reason (internal/resolved.New).
+resolved_possible=0
+if [ "$tunnel_possible" = "1" ] && command -v resolvectl >/dev/null 2>&1 && resolvectl status >/dev/null 2>&1; then
+  resolved_possible=1
+fi
+
 # Over TLS, and the control plane says so. A run that quietly fell back to plaintext would
 # pass every assertion below while testing the one path a real deployment must never take.
 if [ -n "${CURL_CA[*]}" ]; then
@@ -445,6 +454,89 @@ if [ "$tunnel_possible" = "1" ]; then
   ip route show dev meshp0 | grep -q "100.90.${OCTET}.2" \
     || { ip route show dev meshp0 >&2; fail "no route to the peer via the interface"; }
   echo "  route to the peer installed"
+
+  # ---------------------------------------------------------------------------
+  # A name a person could type
+  #
+  # Everything above proves the resolver is listening and the peer is configured. Neither
+  # proves the thing the feature exists for: that somebody types a name and reaches a
+  # machine. ADR-0021's chain has three links — the agent knows the name, this host's
+  # resolver is pointed at the agent for that domain, and the C library asks this host's
+  # resolver — and every one is tested on its own while the joins between them are
+  # inference. The resolver's own tests query it directly, so they would pass on a machine
+  # where nothing else in the world can find it.
+  #
+  # This is the join. getent goes through nsswitch and the resolved stub exactly as ssh or
+  # a browser does, so a break anywhere along that chain fails here and nowhere else.
+  if [ "$resolved_possible" = "1" ]; then
+    # From the database, not derived here: the label is the server's to assign (ADR-0021),
+    # and a name this script computed would be a test of this script's arithmetic. Reading
+    # it back also asserts that enrolment gave the membership a label at all.
+    peer_row="$(psql "$DB_URL" -tAqc "
+      SELECT m.dns_label || ' ' || host(m.address_v4)
+      FROM device_network_memberships m JOIN devices d ON d.id = m.device_id
+      WHERE m.network_id = '${NETWORK_ID}' AND d.name = 'e2e-second'")"
+    PEER_LABEL="${peer_row%% *}"
+    PEER_V4="${peer_row##* }"
+    [ -n "$PEER_LABEL" ] || fail "the peer's membership has no dns_label, so it cannot be named"
+    PEER_FQDN="${PEER_LABEL}.${SLUG}.internal"
+
+    # The reconciler configures resolved on its own timer, so this waits rather than
+    # assuming the last reconcile has happened.
+    pointed=0
+    for _ in $(seq 1 20); do
+      if resolvectl status meshp0 2>/dev/null | grep -q "${SLUG}.internal"; then pointed=1; break; fi
+      sleep 1
+    done
+    if [ "$pointed" != "1" ]; then
+      echo "--- resolvectl status meshp0 ---" >&2; resolvectl status meshp0 >&2 || true
+      echo "--- agent log, resolver lines ---" >&2
+      grep -iE "resolver|resolve" "$AGENT_LOG" | tail -20 >&2
+      fail "this host's resolver was never pointed at meshp for ${SLUG}.internal"
+    fi
+    echo "  resolved routes ${SLUG}.internal to meshp"
+
+    # Negative caching is real: anything that asked for this name before the link was
+    # configured left a failure behind that outlives the fix.
+    resolvectl flush-caches 2>/dev/null || true
+
+    resolved_name=0
+    for _ in $(seq 1 15); do
+      if getent ahostsv4 "$PEER_FQDN" >"$WORK/getent.out" 2>&1; then resolved_name=1; break; fi
+      sleep 1
+    done
+    if [ "$resolved_name" != "1" ]; then
+      echo "--- getent ---" >&2; cat "$WORK/getent.out" >&2
+      echo "--- resolvectl status meshp0 ---" >&2; resolvectl status meshp0 >&2 || true
+      echo "--- resolvectl query ---" >&2; resolvectl query "$PEER_FQDN" >&2 2>&1 || true
+      # Which link in the chain broke. If resolvectl can answer and getent cannot, this
+      # host's C library is not asking resolved at all — /etc/resolv.conf points somewhere
+      # other than the stub — and no amount of configuring a link would have helped.
+      echo "--- /etc/resolv.conf ---" >&2; cat /etc/resolv.conf >&2 2>&1 || true
+      echo "--- nsswitch hosts ---" >&2; grep '^hosts:' /etc/nsswitch.conf >&2 2>&1 || true
+      echo "--- agent log, resolver lines ---" >&2
+      grep -iE "resolver|resolve|names" "$AGENT_LOG" | tail -20 >&2
+      fail "a name this device holds does not resolve on the machine holding it: ${PEER_FQDN}"
+    fi
+    # The right machine, not merely an answer. A resolver that replied with anything at all
+    # would pass the check above.
+    grep -q "^${PEER_V4}\b" "$WORK/getent.out" \
+      || { cat "$WORK/getent.out" >&2; fail "${PEER_FQDN} resolved, but not to ${PEER_V4}"; }
+    echo "  ${PEER_FQDN} -> ${PEER_V4}, through this host's own resolver"
+
+    # And only that domain. A resolver handed every query would break split-horizon
+    # corporate DNS on the first laptop that joined, which is why the domain is installed
+    # as a routing domain rather than a search domain.
+    if getent ahostsv4 "${PEER_LABEL}.not-a-meshp-network.internal" >"$WORK/getent-foreign.out" 2>&1; then
+      if grep -qE "^100\.90\." "$WORK/getent-foreign.out"; then
+        cat "$WORK/getent-foreign.out" >&2
+        fail "a name outside this network's domain was answered from the mesh"
+      fi
+    fi
+    echo "  a name outside the network's domain is not answered from the mesh"
+  else
+    echo "  skipped-resolver: this host has no systemd-resolved to configure"
+  fi
 
   # ---------------------------------------------------------------------------
   # The relay


### PR DESCRIPTION
Every part of ADR-0021 was tested and the feature was not. The wire format, the zones, the label rules, `resolvectl` and the bound port each have tests that ask meshp directly — **all of which pass on a host where no ordinary program can find these names.** The join between "meshp answers" and "a person types a name" was inference.

## The test

`e2e-enrol.sh` already runs a real daemon, a real kernel tunnel and a real peer in the **host** network namespace. That last part is why it goes here and not in `e2e-failover.sh`: `resolvectl` configures a link through the host's `systemd-resolved` over D-Bus, so an interface inside `ip netns` is invisible to it. My earlier suggestion of the failover script was wrong for that reason.

```
resolved routes e2e-1234.internal to meshp
e2e-second.e2e-1234.internal -> 100.90.7.2, through this host's own resolver
a name outside the network's domain is not answered from the mesh
```

- The label and address are **read back from the database**, not computed in the script — the label is the server's to assign (ADR-0021), and a name this script derived would be testing its own arithmetic. It also asserts enrolment gave the membership a label at all.
- `getent` goes through nsswitch and the resolved stub exactly as `ssh` does, so a break anywhere along the chain fails here.
- The negative matters as much: a name outside the network's domain must not be answered from the mesh. That is what a *routing* domain buys, and getting it wrong breaks split-horizon corporate DNS on the first laptop that joins.
- A CI step fails if the assertion skipped, following the existing "the tunnel assertions were not skipped" precedent. A feature gated by a step that quietly no-ops is gated by nothing.

## What writing it exposed

`applySystemResolver` remembered what it had already asked of the host and skipped a repeat — a cache, not a reconciler.

systemd-resolved holds per-link configuration **in memory only**. `systemctl restart systemd-resolved`, which happens on an ordinary systemd package upgrade, drops it. Nothing put it back: names stayed broken until meshpd restarted, while the interface, the routes and the filter all healed on that same timer. That is Invariant 18 holding everywhere except here.

There is no cheap, stable way to read back what a link is currently set to, so it re-asserts every pass rather than comparing. The operation is declarative and the default reconcile interval is a minute, so the cost is two process spawns a minute.

**The announcement is what is now conditional, not the work** — a line when the situation changes, rather than one a minute saying nothing happened. The persistent condition is carried by the `dns` unapplied component instead, which is the channel built for a state rather than an event. A recovery is announced, so a failure that came good is not silent.

## Verification

`TestTheHostResolverIsNotReconfiguredForNothing` asserted the old behaviour and is replaced by `TestTheHostResolverIsAskedAgainOnEveryPass`. The reversal is deliberate: that test was protecting two process spawns a minute at the cost of the feature repairing itself.

| mutation | test that fails |
|---|---|
| restore the cache | `TestTheHostResolverIsAskedAgainOnEveryPass` |
| announce every pass | `TestASteadyResolverIsAnnouncedOnce` |
| log the error every pass | `TestAResolverThatFailsThenRecoversSaysSoOnce` |
| don't record the failure, so recovery is silent | `TestAResolverThatFailsThenRecoversSaysSoOnce` |

The e2e run exercises the repair for real, incidentally: the second daemon in that script is handed the same interface name, points resolved at *its* port, and is then killed without a teardown. Under the old code the first daemon would never have taken the link back.

**This is the first CI run that exercises the whole chain**, so it is the run that matters. If `getent` fails where `resolvectl query` succeeds, the failure dump includes `/etc/resolv.conf` and the `hosts:` line, which distinguishes "meshp is not configured" from "this host's C library never asks resolved".