### PR TITLE
feat(nftables): two customers on the same prefix, told apart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,6 +517,21 @@ jobs:
           sudo modprobe dummy || true
           echo "systemd-resolved is answering here"
 
+      # Docker is installed on this runner and sets the forward policy to DROP. A drop in one
+      # table wins over an accept in another, so meshp's forwarding chain cannot undo it and
+      # the packet tests below measure the runner image rather than meshp.
+      #
+      # Set here rather than worked around in the tests, because the tests are right: they
+      # prove the ruleset carries a packet when nothing else is refusing it. That another
+      # tool can silently defeat meshp's forwarding is a real defect in meshp and is filed
+      # separately -- it is not something this job should paper over quietly, which is why
+      # the previous policy is printed.
+      - name: nothing else on this runner is dropping forwarded packets
+        run: |
+          echo "before: $(sudo iptables -L FORWARD -n | head -1)"
+          sudo iptables -P FORWARD ACCEPT
+          echo "after:  $(sudo iptables -L FORWARD -n | head -1)"
+
       # nftables joins them for the reason the others are here, and it arrives late: this
       # package has held real-packet tests since the forwarding work — a packet crossing into
       # a carried LAN, and stopping when the group is withdrawn — and none of them has ever

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,7 +493,10 @@ jobs:
           sudo ip link del dev wgprobe
           echo "this runner can create WireGuard interfaces"
 
-      - run: sudo apt-get install -y --no-install-recommends wireguard-tools
+      # netcat-openbsd is what the mapping tests listen with: proving two customers on the
+      # same prefix are distinguishable needs a service on each of them, and ping cannot say
+      # which machine answered.
+      - run: sudo apt-get install -y --no-install-recommends wireguard-tools nftables netcat-openbsd
 
       # Creating interfaces and entering namespaces both need root, so these tests skip
       # rather than fail without it — which means an unprivileged run would report success
@@ -514,10 +517,16 @@ jobs:
           sudo modprobe dummy || true
           echo "systemd-resolved is answering here"
 
-      - name: interfaces, routes, teardown, a packet across the tunnel, a bound probe, and the host resolver
+      # nftables joins them for the reason the others are here, and it arrives late: this
+      # package has held real-packet tests since the forwarding work — a packet crossing into
+      # a carried LAN, and stopping when the group is withdrawn — and none of them has ever
+      # run in CI. They need root, so the unprivileged test job skips them, and this job did
+      # not name the package. They gated nothing. Adding it also gates the mapping tests,
+      # which are the only place two customers on 192.168.1.0/24 are proven distinguishable.
+      - name: interfaces, routes, teardown, a packet across the tunnel, a bound probe, the host resolver, and two customers on one prefix
         run: |
           set -o pipefail
-          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/pathprobe/ ./internal/resolved/ -count=1 -v 2>&1 | tee dataplane.log
+          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/pathprobe/ ./internal/resolved/ ./internal/nftables/ -count=1 -v 2>&1 | tee dataplane.log
         continue-on-error: false
 
       - name: report, and refuse a silent skip

--- a/internal/nftables/mapping.go
+++ b/internal/nftables/mapping.go
@@ -1,0 +1,175 @@
+package nftables
+
+import (
+	"fmt"
+	"net/netip"
+	"sort"
+	"strings"
+)
+
+// MapTableName is the table that makes two customers on the same prefix distinguishable.
+//
+// Its own table, like the lock and the forwarding rules, and rebuilt on its own trigger: the
+// mappings change when a device's memberships change, which is a different event from a
+// policy update or a route group moving between advertisers.
+const MapTableName = "meshp_map"
+
+// Mapping is one colliding prefix and the range this device reaches it by.
+//
+// Both halves are the same size. A /24 is mapped to a /24 and the host part is carried
+// across unchanged, so 100.71.5.5 is 192.168.1.5 at the other end — which is what makes the
+// translation stateless, and what makes a packet capture on the advertiser legible to
+// somebody who knows the mapping.
+type Mapping struct {
+	// Mapped is what the routing table holds and what a person types. Allocated by the
+	// control plane, which is the only party that can see both memberships (ADR-0020).
+	Mapped netip.Prefix
+
+	// Real is what the customer actually uses, and what crosses the tunnel.
+	Real netip.Prefix
+}
+
+// RenderMap turns a device's mappings into a ruleset that performs them.
+//
+// Two rewrites per mapping, both stateless, both scoped to one interface.
+//
+// A raw header rewrite, not a conntrack DNAT, and that is the decision this rests on. DNAT
+// re-routes after rewriting, which would send the kernel back to a routing table holding two
+// identical prefixes — the ambiguity this exists to resolve. It also keeps per-connection
+// state, and ADR-0020 refuses to put any of that on the path: an entry that expires, or a
+// daemon that restarts, drops established connections. These rules are pure arithmetic, so a
+// packet arriving after any interruption is translated exactly as the one before it was.
+//
+// Postrouting rather than output, which is the weaker of the two choices and worth saying so.
+// For locally-generated traffic the routing decision is already made by the time either hook
+// runs, so a raw rewrite in output would behave identically — a mutation moving it there
+// passes every test here. Postrouting is kept because it is also traversed by forwarded
+// packets, so it stays correct if this device ever carries a mapped range on behalf of
+// something behind it, which output would not.
+//
+// Inbound is the mirror, and it has to exist: the customer's server replies to the source it
+// saw, so the reply arrives from 192.168.1.5 to a technician whose socket is connected to
+// 100.71.5.5. Rewriting the source back on the way in closes that loop.
+//
+// The source address is never touched in either direction. ADR-0007 enforces ACLs at the
+// destination against the identity of the device reaching it, and a rewritten source would
+// hand every server in every customer's network one address for the whole MSP.
+//
+// No mappings renders a script that removes the table, so a device that stopped colliding
+// stops translating (Invariant 20).
+func RenderMap(iface string, mappings []Mapping) (string, error) {
+	if !interfaceNamePattern.MatchString(iface) {
+		return "", fmt.Errorf("nftables: %q is not a usable interface name", iface)
+	}
+
+	var b strings.Builder
+	// add-then-delete so removal is idempotent, as everywhere else here: deleting a table
+	// that is not there is an error, and adding one that is already there is not.
+	fmt.Fprintf(&b, "add table inet %s\n", MapTableName)
+	fmt.Fprintf(&b, "delete table inet %s\n", MapTableName)
+	if len(mappings) == 0 {
+		return b.String(), nil
+	}
+
+	ordered, err := validMappings(mappings)
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Fprintf(&b, "add table inet %s\n", MapTableName)
+	// Priority mangle on the way out, and -300 on the way in, so both run before anything
+	// that inspects addresses. The filter chain's rules are written in terms of the real
+	// mesh addresses on the wire, and the forwarding chain's in terms of carried prefixes;
+	// translating outside them keeps every other table reading the address it expects.
+	fmt.Fprintf(&b, "add chain inet %s outbound { type filter hook postrouting priority mangle; policy accept; }\n",
+		MapTableName)
+	fmt.Fprintf(&b, "add chain inet %s inbound { type filter hook prerouting priority -300; policy accept; }\n",
+		MapTableName)
+
+	for _, m := range ordered {
+		host := hostWildcard(m.Mapped)
+		fmt.Fprintf(&b, "add rule inet %s outbound oifname \"%s\" %s daddr %s %s daddr set %s daddr & %s | %s\n",
+			MapTableName, iface, family(m.Mapped), m.Mapped,
+			family(m.Mapped), family(m.Mapped), host, m.Real.Masked().Addr())
+		fmt.Fprintf(&b, "add rule inet %s inbound iifname \"%s\" %s saddr %s %s saddr set %s saddr & %s | %s\n",
+			MapTableName, iface, family(m.Real), m.Real,
+			family(m.Real), family(m.Real), host, m.Mapped.Masked().Addr())
+	}
+	return b.String(), nil
+}
+
+// validMappings checks what cannot be expressed, and sorts what can.
+//
+// Refusing rather than rendering something approximate: a mapping that is wrong sends a
+// technician to the wrong customer's machine, which is the exact failure the refusal in
+// PR #70 exists to avoid. Better to carry neither prefix and say so.
+func validMappings(mappings []Mapping) ([]Mapping, error) {
+	seen := make(map[netip.Prefix]bool, len(mappings))
+	out := make([]Mapping, 0, len(mappings))
+
+	for _, m := range mappings {
+		if !m.Mapped.IsValid() || !m.Real.IsValid() {
+			return nil, fmt.Errorf("nftables: a mapping is missing one of its halves: %v -> %v", m.Mapped, m.Real)
+		}
+		if m.Mapped.Addr().Is4() != m.Real.Addr().Is4() {
+			return nil, fmt.Errorf("nftables: %v and %v are different families", m.Mapped, m.Real)
+		}
+		if m.Mapped.Bits() != m.Real.Bits() {
+			// The host part is carried across unchanged, so the two halves must hold the
+			// same number of hosts. Mapping a /24 onto a /25 would silently drop half the
+			// customer's network.
+			return nil, fmt.Errorf("nftables: %v and %v are different sizes; a mapping carries the host part across",
+				m.Mapped, m.Real)
+		}
+		if m.Mapped.Masked() != m.Mapped || m.Real.Masked() != m.Real {
+			// A prefix with host bits set means the caller is describing something other
+			// than a network, and the arithmetic below would quietly ignore them.
+			return nil, fmt.Errorf("nftables: %v -> %v has bits set below the prefix", m.Mapped, m.Real)
+		}
+		if seen[m.Mapped] {
+			// Two rules matching the same mapped range would fire in file order, so the
+			// second is unreachable and the caller believes something that is not true.
+			return nil, fmt.Errorf("nftables: %v is mapped twice", m.Mapped)
+		}
+		seen[m.Mapped] = true
+		out = append(out, m)
+	}
+
+	// Sorted so the same set of mappings renders the same script every time. An unstable
+	// order would reinstall the ruleset on every reconcile and look like churn.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Mapped.Addr() != out[j].Mapped.Addr() {
+			return out[i].Mapped.Addr().Less(out[j].Mapped.Addr())
+		}
+		return out[i].Mapped.Bits() < out[j].Mapped.Bits()
+	})
+	return out, nil
+}
+
+// family is the nftables keyword for the address family, in an inet table where both live.
+func family(p netip.Prefix) string {
+	if p.Addr().Is4() {
+		return "ip"
+	}
+	return "ip6"
+}
+
+// hostWildcard is the mask that keeps the host part and discards the network.
+//
+// The complement of the prefix mask: for a /24 it is 0.0.0.255, and for a /25 it is
+// 0.0.0.127 — which is why this is computed rather than written per byte. A prefix that does
+// not fall on a byte boundary is ordinary in a customer's network and gets the same treatment
+// as one that does.
+func hostWildcard(p netip.Prefix) netip.Addr {
+	// Built at the address's own width, so an IPv4 mask renders as 0.0.0.255 rather than
+	// the IPv4-in-IPv6 form nft would not accept.
+	octets := make([]byte, p.Addr().BitLen()/8)
+	for i := range octets {
+		octets[i] = 0xff
+	}
+	for i := range p.Bits() {
+		octets[i/8] &^= 1 << (7 - i%8)
+	}
+	addr, _ := netip.AddrFromSlice(octets)
+	return addr
+}

--- a/internal/nftables/mapping_linux_test.go
+++ b/internal/nftables/mapping_linux_test.go
@@ -1,0 +1,259 @@
+//go:build linux
+
+package nftables
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The claim ADR-0004 has made since the beginning and that has never been true: one device,
+// two customers, both using 192.168.1.0/24, and reaching one of them does not reach the
+// other.
+//
+// Real interfaces, real namespaces, real packets. Every part of this can be made to pass by
+// a renderer that produces plausible text — the crossover checks are the ones that cannot,
+// because they require the two identical prefixes to actually be distinguishable.
+//
+// The topology is the smallest one that can be wrong:
+//
+//	custA (192.168.1.5) --vethA-- [this namespace] --vethB-- custB (192.168.1.5)
+func TestTwoCustomersOnTheSamePrefixAreBothReachable(t *testing.T) {
+	requireMapRoot(t)
+	requireNFT(t)
+
+	const (
+		mappedA    = "100.71.5.0/24"
+		mappedB    = "100.71.6.0/24"
+		custPrefix = "192.168.1.0/24"
+	)
+	nsA := namespace(t, "mpmapa", "vethA", "inA", "192.168.1.5/24", "100.71.5.1/32")
+	nsB := namespace(t, "mpmapb", "vethB", "inB", "192.168.1.5/24", "100.71.6.1/32")
+
+	// The routing table holds the mapped prefixes, which are distinct, so there is nothing
+	// for the kernel to contest. This is the whole of ADR-0020's third point.
+	mapRun(t, "ip", "route", "add", mappedA, "dev", "vethA", "src", "100.71.5.1")
+	mapRun(t, "ip", "route", "add", mappedB, "dev", "vethB", "src", "100.71.6.1")
+
+	// Before the rules, so a pass below means the rules did it. Without this the test would
+	// still pass if translation silently never happened and the addresses were reachable
+	// some other way.
+	if reachable("100.71.5.5:9001") {
+		t.Fatal("setup: the mapped address answers before anything was mapped")
+	}
+
+	for _, spec := range []struct{ iface, mapped string }{{"vethA", mappedA}, {"vethB", mappedB}} {
+		script, err := RenderMap(spec.iface, []Mapping{{
+			Mapped: netip.MustParsePrefix(spec.mapped),
+			Real:   netip.MustParsePrefix(custPrefix),
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// One table for the device, so the second interface must not remove the first's
+		// rules. RenderMap rebuilds the table, which is why each interface is applied into
+		// its own table name here -- see the note in the failure below.
+		applyInto(t, spec.iface, script)
+	}
+
+	listen(t, nsA, "192.168.1.5", 9001)
+	listen(t, nsB, "192.168.1.5", 9002)
+	time.Sleep(300 * time.Millisecond)
+
+	// Each customer is reachable at its own mapped address.
+	if !reachable("100.71.5.5:9001") {
+		t.Error("customer A is not reachable at its mapped address")
+	}
+	if !reachable("100.71.6.5:9002") {
+		t.Error("customer B is not reachable at its mapped address")
+	}
+
+	// And this is the assertion the feature exists for. If the two prefixes were not really
+	// disambiguated, one of these would open: both customers listen on 192.168.1.5, so a
+	// packet that went to the wrong interface would still find a machine at that address --
+	// just the wrong one, on a port it does not serve.
+	if reachable("100.71.5.5:9002") {
+		t.Error("customer B's port answered at customer A's mapped address: the prefixes are not disambiguated")
+	}
+	if reachable("100.71.6.5:9001") {
+		t.Error("customer A's port answered at customer B's mapped address: the prefixes are not disambiguated")
+	}
+}
+
+// The source arrives unmodified, which is what ADR-0007 runs on.
+//
+// The ACL check is inbound, at the destination, against the identity of the device reaching
+// it. A translation that rewrote the source would hand every server in every customer's
+// network one address for the whole MSP, and flatten every audit log to that address. This
+// is asserted separately because a mapping that breaks it still passes every reachability
+// check above.
+func TestTheCustomerSeesTheRealSource(t *testing.T) {
+	requireMapRoot(t)
+	requireNFT(t)
+
+	ns := namespace(t, "mpmapsrc", "vethS", "inS", "192.168.1.5/24", "100.71.5.1/32")
+	mapRun(t, "ip", "route", "add", "100.71.5.0/24", "dev", "vethS", "src", "100.71.5.1")
+
+	script, err := RenderMap("vethS", []Mapping{{
+		Mapped: netip.MustParsePrefix("100.71.5.0/24"),
+		Real:   netip.MustParsePrefix("192.168.1.0/24"),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	applyInto(t, "vethS", script)
+
+	listen(t, ns, "192.168.1.5", 9101)
+	time.Sleep(300 * time.Millisecond)
+
+	// Read from the customer's side: what address did the connection appear to come from?
+	seen := connectAndReadPeer(t, ns, "100.71.5.5:9101", 9101)
+	if seen == "" {
+		t.Fatal("the customer never saw a connection")
+	}
+	if seen != "100.71.5.1" {
+		t.Errorf("the customer saw the connection from %s, want 100.71.5.1 -- the source was rewritten", seen)
+	}
+}
+
+// A prefix that does not fall on a byte boundary is ordinary in a customer's network, and the
+// mask arithmetic is where that goes wrong. A /25 keeps seven host bits, so 100.71.7.130 must
+// become 192.168.2.130 and not 192.168.2.2.
+func TestAPrefixOffAByteBoundaryIsMappedCorrectly(t *testing.T) {
+	requireMapRoot(t)
+	requireNFT(t)
+
+	ns := namespace(t, "mpmap25", "veth25", "in25", "192.168.2.130/25", "100.71.7.129/32")
+	mapRun(t, "ip", "route", "add", "100.71.7.128/25", "dev", "veth25", "src", "100.71.7.129")
+
+	script, err := RenderMap("veth25", []Mapping{{
+		Mapped: netip.MustParsePrefix("100.71.7.128/25"),
+		Real:   netip.MustParsePrefix("192.168.2.128/25"),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	applyInto(t, "veth25", script)
+
+	listen(t, ns, "192.168.2.130", 9201)
+	time.Sleep(300 * time.Millisecond)
+
+	if !reachable("100.71.7.130:9201") {
+		t.Error("a /25 mapping did not carry the host part across")
+	}
+}
+
+// --- helpers ---------------------------------------------------------------------------
+
+func requireMapRoot(t *testing.T) {
+	t.Helper()
+	if out, err := exec.Command("id", "-u").Output(); err != nil || string(out) != "0\n" {
+		t.Skip("needs root")
+	}
+}
+
+func mapRun(t *testing.T, args ...string) {
+	t.Helper()
+	out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("%v: %v\n%s", args, err, out)
+	}
+}
+
+// namespace builds one customer: a namespace holding an address, and a veth to reach it by.
+func namespace(t *testing.T, name, outer, inner, custAddr, ourAddr string) string {
+	t.Helper()
+	_ = exec.Command("ip", "netns", "del", name).Run()
+	mapRun(t, "ip", "netns", "add", name)
+	t.Cleanup(func() { _ = exec.Command("ip", "netns", "del", name).Run() })
+
+	mapRun(t, "ip", "link", "add", outer, "type", "veth", "peer", "name", inner)
+	t.Cleanup(func() { _ = exec.Command("ip", "link", "del", outer).Run() })
+	mapRun(t, "ip", "link", "set", inner, "netns", name)
+
+	mapRun(t, "ip", "netns", "exec", name, "ip", "addr", "add", custAddr, "dev", inner)
+	mapRun(t, "ip", "netns", "exec", name, "ip", "link", "set", inner, "up")
+	mapRun(t, "ip", "netns", "exec", name, "ip", "link", "set", "lo", "up")
+
+	// This side never holds an address inside the customer's prefix. It cannot hold one on
+	// two interfaces at once, and never needing to is the point of the mapping.
+	mapRun(t, "ip", "addr", "add", ourAddr, "dev", outer)
+	mapRun(t, "ip", "link", "set", outer, "up")
+
+	// The customer needs a route back to the address it will see as the source.
+	ourIP, _, _ := net.ParseCIDR(ourAddr)
+	mapRun(t, "ip", "netns", "exec", name, "ip", "route", "add", ourIP.String()+"/32", "dev", inner)
+	return name
+}
+
+// applyInto installs one interface's rules under a table of its own.
+//
+// RenderMap rebuilds MapTableName, so two interfaces rendered into the same table would have
+// the second erase the first. That is correct for production, where one call carries every
+// mapping the device holds, and wrong for this test, which renders per interface to keep each
+// case readable. Rewriting the table name is the smaller distortion.
+func applyInto(t *testing.T, iface, script string) {
+	t.Helper()
+	table := MapTableName + "_" + iface
+	renamed := strings.ReplaceAll(script, MapTableName, table)
+	t.Cleanup(func() {
+		_ = exec.Command("nft", "delete", "table", "inet", table).Run()
+	})
+	cmd := exec.Command("nft", "-f", "-")
+	cmd.Stdin = strings.NewReader(renamed)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("nft rejected the ruleset: %v\n%s\n%s", err, out, renamed)
+	}
+}
+
+func listen(t *testing.T, ns, addr string, port int) {
+	t.Helper()
+	cmd := exec.Command("ip", "netns", "exec", ns, "nc", "-l", "-k", "-s", addr, "-p", fmt.Sprint(port))
+	if err := cmd.Start(); err != nil {
+		t.Skipf("needs nc: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
+}
+
+func reachable(hostport string) bool {
+	c, err := net.DialTimeout("tcp", hostport, 2*time.Second)
+	if err != nil {
+		return false
+	}
+	_ = c.Close()
+	return true
+}
+
+// connectAndReadPeer opens a connection and asks the customer's side who it came from.
+func connectAndReadPeer(t *testing.T, ns, hostport string, port int) string {
+	t.Helper()
+	// ss inside the namespace reports the peer of the established connection, which is the
+	// source address as the customer's kernel sees it -- not as this side believes it sent.
+	c, err := net.DialTimeout("tcp", hostport, 3*time.Second)
+	if err != nil {
+		t.Fatalf("could not connect: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+	time.Sleep(300 * time.Millisecond)
+
+	out, err := exec.Command("ip", "netns", "exec", ns, "ss", "-Htn", "state", "established",
+		"sport", fmt.Sprintf("= :%d", port)).Output()
+	if err != nil {
+		t.Skipf("needs ss: %v", err)
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		return ""
+	}
+	// The peer address is the last column; strip the port.
+	peer := fields[len(fields)-1]
+	if i := strings.LastIndexByte(peer, ':'); i >= 0 {
+		return peer[:i]
+	}
+	return peer
+}

--- a/internal/nftables/mapping_test.go
+++ b/internal/nftables/mapping_test.go
@@ -1,0 +1,174 @@
+package nftables
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+func mapping(mapped, real string) Mapping {
+	return Mapping{Mapped: netip.MustParsePrefix(mapped), Real: netip.MustParsePrefix(real)}
+}
+
+func renderMap(t *testing.T, iface string, mappings ...Mapping) string {
+	t.Helper()
+	out, err := RenderMap(iface, mappings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// The mask is the arithmetic, and getting it wrong sends a technician to the wrong host
+// inside the right customer — which is worse than sending them nowhere, because it works.
+func TestTheHostPartIsCarriedAcross(t *testing.T) {
+	for _, tc := range []struct{ mapped, real, wildcard string }{
+		{"100.71.5.0/24", "192.168.1.0/24", "0.0.0.255"},
+		{"100.71.0.0/16", "10.4.0.0/16", "0.0.255.255"},
+		{"100.71.7.128/25", "192.168.2.128/25", "0.0.0.127"},
+		{"100.71.8.0/30", "172.16.9.0/30", "0.0.0.3"},
+	} {
+		got := renderMap(t, "meshp0", mapping(tc.mapped, tc.real))
+		if !strings.Contains(got, "& "+tc.wildcard+" |") {
+			t.Errorf("%s -> %s used no %s mask:\n%s", tc.mapped, tc.real, tc.wildcard, got)
+		}
+	}
+}
+
+// Both directions, or the reply never gets home. The customer answers the source it saw, so
+// something has to turn 192.168.1.5 back into the address the technician's socket knows.
+func TestBothDirectionsAreRewritten(t *testing.T) {
+	got := renderMap(t, "meshp0", mapping("100.71.5.0/24", "192.168.1.0/24"))
+
+	if !strings.Contains(got, `oifname "meshp0" ip daddr 100.71.5.0/24 ip daddr set`) {
+		t.Errorf("nothing rewrites the destination on the way out:\n%s", got)
+	}
+	if !strings.Contains(got, `iifname "meshp0" ip saddr 192.168.1.0/24 ip saddr set`) {
+		t.Errorf("nothing rewrites the source on the way back:\n%s", got)
+	}
+}
+
+// The source is never touched. ADR-0007 enforces ACLs at the destination against the identity
+// of the device reaching it, and rewriting the source would hand every customer's server one
+// address for the entire MSP.
+func TestTheSourceIsNeverRewrittenOnTheWayOut(t *testing.T) {
+	got := renderMap(t, "meshp0", mapping("100.71.5.0/24", "192.168.1.0/24"))
+
+	for _, line := range strings.Split(got, "\n") {
+		if strings.Contains(line, "oifname") && strings.Contains(line, "saddr set") {
+			t.Errorf("an outbound rule rewrites the source: %s", line)
+		}
+	}
+}
+
+// No connection tracking, which is the choice the design actually rests on.
+//
+// A conntrack DNAT would re-route after rewriting, against a table holding two identical
+// prefixes, and would keep per-connection state that an expiry or a daemon restart drops
+// underneath an established connection. Raw arithmetic has neither problem.
+func TestTranslationDoesNotTrackConnections(t *testing.T) {
+	got := renderMap(t, "meshp0", mapping("100.71.5.0/24", "192.168.1.0/24"))
+
+	for _, banned := range []string{"dnat", "snat", "masquerade", "ct "} {
+		if strings.Contains(got, banned) {
+			t.Errorf("the ruleset uses %q, which puts per-connection state on the path:\n%s", banned, got)
+		}
+	}
+}
+
+// The hook, asserted for what it is: a convention with one real property behind it.
+//
+// This is deliberately a weaker claim than it looks. For locally-generated traffic the route
+// is already chosen before either hook runs, so a raw rewrite in output behaves identically —
+// a mutation moving it there passes every real-packet test in this package. Postrouting earns
+// its place only because forwarded packets traverse it and never reach output.
+func TestTheOutboundRewriteIsInPostrouting(t *testing.T) {
+	got := renderMap(t, "meshp0", mapping("100.71.5.0/24", "192.168.1.0/24"))
+
+	if !strings.Contains(got, "hook postrouting") {
+		t.Errorf("the outbound rewrite is not in postrouting:\n%s", got)
+	}
+}
+
+// Nothing to map means nothing installed, which is Invariant 20: a device that stopped
+// colliding stops translating rather than keeping a rewrite nobody asked for.
+func TestNoMappingsRemovesTheTable(t *testing.T) {
+	got := renderMap(t, "meshp0")
+
+	if !strings.Contains(got, "delete table inet "+MapTableName) {
+		t.Errorf("an empty mapping set does not remove the table:\n%s", got)
+	}
+	if strings.Contains(got, "add rule") {
+		t.Errorf("an empty mapping set still installed rules:\n%s", got)
+	}
+}
+
+// Refused rather than approximated. Every one of these would produce a ruleset that
+// translates something, and translating the wrong thing is how a technician reaches a machine
+// they did not mean to touch.
+func TestAMappingThatCannotBeExpressedIsRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		m    Mapping
+	}{
+		{"different sizes", mapping("100.71.5.0/24", "192.168.1.0/25")},
+		{"different families", mapping("100.71.5.0/24", "fd00::/24")},
+		{"host bits set in the mapped half", mapping("100.71.5.7/24", "192.168.1.0/24")},
+		{"host bits set in the real half", mapping("100.71.5.0/24", "192.168.1.9/24")},
+		{"a half that is missing", Mapping{Mapped: netip.MustParsePrefix("100.71.5.0/24")}},
+	} {
+		if _, err := RenderMap("meshp0", []Mapping{tc.m}); err == nil {
+			t.Errorf("%s was accepted", tc.name)
+		}
+	}
+}
+
+// Two rules for the same mapped range would fire in file order, so the second never runs and
+// whoever wrote it believes something untrue.
+func TestTheSameMappedRangeTwiceIsRefused(t *testing.T) {
+	_, err := RenderMap("meshp0", []Mapping{
+		mapping("100.71.5.0/24", "192.168.1.0/24"),
+		mapping("100.71.5.0/24", "10.0.0.0/24"),
+	})
+	if err == nil {
+		t.Error("the same mapped range was accepted twice")
+	}
+}
+
+// A stable order, so an unchanged set of mappings renders an unchanged script. Otherwise the
+// reconciler reinstalls the ruleset every pass and it reads as churn.
+func TestTheSameMappingsRenderTheSameScript(t *testing.T) {
+	forward := renderMap(t, "meshp0",
+		mapping("100.71.5.0/24", "192.168.1.0/24"),
+		mapping("100.71.6.0/24", "192.168.1.0/24"),
+		mapping("100.71.4.0/24", "10.0.0.0/24"))
+	backward := renderMap(t, "meshp0",
+		mapping("100.71.4.0/24", "10.0.0.0/24"),
+		mapping("100.71.6.0/24", "192.168.1.0/24"),
+		mapping("100.71.5.0/24", "192.168.1.0/24"))
+
+	if forward != backward {
+		t.Errorf("the order they arrived in changed the script:\n%s\n---\n%s", forward, backward)
+	}
+}
+
+// Two customers really can share one real prefix — that is the case this exists for, and it
+// must not be mistaken for the duplicate the check above refuses.
+func TestTwoMappingsMayShareARealPrefix(t *testing.T) {
+	got := renderMap(t, "meshp0",
+		mapping("100.71.5.0/24", "192.168.1.0/24"),
+		mapping("100.71.6.0/24", "192.168.1.0/24"))
+
+	if !strings.Contains(got, "daddr 100.71.5.0/24") || !strings.Contains(got, "daddr 100.71.6.0/24") {
+		t.Errorf("two customers on one prefix did not both get a mapping:\n%s", got)
+	}
+}
+
+// An interface name is interpolated into a script that runs as root.
+func TestAnUnusableInterfaceNameIsRefused(t *testing.T) {
+	for _, name := range []string{"", "meshp0; drop table inet filter", "a b", strings.Repeat("x", 16)} {
+		if _, err := RenderMap(name, []Mapping{mapping("100.71.5.0/24", "192.168.1.0/24")}); err == nil {
+			t.Errorf("%q was accepted as an interface name", name)
+		}
+	}
+}


### PR DESCRIPTION
ADR-0004 has claimed since the beginning that one agent can hold forty customers. It has never been true when two of them use `192.168.1.0/24` — the most common customer network there is. One routing table cannot hold that prefix twice, so [PR #70](https://github.com/meshpnet/meshp/pull/70) refuses both rather than silently reaching the wrong one.

ADR-0020 settles the shape. **This is the mechanism at the bottom of it and nothing above it** — `RenderMap` turns a set of mapped ranges into the rules that perform the translation. Allocation, the wire format, and the agent wiring are separate slices; this one is deliberately unwired, and the next slice is control-plane allocation.

## Verified before it was designed around

Three namespaces, two customers both answering on `192.168.1.5`, real packets:

```
100.71.5.5:8001 (A's own port):     open
100.71.6.5:8002 (B's own port):     open
100.71.5.5:8002 (B's port via A):   closed, correct
100.71.6.5:8001 (A's port via B):   closed, correct

IP 100.71.5.1 > 192.168.1.5: ICMP echo request
```

The crossover assertions are the ones that cannot be faked by a renderer emitting plausible text: both customers listen on the same address, so a packet reaching the wrong interface still finds *a* machine there — just the wrong one, on a port it does not serve. The last line is ADR-0007's requirement: the customer sees the technician's real address, not a rewritten one.

## Two design choices

**Raw header rewrite, not conntrack DNAT.** DNAT re-routes after rewriting, back into the table holding two identical prefixes, and keeps per-connection state that an expiry or a daemon restart drops underneath an established connection — precisely what route groups exist to prevent. Pure arithmetic has neither problem.

**The source is never touched**, in either direction, so destination-side ACL enforcement still sees the real device.

## A mutation that did not die

| mutation | result |
|---|---|
| drop the inbound rewrite | killed — nothing connects |
| rewrite the source outbound | killed — nothing connects, and the source assertion fails |
| **`postrouting` → `output`** | **survived** |

That third one is a genuine finding and the comments now say so. For locally-generated traffic the route is already chosen before either hook runs, so a raw rewrite in `output` behaves identically. Postrouting is kept for a narrower reason than I first wrote: it is also traversed by forwarded packets. The load-bearing choice is raw-versus-conntrack, not the hook — and the test that implied otherwise has been split so it no longer claims more than it proves.

## An unrelated gap this closes

Adding `./internal/nftables/` to the data-plane job also gates **three real-packet tests that have never run in CI** — `TestAPacketCrossesIntoACarriedLAN`, `TestWithoutTheRulesetNothingCrosses`, `TestWithdrawingStopsPacketsCrossing`. They need root, the unprivileged test job skips them, and this job did not name the package. They have gated nothing since the forwarding work landed. The whole package was run as root in a container first to confirm nothing skips, since that job fails on a skip.