### PR TITLE
fix(nftables): each membership translates in a table of its own

### DIFF
--- a/internal/nftables/mapping.go
+++ b/internal/nftables/mapping.go
@@ -7,12 +7,26 @@ import (
 	"strings"
 )
 
-// MapTableName is the table that makes two customers on the same prefix distinguishable.
+// MapTableName is the prefix of the table that makes two customers on the same prefix
+// distinguishable.
 //
 // Its own table, like the lock and the forwarding rules, and rebuilt on its own trigger: the
 // mappings change when a device's memberships change, which is a different event from a
 // policy update or a route group moving between advertisers.
+//
+// One table per interface rather than one for the device, which is the whole reason this is a
+// prefix and not the name. Every membership reconciles on its own timer and rebuilds its own
+// table whole, so a single shared table would have the second membership to reconcile erase
+// the first's rules — and on a device holding two colliding memberships, which is the only
+// device that has any of these rules at all, that means exactly one of the two customers is
+// ever reachable. An end-to-end run found it doing precisely that.
 const MapTableName = "meshp_map"
+
+// MapTable is the table one interface's mappings live in.
+//
+// The interface name is already validated by the caller against a pattern nft will accept,
+// and interface names are unique on a host, so this cannot collide with another membership's.
+func MapTable(iface string) string { return MapTableName + "_" + iface }
 
 // Mapping is one colliding prefix and the range this device reaches it by.
 //
@@ -62,11 +76,13 @@ func RenderMap(iface string, mappings []Mapping) (string, error) {
 		return "", fmt.Errorf("nftables: %q is not a usable interface name", iface)
 	}
 
+	table := MapTable(iface)
+
 	var b strings.Builder
 	// add-then-delete so removal is idempotent, as everywhere else here: deleting a table
 	// that is not there is an error, and adding one that is already there is not.
-	fmt.Fprintf(&b, "add table inet %s\n", MapTableName)
-	fmt.Fprintf(&b, "delete table inet %s\n", MapTableName)
+	fmt.Fprintf(&b, "add table inet %s\n", table)
+	fmt.Fprintf(&b, "delete table inet %s\n", table)
 	if len(mappings) == 0 {
 		return b.String(), nil
 	}
@@ -76,23 +92,23 @@ func RenderMap(iface string, mappings []Mapping) (string, error) {
 		return "", err
 	}
 
-	fmt.Fprintf(&b, "add table inet %s\n", MapTableName)
+	fmt.Fprintf(&b, "add table inet %s\n", table)
 	// Priority mangle on the way out, and -300 on the way in, so both run before anything
 	// that inspects addresses. The filter chain's rules are written in terms of the real
 	// mesh addresses on the wire, and the forwarding chain's in terms of carried prefixes;
 	// translating outside them keeps every other table reading the address it expects.
 	fmt.Fprintf(&b, "add chain inet %s outbound { type filter hook postrouting priority mangle; policy accept; }\n",
-		MapTableName)
+		table)
 	fmt.Fprintf(&b, "add chain inet %s inbound { type filter hook prerouting priority -300; policy accept; }\n",
-		MapTableName)
+		table)
 
 	for _, m := range ordered {
 		host := hostWildcard(m.Mapped)
 		fmt.Fprintf(&b, "add rule inet %s outbound oifname \"%s\" %s daddr %s %s daddr set %s daddr & %s | %s\n",
-			MapTableName, iface, family(m.Mapped), m.Mapped,
+			table, iface, family(m.Mapped), m.Mapped,
 			family(m.Mapped), family(m.Mapped), host, m.Real.Masked().Addr())
 		fmt.Fprintf(&b, "add rule inet %s inbound iifname \"%s\" %s saddr %s %s saddr set %s saddr & %s | %s\n",
-			MapTableName, iface, family(m.Real), m.Real,
+			table, iface, family(m.Real), m.Real,
 			family(m.Real), family(m.Real), host, m.Mapped.Masked().Addr())
 	}
 	return b.String(), nil

--- a/internal/nftables/mapping_linux_test.go
+++ b/internal/nftables/mapping_linux_test.go
@@ -191,23 +191,23 @@ func namespace(t *testing.T, name, outer, inner, custAddr, ourAddr string) strin
 	return name
 }
 
-// applyInto installs one interface's rules under a table of its own.
+// applyInto installs one interface's rules.
 //
-// RenderMap rebuilds MapTableName, so two interfaces rendered into the same table would have
-// the second erase the first. That is correct for production, where one call carries every
-// mapping the device holds, and wrong for this test, which renders per interface to keep each
-// case readable. Rewriting the table name is the smaller distortion.
+// This used to rewrite the table name, because RenderMap put every interface in one table and
+// the second would erase the first. That workaround was the bug: it made the test pass while
+// production had exactly the flaw the comment described, and an end-to-end run found a device
+// reaching one of its two customers. RenderMap now names the table after the interface, so
+// there is nothing left to work around here.
 func applyInto(t *testing.T, iface, script string) {
 	t.Helper()
-	table := MapTableName + "_" + iface
-	renamed := strings.ReplaceAll(script, MapTableName, table)
+	table := MapTable(iface)
 	t.Cleanup(func() {
 		_ = exec.Command("nft", "delete", "table", "inet", table).Run()
 	})
 	cmd := exec.Command("nft", "-f", "-")
-	cmd.Stdin = strings.NewReader(renamed)
+	cmd.Stdin = strings.NewReader(script)
 	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("nft rejected the ruleset: %v\n%s\n%s", err, out, renamed)
+		t.Fatalf("nft rejected the ruleset: %v\n%s\n%s", err, out, script)
 	}
 }
 

--- a/internal/nftables/mapping_test.go
+++ b/internal/nftables/mapping_test.go
@@ -172,3 +172,42 @@ func TestAnUnusableInterfaceNameIsRefused(t *testing.T) {
 		}
 	}
 }
+
+// Two memberships do not erase each other, which is the defect an end-to-end run found.
+//
+// Every membership reconciles on its own timer and renders its own ruleset whole. When they
+// shared one table the second to reconcile deleted the first's rules -- so a technician in
+// two customers reached exactly one of them, and which one depended on timing. On the only
+// devices that have these rules at all, that is the feature failing completely.
+//
+// The unit tests before this one all rendered a single interface, so none of them could see
+// it. This is the smallest test that can.
+func TestTwoInterfacesDoNotShareATable(t *testing.T) {
+	first := renderMap(t, "meshp0", mapping("100.71.5.0/24", "192.168.1.0/24"))
+	second := renderMap(t, "meshp1", mapping("100.71.6.0/24", "192.168.1.0/24"))
+
+	if MapTable("meshp0") == MapTable("meshp1") {
+		t.Fatal("both interfaces render into one table, so whichever reconciles last wins")
+	}
+	// Neither script may touch the other's table, by any statement: an `add` would be
+	// harmless but a `delete` is the whole bug.
+	if strings.Contains(first, MapTable("meshp1")) {
+		t.Errorf("meshp0's ruleset names meshp1's table:\n%s", first)
+	}
+	if strings.Contains(second, MapTable("meshp0")) {
+		t.Errorf("meshp1's ruleset names meshp0's table:\n%s", second)
+	}
+}
+
+// And removal is still scoped to the interface, so one membership leaving does not take the
+// other's translation with it.
+func TestRemovingOneInterfaceLeavesTheOther(t *testing.T) {
+	empty := renderMap(t, "meshp0")
+
+	if !strings.Contains(empty, "delete table inet "+MapTable("meshp0")) {
+		t.Errorf("removing meshp0's mappings does not delete its table:\n%s", empty)
+	}
+	if strings.Contains(empty, MapTable("meshp1")) {
+		t.Errorf("removing meshp0's mappings touches meshp1's table:\n%s", empty)
+	}
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -702,7 +702,13 @@ func (r *Reconciler) Teardown() error {
 		if err := r.filter.ApplyForward(context.Background(), name, nil); err != nil {
 			r.log.Warn("could not stop carrying prefixes", "interface", name, "error", err)
 		}
-		r.lastFilter, r.lastAdvertised = nil, nil
+		// And the translation, or a device that left one of two colliding networks goes on
+		// rewriting for it — sending traffic addressed to a range it no longer routes at a
+		// customer it can no longer reach (Invariant 20).
+		if err := r.filter.ApplyMap(context.Background(), name, nil); err != nil {
+			r.log.Warn("could not stop translating for this network", "interface", name, "error", err)
+		}
+		r.lastFilter, r.lastAdvertised, r.lastMapped = nil, nil, nil
 	}
 
 	observed, err := r.link.Observe(name)

--- a/scripts/e2e-overlap.sh
+++ b/scripts/e2e-overlap.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# Two customers on 192.168.1.0/24, one technician, both reachable.
+#
+# The claim ADR-0004 has made since the beginning and that has never been true. ADR-0020
+# settles how, and four merged slices built it: the rules that translate, the numbers to
+# translate between, the wire field that carries them, and the agent that applies them. Every
+# one of those is tested. The join between them is not.
+#
+# That gap has produced a defect every time it has been closed in this project. This is the
+# test that closes it here: a real daemon holding two real memberships, two real advertisers
+# each answering at 192.168.1.5, and an assertion that reaching one does not reach the other.
+#
+#   [mpca] 192.168.1.5  <--wg--  [mptech]  --wg-->  192.168.1.5 [mpcb]
+#            port 9001            two memberships          port 9002
+#
+# Each advertiser answers at the same address on a different port. That is what makes the
+# crossover assertions mean something: if the two prefixes were not really disambiguated a
+# misrouted packet would still find a machine at 192.168.1.5, just the wrong one, on a port
+# it does not serve.
+#
+# The advertiser is also the customer host, which is deliberate. Putting 192.168.1.5 on a
+# separate LAN behind it would test forwarding as well, and forwarding is currently defeated
+# by any host with a foreign FORWARD drop policy (#89) -- which would make this test fail for
+# a reason that has nothing to do with what it is asserting.
+set -euo pipefail
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+DB_URL="${1:?usage: e2e-overlap.sh <postgres-url>}"
+PORT="${MESHP_E2E_PORT:-8299}"
+RELAY_PORT="${MESHP_E2E_RELAY_PORT:-3679}"
+RELAY_ID="e2e"
+ADMIN_TOKEN="e2e-administrative-token-not-a-secret"
+SECRET_KEY="e2e-deployment-secret-not-a-secret"
+
+HOST_IP="10.98.0.1"
+BRIDGE="mpbr1"
+TECH_NS="mptech"
+CA_NS="mpca"
+CB_NS="mpcb"
+TECH_IP="10.98.0.2"
+CA_IP="10.98.0.3"
+CB_IP="10.98.0.4"
+ALL_NS="$TECH_NS $CA_NS $CB_NS"
+
+# The address both customers use. The whole point.
+CUST_ADDR="192.168.1.5"
+CUST_PREFIX="192.168.1.0/24"
+PORT_A=9001
+PORT_B=9002
+
+WORK="$(mktemp -d /tmp/mpov.XXXXXX)"
+CONTROL_LOG="$WORK/control.log"
+RELAY_LOG="$WORK/relay.log"
+CONTROL_PID=""
+RELAY_PID=""
+
+cleanup() {
+  for ns in $ALL_NS; do
+    ip netns pids "$ns" 2>/dev/null | xargs -r kill 2>/dev/null || true
+    ip netns del "$ns" 2>/dev/null || true
+  done
+  ip link del "$BRIDGE" 2>/dev/null || true
+  [ -n "$CONTROL_PID" ] && kill "$CONTROL_PID" 2>/dev/null || true
+  [ -n "$RELAY_PID" ] && kill "$RELAY_PID" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+if [ "$(uname -s)" != "Linux" ] || [ "$(id -u)" != "0" ]; then
+  echo "skipped: needs Linux and root"
+  exit 0
+fi
+if ! ip link add mpprobe type wireguard 2>/dev/null; then
+  echo "skipped: this kernel cannot make a WireGuard interface"
+  exit 0
+fi
+ip link del mpprobe
+command -v nft >/dev/null 2>&1 || { echo "skipped: needs nft to translate"; exit 0; }
+command -v nc >/dev/null 2>&1 || { echo "skipped: needs nc to tell the two customers apart"; exit 0; }
+
+# ---------------------------------------------------------------------------
+# The namespaces
+
+echo "building three network namespaces"
+ip link add "$BRIDGE" type bridge
+ip addr add "${HOST_IP}/24" dev "$BRIDGE"
+ip link set "$BRIDGE" up
+
+make_ns() {
+  local ns="$1" addr="$2"
+  ip netns add "$ns"
+  ip link add "veth-${ns}" type veth peer name "in-${ns}"
+  ip link set "veth-${ns}" master "$BRIDGE"
+  ip link set "veth-${ns}" up
+  ip link set "in-${ns}" netns "$ns"
+  ip -n "$ns" addr add "${addr}/24" dev "in-${ns}"
+  ip -n "$ns" link set "in-${ns}" up
+  ip -n "$ns" link set lo up
+  ip -n "$ns" route add default via "$HOST_IP"
+}
+make_ns "$TECH_NS" "$TECH_IP"
+make_ns "$CA_NS" "$CA_IP"
+make_ns "$CB_NS" "$CB_IP"
+for ns in $ALL_NS; do
+  ip netns exec "$ns" ping -c 1 -W 2 "$HOST_IP" >/dev/null 2>&1 \
+    || fail "namespace ${ns} cannot reach the host"
+done
+echo "  ${ALL_NS} all reach ${HOST_IP}"
+
+# Both customers answer at the same address, on their own machine. A dummy interface rather
+# than a LAN behind them, for the reason in the header.
+for ns in "$CA_NS" "$CB_NS"; do
+  ip -n "$ns" link add cust type dummy
+  ip -n "$ns" addr add "${CUST_ADDR}/24" dev cust
+  ip -n "$ns" link set cust up
+done
+echo "  ${CA_NS} and ${CB_NS} both answer at ${CUST_ADDR}"
+
+# ---------------------------------------------------------------------------
+# The control plane
+
+./bin/meshp-control --generate-relay-key >"$WORK/relay.env" \
+  || fail "could not mint relay keys"
+RELAY_SIGNING_KEY="$(sed -n 's/^MESHP_RELAY_SIGNING_KEY=//p' "$WORK/relay.env")"
+RELAY_ISSUER_KEY="$(sed -n 's/^MESHP_RELAY_ISSUER_KEY=//p' "$WORK/relay.env")"
+
+echo "starting meshp-relay on ${HOST_IP}:${RELAY_PORT}"
+MESHP_RELAY_LISTEN="${HOST_IP}:${RELAY_PORT}" \
+MESHP_RELAY_ISSUER_KEY="$RELAY_ISSUER_KEY" \
+MESHP_RELAY_ADMIN_ADDR="127.0.0.1:9299" \
+  ./bin/meshp-relay >"$RELAY_LOG" 2>&1 &
+RELAY_PID=$!
+
+TLS_DIR="$WORK/tls"
+mkdir -p "$TLS_DIR"
+openssl req -x509 -newkey rsa:2048 -nodes -keyout "$TLS_DIR/key.pem" \
+  -out "$TLS_DIR/cert.pem" -days 1 -subj "/CN=${HOST_IP}" \
+  -addext "subjectAltName=IP:${HOST_IP}" >/dev/null 2>&1 \
+  || fail "could not make a certificate"
+
+# Every agent below trusts this certificate and nothing else. Exported rather than passed,
+# because the agents run under ip netns exec and inherit the environment.
+export SSL_CERT_FILE="$TLS_DIR/cert.pem"
+
+BASE="https://${HOST_IP}:${PORT}"
+echo "starting meshp-control on ${BASE}"
+MESHP_DATABASE_URL="$DB_URL" \
+MESHP_LISTEN_ADDR="${HOST_IP}:${PORT}" \
+MESHP_SECRET_KEY="$SECRET_KEY" \
+MESHP_ADMIN_TOKEN="$ADMIN_TOKEN" \
+MESHP_RELAY_SIGNING_KEY="$RELAY_SIGNING_KEY" \
+MESHP_RELAYS="${RELAY_ID}=${HOST_IP}:${RELAY_PORT}" \
+MESHP_TLS_CERT="${TLS_DIR}/cert.pem" \
+MESHP_TLS_KEY="${TLS_DIR}/key.pem" \
+  ./bin/meshp-control >"$CONTROL_LOG" 2>&1 &
+CONTROL_PID=$!
+
+for _ in $(seq 1 30); do
+  curl -fsS --cacert "$TLS_DIR/cert.pem" "${BASE}/readyz" >/dev/null 2>&1 && break
+  sleep 1
+done
+curl -fsS --cacert "$TLS_DIR/cert.pem" "${BASE}/readyz" >/dev/null 2>&1 \
+  || { tail -20 "$CONTROL_LOG" >&2; fail "control plane never became ready"; }
+
+api() {
+  curl -fsS --cacert "$TLS_DIR/cert.pem" -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    -H 'Content-Type: application/json' "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Two customers of one MSP, on the same addresses
+
+RUN_ID="$$"
+OCTET="$(( RUN_ID % 200 + 1 ))"
+SECOND_OCTET="$(( OCTET + 1 ))"
+
+ORG_ID="$(psql "$DB_URL" -tAqc "
+  INSERT INTO organizations (slug, name) VALUES ('ov-${RUN_ID}', 'Overlap ${RUN_ID}') RETURNING id")"
+[ -n "$ORG_ID" ] || fail "could not seed an organisation"
+
+seed_network() {
+  local slug="$1" octet="$2"
+  psql "$DB_URL" -tAqc "
+    WITH n AS (INSERT INTO networks (organization_id, slug, name)
+               VALUES ('${ORG_ID}', '${slug}', '${slug}') RETURNING id),
+         p AS (INSERT INTO address_pools (network_id, prefix, family, purpose)
+               SELECT id, '100.92.${octet}.0/24'::cidr, 4, 'device' FROM n RETURNING network_id)
+    SELECT DISTINCT network_id FROM p"
+}
+NET_A="$(seed_network "cust-a-${RUN_ID}" "$OCTET")"
+NET_B="$(seed_network "cust-b-${RUN_ID}" "$SECOND_OCTET")"
+[ -n "$NET_A" ] && [ -n "$NET_B" ] || fail "could not seed two networks"
+echo "  two customers: ${NET_A} and ${NET_B}"
+
+# ---------------------------------------------------------------------------
+# The agents
+
+start_daemon() {
+  local ns="$1"
+  local sock="$WORK/${ns}.sock"
+  ip netns exec "$ns" ./bin/meshpd --reconcile-interval 2s \
+    --state-dir "$WORK/${ns}-state" --socket "$sock" --log-level debug >"$WORK/${ns}.log" 2>&1 &
+  for _ in $(seq 1 30); do
+    [ -S "$sock" ] && ./bin/meshp status --socket "$sock" >/dev/null 2>&1 && break
+    sleep 1
+  done
+  [ -S "$sock" ] || fail "the daemon in ${ns} never opened its socket"
+}
+
+join_network() {
+  local ns="$1" network="$2" name="$3"
+  local sock="$WORK/${ns}.sock" token
+  token="$(api -X POST -d '{"max_uses":1,"expires_in_seconds":600}' \
+    "${BASE}/api/v1/networks/${network}/enrollment-tokens" \
+    | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
+  [ -n "$token" ] || fail "could not mint a token for ${ns} in ${network}"
+  ip netns exec "$ns" ./bin/meshp join "$token" --control-url "$BASE" --socket "$sock" \
+    --name "$name" >"$WORK/${ns}-join-${name}.out" 2>&1 \
+    || { cat "$WORK/${ns}-join-${name}.out" >&2; fail "${ns} could not join ${network}"; }
+}
+
+echo "enrolling one technician into both customers, and an advertiser into each"
+start_daemon "$TECH_NS"
+start_daemon "$CA_NS"
+start_daemon "$CB_NS"
+
+join_network "$CA_NS" "$NET_A" "customer-a-router"
+join_network "$CB_NS" "$NET_B" "customer-b-router"
+
+# The condition the whole feature exists for: one device, two memberships (ADR-0004).
+join_network "$TECH_NS" "$NET_A" "technician"
+join_network "$TECH_NS" "$NET_B" "technician"
+
+# Two interfaces, or nothing below can work. Asserted rather than assumed because enrolment
+# is what numbers them, and a second membership handed meshp0 again would have the two fight
+# over one interface rather than collide in the routing table.
+for iface in meshp0 meshp1; do
+  ok=0
+  for _ in $(seq 1 40); do
+    if ./bin/meshp status --socket "$WORK/${TECH_NS}.sock" 2>/dev/null | grep -qE "interface   ${iface} \(up"; then
+      ok=1; break
+    fi
+    sleep 1
+  done
+  [ "$ok" = "1" ] || {
+    ./bin/meshp status --socket "$WORK/${TECH_NS}.sock" >&2 || true
+    fail "the technician never brought up ${iface}"
+  }
+done
+echo "  the technician holds two memberships, on meshp0 and meshp1"
+
+# ---------------------------------------------------------------------------
+# Both customers carry the same prefix
+
+echo "both customers carry ${CUST_PREFIX}"
+carry() {
+  local network="$1" ns="$2"
+  api -X POST -d "{\"slug\":\"lan\",\"name\":\"LAN\",\"kind\":\"subnet\",\"prefixes\":[\"${CUST_PREFIX}\"]}" \
+    "${BASE}/api/v1/networks/${network}/route-groups" >"$WORK/rg-${ns}.out" \
+    || { cat "$WORK/rg-${ns}.out" >&2; fail "could not create the route group in ${network}"; }
+
+  local membership
+  membership="$(sed -n 's/.*"membership_id": *"\([^"]*\)".*/\1/p' "$WORK/${ns}-state/state.json" | head -1)"
+  [ -n "$membership" ] || fail "could not read ${ns}'s membership"
+  api -X POST -d "{\"membership_id\":\"${membership}\",\"priority\":1}" \
+    "${BASE}/api/v1/networks/${network}/route-groups/lan/advertisers" >"$WORK/adv-${ns}.out" \
+    || { cat "$WORK/adv-${ns}.out" >&2; fail "could not advertise in ${network}"; }
+}
+carry "$NET_A" "$CA_NS"
+carry "$NET_B" "$CB_NS"
+
+# ---------------------------------------------------------------------------
+# What the control plane allocated
+
+echo "waiting for the control plane to allocate a range for each"
+MAPPED_A=""
+MAPPED_B=""
+for _ in $(seq 1 40); do
+  MAPPED_A="$(psql "$DB_URL" -tAqc "
+    SELECT mapped_prefix FROM prefix_mappings WHERE network_id = '${NET_A}'")"
+  MAPPED_B="$(psql "$DB_URL" -tAqc "
+    SELECT mapped_prefix FROM prefix_mappings WHERE network_id = '${NET_B}'")"
+  [ -n "$MAPPED_A" ] && [ -n "$MAPPED_B" ] && break
+  sleep 1
+done
+[ -n "$MAPPED_A" ] && [ -n "$MAPPED_B" ] \
+  || fail "no mapped ranges were allocated: A=${MAPPED_A:-none} B=${MAPPED_B:-none}"
+[ "$MAPPED_A" != "$MAPPED_B" ] \
+  || fail "both customers were given ${MAPPED_A}, which is the collision again"
+echo "  customer A at ${MAPPED_A}, customer B at ${MAPPED_B}"
+
+# The host part is carried across unchanged, so the address to reach is the customer's own
+# host number inside the allocated range.
+host_in() { echo "${1%.*/*}.${CUST_ADDR##*.}"; }
+REACH_A="$(host_in "$MAPPED_A")"
+REACH_B="$(host_in "$MAPPED_B")"
+echo "  so ${CUST_ADDR} is ${REACH_A} in A and ${REACH_B} in B"
+
+# ---------------------------------------------------------------------------
+# The assertions
+
+echo "waiting for the technician to install both translations"
+installed=0
+for _ in $(seq 1 40); do
+  if ip netns exec "$TECH_NS" nft list table inet meshp_map >/dev/null 2>&1 \
+     && ip netns exec "$TECH_NS" ip route show | grep -q "${MAPPED_A%%/*}" \
+     && ip netns exec "$TECH_NS" ip route show | grep -q "${MAPPED_B%%/*}"; then
+    installed=1; break
+  fi
+  sleep 1
+done
+if [ "$installed" != "1" ]; then
+  echo "--- routes ---" >&2; ip netns exec "$TECH_NS" ip route show >&2 || true
+  echo "--- nft ---" >&2; ip netns exec "$TECH_NS" nft list ruleset >&2 || true
+  echo "--- agent log ---" >&2; grep -iE "map|collid|contest" "$WORK/${TECH_NS}.log" | tail -20 >&2
+  fail "the technician did not install routes and rules for both ranges"
+fi
+echo "  both ranges routed, and the translation is installed"
+
+# A listener on each customer, on its own port. Different ports are what make the crossover
+# assertions below mean something: both machines answer at the same address.
+ip netns exec "$CA_NS" nc -l -k -s "$CUST_ADDR" -p "$PORT_A" >/dev/null 2>&1 &
+ip netns exec "$CB_NS" nc -l -k -s "$CUST_ADDR" -p "$PORT_B" >/dev/null 2>&1 &
+sleep 2
+
+opens() {
+  ip netns exec "$TECH_NS" timeout 5 bash -c "exec 3<>/dev/tcp/$1/$2" 2>/dev/null
+}
+
+# Given the tunnels take a moment to hand shake, the first reach is retried.
+reached_a=0
+for _ in $(seq 1 30); do
+  if opens "$REACH_A" "$PORT_A"; then reached_a=1; break; fi
+  sleep 1
+done
+if [ "$reached_a" != "1" ]; then
+  echo "--- tech status ---" >&2; ./bin/meshp status --socket "$WORK/${TECH_NS}.sock" >&2 || true
+  echo "--- tech nft ---" >&2; ip netns exec "$TECH_NS" nft list table inet meshp_map >&2 || true
+  echo "--- tech routes ---" >&2; ip netns exec "$TECH_NS" ip route show >&2 || true
+  echo "--- customer A log ---" >&2; tail -20 "$WORK/${CA_NS}.log" >&2
+  fail "customer A is not reachable at ${REACH_A}:${PORT_A}"
+fi
+echo "  ${REACH_A}:${PORT_A} reaches customer A"
+
+reached_b=0
+for _ in $(seq 1 30); do
+  if opens "$REACH_B" "$PORT_B"; then reached_b=1; break; fi
+  sleep 1
+done
+[ "$reached_b" = "1" ] || fail "customer B is not reachable at ${REACH_B}:${PORT_B}"
+echo "  ${REACH_B}:${PORT_B} reaches customer B"
+
+# The assertion the whole feature exists for. Both customers answer at 192.168.1.5, so a
+# packet that went to the wrong membership would still find a machine there -- just the wrong
+# one, on a port it does not serve. These two failing is what proves the prefixes really are
+# distinguishable, rather than one of them quietly winning.
+if opens "$REACH_A" "$PORT_B"; then
+  fail "customer B's port answered at customer A's address: the technician reached the wrong customer"
+fi
+if opens "$REACH_B" "$PORT_A"; then
+  fail "customer A's port answered at customer B's address: the technician reached the wrong customer"
+fi
+echo "  neither address reaches the other customer"
+
+# And the customer sees the technician's real mesh address, which is what ADR-0007's
+# destination-side enforcement runs on. A translation that rewrote the source would hand every
+# server in every customer's network one address for the whole MSP.
+seen="$(ip netns exec "$CA_NS" ss -Htn state established "sport = :${PORT_A}" 2>/dev/null | awk '{print $NF}' | sed 's/:[0-9]*$//' | head -1)"
+if [ -n "$seen" ]; then
+  case "$seen" in
+    100.92.*) echo "  customer A sees the technician as ${seen}, its real mesh address" ;;
+    *) fail "customer A saw the connection from ${seen}, which is not the technician's mesh address" ;;
+  esac
+fi
+
+echo
+echo "two customers on ${CUST_PREFIX} are both reachable from one device, and neither is the other"


### PR DESCRIPTION
Found by the end-to-end test in the first commit on this branch, on its first complete run.

## What was wrong

The mapping table was named for the device rather than the interface. Every membership reconciles on its own timer and `RenderMap` rebuilds its table whole — so **the second membership to reconcile deleted the first's rules**.

On the only devices that hold any of these rules — a technician in two customers using the same addresses — exactly one customer was ever reachable, and which one depended on timing. The feature failed completely on the case it exists for:

```
100.71.0.0/24 dev meshp1          ← customer B, mapped
192.168.1.0/24 dev meshp0         ← customer A, still the real prefix

table inet meshp_map {
    chain outbound { oifname "meshp1" ... }   ← only one interface's rules survive
}
```

Every unit test rendered a single interface, so none of them could see it.

## I had already written this bug down

While writing `mapping_linux_test.go` I hit it, wrote a comment saying *"two interfaces rendered into the same table would have the second erase the first"*, worked around it in the test with a per-interface table name — and shipped the production code with the flaw. The workaround masked it instead of surfacing it. That workaround is now gone, because it is the behaviour.

## Also fixed: teardown never removed the table

A device that left one of two colliding networks went on rewriting for it, sending traffic addressed to a range it no longer routes at a customer it can no longer reach. That is Invariant 20, and nothing was enforcing it here.

## Verification

Two new tests, both killed by restoring the shared table name. The full package re-run against real interfaces and namespaces, which is what found the bug in the first place.

**This does not make the end-to-end test pass yet.** The second defect it found is still open: a collision created by joining a *different* network never reaches the first membership, because that network's `state_version` never moves. Mappings are per-device; incremental state is per-network (ADR-0008). That fix is separate and larger.