### PR TITLE
fix(forwarding): an advertiser that carries nothing stops looking healthy

### DIFF
--- a/internal/nftables/filter.go
+++ b/internal/nftables/filter.go
@@ -65,3 +65,19 @@ func (f *Filter) ApplyForward(ctx context.Context, iface string, groups []*meshp
 	}
 	return Apply(ctx, script)
 }
+
+// ForwardObstacles names anything else on this host that drops forwarded packets.
+//
+// A thin wrapper on ForwardRefusals so the reconciler can hold one interface rather than
+// reaching into this package for the one call that is not an Apply.
+func (f *Filter) ForwardObstacles(ctx context.Context) ([]string, error) {
+	found, err := ForwardRefusals(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(found))
+	for _, r := range found {
+		out = append(out, r.String())
+	}
+	return out, nil
+}

--- a/internal/nftables/foreign.go
+++ b/internal/nftables/foreign.go
@@ -1,0 +1,91 @@
+package nftables
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Refusal names something on this host that will drop packets meshp means to carry.
+//
+// A description rather than a handle, because meshp does not act on it. The operator is the
+// one who can decide whether the other tool's rule or meshp's forwarding is the one that
+// should give way, and they need to be told which tool to go and look at.
+type Refusal struct {
+	Family string // ip, ip6, inet
+	Table  string
+	Chain  string
+}
+
+func (r Refusal) String() string { return r.Family + " " + r.Table + " " + r.Chain }
+
+// forwardRefusals finds base chains at the forward hook that drop by default.
+//
+// Why this can happen at all is worth stating, because the ruleset meshp writes looks
+// correct while it does. Every base chain registered at a hook runs, in priority order, and
+// a drop in any of them ends the packet. An accept only means *that* chain is finished with
+// it. So meshp's forward chain accepting a carried prefix does not survive another table
+// dropping it afterwards, and there is no rule meshp can write in its own table to win.
+//
+// Docker sets exactly this policy on every host it is installed on, and so do firewalld and
+// several VPN clients. The result is an advertiser that renders a correct ruleset, reports
+// the route group applied, and carries nothing.
+//
+// A drop policy is a strong signal rather than a proof: the other chain may hold a rule that
+// accepts this traffic before the policy is reached, and deciding that would mean evaluating
+// somebody else's ruleset against a hypothetical packet. So this reports what it found and
+// says it plainly, rather than claiming forwarding is definitely broken.
+//
+// meshp's own tables are excluded. The forward chain here is policy accept today, but a
+// device reporting itself as refusing its own traffic would be a confusing way to find out
+// that had changed.
+func forwardRefusals(chainsJSON []byte) ([]Refusal, error) {
+	var doc struct {
+		Nftables []struct {
+			Chain *struct {
+				Family string `json:"family"`
+				Table  string `json:"table"`
+				Name   string `json:"name"`
+				Hook   string `json:"hook"`
+				Policy string `json:"policy"`
+			} `json:"chain"`
+		} `json:"nftables"`
+	}
+	if err := json.Unmarshal(chainsJSON, &doc); err != nil {
+		return nil, fmt.Errorf("nftables: reading the chain list: %w", err)
+	}
+
+	var out []Refusal
+	for _, entry := range doc.Nftables {
+		c := entry.Chain
+		if c == nil {
+			continue
+		}
+		// Only base chains are registered at a hook, and only they have a policy. A
+		// regular chain is reached by a jump and cannot drop anything on its own.
+		if c.Hook != "forward" || strings.ToLower(c.Policy) != "drop" {
+			continue
+		}
+		if isOurTable(c.Table) {
+			continue
+		}
+		out = append(out, Refusal{Family: c.Family, Table: c.Table, Chain: c.Name})
+	}
+
+	// Sorted so the same host reports the same thing every pass, rather than reordering
+	// with whatever nft happened to list first and looking like a new condition.
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	return out, nil
+}
+
+// isOurTable reports whether a table is one meshp writes.
+func isOurTable(name string) bool {
+	switch name {
+	case TableName, ForwardTableName, LockTableName, MapTableName:
+		return true
+	}
+	// The mapping tests install per-interface variants, and a device that somehow held one
+	// should not report itself as its own obstacle.
+	return strings.HasPrefix(name, MapTableName+"_")
+}

--- a/internal/nftables/foreign_linux.go
+++ b/internal/nftables/foreign_linux.go
@@ -1,0 +1,37 @@
+//go:build linux
+
+package nftables
+
+import (
+	"context"
+	"os/exec"
+)
+
+// ForwardRefusals reports what else on this host will drop forwarded packets.
+//
+// Asked of nft rather than inferred, for the reason Available is: what a host will do with a
+// packet is not something that can be worked out from what meshp installed.
+//
+// One blind spot, stated because it changes what a clean result means. This sees only the
+// nftables ruleset, which on any current distribution includes iptables — `iptables` is
+// iptables-nft, and its FORWARD chain appears here as `ip filter FORWARD`. A host still
+// running iptables-legacy has a second, entirely separate packet path that nft cannot see,
+// and a drop there would be invisible to this. Empty therefore means "nothing found", not
+// "nothing there".
+//
+// Errors are returned rather than swallowed, but a caller that cannot ask is not a caller
+// that should stop forwarding: not knowing is the state meshp was already in.
+func ForwardRefusals(ctx context.Context) ([]Refusal, error) {
+	path, err := exec.LookPath("nft")
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, applyTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, path, "--json", "list", "chains").Output()
+	if err != nil {
+		return nil, err
+	}
+	return forwardRefusals(out)
+}

--- a/internal/nftables/foreign_linux_test.go
+++ b/internal/nftables/foreign_linux_test.go
@@ -1,0 +1,100 @@
+//go:build linux
+
+package nftables
+
+import (
+	"context"
+	"os/exec"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The parser is tested against captured output; this tests the part that cannot be: asking a
+// real nft on a real host and reading what it says back.
+//
+// Asserted as a difference rather than an absolute. A runner may have anything else in its
+// ruleset — this one has Docker — so "finds exactly one refusal" would be a claim about the
+// machine. That the table appears when installed and is gone when removed is a claim about
+// meshp.
+//
+// A table of its own rather than changing the host's forward policy. Setting
+// `iptables -P FORWARD DROP` would reproduce Docker exactly and would also stop every other
+// forwarding test in this package if anything here failed before the policy was put back.
+func TestARealForeignDropIsFound(t *testing.T) {
+	requireMapRoot(t)
+	requireNFT(t)
+
+	const foreign = "othervpn"
+	before := refusals(t)
+	if slices.ContainsFunc(before, func(r Refusal) bool { return r.Table == foreign }) {
+		t.Fatalf("setup: %s is already in the ruleset", foreign)
+	}
+
+	// Something else on the host, dropping forwarded packets by default — the shape Docker,
+	// firewalld and several VPN clients all leave behind.
+	load(t, "add table inet "+foreign+"\n"+
+		"add chain inet "+foreign+" forward { type filter hook forward priority filter; policy drop; }\n")
+	t.Cleanup(func() { _ = exec.Command("nft", "delete", "table", "inet", foreign).Run() })
+
+	during := refusals(t)
+	found := slices.ContainsFunc(during, func(r Refusal) bool {
+		return r.Table == foreign && r.Chain == "forward" && r.Family == "inet"
+	})
+	if !found {
+		t.Errorf("a table dropping forwarded packets was not reported: %v", during)
+	}
+
+	// And it stops being reported once it is gone, or an operator who cleared the obstacle
+	// would go on being told it is there.
+	mustRun(t, "nft", "delete", "table", "inet", foreign)
+	after := refusals(t)
+	if slices.ContainsFunc(after, func(r Refusal) bool { return r.Table == foreign }) {
+		t.Errorf("a table that has been removed is still reported: %v", after)
+	}
+}
+
+// meshp's own forwarding table is installed at the same hook and must never be reported.
+// This is the case the exclusion exists for, checked against a real ruleset rather than a
+// hand-written chain list.
+func TestOurOwnForwardTableIsNotReportedAsAnObstacle(t *testing.T) {
+	requireMapRoot(t)
+	requireNFT(t)
+
+	script, err := RenderForward("meshp0", branchGroup())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(context.Background(), script); err != nil {
+		t.Fatalf("loading the forwarding ruleset: %v", err)
+	}
+	t.Cleanup(func() {
+		if empty, renderErr := RenderForward("meshp0", nil); renderErr == nil {
+			_ = Apply(context.Background(), empty)
+		}
+	})
+
+	for _, r := range refusals(t) {
+		if isOurTable(r.Table) {
+			t.Errorf("meshp reported its own table as refusing its traffic: %v", r)
+		}
+	}
+}
+
+func refusals(t *testing.T) []Refusal {
+	t.Helper()
+	got, err := ForwardRefusals(context.Background())
+	if err != nil {
+		t.Fatalf("asking nft what is in the way: %v", err)
+	}
+	return got
+}
+
+func load(t *testing.T, script string) {
+	t.Helper()
+	cmd := exec.Command("nft", "-f", "-")
+	cmd.Stdin = strings.NewReader(script)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("nft rejected the ruleset: %v\n%s", err, out)
+	}
+}

--- a/internal/nftables/foreign_other.go
+++ b/internal/nftables/foreign_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package nftables
+
+import "context"
+
+// ForwardRefusals reports nothing off Linux, where meshp does not forward at all.
+//
+// Nil rather than an error: a host that cannot carry a prefix is refused earlier, by
+// Available, and reporting an obstacle to something that was never going to happen would put
+// a condition in front of an operator that means nothing on their machine.
+func ForwardRefusals(context.Context) ([]Refusal, error) { return nil, nil }

--- a/internal/nftables/foreign_test.go
+++ b/internal/nftables/foreign_test.go
@@ -1,0 +1,149 @@
+package nftables
+
+import (
+	"strings"
+	"testing"
+)
+
+// chains builds the shape nft --json list chains actually returns, taken from a real host
+// rather than invented, so a change in that format shows up here.
+func chains(entries ...string) []byte {
+	return []byte(`{"nftables": [{"metainfo": {"version": "1.0.9", "json_schema_version": 1}}` +
+		func() string {
+			if len(entries) == 0 {
+				return ""
+			}
+			return "," + strings.Join(entries, ",")
+		}() + `]}`)
+}
+
+func base(family, table, name, hook, policy string) string {
+	return `{"chain": {"family": "` + family + `", "table": "` + table + `", "name": "` + name +
+		`", "handle": 1, "type": "filter", "hook": "` + hook + `", "prio": 0, "policy": "` + policy + `"}}`
+}
+
+func regular(family, table, name string) string {
+	return `{"chain": {"family": "` + family + `", "table": "` + table + `", "name": "` + name + `", "handle": 2}}`
+}
+
+// The condition itself: Docker's default, which is on every host it is installed on.
+func TestAForeignDropAtTheForwardHookIsFound(t *testing.T) {
+	got, err := forwardRefusals(chains(base("ip", "filter", "FORWARD", "forward", "drop")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("found %v, want one refusal", got)
+	}
+	if got[0].String() != "ip filter FORWARD" {
+		t.Errorf("described as %q, which does not tell an operator where to look", got[0])
+	}
+}
+
+// A host with nothing in the way reports nothing, or the warning means nothing.
+func TestAnAcceptingForwardHookIsNotARefusal(t *testing.T) {
+	got, err := forwardRefusals(chains(
+		base("ip", "filter", "FORWARD", "forward", "accept"),
+		base("ip", "filter", "INPUT", "input", "drop"),
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("found %v on a host that refuses nothing forwarded", got)
+	}
+}
+
+// A drop at another hook is somebody else's business. Reporting an input policy as a reason
+// forwarding will not work would send an operator to the wrong rule.
+func TestADropAtAnotherHookIsIgnored(t *testing.T) {
+	got, err := forwardRefusals(chains(
+		base("ip", "filter", "INPUT", "input", "drop"),
+		base("ip", "filter", "OUTPUT", "output", "drop"),
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("found %v from hooks that do not carry forwarded packets", got)
+	}
+}
+
+// Only base chains are registered at a hook. A regular chain is reached by a jump and cannot
+// drop anything on its own, and it has no policy to read.
+func TestARegularChainIsNotARefusal(t *testing.T) {
+	got, err := forwardRefusals(chains(
+		regular("ip", "filter", "DOCKER-USER"),
+		regular("ip", "filter", "DOCKER-ISOLATION-STAGE-1"),
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("found %v from chains that are not registered at a hook", got)
+	}
+}
+
+// meshp does not report itself as its own obstacle. Its forward chain is policy accept
+// today, and a device blaming its own table would be a confusing way to learn otherwise.
+func TestOurOwnTablesAreNotRefusals(t *testing.T) {
+	got, err := forwardRefusals(chains(
+		base("inet", ForwardTableName, "forward", "forward", "drop"),
+		base("inet", LockTableName, "forward", "forward", "drop"),
+		base("inet", MapTableName, "outbound", "forward", "drop"),
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("meshp reported its own tables as refusing its traffic: %v", got)
+	}
+}
+
+// Everything in the way, not just the first thing, and in a stable order — an operator who
+// clears one obstacle needs to know about the second without waiting for another pass.
+func TestEveryRefusalIsReportedInAStableOrder(t *testing.T) {
+	in := chains(
+		base("ip6", "filter", "FORWARD", "forward", "drop"),
+		base("ip", "filter", "FORWARD", "forward", "drop"),
+		base("inet", "firewalld", "filter_FORWARD", "forward", "drop"),
+	)
+	first, err := forwardRefusals(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 3 {
+		t.Fatalf("found %v, want all three", first)
+	}
+	for range 5 {
+		again, err := forwardRefusals(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range again {
+			if again[i] != first[i] {
+				t.Fatalf("the order changed between passes: %v then %v", first, again)
+			}
+		}
+	}
+}
+
+// A ruleset with nothing in it at all is the ordinary case on a fresh host.
+func TestAnEmptyRulesetRefusesNothing(t *testing.T) {
+	got, err := forwardRefusals(chains())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("found %v on an empty ruleset", got)
+	}
+}
+
+// Unparseable output is an error rather than an empty answer. Silently reporting "nothing in
+// the way" because nft printed something unexpected is how a device claims to be healthy for
+// a reason nobody can see.
+func TestUnreadableOutputIsAnError(t *testing.T) {
+	if _, err := forwardRefusals([]byte("this is not json")); err == nil {
+		t.Error("unparseable output was read as a clean host")
+	}
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -190,6 +190,15 @@ type Filter interface {
 	// interface name removes it, which is the only way it comes off: these rules are system
 	// state and outlive the process on purpose (ADR-0011).
 	ApplyLock(ctx context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix, preventDNSLeaks bool) error
+
+	// ForwardObstacles names anything else on this host that drops forwarded packets, as
+	// strings an operator can go and look at. Empty means nothing was found, which is not
+	// the same as nothing being there.
+	//
+	// Here rather than called directly, so this reconciler can be tested against a host
+	// that refuses — a condition that otherwise needs root, a real ruleset, and a machine
+	// nobody minds breaking.
+	ForwardObstacles(ctx context.Context) ([]string, error)
 }
 
 // Egress claims and releases a full tunnel's routing.
@@ -559,10 +568,47 @@ func (r *Reconciler) applyForwarding(ctx context.Context, iface string, advertis
 	r.lastAdvertised = proto.CloneOf(advertised)
 	if n := len(advertised.GetGroups()); n > 0 {
 		r.log.Info("carrying prefixes for the network", "interface", iface, "groups", n)
-	} else {
-		r.log.Info("no longer carrying anything", "interface", iface)
+		// Installed is not the same as working, and this is the one place that difference
+		// is invisible. Every base chain at a hook runs and a drop in any of them ends the
+		// packet, so another table refusing forwarded traffic defeats a ruleset meshp
+		// rendered correctly — and nothing above would notice: the rules are right, the
+		// group is applied, and nothing crosses.
+		return r.reportForwardObstacles(ctx)
 	}
+	r.log.Info("no longer carrying anything", "interface", iface)
 	return nil
+}
+
+// reportForwardObstacles says when something else on the host will drop what this device
+// carries, and reports the forwarding unapplied when it does.
+//
+// Unapplied rather than a warning alone, because the control plane is where an operator sees
+// whether an advertiser is doing its job. An advertiser that renders a correct ruleset and
+// carries nothing must not appear healthy — a route group would fail over to it and traffic
+// would stop, with every diagnostic saying the group was applied.
+//
+// Only when this device actually carries something. A host with a strict forward policy and
+// nothing to forward has no problem, and telling it otherwise is a warning that trains people
+// to ignore warnings.
+func (r *Reconciler) reportForwardObstacles(ctx context.Context) []string {
+	found, err := r.filter.ForwardObstacles(ctx)
+	if err != nil {
+		// Not knowing is the state this was in before it could ask, so it is not a reason
+		// to declare the forwarding broken. Said at debug because a host where nft cannot
+		// be read has louder problems than this.
+		r.log.Debug("could not check what else might refuse forwarded packets",
+			"error", logx.SafeError(err))
+		return nil
+	}
+	if len(found) == 0 {
+		return nil
+	}
+
+	r.log.Error("something else on this host drops forwarded packets, so this device may carry nothing",
+		"refused_by", logx.Safe(strings.Join(found, ", ")),
+		"why", "every chain at a hook runs and a drop in any of them wins; meshp cannot undo it from its own table",
+		"hint", "docker sets this policy by default; allow forwarding for this interface or remove the drop")
+	return []string{"forwarding"}
 }
 
 // Teardown removes everything this membership installed (Invariant 20).

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/netip"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -846,6 +847,16 @@ type fakeFilter struct {
 	// is the whole property under test — a mutation that swapped them survived until this
 	// existed.
 	order *[]string
+
+	// obstacles is what this host has in the way of forwarded packets, and obstacleErr is
+	// a host that could not be asked. Both default to the ordinary case: nothing in the
+	// way, asked successfully.
+	obstacles   []string
+	obstacleErr error
+}
+
+func (f *fakeFilter) ForwardObstacles(context.Context) ([]string, error) {
+	return f.obstacles, f.obstacleErr
 }
 
 func (f *fakeFilter) ApplyLock(_ context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix, preventDNSLeaks bool) error {
@@ -1355,6 +1366,90 @@ func TestAnAdvertiserIsMadeToForward(t *testing.T) {
 	}
 	if len(filter.forwarded) != 1 || len(filter.forwarded[0]) != 1 {
 		t.Fatalf("forwarding was configured %d times: %+v", len(filter.forwarded), filter.forwarded)
+	}
+}
+
+// An advertiser that cannot actually carry anything must not look healthy.
+//
+// This is the failure that prompted #89 and it has no other symptom: the ruleset meshp
+// renders is correct, the group is applied, `meshp status` says so, and nothing crosses.
+// Every base chain at a hook runs and a drop in any of them ends the packet, so another
+// table refusing forwarded traffic beats an accept meshp wrote in its own. Reporting the
+// component unapplied is what stops a route group failing over onto a gateway that is not
+// one.
+func TestAnAdvertiserBlockedBySomethingElseSaysSo(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{obstacles: []string{"ip filter FORWARD"}}
+	r := New(link, membership(), nil, filter, nil)
+
+	unapplied, err := r.Apply(context.Background(),
+		stateAdvertising(1, advertising("192.168.10.0/24"), peer(bobKey, "100.90.0.2/32")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(unapplied, "forwarding") {
+		t.Errorf("unapplied = %v; a device that carries nothing reported itself as carrying", unapplied)
+	}
+	// And it still installed the rules. The obstacle may be removed by an operator at any
+	// moment, and a device that had refused to configure itself would then need a reconcile
+	// nobody triggers.
+	if len(filter.forwarded) != 1 {
+		t.Errorf("forwarding was configured %d times; the rules should still go in", len(filter.forwarded))
+	}
+}
+
+// And a host with nothing in the way is not warned about anything.
+//
+// A warning that fires when the thing works is worse than no warning: it teaches whoever
+// reads the logs to skip this line, which is the line that matters on the day it is true.
+func TestAClearHostReportsNoObstacle(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{}
+	r := New(link, membership(), nil, filter, nil)
+
+	unapplied, err := r.Apply(context.Background(),
+		stateAdvertising(1, advertising("192.168.10.0/24"), peer(bobKey, "100.90.0.2/32")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(unapplied, "forwarding") {
+		t.Errorf("unapplied = %v on a host that refuses nothing", unapplied)
+	}
+}
+
+// A host that could not be asked is not a host that is broken.
+//
+// Not knowing is exactly the state this was in before it could ask, so it must not turn a
+// working advertiser into one that reports itself unapplied — a false alarm here fails a
+// route group over to somebody else for no reason.
+func TestAHostThatCannotBeAskedIsNotDeclaredBroken(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{obstacleErr: errors.New("nft: permission denied")}
+	r := New(link, membership(), nil, filter, nil)
+
+	unapplied, err := r.Apply(context.Background(),
+		stateAdvertising(1, advertising("192.168.10.0/24"), peer(bobKey, "100.90.0.2/32")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(unapplied, "forwarding") {
+		t.Errorf("unapplied = %v; not being able to check was read as a failure", unapplied)
+	}
+}
+
+// Nothing to carry, nothing to warn about. A laptop with a strict forward policy and no route
+// groups has no problem at all.
+func TestAHostThatCarriesNothingIsNotWarned(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{obstacles: []string{"ip filter FORWARD"}}
+	r := New(link, membership(), nil, filter, nil)
+
+	unapplied, err := r.Apply(context.Background(), stateAdvertising(1, nil, peer(bobKey, "100.90.0.2/32")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(unapplied, "forwarding") {
+		t.Errorf("unapplied = %v on a device that carries nothing", unapplied)
 	}
 }
 


### PR DESCRIPTION
Closes #89.

Every base chain registered at a netfilter hook runs, and a drop in any of them ends the packet — an accept only means *that* chain is finished with it. So a foreign table dropping forwarded traffic beats the accept meshp wrote in its own, and **there is no rule meshp can add to its own table to win**.

Docker sets exactly that policy on every host it is installed on. So do firewalld and several VPN clients.

The result was an advertiser that rendered a correct ruleset, reported the route group applied, said it was reachable, and carried nothing — with no diagnostic anywhere disagreeing. A route group would fail over onto it and traffic would stop.

## This does not make forwarding work

It makes it stop lying, which is what #89 says has to come first. The reconciler asks what else sits at the forward hook, says plainly what it found and why meshp cannot overrule it, and reports the `forwarding` component unapplied so the control plane sees a gateway that is not one.

Making it actually work means writing an accept into a table meshp does not own — the way Docker's own `DOCKER-USER` chain works, and what Tailscale does. That is a real design decision with ordering problems against other tools doing the same, and it belongs in its own change.

## Three things it deliberately does not do

- **It does not report on a device that carries nothing.** A laptop with a strict forward policy and no route groups has no problem, and a warning there teaches whoever reads the logs to skip the line that matters on the day it is true.
- **It does not treat a host it could not ask as broken.** Not knowing is the state this was already in, and a false alarm fails a route group over to somebody else for no reason.
- **It still installs the rules.** The obstacle may be cleared at any moment, and a device that had refused to configure itself would then be waiting for a reconcile nobody triggers.

## Honest about what it knows

A drop policy is a strong signal, not a proof — the other chain may hold a rule that accepts this traffic before the policy is reached, and deciding that would mean evaluating somebody else's ruleset against a hypothetical packet. The wording reports what was found, not what will happen.

One blind spot, stated in the code because it changes what a clean result means: this reads the nftables ruleset, which on any current distribution includes iptables (`iptables` is iptables-nft, and its FORWARD chain appears as `ip filter FORWARD` — this is how Docker is seen). A host still running iptables-legacy has a second packet path nft cannot see. **Empty means "nothing found", not "nothing there."**

`meshp doctor` is left alone on purpose: it cannot tell whether the device is meant to carry anything, because the agent's status does not report that, so it would warn on every laptop with Docker installed.

## Verification

| mutation | test that fails |
|---|---|
| never report the obstacle | `TestAnAdvertiserBlockedBySomethingElseSaysSo` |
| declare an unaskable host broken | `TestAHostThatCannotBeAskedIsNotDeclaredBroken` |
| count drops at any hook, not just forward | `TestADropAtAnotherHookIsIgnored` |
| stop excluding meshp's own tables | `TestOurOwnTablesAreNotRefusals` |

The parser is tested against JSON captured from a real host so a format change shows up. The detection itself is tested against a **real nft** — installing a foreign table that drops at the forward hook and asserting it appears, then disappears when removed. That is asserted as a difference rather than an absolute, because a runner may have anything else in its ruleset and "finds exactly one" would be a claim about the machine rather than about meshp.