### PR TITLE
feat(tunnel): a technician reaches both customers on 192.168.1.0/24

### DIFF
--- a/internal/nftables/filter.go
+++ b/internal/nftables/filter.go
@@ -81,3 +81,21 @@ func (f *Filter) ForwardObstacles(ctx context.Context) ([]string, error) {
 	}
 	return out, nil
 }
+
+// ApplyMap makes this host reach colliding prefixes at the ranges allocated for them.
+//
+// Rebuilt whole on every call, like the other tables here: the ruleset is one nft transaction
+// and replacing it is atomic, so there is no moment where half a device's mappings are in
+// force. An empty map removes the table, which is what a device that stopped colliding needs
+// (Invariant 20).
+func (f *Filter) ApplyMap(ctx context.Context, iface string, mapped map[netip.Prefix]netip.Prefix) error {
+	mappings := make([]Mapping, 0, len(mapped))
+	for real, to := range mapped {
+		mappings = append(mappings, Mapping{Mapped: to, Real: real})
+	}
+	script, err := RenderMap(iface, mappings)
+	if err != nil {
+		return err
+	}
+	return Apply(ctx, script)
+}

--- a/internal/tunnel/prefixmap_test.go
+++ b/internal/tunnel/prefixmap_test.go
@@ -1,0 +1,212 @@
+package tunnel
+
+import (
+	"context"
+	"net/netip"
+	"slices"
+	"testing"
+
+	"github.com/meshpnet/meshp/internal/wgplan"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// mappedTo adds an allocated range to an assignment.
+func mappedTo(a *meshpv1.RouteGroupAssignment, real, to string) *meshpv1.RouteGroupAssignment {
+	a.MappedPrefixes = append(a.MappedPrefixes,
+		&meshpv1.RouteGroupAssignment_MappedPrefix{Prefix: real, Mapped: to})
+	return a
+}
+
+// The whole of ADR-0020, at the device: two memberships carrying 192.168.1.0/24 both work,
+// because the routing table holds two distinct ranges instead of one prefix twice.
+//
+// Without the mapping this is the case PR #70 refuses outright, and refusing is still what
+// happens if anything here is missing -- which is what makes the assertion meaningful rather
+// than a restatement of the setup.
+func TestTwoMembershipsOnOnePrefixAreBothCarried(t *testing.T) {
+	claims := NewClaims()
+	first := desiredWithMapping(t, "meshp0", claims, "100.71.5.0/24")
+	second := desiredWithMapping(t, "meshp1", claims, "100.71.6.0/24")
+
+	for _, c := range []struct {
+		iface  string
+		iface2 wgplan.Interface
+		mapped string
+	}{{"meshp0", first, "100.71.5.0/24"}, {"meshp1", second, "100.71.6.0/24"}} {
+		// The allowed IP stays the customer's own prefix: that is the destination in the
+		// packet once the rewrite has happened, and WireGuard drops anything outside it.
+		if got := allowedIPsOf(c.iface2, bobKey); !slices.Contains(got, "192.168.1.0/24") {
+			t.Errorf("%s allows %v, missing the prefix that actually crosses the tunnel", c.iface, got)
+		}
+		// And the mapping is what the interface will translate by.
+		want := netip.MustParsePrefix(c.mapped)
+		if got := c.iface2.Mapped[netip.MustParsePrefix("192.168.1.0/24")]; got != want {
+			t.Errorf("%s maps to %v, want %v", c.iface, got, want)
+		}
+	}
+}
+
+// desiredWithMapping builds one membership's interface for a colliding prefix.
+func desiredWithMapping(t *testing.T, iface string, claims *Claims, mapped string) wgplan.Interface {
+	t.Helper()
+	m := membership()
+	m.InterfaceName = iface
+	assignment := mappedTo(assignmentTo("branch", bobKey, "192.168.1.0/24"), "192.168.1.0/24", mapped)
+
+	got, unhonoured, err := Desired(m, stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{assignment},
+		peer(bobKey, "100.90.0.2/32")), nil, nil, claims, true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unhonoured) != 0 {
+		t.Fatalf("%s refused %v; a mapped prefix is not contested", iface, unhonoured)
+	}
+	return got
+}
+
+// The honest failure ADR-0020 insists on: a host that cannot translate keeps refusing rather
+// than carrying one of two identical prefixes.
+//
+// This is the assertion that stops the feature being worse than what it replaced. A device
+// that installed a route to a mapped range with nothing to rewrite it would blackhole the
+// customer it was meant to reach, and would look configured while doing it.
+func TestAHostThatCannotTranslateStillRefuses(t *testing.T) {
+	claims := NewClaims()
+	assignment := mappedTo(assignmentTo("branch", bobKey, "192.168.1.0/24"), "192.168.1.0/24", "100.71.5.0/24")
+
+	// The first membership claims the real prefix, because it cannot translate either.
+	one := membership()
+	one.InterfaceName = "meshp0"
+	if _, _, err := Desired(one, stateWithRoutes(1, []*meshpv1.RouteGroupAssignment{assignment},
+		peer(bobKey, "100.90.0.2/32")), nil, nil, claims, false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	two := membership()
+	two.InterfaceName = "meshp1"
+	iface, unhonoured, err := Desired(two, stateWithRoutes(1, []*meshpv1.RouteGroupAssignment{assignment},
+		peer(bobKey, "100.90.0.2/32")), nil, nil, claims, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unhonoured) == 0 {
+		t.Error("a host that cannot translate carried a prefix another membership also claims")
+	}
+	if len(iface.Mapped) != 0 {
+		t.Errorf("Mapped = %v on a host with nothing to perform the translation", iface.Mapped)
+	}
+}
+
+// A mapping whose halves are different sizes is refused rather than approximated: the host
+// part is carried across unchanged, so a mismatched pair reaches the wrong machine inside the
+// right customer.
+func TestAMappingThatCannotWorkIsIgnored(t *testing.T) {
+	assignment := mappedTo(assignmentTo("branch", bobKey, "192.168.1.0/24"), "192.168.1.0/24", "100.71.5.0/25")
+
+	iface, _, err := Desired(membership(), stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{assignment},
+		peer(bobKey, "100.90.0.2/32")), nil, nil, NewClaims(), true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(iface.Mapped) != 0 {
+		t.Errorf("Mapped = %v; a mapping of mismatched sizes cannot carry the host part", iface.Mapped)
+	}
+}
+
+// The rules reach the host, and stop when the device stops colliding.
+func TestTheMappingIsInstalledAndRemoved(t *testing.T) {
+	link := newFakeLink()
+	filter := &fakeFilter{}
+	r := New(link, membership(), nil, filter, nil).WithClaims(NewClaims())
+
+	assignment := mappedTo(assignmentTo("branch", bobKey, "192.168.1.0/24"), "192.168.1.0/24", "100.71.5.0/24")
+	if _, err := r.Apply(context.Background(), stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{assignment}, peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.mappings) != 1 || len(filter.mappings[0]) != 1 {
+		t.Fatalf("mappings installed = %v", filter.mappings)
+	}
+
+	// Unchanged: not reinstalled, because rebuilding the table runs on the reconcile timer.
+	if _, err := r.Apply(context.Background(), stateWithRoutes(1,
+		[]*meshpv1.RouteGroupAssignment{assignment}, peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.mappings) != 1 {
+		t.Errorf("an unchanged mapping was installed %d times", len(filter.mappings))
+	}
+
+	// And the collision going away takes the rules with it (Invariant 20).
+	plain := assignmentTo("branch", bobKey, "192.168.1.0/24")
+	if _, err := r.Apply(context.Background(), stateWithRoutes(2,
+		[]*meshpv1.RouteGroupAssignment{plain}, peer(bobKey, "100.90.0.2/32"))); err != nil {
+		t.Fatal(err)
+	}
+	if len(filter.mappings) != 2 {
+		t.Fatalf("the mapping was not removed: %v", filter.mappings)
+	}
+	if len(filter.mappings[1]) != 0 {
+		t.Errorf("removal installed %v rather than nothing", filter.mappings[1])
+	}
+}
+
+// A mapped range is itself a routing-table entry, and can be contested like any other.
+//
+// This is the case that pins down what Claims must talk about. Declaring and contesting are
+// two halves of one rule, and a mutation to either alone leaves them agreeing with each other
+// while both look at the wrong thing -- the test above cannot tell. Here one membership's
+// allocated range is a prefix another membership genuinely carries, so the two halves have to
+// be looking at the routing table or the device installs the same entry twice.
+//
+// It is not hypothetical: the allocator avoids the organisation's own address pools and other
+// mapped ranges, but nothing stops a customer's LAN being inside the mapped block. It is
+// carrier-grade NAT space and unusual for a LAN, which makes this rare and not impossible.
+func TestAMappedRangeCanItselfBeContested(t *testing.T) {
+	const overlap = "100.71.5.0/24"
+
+	// The mapped membership first: it claims the range it will route by.
+	t.Run("the plain membership loses when the mapped one claimed first", func(t *testing.T) {
+		claims := NewClaims()
+		desiredWithMapping(t, "meshp0", claims, overlap)
+
+		plain := membership()
+		plain.InterfaceName = "meshp1"
+		_, unhonoured, err := Desired(plain, stateWithRoutes(1,
+			[]*meshpv1.RouteGroupAssignment{assignmentTo("theirs", bobKey, overlap)},
+			peer(bobKey, "100.90.0.2/32")), nil, nil, claims, true, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(unhonoured) == 0 {
+			t.Errorf("a prefix already held as somebody's mapped range was carried anyway")
+		}
+	})
+
+	// And the other way round: the range was taken, so the mapping cannot use it.
+	t.Run("the mapped membership loses when the plain one claimed first", func(t *testing.T) {
+		claims := NewClaims()
+		plain := membership()
+		plain.InterfaceName = "meshp1"
+		if _, _, err := Desired(plain, stateWithRoutes(1,
+			[]*meshpv1.RouteGroupAssignment{assignmentTo("theirs", bobKey, overlap)},
+			peer(bobKey, "100.90.0.2/32")), nil, nil, claims, true, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		m := membership()
+		m.InterfaceName = "meshp0"
+		assignment := mappedTo(assignmentTo("branch", bobKey, "192.168.1.0/24"), "192.168.1.0/24", overlap)
+		_, unhonoured, err := Desired(m, stateWithRoutes(1,
+			[]*meshpv1.RouteGroupAssignment{assignment},
+			peer(bobKey, "100.90.0.2/32")), nil, nil, claims, true, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(unhonoured) == 0 {
+			t.Errorf("a mapped range another membership already routes was used anyway")
+		}
+	})
+}

--- a/internal/tunnel/routegroups.go
+++ b/internal/tunnel/routegroups.go
@@ -27,11 +27,22 @@ import (
 // Returns the group names it could not honour, which the caller reports as unapplied rather
 // than swallowing: a device quietly not carrying a prefix it was assigned is indistinguishable
 // from one that is, right up until somebody tries to use it.
-func applyRouteGroups(iface *wgplan.Interface, assignments []*meshpv1.RouteGroupAssignment, chooser *routeprobe.Chooser, claims *Claims, log *slog.Logger) []string {
+func applyRouteGroups(iface *wgplan.Interface, assignments []*meshpv1.RouteGroupAssignment, chooser *routeprobe.Chooser, claims *Claims, canTranslate bool, log *slog.Logger) []string {
+	// Where colliding prefixes are reached, but only on a host that can actually perform the
+	// translation. On one that cannot, the mapping is dropped here and the real prefix is
+	// claimed instead — so the two memberships contest it and both are refused, exactly as
+	// before ADR-0020. A device that installed a route to a mapped range nothing rewrites
+	// would blackhole the customer it was meant to reach, which is worse than saying no.
+	iface.Mapped = mappedPrefixes(assignments, canTranslate, log)
+
 	// Declared before the early return, so a membership that has been taken out of every
 	// route group stops contesting prefixes it no longer carries. Leaving a stale claim
 	// behind would keep another membership refused for a network this one has left.
-	claims.Declare(iface.Name, declaredPrefixes(assignments))
+	//
+	// What is claimed is what reaches the routing table, which for a mapped prefix is its
+	// range and not the customer's own. That is what makes the collision go away rather than
+	// needing to be special-cased: two mapped ranges are different, so nothing contests.
+	claims.Declare(iface.Name, declaredPrefixes(assignments, iface.Mapped))
 
 	if len(assignments) == 0 {
 		return nil
@@ -81,7 +92,7 @@ func applyRouteGroups(iface *wgplan.Interface, assignments []*meshpv1.RouteGroup
 		// picked between: which one a packet reaches would depend on the order the routing
 		// table was written, so the technician who types `ssh 192.168.1.5` would sometimes
 		// reach one customer and sometimes the other (ADR-0019).
-		if contested := contestedPrefixes(claims, iface.Name, prefixes); len(contested) > 0 {
+		if contested := contestedPrefixes(claims, iface.Name, routedAs(prefixes, iface.Mapped)); len(contested) > 0 {
 			log.Error("not carrying a route group whose prefixes another network also claims",
 				"group", logx.Safe(name),
 				"prefixes", contested,
@@ -137,12 +148,76 @@ func groupPrefixes(assignment *meshpv1.RouteGroupAssignment) (prefixes []netip.P
 // Unparseable ones are skipped rather than refused: a prefix this build cannot read is
 // already reported as an unhonoured group above, and it cannot contest anything because
 // nothing can route it either.
-func declaredPrefixes(assignments []*meshpv1.RouteGroupAssignment) []netip.Prefix {
+func declaredPrefixes(assignments []*meshpv1.RouteGroupAssignment, mapped map[netip.Prefix]netip.Prefix) []netip.Prefix {
 	var out []netip.Prefix
 	for _, assignment := range assignments {
 		for _, raw := range assignment.GetPrefixes() {
-			if prefix, err := netip.ParsePrefix(raw); err == nil {
-				out = append(out, prefix.Masked())
+			prefix, err := netip.ParsePrefix(raw)
+			if err != nil {
+				continue
+			}
+			out = append(out, routedAs([]netip.Prefix{prefix.Masked()}, mapped)...)
+		}
+	}
+	return out
+}
+
+// routedAs is what these prefixes look like in the routing table.
+//
+// The mapped range where there is one, the prefix itself otherwise. Everything that decides
+// whether two memberships collide has to ask this rather than look at the prefix directly,
+// because the collision is about the routing table and nothing else.
+func routedAs(prefixes []netip.Prefix, mapped map[netip.Prefix]netip.Prefix) []netip.Prefix {
+	if len(mapped) == 0 {
+		return prefixes
+	}
+	out := make([]netip.Prefix, 0, len(prefixes))
+	for _, p := range prefixes {
+		if to, ok := mapped[p.Masked()]; ok {
+			out = append(out, to)
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// mappedPrefixes reads the ranges the control plane allocated, on a host that can use them.
+//
+// Refused rather than approximated when a half will not parse or the two are different sizes:
+// the host part is carried across unchanged, so a mismatched pair would send a technician to
+// an address inside the right customer and the wrong machine.
+func mappedPrefixes(assignments []*meshpv1.RouteGroupAssignment, canTranslate bool, log *slog.Logger) map[netip.Prefix]netip.Prefix {
+	var out map[netip.Prefix]netip.Prefix
+	for _, assignment := range assignments {
+		for _, m := range assignment.GetMappedPrefixes() {
+			real, realErr := netip.ParsePrefix(m.GetPrefix())
+			to, toErr := netip.ParsePrefix(m.GetMapped())
+			if realErr != nil || toErr != nil || real.Bits() != to.Bits() ||
+				real.Addr().Is4() != to.Addr().Is4() {
+				log.Error("a mapped range this device cannot use was sent for a colliding prefix",
+					"prefix", logx.Safe(m.GetPrefix()), "mapped", logx.Safe(m.GetMapped()),
+					"consequence", "the prefix stays contested and the group is not carried")
+				continue
+			}
+			if !canTranslate {
+				// Said once per pass rather than per prefix, further down, because a host
+				// with no nftables collides on everything or nothing.
+				continue
+			}
+			if out == nil {
+				out = make(map[netip.Prefix]netip.Prefix)
+			}
+			out[real.Masked()] = to.Masked()
+		}
+	}
+	if !canTranslate && len(out) == 0 {
+		for _, assignment := range assignments {
+			if len(assignment.GetMappedPrefixes()) > 0 {
+				log.Error("this device was given ranges for colliding prefixes and cannot translate",
+					"why", "translation needs nftables, which this host does not have",
+					"consequence", "the colliding groups stay refused rather than reaching one customer at another's address")
+				break
 			}
 		}
 	}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/netip"
 	"strings"
 	"sync"
@@ -160,6 +161,10 @@ type Reconciler struct {
 	// every pass — see applySystemResolver.
 	announced systemResolverState
 
+	// lastMapped is what was last installed, so an unchanged set is not reinstalled on every
+	// reconcile. Rebuilding the table is atomic but not free, and it runs on a timer.
+	lastMapped map[netip.Prefix]netip.Prefix
+
 	// lastProbe is when each group was last probed, so a group can ask to be quieter than
 	// the daemon's reconcile interval. Under mu because Apply is entered both from the
 	// session's applier and from the reconcile ticker.
@@ -190,6 +195,11 @@ type Filter interface {
 	// interface name removes it, which is the only way it comes off: these rules are system
 	// state and outlive the process on purpose (ADR-0011).
 	ApplyLock(ctx context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix, preventDNSLeaks bool) error
+
+	// ApplyMap makes this host reach colliding prefixes at the ranges allocated for them.
+	// An empty map means nothing collides and must remove whatever was installed before,
+	// or a device that left a network keeps rewriting for it.
+	ApplyMap(ctx context.Context, iface string, mapped map[netip.Prefix]netip.Prefix) error
 
 	// ForwardObstacles names anything else on this host that drops forwarded packets, as
 	// strings an operator can go and look at. Empty means nothing was found, which is not
@@ -306,7 +316,7 @@ func (r *Reconciler) Status() Status {
 // The returned components are the parts that did not converge, which the agent reports back
 // so the control plane knows this device is not where it says it is.
 func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, error) {
-	want, unhonoured, err := Desired(r.membership, state, r.relay, r.chooser, r.claims, r.log)
+	want, unhonoured, err := Desired(r.membership, state, r.relay, r.chooser, r.claims, r.filter != nil, r.log)
 	if err != nil {
 		// A description the kernel would refuse, or one wgplan judged unsafe. Reported
 		// rather than approximated: applying part of a rejected configuration is how an
@@ -427,6 +437,12 @@ func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, e
 		unapplied = append(unapplied, failed...)
 	}
 
+	// Before the forwarding and after the interface, because the rules name an interface
+	// that has to exist and rewrite traffic the routes above will start sending.
+	if failed := r.applyMappings(ctx, want.Name, want.Mapped); failed != nil {
+		unapplied = append(unapplied, failed...)
+	}
+
 	if failed := r.applyForwarding(ctx, want.Name, state.Advertised()); failed != nil {
 		unapplied = append(unapplied, failed...)
 	}
@@ -536,6 +552,41 @@ func (r *Reconciler) observeAdvertisers(ctx context.Context, iface string, obser
 	// A group no longer assigned should not be remembered, or a device that carried a
 	// prefix for a while keeps its choice forever.
 	r.chooser.Forget(assignments)
+}
+
+// applyMappings makes this host reach colliding prefixes at the ranges allocated for them.
+//
+// Applied whenever the set changes, and applied empty when it becomes empty: a device that
+// left one of two colliding networks stops colliding, and rules left rewriting for a network
+// it is no longer in would send its traffic to an address it can no longer reach.
+//
+// A host with no filter never gets here with anything to do. Desired refuses the mapping on a
+// host that cannot translate, so want.Mapped is empty and the colliding groups were already
+// reported unhonoured — the honest refusal rather than a route into nothing.
+func (r *Reconciler) applyMappings(ctx context.Context, iface string, mapped map[netip.Prefix]netip.Prefix) []string {
+	if r.filter == nil {
+		return nil
+	}
+	if len(mapped) == 0 && len(r.lastMapped) == 0 {
+		return nil
+	}
+	if maps.Equal(mapped, r.lastMapped) {
+		return nil
+	}
+	if err := r.filter.ApplyMap(ctx, iface, mapped); err != nil {
+		r.log.Error("could not reach colliding prefixes at the ranges allocated for them",
+			"interface", iface, "error", logx.SafeError(err),
+			"consequence", "the customers sharing those addresses are not reachable")
+		return []string{"mapping"}
+	}
+	r.lastMapped = maps.Clone(mapped)
+	if len(mapped) > 0 {
+		r.log.Info("reaching colliding prefixes at their allocated ranges",
+			"interface", iface, "mappings", len(mapped))
+	} else {
+		r.log.Info("no longer translating any prefixes", "interface", iface)
+	}
+	return nil
 }
 
 // applyForwarding makes this host carry what it advertises, or stop.
@@ -701,7 +752,7 @@ func (r *Reconciler) fail(err error) {
 // The second return names route groups this device was assigned and could not carry. It is
 // a translation result rather than part of the interface description, which is why it comes
 // back separately: wgplan plans kernel operations, and "what is missing" is not one.
-func Desired(m Membership, state *peerset.Set, relay Relay, chooser *routeprobe.Chooser, claims *Claims, log *slog.Logger) (wgplan.Interface, []string, error) {
+func Desired(m Membership, state *peerset.Set, relay Relay, chooser *routeprobe.Chooser, claims *Claims, canTranslate bool, log *slog.Logger) (wgplan.Interface, []string, error) {
 	if log == nil {
 		log = slog.New(slog.DiscardHandler)
 	}
@@ -753,7 +804,7 @@ func Desired(m Membership, state *peerset.Set, relay Relay, chooser *routeprobe.
 	//
 	// Reported rather than fatal: one group this device cannot honour must not cost it the
 	// peers and prefixes it can.
-	unhonoured := applyRouteGroups(&iface, state.RouteGroups(), chooser, claims, log)
+	unhonoured := applyRouteGroups(&iface, state.RouteGroups(), chooser, claims, canTranslate, log)
 	return iface, unhonoured, nil
 }
 

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -3,9 +3,11 @@ package tunnel
 import (
 	"context"
 	"errors"
+	"maps"
 	"net/netip"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -338,7 +340,7 @@ func TestDesiredRendersAddressesAsHostPrefixes(t *testing.T) {
 	m.AddressV4 = "100.90.0.1"
 	m.AddressV6 = "fd7c::1"
 
-	iface, _, err := Desired(m, stateWith(1), nil, nil, nil, nil)
+	iface, _, err := Desired(m, stateWith(1), nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -360,7 +362,7 @@ func TestDesiredRefusesAnAddressThatIsNotOneHost(t *testing.T) {
 		m := membership()
 		m.AddressV4 = addr
 		m.AddressV6 = ""
-		if _, _, err := Desired(m, stateWith(1), nil, nil, nil, nil); err == nil {
+		if _, _, err := Desired(m, stateWith(1), nil, nil, nil, false, nil); err == nil {
 			t.Errorf("%s was accepted", addr)
 		}
 	}
@@ -373,7 +375,7 @@ func TestDesiredAcceptsAnAddressThatAlreadyCarriesItsPrefix(t *testing.T) {
 	m.AddressV4 = "100.90.0.1/32"
 	m.AddressV6 = "fd7c::1/128"
 
-	iface, _, err := Desired(m, stateWith(1), nil, nil, nil, nil)
+	iface, _, err := Desired(m, stateWith(1), nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatalf("Desired: %v", err)
 	}
@@ -386,14 +388,14 @@ func TestDesiredRefusesAMembershipWithNothingToWorkFrom(t *testing.T) {
 	t.Run("no private key", func(t *testing.T) {
 		m := membership()
 		m.PrivateKey = ""
-		if _, _, err := Desired(m, stateWith(1), nil, nil, nil, nil); err == nil {
+		if _, _, err := Desired(m, stateWith(1), nil, nil, nil, false, nil); err == nil {
 			t.Error("a membership with no private key was accepted")
 		}
 	})
 	t.Run("no addresses", func(t *testing.T) {
 		m := membership()
 		m.AddressV4, m.AddressV6 = "", ""
-		if _, _, err := Desired(m, stateWith(1), nil, nil, nil, nil); err == nil {
+		if _, _, err := Desired(m, stateWith(1), nil, nil, nil, false, nil); err == nil {
 			t.Error("a membership with no addresses was accepted")
 		}
 	})
@@ -408,7 +410,7 @@ func TestDesiredTakesTheMTUFromTheServer(t *testing.T) {
 		Tunnel: &meshpv1.TunnelConfig{Mtu: 1280},
 	})
 
-	iface, _, err := Desired(membership(), state, nil, nil, nil, nil)
+	iface, _, err := Desired(membership(), state, nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -423,7 +425,7 @@ func TestDesiredFallsBackToADefaultMTU(t *testing.T) {
 	state := peerset.New()
 	state.Apply(&meshpv1.StateDelta{FromVersion: 0, ToVersion: 1})
 
-	iface, _, err := Desired(membership(), state, nil, nil, nil, nil)
+	iface, _, err := Desired(membership(), state, nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -438,7 +440,7 @@ func TestDesiredFallsBackToADefaultMTU(t *testing.T) {
 // A peer with no endpoint is configured and unreachable, which is the honest state of every
 // peer today: nothing discovers endpoints yet.
 func TestAPeerWithNoEndpointIsStillConfigured(t *testing.T) {
-	iface, _, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil, nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -459,7 +461,7 @@ func TestTheFirstEndpointIsUsed(t *testing.T) {
 	p := peer(bobKey, "100.90.0.2/32")
 	p.Endpoints = []string{"203.0.113.2:51820", "198.51.100.2:51820"}
 
-	iface, _, err := Desired(membership(), stateWith(1, p), nil, nil, nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, p), nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -471,7 +473,7 @@ func TestTheFirstEndpointIsUsed(t *testing.T) {
 // The key is carried through untouched. wgplan does not parse keys, so a translation that
 // mangled one would only fail at the kernel, on a real host, with a confusing message.
 func TestKeysArePassedThroughUnchanged(t *testing.T) {
-	iface, _, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil, nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, peer(bobKey, "100.90.0.2/32")), nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -585,7 +587,7 @@ func TestARememberedPortIsAskedForAgain(t *testing.T) {
 	m := membership()
 	m.ListenPort = 51999
 
-	iface, _, err := Desired(m, stateWith(1), nil, nil, nil, nil)
+	iface, _, err := Desired(m, stateWith(1), nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -596,7 +598,7 @@ func TestARememberedPortIsAskedForAgain(t *testing.T) {
 
 // A membership that has never come up asks for any port.
 func TestAMembershipWithNoPortAsksForAny(t *testing.T) {
-	iface, _, err := Desired(membership(), stateWith(1), nil, nil, nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1), nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -655,7 +657,7 @@ func relayedPeer(key, relayID string, ips ...string) *meshpv1.Peer {
 func TestARelayedPeerIsGivenItsLoopbackEndpoint(t *testing.T) {
 	relay := newFakeRelay("relay1")
 
-	iface, _, err := Desired(membership(), stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32")), relay, nil, nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32")), relay, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -683,7 +685,7 @@ func TestADirectEndpointWinsOverARelay(t *testing.T) {
 	p := relayedPeer(bobKey, "relay1", "100.90.0.2/32")
 	p.Endpoints = []string{"203.0.113.2:51820"}
 
-	iface, _, err := Desired(membership(), stateWith(1, p), relay, nil, nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, p), relay, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -706,7 +708,7 @@ func TestAPeerOnAnUnreachableRelayDoesNotBreakTheOthers(t *testing.T) {
 	iface, _, err := Desired(membership(), stateWith(1,
 		relayedPeer(bobKey, "relay1", "100.90.0.2/32"),
 		relayedPeer(carolKey, "relay2", "100.90.0.3/32"),
-	), relay, nil, nil, nil)
+	), relay, nil, nil, false, nil)
 	if err != nil {
 		t.Fatalf("one unreachable relay refused the whole interface: %v", err)
 	}
@@ -729,7 +731,7 @@ func TestAPeerOnAnUnreachableRelayDoesNotBreakTheOthers(t *testing.T) {
 // With no relay at all — no data plane, or a deployment that has not configured one — a
 // relayed peer is unreachable rather than refused.
 func TestNoRelayLeavesRelayedPeersWithoutEndpoints(t *testing.T) {
-	iface, _, err := Desired(membership(), stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32")), nil, nil, nil, nil)
+	iface, _, err := Desired(membership(), stateWith(1, relayedPeer(bobKey, "relay1", "100.90.0.2/32")), nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -827,6 +829,8 @@ func TestTheListenPortIsHandedToTheRelayAfterConverging(t *testing.T) {
 
 // fakeFilter records what it was asked to enforce.
 type fakeFilter struct {
+	mu sync.Mutex
+
 	applied   []*meshpv1.PacketFilter
 	forwarded [][]*meshpv1.AdvertisedRoutes_Group
 	iface     string
@@ -853,6 +857,20 @@ type fakeFilter struct {
 	// way, asked successfully.
 	obstacles   []string
 	obstacleErr error
+
+	mappings []map[netip.Prefix]netip.Prefix
+	mappedOn string
+	mapErr   error
+}
+
+// mappings records every set of mapped ranges installed, in order, so a test can see both
+// what went in and that an empty one came after.
+func (f *fakeFilter) ApplyMap(_ context.Context, iface string, mapped map[netip.Prefix]netip.Prefix) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.mappings = append(f.mappings, maps.Clone(mapped))
+	f.mappedOn = iface
+	return f.mapErr
 }
 
 func (f *fakeFilter) ForwardObstacles(context.Context) ([]string, error) {
@@ -1145,7 +1163,7 @@ func TestACarriedPrefixReachesTheCarrierAndTheRoutingTable(t *testing.T) {
 		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch-lan", bobKey, "192.168.10.0/24")},
 		peer(bobKey, "100.90.0.2/32"))
 
-	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil, nil)
+	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1186,7 +1204,7 @@ func TestAnEgressGroupPutsTheDefaultInAllowedIPs(t *testing.T) {
 		[]*meshpv1.RouteGroupAssignment{assignmentTo("exit", bobKey, "0.0.0.0/0", "::/0")},
 		peer(bobKey, "100.90.0.2/32"))
 
-	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil, nil)
+	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatalf("an egress group made the whole description fail: %v", err)
 	}
@@ -1228,7 +1246,7 @@ func TestACarrierThatIsNotAPeerIsReported(t *testing.T) {
 		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch-lan", carolKey, "192.168.10.0/24")},
 		peer(bobKey, "100.90.0.2/32"))
 
-	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil, nil)
+	iface, unhonoured, err := Desired(membership(), state, nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1247,7 +1265,7 @@ func TestAnUnparseablePrefixIsReportedRatherThanGuessed(t *testing.T) {
 		[]*meshpv1.RouteGroupAssignment{assignmentTo("branch-lan", bobKey, "not-a-prefix")},
 		peer(bobKey, "100.90.0.2/32"))
 
-	_, unhonoured, err := Desired(membership(), state, nil, nil, nil, nil)
+	_, unhonoured, err := Desired(membership(), state, nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1265,7 +1283,7 @@ func TestAGroupWithNoCandidatesIsReported(t *testing.T) {
 	state := stateWithRoutes(1, []*meshpv1.RouteGroupAssignment{assignment},
 		peer(bobKey, "100.90.0.2/32"))
 
-	_, unhonoured, err := Desired(membership(), state, nil, nil, nil, nil)
+	_, unhonoured, err := Desired(membership(), state, nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1287,7 +1305,7 @@ func TestTheFirstCandidateCarriesIt(t *testing.T) {
 	state := stateWithRoutes(1, []*meshpv1.RouteGroupAssignment{assignment},
 		peer(bobKey, "100.90.0.2/32"), peer(carolKey, "100.90.0.3/32"))
 
-	iface, _, err := Desired(membership(), state, nil, nil, nil, nil)
+	iface, _, err := Desired(membership(), state, nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1608,7 +1626,7 @@ func TestADeviceFailsOverFromASilentAdvertiser(t *testing.T) {
 	if _, err := r.Apply(context.Background(), state); err != nil {
 		t.Fatal(err)
 	}
-	iface, _, err := Desired(membership(), state, nil, nil, nil, nil)
+	iface, _, err := Desired(membership(), state, nil, nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1636,7 +1654,7 @@ func TestADeviceFailsOverFromASilentAdvertiser(t *testing.T) {
 // currentInterface recomputes what the reconciler would configure now.
 func currentInterface(t *testing.T, r *Reconciler, state *peerset.Set) wgplan.Interface {
 	t.Helper()
-	iface, _, err := Desired(r.membership, state, r.relay, r.chooser, r.claims, r.log)
+	iface, _, err := Desired(r.membership, state, r.relay, r.chooser, r.claims, false, r.log)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/wgplan/wgplan.go
+++ b/internal/wgplan/wgplan.go
@@ -106,6 +106,20 @@ type Interface struct {
 	Addresses []netip.Prefix
 
 	Peers []Peer
+
+	// Mapped is where a colliding prefix is reached, keyed by the prefix the customer
+	// actually uses (ADR-0020).
+	//
+	// It exists because these two cannot be the same list. WireGuard's allowed IPs must hold
+	// the customer's real prefix, since that is the destination in the packet by the time the
+	// tunnel sees it — the rewrite happens in postrouting, before the device transmits. The
+	// system routing table must hold the mapped range instead, because that is what the
+	// packet is addressed to when the routing decision is made, and because holding the real
+	// prefix is precisely what it cannot do twice.
+	//
+	// Empty on almost every device. A prefix nothing contests is routed and allowed under the
+	// same address, which is what the code below does when this is nil.
+	Mapped map[netip.Prefix]netip.Prefix
 }
 
 // Observed is what the platform reports an existing interface currently holds.
@@ -487,6 +501,14 @@ func wantRoutes(want Interface) []netip.Prefix {
 	for _, peer := range want.Peers {
 		for _, prefix := range peer.AllowedIPs {
 			if prefix.Bits() == 0 {
+				continue
+			}
+			// A colliding prefix is routed by the range it is reached at, not by the one the
+			// customer uses. The allowed IP stays the real prefix — that is the destination
+			// once the rewrite has happened — while the routing table holds something it can
+			// hold twice over, which is the whole of ADR-0020's third point.
+			if mapped, ok := want.Mapped[prefix]; ok {
+				out = append(out, mapped)
 				continue
 			}
 			out = append(out, prefix)

--- a/internal/wgplan/wgplan_test.go
+++ b/internal/wgplan/wgplan_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/netip"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1206,5 +1207,57 @@ func TestTwoCatchAllsAreRefused(t *testing.T) {
 	}
 	if err := iface.Validate(); err == nil {
 		t.Error("two peers both claiming every destination were accepted")
+	}
+}
+
+// A colliding prefix is routed by the range it is reached at, and allowed by the one the
+// customer uses (ADR-0020).
+//
+// The two must differ, and that is the point: the routing table cannot hold 192.168.1.0/24
+// twice, while WireGuard must be told to accept it because that is the destination in the
+// packet by the time the tunnel sees it -- the rewrite happens in postrouting, before the
+// device transmits. Getting this backwards produces a device that either cannot route to the
+// customer or silently drops every packet it does route.
+func TestAMappedPrefixIsRoutedByItsRangeAndAllowedByItsOwn(t *testing.T) {
+	real := netip.MustParsePrefix("192.168.1.0/24")
+	mapped := netip.MustParsePrefix("100.71.5.0/24")
+
+	want := Interface{
+		Name:       "meshp0",
+		PrivateKey: "private-key-of-this-device",
+		Addresses:  []netip.Prefix{netip.MustParsePrefix("100.90.0.1/32")},
+		Peers: []Peer{{
+			PublicKey:  "peer-public-key",
+			AllowedIPs: []netip.Prefix{netip.MustParsePrefix("100.90.0.2/32"), real},
+		}},
+		Mapped: map[netip.Prefix]netip.Prefix{real: mapped},
+	}
+
+	routes := wantRoutes(want)
+	if !slices.Contains(routes, mapped) {
+		t.Errorf("routes = %v; the mapped range is what the routing table must hold", routes)
+	}
+	if slices.Contains(routes, real) {
+		t.Errorf("routes = %v; the customer's own prefix is the thing that cannot be held twice", routes)
+	}
+
+	// And the allowed IP is untouched, or WireGuard drops the packet the rewrite produced.
+	if !slices.Contains(want.Peers[0].AllowedIPs, real) {
+		t.Error("the peer no longer allows the prefix that actually crosses the tunnel")
+	}
+}
+
+// Everything not mapped is routed exactly as before, which is almost every prefix on almost
+// every device.
+func TestAnUnmappedPrefixIsRoutedAsItself(t *testing.T) {
+	plain := netip.MustParsePrefix("10.20.0.0/16")
+	want := Interface{
+		Name:       "meshp0",
+		PrivateKey: "private-key-of-this-device",
+		Peers:      []Peer{{PublicKey: "peer-public-key", AllowedIPs: []netip.Prefix{plain}}},
+		Mapped:     map[netip.Prefix]netip.Prefix{netip.MustParsePrefix("192.168.1.0/24"): netip.MustParsePrefix("100.71.5.0/24")},
+	}
+	if routes := wantRoutes(want); !slices.Contains(routes, plain) {
+		t.Errorf("routes = %v, want the prefix itself", routes)
 	}
 }


### PR DESCRIPTION
The last slice of ADR-0020, and the first one a person can see. [#88](https://github.com/meshpnet/meshp/pull/88) built the rules, [#91](https://github.com/meshpnet/meshp/pull/91) chose the numbers, [#92](https://github.com/meshpnet/meshp/pull/92) put them on the wire; this makes the device act on them.

## The routing table and AllowedIPs have to disagree

This is the part that needed a change underneath, and it is easy to get backwards.

- **AllowedIPs keeps the customer's real prefix.** That is the destination in the packet by the time the tunnel sees it — the rewrite happens in postrouting, before the device transmits. Put the mapped range here and WireGuard drops every packet the rewrite produced.
- **The routing table holds the mapped range.** That is what the packet is addressed to when the route is chosen, and the real prefix is precisely the thing it cannot hold twice.

`wgplan.Interface` gained `Mapped` so `wantRoutes` can tell them apart; it derived routes straight from AllowedIPs before, so the two could not differ.

## Claims stopped needing a special case

It now talks about what reaches the routing table rather than what the control plane called it. Two mapped ranges are different, so nothing contests — and no code anywhere says "unless it is mapped".

## The honest failure survives

A host that cannot translate has the mapping dropped **before anything claims it**, so the two memberships contest the real prefix and both stay unhonoured, exactly as before ADR-0020. A device that routed to a mapped range with nothing to rewrite it would blackhole the customer it was meant to reach while looking configured — worse than saying no.

## Mutations: three killed, two that taught me something

| mutation | outcome |
|---|---|
| mapping used even without translation | killed |
| mismatched-size mapping accepted | killed |
| rules never applied | killed |
| **claims declare the real prefix** | **survived** |
| **contest checked on the real prefix** | **survived** |

Those last two survived *together*, and that is the interesting part: declaring and contesting are two halves of one rule, so changing either alone leaves them agreeing with each other about the wrong thing. My first test could only prove they were consistent.

The test that pins it down is a mapped range that is itself a prefix another membership genuinely carries, asserted in both orderings. Both mutations now die.

## A limitation that test surfaced

The allocator avoids the organisation's address pools and other mapped ranges, but **nothing stops a customer's LAN sitting inside the mapped block**. `100.71.0.0/16` is carrier-grade NAT space so a LAN there is unusual — but not impossible, and if it happens the two contest and one is refused rather than anything silently going wrong. Worth a follow-up to have allocation avoid carried prefixes too; the honest refusal holds in the meantime.