### PR TITLE
feat(prefixmap): the control plane can choose where a colliding prefix is reached

### DIFF
--- a/internal/prefixmap/prefixmap.go
+++ b/internal/prefixmap/prefixmap.go
@@ -1,0 +1,176 @@
+// Package prefixmap chooses the range a colliding customer prefix is reached by.
+//
+// The decision logic, held in memory and free of any database, for the reason internal/ipam
+// is: what makes a mapped range correct is arithmetic and a set of things it must not
+// overlap, and both are far easier to get right and to test here than in SQL. The store
+// persists what this decides.
+//
+// ADR-0020 is the why. Two customers of one MSP both use 192.168.1.0/24 and a technician's
+// routing table cannot hold that prefix twice, so each colliding prefix is given a distinct
+// range to be reached by and the device rewrites the destination on the way into the tunnel.
+package prefixmap
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"slices"
+)
+
+// Errors a caller is expected to tell apart.
+var (
+	// ErrExhausted means the block has no room left for a prefix of this size.
+	ErrExhausted = errors.New("prefixmap: the mapped block has no free range of that size")
+
+	// ErrUnmappable means the prefix cannot be given a mapped range at all, whatever the
+	// block contains — a default route, or one larger than the block itself.
+	ErrUnmappable = errors.New("prefixmap: this prefix cannot be mapped")
+)
+
+// Reserved is a range the allocator must not hand out.
+//
+// Mesh address pools, other mappings, and anything else already meaningful to a device that
+// will hold the result. ADR-0020's warning is that choosing the block badly "recreates this
+// problem one level up", and this is where that is prevented rather than hoped for.
+type Reserved []netip.Prefix
+
+// Allocate returns the lowest free range in block that can carry prefix.
+//
+// Same size as the prefix, because the host part is carried across unchanged: 100.71.5.5 is
+// 192.168.1.5 at the other end. That is what makes the translation stateless, and a range of
+// a different size could not express it.
+//
+// Lowest free rather than random or sequential-from-last. The result ends up in support
+// tickets and in `ip route` output, so a deployment that has allocated three ranges should
+// have three small numbers rather than three scattered ones, and re-running after a release
+// should produce the same answer.
+//
+// Aligned to its own size, so the arithmetic on the device is a mask rather than an offset.
+func Allocate(block, prefix netip.Prefix, reserved Reserved) (netip.Prefix, error) {
+	if !block.IsValid() || !prefix.IsValid() {
+		return netip.Prefix{}, fmt.Errorf("%w: block %v, prefix %v", ErrUnmappable, block, prefix)
+	}
+	if block.Addr().Is4() != prefix.Addr().Is4() {
+		return netip.Prefix{}, fmt.Errorf("%w: %v cannot come out of %v", ErrUnmappable, prefix, block)
+	}
+	if prefix.Bits() == 0 {
+		// A default route contains every address, so there is no distinct range to reach it
+		// by. Two full tunnels on one device stay refused, which is the honest answer.
+		return netip.Prefix{}, fmt.Errorf("%w: a default route has nothing to be mapped into", ErrUnmappable)
+	}
+	if prefix.Bits() < block.Bits() {
+		// A customer network larger than the whole block. Distinguished from exhaustion
+		// because no amount of freeing up would help.
+		return netip.Prefix{}, fmt.Errorf("%w: %v is larger than the block %v", ErrUnmappable, prefix, block)
+	}
+
+	for candidate := range candidates(block, prefix.Bits()) {
+		if overlapsAny(candidate, reserved) {
+			continue
+		}
+		return candidate, nil
+	}
+	return netip.Prefix{}, fmt.Errorf("%w: %v in %v", ErrExhausted, prefix, block)
+}
+
+// candidates walks the block in aligned steps of the requested size, lowest first.
+//
+// An iterator rather than a slice: a /16 block cut into /30s is sixteen thousand ranges, and
+// all but the first few are usually reserved. Building them all to use one is work nobody
+// asked for, on a path the control plane runs while a device waits.
+func candidates(block netip.Prefix, bits int) func(func(netip.Prefix) bool) {
+	return func(yield func(netip.Prefix) bool) {
+		addr := block.Masked().Addr()
+		for {
+			candidate := netip.PrefixFrom(addr, bits)
+			if !block.Contains(addr) {
+				return
+			}
+			if !yield(candidate) {
+				return
+			}
+			next, ok := advance(addr, bits)
+			if !ok {
+				return // the address space ran out before the block did
+			}
+			addr = next
+		}
+	}
+}
+
+// advance returns the first address of the next aligned range of this size.
+func advance(addr netip.Addr, bits int) (netip.Addr, bool) {
+	// The last address of this range, then one past it. Adding the range's size directly
+	// would need arithmetic on a 128-bit integer; walking the boundary is the same thing
+	// expressed with what netip already offers.
+	last := lastOf(netip.PrefixFrom(addr, bits))
+	next := last.Next()
+	return next, next.IsValid()
+}
+
+// lastOf returns the highest address in a prefix.
+func lastOf(p netip.Prefix) netip.Addr {
+	bytes := p.Addr().AsSlice()
+	for i := p.Bits(); i < len(bytes)*8; i++ {
+		bytes[i/8] |= 1 << (7 - i%8)
+	}
+	addr, _ := netip.AddrFromSlice(bytes)
+	return addr
+}
+
+// overlapsAny reports whether a candidate touches anything spoken for.
+//
+// Overlap in either direction, which is the part that is easy to get wrong: a candidate /24
+// inside a reserved /16 does not contain it, and a reserved /28 inside a candidate /24 is not
+// contained by it either. Both are collisions.
+func overlapsAny(candidate netip.Prefix, reserved Reserved) bool {
+	return slices.ContainsFunc(reserved, func(r netip.Prefix) bool {
+		return r.IsValid() && r.Addr().Is4() == candidate.Addr().Is4() &&
+			(r.Overlaps(candidate) || candidate.Overlaps(r))
+	})
+}
+
+// Colliding reports the prefixes carried in more than one of a device's networks.
+//
+// The input is what each network the device belongs to carries. A prefix appearing in two of
+// them is one the device's routing table cannot hold twice, which is the whole condition
+// ADR-0020 addresses.
+//
+// Identical prefixes only, not overlapping ones. ADR-0019 settled that overlap is decided by
+// longest match and is well defined — a /24 inside somebody else's /16 is reached by the /24,
+// which is what the operator meant. Only an exact repeat is genuinely ambiguous.
+//
+// Default routes are excluded here as well as refused by Allocate, because this is what
+// decides whether anything is wrong at all: reporting a device as colliding when the only
+// repeat is 0.0.0.0/0 would mark two ordinary full-tunnel networks as a fault nobody can fix.
+func Colliding(byNetwork map[string][]netip.Prefix) []netip.Prefix {
+	seen := make(map[netip.Prefix]map[string]bool)
+	for network, prefixes := range byNetwork {
+		for _, p := range prefixes {
+			if !p.IsValid() || p.Bits() == 0 {
+				continue
+			}
+			p = p.Masked()
+			if seen[p] == nil {
+				seen[p] = make(map[string]bool)
+			}
+			seen[p][network] = true
+		}
+	}
+
+	var out []netip.Prefix
+	for prefix, networks := range seen {
+		if len(networks) > 1 {
+			out = append(out, prefix)
+		}
+	}
+	// Sorted, so the same device produces the same list every pass rather than reordering
+	// with map iteration and looking like something changed.
+	slices.SortFunc(out, func(a, b netip.Prefix) int {
+		if c := a.Addr().Compare(b.Addr()); c != 0 {
+			return c
+		}
+		return a.Bits() - b.Bits()
+	})
+	return out
+}

--- a/internal/prefixmap/prefixmap_test.go
+++ b/internal/prefixmap/prefixmap_test.go
@@ -1,0 +1,247 @@
+package prefixmap
+
+import (
+	"errors"
+	"net/netip"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func p(s string) netip.Prefix { return netip.MustParsePrefix(s) }
+
+func prefixes(ss ...string) []netip.Prefix {
+	out := make([]netip.Prefix, 0, len(ss))
+	for _, s := range ss {
+		out = append(out, p(s))
+	}
+	return out
+}
+
+func alloc(t *testing.T, block, prefix string, reserved ...string) netip.Prefix {
+	t.Helper()
+	got, err := Allocate(p(block), p(prefix), prefixes(reserved...))
+	if err != nil {
+		t.Fatalf("Allocate(%s, %s): %v", block, prefix, err)
+	}
+	return got
+}
+
+// The size has to match, because the host part is carried across unchanged: 100.71.5.5 is
+// 192.168.1.5 at the other end, and a range of another size could not express that.
+func TestAMappedRangeIsTheSameSizeAsWhatItCarries(t *testing.T) {
+	for _, size := range []string{"/16", "/20", "/24", "/25", "/30"} {
+		got := alloc(t, "100.71.0.0/16", "192.168.0.0"+size)
+		if got.Bits() != p("192.168.0.0"+size).Bits() {
+			t.Errorf("%s was mapped to %v, a different size", size, got)
+		}
+		if got.Masked() != got {
+			t.Errorf("%v is not aligned to its own size", got)
+		}
+	}
+}
+
+// Lowest free, so a deployment that has allocated three ranges has three small numbers rather
+// than three scattered ones. These end up in support tickets.
+func TestAllocationStartsAtTheBottomOfTheBlock(t *testing.T) {
+	if got := alloc(t, "100.71.0.0/16", "192.168.1.0/24"); got != p("100.71.0.0/24") {
+		t.Errorf("first allocation = %v, want 100.71.0.0/24", got)
+	}
+	if got := alloc(t, "100.71.0.0/16", "192.168.1.0/24", "100.71.0.0/24"); got != p("100.71.1.0/24") {
+		t.Errorf("second allocation = %v, want 100.71.1.0/24", got)
+	}
+}
+
+// The same inputs give the same answer, every time. A mapped address that moved between
+// releases would be one an operator had already written down somewhere.
+func TestAllocationIsDeterministic(t *testing.T) {
+	reserved := []string{"100.71.0.0/24", "100.71.2.0/24"}
+	first := alloc(t, "100.71.0.0/16", "192.168.1.0/24", reserved...)
+	for range 10 {
+		if got := alloc(t, "100.71.0.0/16", "192.168.1.0/24", reserved...); got != first {
+			t.Fatalf("the same question answered %v then %v", first, got)
+		}
+	}
+}
+
+// The point of Reserved: a mapped range must not land on the mesh addresses of a network the
+// device is already in, or the collision comes back one level up with nothing left to resolve
+// it (ADR-0020).
+func TestAMappedRangeAvoidsWhatIsSpokenFor(t *testing.T) {
+	got := alloc(t, "100.71.0.0/16", "192.168.1.0/24", "100.71.0.0/20")
+	if p("100.71.0.0/20").Overlaps(got) {
+		t.Errorf("%v was allocated inside a reserved /20", got)
+	}
+	if got != p("100.71.16.0/24") {
+		t.Errorf("got %v, want the first range past the reservation", got)
+	}
+}
+
+// Overlap in both directions. A reserved range smaller than the candidate is easy to miss:
+// the candidate does not sit inside it, but they still collide.
+func TestASmallReservationInsideACandidateStillBlocksIt(t *testing.T) {
+	got := alloc(t, "100.71.0.0/16", "192.168.1.0/24", "100.71.0.128/28")
+	if p("100.71.0.128/28").Overlaps(got) {
+		t.Errorf("%v was allocated around a reservation inside it", got)
+	}
+	if got != p("100.71.1.0/24") {
+		t.Errorf("got %v, want the next range after the one holding the reservation", got)
+	}
+}
+
+// A default route contains every address, so there is nothing distinct to reach it by. Two
+// full tunnels on one device stay refused, which is honest rather than a mapping that cannot
+// work.
+//
+// The message is asserted, not just the error kind, and that is the whole reason the guard
+// exists. A /0 is smaller than any real block, so removing the check still refuses it — via
+// "larger than the block", which is true and would send an operator to enlarge a block that
+// could never be large enough. A mutation removing the guard survives an errors.Is check
+// alone, which is how this test came to check the wording.
+func TestADefaultRouteCannotBeMapped(t *testing.T) {
+	_, err := Allocate(p("100.71.0.0/16"), p("0.0.0.0/0"), nil)
+	if !errors.Is(err, ErrUnmappable) {
+		t.Fatalf("err = %v, want ErrUnmappable", err)
+	}
+	if !strings.Contains(err.Error(), "default route") {
+		t.Errorf("err = %q; it should say what is actually wrong, not send somebody to resize a block", err)
+	}
+}
+
+// A customer network larger than the block is a different failure from a full block: freeing
+// something up would not help, and an operator needs to be told to enlarge the block instead.
+func TestAPrefixLargerThanTheBlockIsUnmappableNotExhausted(t *testing.T) {
+	_, err := Allocate(p("100.71.0.0/16"), p("10.0.0.0/8"), nil)
+	if !errors.Is(err, ErrUnmappable) {
+		t.Errorf("err = %v, want ErrUnmappable", err)
+	}
+	if errors.Is(err, ErrExhausted) {
+		t.Error("a prefix too large to ever fit was reported as the block being full")
+	}
+}
+
+// And a genuinely full block says so, rather than returning something that overlaps.
+func TestAFullBlockIsReportedAsExhausted(t *testing.T) {
+	_, err := Allocate(p("100.71.0.0/24"), p("192.168.1.0/24"), prefixes("100.71.0.0/24"))
+	if !errors.Is(err, ErrExhausted) {
+		t.Errorf("err = %v, want ErrExhausted", err)
+	}
+}
+
+// A block exactly one range wide still works, which is the boundary either side of the case
+// above.
+func TestABlockThatHoldsExactlyOneRangeWorks(t *testing.T) {
+	if got := alloc(t, "100.71.0.0/24", "192.168.1.0/24"); got != p("100.71.0.0/24") {
+		t.Errorf("got %v", got)
+	}
+}
+
+// Families are not interchangeable. Handing back an IPv4 range for an IPv6 prefix would
+// produce a rule that matches nothing.
+func TestFamiliesAreNotMixed(t *testing.T) {
+	if _, err := Allocate(p("100.71.0.0/16"), p("fd00:1::/64"), nil); !errors.Is(err, ErrUnmappable) {
+		t.Errorf("an IPv6 prefix was given a range from an IPv4 block: %v", err)
+	}
+	if _, err := Allocate(p("fd00:71::/48"), p("192.168.1.0/24"), nil); !errors.Is(err, ErrUnmappable) {
+		t.Errorf("an IPv4 prefix was given a range from an IPv6 block: %v", err)
+	}
+}
+
+// IPv6 works, because a device in two networks can collide there too -- ULA prefixes are
+// meant to be random but are routinely copied from an example.
+func TestAnIPv6PrefixGetsAnIPv6Range(t *testing.T) {
+	got := alloc(t, "fd00:71::/48", "fd12:3456:789a::/64")
+	if !got.Addr().Is6() || got.Bits() != 64 {
+		t.Errorf("got %v, want a /64 out of the IPv6 block", got)
+	}
+	if !p("fd00:71::/48").Overlaps(got) {
+		t.Errorf("%v is not inside the block", got)
+	}
+}
+
+// --- Colliding -------------------------------------------------------------------------
+
+// The condition the whole feature exists for.
+func TestTheSamePrefixInTwoNetworksCollides(t *testing.T) {
+	got := Colliding(map[string][]netip.Prefix{
+		"customer-a": prefixes("192.168.1.0/24", "10.20.0.0/16"),
+		"customer-b": prefixes("192.168.1.0/24"),
+	})
+	if !slices.Equal(got, prefixes("192.168.1.0/24")) {
+		t.Errorf("collisions = %v, want just 192.168.1.0/24", got)
+	}
+}
+
+// One network carrying a prefix is the ordinary case and must not be mapped. Mapping it would
+// give a technician an address to type that is not the one the customer uses, for no reason.
+func TestAPrefixInOneNetworkDoesNotCollide(t *testing.T) {
+	got := Colliding(map[string][]netip.Prefix{
+		"customer-a": prefixes("192.168.1.0/24", "10.20.0.0/16"),
+		"customer-b": prefixes("172.16.0.0/24"),
+	})
+	if len(got) != 0 {
+		t.Errorf("collisions = %v on a device where nothing repeats", got)
+	}
+}
+
+// Overlap is not collision. ADR-0019 settled that longest match decides it and the result is
+// what the operator meant: a /24 inside somebody else's /16 is reached by the /24.
+func TestOverlappingButDistinctPrefixesDoNotCollide(t *testing.T) {
+	got := Colliding(map[string][]netip.Prefix{
+		"customer-a": prefixes("10.0.0.0/8"),
+		"customer-b": prefixes("10.20.30.0/24"),
+	})
+	if len(got) != 0 {
+		t.Errorf("collisions = %v; overlap is decided by longest match, not by mapping", got)
+	}
+}
+
+// Two full tunnels are not a mappable collision. Marking them as one would report a fault
+// nobody can act on, since a default route has nothing to be mapped into.
+func TestTwoDefaultRoutesAreNotReportedAsAMappableCollision(t *testing.T) {
+	got := Colliding(map[string][]netip.Prefix{
+		"customer-a": prefixes("0.0.0.0/0"),
+		"customer-b": prefixes("0.0.0.0/0"),
+	})
+	if len(got) != 0 {
+		t.Errorf("collisions = %v, want none: a default route cannot be mapped", got)
+	}
+}
+
+// The same prefix twice in one network is a duplicate, not a collision -- one routing table
+// entry serves both route groups.
+func TestARepeatWithinOneNetworkIsNotACollision(t *testing.T) {
+	got := Colliding(map[string][]netip.Prefix{
+		"customer-a": prefixes("192.168.1.0/24", "192.168.1.0/24"),
+	})
+	if len(got) != 0 {
+		t.Errorf("collisions = %v within a single network", got)
+	}
+}
+
+// A stable order, so the same device does not look like it changed between passes.
+func TestCollisionsComeBackInAStableOrder(t *testing.T) {
+	in := map[string][]netip.Prefix{
+		"a": prefixes("192.168.1.0/24", "10.0.0.0/24", "172.16.5.0/24"),
+		"b": prefixes("192.168.1.0/24", "10.0.0.0/24", "172.16.5.0/24"),
+	}
+	want := Colliding(in)
+	if len(want) != 3 {
+		t.Fatalf("collisions = %v, want three", want)
+	}
+	for range 20 {
+		if got := Colliding(in); !slices.Equal(got, want) {
+			t.Fatalf("order changed: %v then %v", want, got)
+		}
+	}
+}
+
+// A device in no networks, or networks carrying nothing, has no collisions and no panic.
+func TestNothingCarriedIsNoCollision(t *testing.T) {
+	if got := Colliding(nil); len(got) != 0 {
+		t.Errorf("collisions = %v from nothing", got)
+	}
+	if got := Colliding(map[string][]netip.Prefix{"a": nil, "b": {}}); len(got) != 0 {
+		t.Errorf("collisions = %v from empty networks", got)
+	}
+}

--- a/migrations/0007_prefix_mappings.sql
+++ b/migrations/0007_prefix_mappings.sql
@@ -1,0 +1,69 @@
+-- Where a colliding customer prefix is reached, when the real one cannot be routed to.
+--
+-- ADR-0020. Two customers of one MSP both use 192.168.1.0/24 -- the most common customer
+-- network there is -- and a technician's routing table cannot hold that prefix twice. Today
+-- both route groups are refused (PR #70), so the technician reaches neither. Each colliding
+-- prefix gets a distinct range to be reached by, and the device rewrites the destination on
+-- the way into the tunnel.
+--
+-- Keyed by (network_id, prefix) rather than by membership, and that is the decision worth
+-- explaining. ADR-0020 allocates "for each colliding membership", which would allow the same
+-- customer to be 100.71.5.0/24 on one technician's laptop and 100.71.9.0/24 on another's.
+-- The ADR's own consequences rule that out: the mapped ranges have to be quotable in a
+-- support ticket and "correlated across the devices of one deployment", and an address that
+-- means something different on every laptop is a diagnostic that costs more than it gives.
+-- One customer prefix therefore has one mapped range for the whole deployment, and every
+-- device that needs it gets the same one.
+--
+-- Rows are allocated lazily, only when some device actually holds two memberships that
+-- collide. A deployment where nobody is in two networks at once never has a row here, and
+-- the addresses stay unspent.
+
+-- +goose Up
+
+CREATE TABLE prefix_mappings (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- The organisation, because that is the scope a device sees. devices.organization_id is
+    -- NOT NULL, so every membership a device holds is in one organisation's networks, and
+    -- two mapped ranges only need to differ if they can land in one routing table.
+    organization_id uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+    network_id      uuid NOT NULL REFERENCES networks (id) ON DELETE CASCADE,
+
+    -- The customer's own prefix, as their router has it.
+    prefix          cidr NOT NULL,
+    -- What a device reaches it by, and what its routing table holds.
+    mapped_prefix   cidr NOT NULL,
+
+    created_at      timestamptz NOT NULL DEFAULT now(),
+
+    -- One mapped range per customer prefix, for the whole deployment. This is the constraint
+    -- that makes a mapped address mean one thing.
+    UNIQUE (network_id, prefix),
+    -- And no two customer prefixes reached by the same range, or the collision is back one
+    -- level up with nothing left to resolve it.
+    UNIQUE (organization_id, mapped_prefix),
+
+    -- The host part is carried across unchanged, so the two halves must hold the same number
+    -- of hosts. Mapping a /24 onto a /25 would silently drop half the customer's network,
+    -- and the device's rules cannot express it -- internal/nftables refuses the same thing.
+    CONSTRAINT prefix_mappings_same_size CHECK (masklen(prefix) = masklen(mapped_prefix)),
+    -- Both halves are networks rather than addresses inside one, which needs no constraint:
+    -- the cidr type refuses bits set below the netmask outright, so '10.1.2.3/24' cannot be
+    -- stored here at all. Said rather than checked, because a CHECK that can never fire
+    -- implies the type does not already guarantee it.
+    --
+    -- A default route has nothing to be mapped into: every address is inside it, so there is
+    -- no distinct range to reach it by. Two full tunnels on one device stay refused, which is
+    -- the honest answer rather than a mapping that cannot work.
+    CONSTRAINT prefix_mappings_not_default CHECK (masklen(prefix) > 0)
+);
+
+-- The lookup the session path makes: everything mapped in the networks a device belongs to.
+CREATE INDEX prefix_mappings_network_idx ON prefix_mappings (network_id);
+
+COMMENT ON TABLE prefix_mappings IS
+    'Distinct ranges for customer prefixes that collide on some device (ADR-0020). One row per (network, prefix) so a mapped address means the same thing across the deployment.';
+
+-- +goose Down
+
+DROP TABLE IF EXISTS prefix_mappings;


### PR DESCRIPTION
Slice two of ADR-0020. [#88](https://github.com/meshpnet/meshp/pull/88) built the rules that perform the translation; this decides the numbers they translate between.

**Neither is wired to a device yet.** The proto field and the session state are the next slice, and the migration is unused until then.

## A departure from the ADR's wording

ADR-0020 allocates "for each colliding membership", which would let one customer be `100.71.5.0/24` on one technician's laptop and `100.71.9.0/24` on another's. The ADR's own consequences rule that out — the ranges have to be quotable in a support ticket and "correlated across the devices of one deployment", and an address that means something different on every laptop is a diagnostic that costs more than it gives.

So the table is keyed by `(network_id, prefix)`: **one customer prefix has one mapped range for the whole deployment**, and every device that needs it gets the same one. Rows are allocated lazily, so a deployment where nobody holds two memberships never has a row and spends no addresses.

## What the allocator refuses to get wrong

- **Lowest free and deterministic.** These end up in support tickets and in `ip route`; three mappings should be three small numbers, and a release should not move them.
- **Overlap checked in both directions.** A reserved range *smaller* than the candidate neither contains it nor is contained by it — missing that would drop a mapped range on top of a network's mesh addresses, which is this same collision one level up with nothing left to resolve it.
- **Not every repeat is a collision.** Overlapping but distinct prefixes are decided by longest match and are well defined (ADR-0019). Two default routes cannot be mapped at all. Reporting either would show an operator a fault they cannot act on.

## Verified against a real Postgres

Every constraint refuses what it should, and two things came out of checking rather than assuming:

- The `cidr` type **already rejects host bits** — `'10.1.2.3/24'::cidr` is an error. My `CHECK (prefix = network(prefix))` could never fire, so it is gone rather than left implying the type does not guarantee it.
- My first default-route test was malformed: `100.71.0.0/0` is not a valid `cidr`, so it was rejected by the type and proved nothing about the constraint. Retested with `0.0.0.0/0`, which the CHECK does catch.

## Mutations

Three killed outright: one-directional overlap, counting default routes as collisions, and dropping the oversized-prefix guard.

The fourth **survived and changed the test.** Removing the default-route guard still refuses a `/0` — it falls through to "larger than the block" — so that guard exists for its *message*, not its verdict. The test now asserts the wording, because telling somebody to enlarge a block that could never be large enough is the actual failure.

One process note: that mutation initially appeared to survive too, and so did the oversized-prefix one. The oversized result was false — my `perl` pattern stopped at the `}` inside `netip.Prefix{}` and never applied. I now verify a mutation actually changed the file before believing a survival.