### PR TITLE
test(e2e): a lock that does not block is not a lock that went away

### DIFF
--- a/scripts/e2e-failover.sh
+++ b/scripts/e2e-failover.sh
@@ -501,6 +501,32 @@ reaches_beyond() {
   ip netns exec "$CLIENT_NS" ping -c 1 -W 2 "$BEYOND" >/dev/null 2>&1
 }
 
+lock_installed() {
+  ip netns exec "$CLIENT_NS" nft list table inet meshp_lock >/dev/null 2>&1
+}
+
+# What to look at when an assertion about the lock fails.
+#
+# The ruleset says whether the lock is installed and what it is permitting; the claim and
+# release lines say whether it has been going up and down; the applied versions say why it
+# would have. Dumped in full rather than summarised, because this exists for a failure that
+# did not reproduce on a re-run of the same commit, and the next one has to be readable
+# without a third run to ask a further question.
+dump_egress_state() {
+  echo "--- client nftables ruleset ---" >&2
+  ip netns exec "$CLIENT_NS" nft list ruleset >&2 || true
+  echo "--- client ip rules ---" >&2
+  ip netns exec "$CLIENT_NS" ip rule show >&2 || true
+  echo "--- client agent: state versions and egress claims ---" >&2
+  grep -a \
+    -e "applied desired state" \
+    -e "refusing a delta" \
+    -e "could not apply desired state" \
+    -e "sends everything through the tunnel" \
+    -e "no longer sending everything through the tunnel" \
+    "$WORK/${CLIENT_NS}.log" | tail -40 >&2 || true
+}
+
 # Without this the rest proves nothing: an address that was never reachable is blocked by
 # the topology rather than by anything meshp did.
 reaches_beyond || fail "the client cannot reach ${BEYOND} before any claim; nothing to prove"
@@ -515,7 +541,7 @@ api -X POST -d "{\"membership_id\":\"${ADV2_MEMBERSHIP}\",\"priority\":1}" \
 
 locked=0
 for _ in $(seq 1 30); do
-  if ip netns exec "$CLIENT_NS" nft list table inet meshp_lock >/dev/null 2>&1; then locked=1; break; fi
+  if lock_installed; then locked=1; break; fi
   sleep 1
 done
 if [ "$locked" != "1" ]; then
@@ -525,10 +551,64 @@ if [ "$locked" != "1" ]; then
 fi
 echo "  the client claimed a default route and locked itself closed"
 
-if reaches_beyond; then
-  fail "traffic still left outside the tunnel with the lock on"
+# Refused, and refused *by the lock* — the two observed together, with a deadline rather
+# than in a single shot.
+#
+# A single shot was flaky, and not for the obvious reason. The lock is installed as one
+# nftables transaction (RenderLock), so a table that exists is a table already enforcing;
+# there is no gap between the table appearing above and its rules arriving. The gap is
+# above that. The reconciler re-applies the last desired state it was handed every couple of
+# seconds, and a state that momentarily arrives without the egress group takes the lock
+# straight back off (tunnel.releaseEgress) until the next state puts it back — one ping
+# landing in that window fails a test whose subject is working correctly.
+#
+# That mechanism is read off the code, not yet seen: what the failing run actually logged was
+# `refusing a delta computed against a different version` and an unapplied peer set, which is
+# the agent declining a state rather than the lock being observed coming off. Which is why
+# the failure paths below dump the ruleset and the version history — so the run after this
+# one settles it instead of inferring it again.
+#
+# Retrying on its own would hide the defect this section exists to catch, so the two are
+# told apart by what the lock is doing at the moment a packet moves. Through while the lock
+# is installed is a lock that does not block: the real failure, and it stops here without
+# retrying. Through while the lock is gone is the window above, and it is waited out.
+# Refused while the lock is gone is not success either — something other than meshp is
+# dropping it, which is the same nothing-proved that the reachability check above rules out.
+#
+# The lock is read either side of the packet, and only a packet that crossed a lock which
+# was there both before and after is called a failure. Reading it once after would put this
+# script's own scheduling in the argument: a reinstall landing between the reply and the
+# read would be indistinguishable from a lock that never blocked, and would report the flake
+# it was written to remove as a defect.
+blocked=0
+reopened=0
+for _ in $(seq 1 30); do
+  locked_before=0
+  if lock_installed; then locked_before=1; fi
+
+  if reaches_beyond; then
+    if [ "$locked_before" = "1" ] && lock_installed; then
+      dump_egress_state
+      fail "traffic still left outside the tunnel with the lock on"
+    fi
+    reopened=$(( reopened + 1 ))
+  elif lock_installed; then
+    blocked=1
+    break
+  fi
+  sleep 1
+done
+if [ "$blocked" != "1" ]; then
+  dump_egress_state
+  fail "the lock never refused anything: traffic outside the tunnel was never blocked while the lock was installed"
 fi
 echo "  and traffic outside the tunnel is refused"
+if [ "$reopened" != "0" ]; then
+  # Said out loud rather than absorbed by the retry. The run passed, and it also saw the
+  # thing that makes this assertion flaky, which is worth knowing before it fails again.
+  echo "  (${reopened} earlier attempt(s) got out while no lock was installed;" \
+       "look for 'no longer sending everything through the tunnel' in ${CLIENT_NS}.log)"
+fi
 
 # The claim in the kernel, not merely a lock that exists. Matched on the mark rather than
 # the table number, because that is what identifies the rule as meshp's and it does not
@@ -543,9 +623,14 @@ echo "  with policy routing exempting the tunnel's own traffic"
 echo "killing the agent outright"
 pkill -9 -f "${CLIENT_NS}.sock" || true
 sleep 2
-ip netns exec "$CLIENT_NS" nft list table inet meshp_lock >/dev/null 2>&1 \
-  || fail "the lock died with the agent, so a crash leaks the user's traffic"
+
+# Checked once and not polled, unlike the assertion above: the agent that could have taken
+# the lock off is gone, so there is no longer anything that could put the device in and out
+# of the locked state, and a retry here would only be waiting for a leak to stop.
+lock_installed \
+  || { dump_egress_state; fail "the lock died with the agent, so a crash leaks the user's traffic"; }
 if reaches_beyond; then
+  dump_egress_state
   fail "traffic leaked the moment the agent was killed, which is the whole failure ADR-0011 exists to prevent"
 fi
 echo "  the lock outlived the agent and traffic is still refused"


### PR DESCRIPTION
CI run [31957357602](https://github.com/meshpnet/meshp/actions/runs/31957357602) (branch `test/dns-e2e-name`, commit `c9a7536`) failed the fail-closed assertion in `e2e-failover.sh` — *"traffic still left outside the tunnel with the lock on"* — and re-running the identical commit passed. The script was reporting a defect in a feature that was working.

## The obvious race is not the cause

Worth ruling out first, because it is the one everybody reaches for. The lock is loaded by `nft -f -` as a **single netlink transaction** ([`apply_linux.go`](https://github.com/meshpnet/meshp/blob/main/internal/nftables/apply_linux.go)), so a table that exists is a table already enforcing. There is no window between the wait loop seeing the table and its rules arriving.

The window is a level up. The reconciler re-applies the last desired state it was handed every couple of seconds, and a state that arrives without the egress group takes the lock straight back off (`tunnel.releaseEgress`) until the next one puts it back. One ping landing there fails the assertion.

**That mechanism is read off the code rather than seen, and the code says so.** What the failing run actually logged was `refusing a delta computed against a different version` (`delta_from=4 have=5 delta_to=6`) and an unapplied peer set — an agent declining a state, not a lock observed coming off. The inference is good and it is still an inference.

## Telling the two failures apart

Polling with a deadline alone would stop the failure and would also hide the defect the section exists to catch. So the two are told apart by what the lock is doing at the moment a packet moves:

| a poll sees | verdict |
|---|---|
| refused, lock installed | pass |
| **out through an installed lock** | the real failure — stops immediately, no retry |
| out while the lock is gone | the window above, waited out |
| refused with no lock installed | not success either |

That last row is not a technicality. Something other than meshp is dropping the packet, which is the same nothing-proved that the reachability check at the top of the section exists to rule out — and **the old single shot would have counted it as a pass.**

The lock is read **either side of the packet**, and only a packet that crossed a lock present both times is called a failure. Reading it once afterwards would put the script's own scheduling into the argument: a reinstall landing between the reply and the read is indistinguishable from a lock that never blocked, and would report the very flake this removes as a defect.

## The next failure has to be readable without a further run

This one was not. Both failure paths now dump the client namespace's full nftables ruleset, its `ip rule` output, and the agent's applied-version and egress claim/release history. A **passing** run that saw the lock come off says so out loud rather than absorbing it into the retry.

The two assertions after `kill -9` get the same dump and stay **single shots on purpose**: the agent that could remove the lock is dead, so nothing can put the device in and out of the locked state, and a retry there would only be waiting for a leak to stop.

## Verification

Seven runs in a privileged Linux container against a real Postgres, all green.

**None of them reproduced the window** — which is what a flake that already survived one re-run should be expected to do. They establish that nothing regressed, not that it is gone. What is actually verified is the decision table, extracted from the script and driven directly with stubbed reachability and lock states: the real defect fails on the first poll, the transient is waited out, and a block with no lock is not counted.

## Left alone

The state-version disagreement underneath. The agent's refusal is correct — folding a delta onto the wrong base would produce a peer set matching neither version while claiming to be the newer one — but a control plane computing a delta from a version the agent does not hold is its own defect. And a device whose state momentarily loses its egress group drops the lock **and** the default route together, which is a real leak on a real machine rather than a test artefact, and the thing ADR-0011 exists to prevent.
