### PR TITLE
ci: one pull request for CodeQL, and majors on their own

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,22 @@ updates:
       prefix: "ci"
     labels: ["dependencies", "ci"]
     open-pull-requests-limit: 5
+    groups:
+      # One pull request for CodeQL, which is one action used three times.
+      # Dependabot treats every `uses:` line as its own dependency, so a patch
+      # bump arrived as three identical pull requests -- init, autobuild and
+      # analyze -- that can only sensibly be merged together anyway.
+      codeql:
+        patterns: ["github/codeql-action*"]
+
+      # And one for everything else that is not a major. Majors are left on
+      # their own on purpose: they are the ones that need somebody to read the
+      # release notes, and burying one in a batch of patch bumps is how it gets
+      # waved through.
+      actions:
+        patterns: ["*"]
+        exclude-patterns: ["github/codeql-action*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: gomod
     directory: "/"


### PR DESCRIPTION
This week's Dependabot batch was five pull requests, three of which were the same action:

```
#98  github/codeql-action/analyze     4.37.6 → 4.37.7
#97  github/codeql-action/autobuild   4.37.6 → 4.37.7
#96  github/codeql-action/init        4.37.6 → 4.37.7
```

`codeql-action` is one repository with three entry points, and Dependabot treats every `uses:` line as its own dependency. The three can only sensibly be merged together, so they should arrive together. The `gomod` block already does this for `golang.org/x`; the `github-actions` block had no equivalent.

Everything else that is **not** a major is grouped as well, and **majors are deliberately left on their own**. They are the ones that need somebody to read the release notes, and burying one in a batch of patch bumps is how it gets waved through — which is precisely the risk in this week's batch.