### PR TITLE
ci: Bump actions/download-artifact from 4.3.0 to 8.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist


### PR DESCRIPTION
Supersedes #100, which Dependabot will not rebase.

## Why this exists rather than #100

`upload-artifact` v7.0.0 and `download-artifact` v8.0.0 were published the same day and are the matched set — v8's release notes state the unzip change exists *"to support direct uploads in `actions/upload-artifact`"*. #99 merged, so `release.yml` currently carries **upload v7 and download v4**, a cross-major mismatch of exactly the shape that broke v3 against v4.

Dependabot then refused to rebase #100:

> Looks like this PR has been edited by someone other than Dependabot. That means Dependabot can't rebase it - sorry!

That is my doing — I ran `gh pr update-branch` on its branch, which puts a commit from somebody else on it. Reproduced here instead of leaving it stuck. **The SHA is verified against `actions/download-artifact`'s own `v8.0.1` tag**, not taken on trust from the pull request:

```
$ gh api repos/actions/download-artifact/git/ref/tags/v8.0.1 --jq .object.sha
3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
```

#100 can be closed once this lands.

## What actually changes in v8

- **A digest mismatch now fails the run** rather than logging a warning. Stricter, and better.
- **Non-zipped downloads are no longer unzipped** — the action checks `Content-Type` first. No effect here: this workflow's artifact is an ordinary zipped directory.
- ESM migration, transparent to callers.

## What CI will and will not tell you

`release.yml` runs on pull requests that touch it — its own header comment explains why, citing ADR-0018. But the `publish` job holding this step is gated `if: startsWith(github.ref, 'refs/tags/v')`, so on a pull request it is **skipped**.

So the upload half is proven on every such run and **this half is not proven until a release is cut**. A green tick here means nothing regressed elsewhere, not that the download works. Closing that gap would mean letting the download step run on pull requests while gating only the release creation on the tag — the same argument the file already makes for itself, and a separate change.