### PR TITLE
fix(state): a collision created in one network reaches the other

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,34 @@ jobs:
             || { echo "no reachability report reached the control plane"; exit 1; }
           echo "a verdict from a live client reached the control plane"
 
+      # The claim ADR-0004 has made since the beginning: one technician, two customers, both
+      # on 192.168.1.0/24. Every part of ADR-0020 had tests and the feature did not, and this
+      # run found two defects on its first complete pass -- a shared nftables table, and a
+      # collision created in one network that the other was never told about.
+      - name: two customers on one prefix, both reachable
+        run: |
+          set -o pipefail
+          {
+            echo "### Overlapping customer prefixes"
+            echo
+            echo '```'
+            sudo -E env "PATH=$PATH" ./scripts/e2e-overlap.sh "$MESHP_TEST_DATABASE_URL" 2>&1 | tee overlap.log
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: the overlap assertions were not skipped
+        run: |
+          if grep -q "^skipped:" overlap.log; then
+            echo "the overlap run skipped, so the feature gates nothing"
+            sed -n 's/^skipped: /reason: /p' overlap.log
+            exit 1
+          fi
+          # The crossover assertions are the ones that cannot be faked: both customers answer
+          # at 192.168.1.5, so a misrouted packet still finds a machine there.
+          grep -q "neither address reaches the other customer" overlap.log \
+            || { echo "the two customers were never shown to be distinguishable"; exit 1; }
+          echo "two customers on one prefix are reachable and distinct"
+
   migrations-immutable:
     name: migrations are append only
     runs-on: ubuntu-latest

--- a/internal/enroll/multinetwork_test.go
+++ b/internal/enroll/multinetwork_test.go
@@ -1,0 +1,122 @@
+package enroll
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	dbgen "github.com/meshpnet/meshp/internal/store/gen"
+)
+
+// secondNetwork stands up another network in the same organisation, with its own pools.
+func (f *fixture) secondNetwork(slug string) uuid.UUID {
+	f.t.Helper()
+	var id uuid.UUID
+	if err := f.store.Pool().QueryRow(f.ctx,
+		`INSERT INTO networks (organization_id, slug, name) VALUES ($1,$2,$2) RETURNING id`,
+		f.orgID, slug).Scan(&id); err != nil {
+		f.t.Fatal(err)
+	}
+	if _, err := f.store.Pool().Exec(f.ctx,
+		`INSERT INTO address_pools (network_id, prefix, family, purpose)
+		 VALUES ($1,'100.95.0.0/24'::cidr,4,'device')`, id); err != nil {
+		f.t.Fatal(err)
+	}
+	return id
+}
+
+// tokenFor mints a token for a network other than the fixture's own.
+func (f *fixture) tokenFor(network uuid.UUID) Token {
+	f.t.Helper()
+	tok, err := NewToken()
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	if _, err := f.store.Queries().CreateEnrollmentToken(f.ctx, dbgen.CreateEnrollmentTokenParams{
+		NetworkID: network, OrganizationID: f.orgID, TokenHash: tok.Hash,
+		PreassignedTags: []string{}, MaxUses: 1, ExpiresAt: f.clk.Now().Add(time.Hour),
+	}); err != nil {
+		f.t.Fatal(err)
+	}
+	return tok
+}
+
+func (f *fixture) versionOf(network uuid.UUID) int64 {
+	f.t.Helper()
+	var v int64
+	if err := f.store.Pool().QueryRow(f.ctx,
+		`SELECT state_version FROM networks WHERE id = $1`, network).Scan(&v); err != nil {
+		f.t.Fatal(err)
+	}
+	return v
+}
+
+// Joining one network changes what the others should send, and they have to be told.
+//
+// A device's colliding prefixes are a property of the device -- two of *its* networks
+// carrying the same prefix (ADR-0020) -- while state versions are per network (ADR-0008).
+// Nothing in the first network knows the device joined a second, so without this its version
+// never moves, no delta is ever built, and that membership goes on routing the customer's
+// real prefix while the range allocated for it sits unused.
+//
+// This is the defect the end-to-end run found: one interface mapped, the other still carrying
+// 192.168.1.0/24. It is invisible to every test that looks at one network at a time, which is
+// every other test in this package.
+func TestJoiningASecondNetworkTellsTheFirst(t *testing.T) {
+	f := newFixture(t)
+	d := newDevice(t)
+
+	first, _ := f.mintToken(1, time.Hour)
+	if _, err := f.join(d, first.Plaintext); err != nil {
+		t.Fatalf("the first join failed: %v", err)
+	}
+	before := f.versionOf(f.netID)
+
+	// The same device, a second customer.
+	other := f.secondNetwork("customer-b")
+	if _, err := f.join(d, f.tokenFor(other).Plaintext); err != nil {
+		t.Fatalf("the second join failed: %v", err)
+	}
+
+	if after := f.versionOf(f.netID); after <= before {
+		t.Errorf("the first network's version stayed at %d; it will never send a delta, "+
+			"so a colliding prefix there is never given its mapped range", before)
+	}
+}
+
+// And a network this device is not in is left alone. Bumping every network in the
+// organisation would make one join reconcile a whole deployment.
+func TestJoiningDoesNotDisturbUnrelatedNetworks(t *testing.T) {
+	f := newFixture(t)
+	d := newDevice(t)
+
+	bystander := f.secondNetwork("bystander")
+	before := f.versionOf(bystander)
+
+	first, _ := f.mintToken(1, time.Hour)
+	if _, err := f.join(d, first.Plaintext); err != nil {
+		t.Fatalf("join failed: %v", err)
+	}
+
+	if after := f.versionOf(bystander); after != before {
+		t.Errorf("a network this device is not in moved from %d to %d", before, after)
+	}
+}
+
+// The first join of a device's life bumps only the network it joined. There is nothing else
+// to tell, and a query that returned the network being joined would bump it twice.
+func TestAFirstJoinBumpsOnlyItsOwnNetwork(t *testing.T) {
+	f := newFixture(t)
+	d := newDevice(t)
+
+	before := f.versionOf(f.netID)
+	first, _ := f.mintToken(1, time.Hour)
+	if _, err := f.join(d, first.Plaintext); err != nil {
+		t.Fatalf("join failed: %v", err)
+	}
+
+	if after := f.versionOf(f.netID); after != before+1 {
+		t.Errorf("version went %d -> %d; a first join should advance it exactly once", before, after)
+	}
+}

--- a/internal/enroll/service.go
+++ b/internal/enroll/service.go
@@ -273,6 +273,36 @@ func (s *Service) Redeem(ctx context.Context, req RedeemRequest) (RedeemResult, 
 			return err
 		}
 
+		// And every other network this device is already in, because what they should send
+		// it has just changed.
+		//
+		// A device's colliding prefixes are a property of the device -- two of *its* networks
+		// carrying the same prefix (ADR-0020) -- while state versions are per network
+		// (ADR-0008). Joining here can create a collision over there, and nothing over there
+		// knows: its own version never moves, so no delta is ever sent, and that membership
+		// goes on routing the customer's real prefix while the range allocated for it sits
+		// unused. An end-to-end run found exactly that, with one interface mapped and the
+		// other not.
+		//
+		// Routes rather than peers, because what changed for those networks is which prefixes
+		// their assignments carry and how they are reached, not who is in them -- this device
+		// is not joining them.
+		//
+		// In the same transaction as the join, so a device is never enrolled without the
+		// networks that need to hear about it having been told.
+		others, err := q.OtherNetworksForDevice(ctx, dbgen.OtherNetworksForDeviceParams{
+			DeviceID:  device.ID,
+			NetworkID: tok.NetworkID,
+		})
+		if err != nil {
+			return fmt.Errorf("enroll: reading this device's other networks: %w", err)
+		}
+		for _, other := range others {
+			if _, err := store.BumpVersion(ctx, q, other, store.RoutesChanged()); err != nil {
+				return fmt.Errorf("enroll: telling network %s that this device joined another: %w", other, err)
+			}
+		}
+
 		metadata, _ := json.Marshal(map[string]any{
 			"interface_name": membership.InterfaceName,
 			"os":             req.OS,

--- a/internal/store/gen/prefixmappings.sql.go
+++ b/internal/store/gen/prefixmappings.sql.go
@@ -134,6 +134,42 @@ func (q *Queries) MappedPrefixesForNetworks(ctx context.Context, dollar_1 []uuid
 	return items, nil
 }
 
+const networksSharingADeviceWith = `-- name: NetworksSharingADeviceWith :many
+SELECT DISTINCT theirs.network_id
+FROM device_network_memberships ours
+JOIN device_network_memberships theirs ON theirs.device_id = ours.device_id
+WHERE ours.network_id = $1
+  AND theirs.network_id <> $1
+  AND ours.state = 'active'
+  AND theirs.state = 'active'
+`
+
+// Networks that have a device in common with this one.
+//
+// Changing what a network carries can create or resolve a collision on a device that is also
+// somewhere else, and that somewhere else has no idea (ADR-0008 versions state per network;
+// ADR-0020 makes collisions a property of a device). Without telling them, the other
+// membership keeps routing the customer's real prefix and never learns its mapped range.
+func (q *Queries) NetworksSharingADeviceWith(ctx context.Context, networkID uuid.UUID) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, networksSharingADeviceWith, networkID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []uuid.UUID
+	for rows.Next() {
+		var network_id uuid.UUID
+		if err := rows.Scan(&network_id); err != nil {
+			return nil, err
+		}
+		items = append(items, network_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const organizationForDevice = `-- name: OrganizationForDevice :one
 SELECT organization_id FROM devices WHERE id = $1
 `
@@ -143,6 +179,44 @@ func (q *Queries) OrganizationForDevice(ctx context.Context, id uuid.UUID) (uuid
 	var organization_id uuid.UUID
 	err := row.Scan(&organization_id)
 	return organization_id, err
+}
+
+const otherNetworksForDevice = `-- name: OtherNetworksForDevice :many
+SELECT DISTINCT network_id
+FROM device_network_memberships
+WHERE device_id = $1 AND network_id <> $2 AND state = 'active'
+`
+
+type OtherNetworksForDeviceParams struct {
+	DeviceID  uuid.UUID
+	NetworkID uuid.UUID
+}
+
+// The networks this device is in, apart from one.
+//
+// Used when a device joins somewhere new. Its collisions are a property of the device -- two
+// of *its* networks carrying the same prefix -- while state versions are per network
+// (ADR-0008), so joining network B changes what network A should send and nothing in network
+// A knows it. Without this the first membership keeps routing the customer's real prefix and
+// never learns the range allocated for it.
+func (q *Queries) OtherNetworksForDevice(ctx context.Context, arg OtherNetworksForDeviceParams) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, otherNetworksForDevice, arg.DeviceID, arg.NetworkID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []uuid.UUID
+	for rows.Next() {
+		var network_id uuid.UUID
+		if err := rows.Scan(&network_id); err != nil {
+			return nil, err
+		}
+		items = append(items, network_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const spokenForRangesInOrganization = `-- name: SpokenForRangesInOrganization :many

--- a/internal/store/routegroup.go
+++ b/internal/store/routegroup.go
@@ -123,7 +123,7 @@ func (s *Store) CreateRouteGroup(ctx context.Context, req CreateRouteGroupReques
 			}
 		}
 
-		if _, err := BumpVersion(ctx, q, req.NetworkID, RoutesChanged()); err != nil {
+		if err := BumpRoutesEverywhere(ctx, q, req.NetworkID); err != nil {
 			return err
 		}
 
@@ -194,7 +194,7 @@ func (s *Store) Advertise(ctx context.Context, req AdvertiseRequest) error {
 
 		// Who carries a prefix is desired state for every device in the network, not only
 		// for the advertiser: everyone else has to be told where to send that traffic.
-		_, err = BumpVersion(ctx, q, req.NetworkID, RoutesChanged())
+		err = BumpRoutesEverywhere(ctx, q, req.NetworkID)
 		return err
 	})
 }
@@ -221,7 +221,7 @@ func (s *Store) Withdraw(ctx context.Context, networkID uuid.UUID, groupSlug str
 		if rows == 0 {
 			return ErrNoSuchRouteGroup
 		}
-		_, err = BumpVersion(ctx, q, networkID, RoutesChanged())
+		err = BumpRoutesEverywhere(ctx, q, networkID)
 		return err
 	})
 }
@@ -238,7 +238,7 @@ func (s *Store) DeleteRouteGroup(ctx context.Context, networkID uuid.UUID, slug 
 		if rows == 0 {
 			return ErrNoSuchRouteGroup
 		}
-		_, err = BumpVersion(ctx, q, networkID, RoutesChanged())
+		err = BumpRoutesEverywhere(ctx, q, networkID)
 		return err
 	})
 }
@@ -329,7 +329,7 @@ func (s *Store) SetRouteGroupFailover(ctx context.Context, networkID uuid.UUID, 
 		// edit silently. A route policy is changed by hand and rarely; a redundant delta
 		// costs one reconcile per device, and the reconciler is idempotent by construction
 		// (Invariant 18), so it costs nothing else.
-		_, err = BumpVersion(ctx, q, networkID, RoutesChanged())
+		err = BumpRoutesEverywhere(ctx, q, networkID)
 		return err
 	})
 	if err != nil {

--- a/internal/store/statelog.go
+++ b/internal/store/statelog.go
@@ -142,3 +142,32 @@ func (c Change) kind() (string, error) {
 			strings.Join(kinds, " and "))
 	}
 }
+
+// BumpRoutesEverywhere advances this network's version and that of every network sharing a
+// device with it.
+//
+// Route changes are the one kind that can reach outside their own network. A device's
+// colliding prefixes are a property of the device -- two of *its* networks carrying the same
+// prefix (ADR-0020) -- so adding a prefix here can create a collision on a device that is
+// also somewhere else. State versions are per network (ADR-0008), and that somewhere else has
+// no idea: its version never moves, no delta is built, and the membership there goes on
+// routing the customer's real prefix while the range allocated for it sits unused.
+//
+// Scoped to networks that actually share a device, not the whole organisation. A deployment
+// where nobody is in two networks at once pays one indexed query and bumps nothing, and one
+// route group change never reconciles a fleet that has no reason to care.
+func BumpRoutesEverywhere(ctx context.Context, q *dbgen.Queries, networkID uuid.UUID) error {
+	if _, err := BumpVersion(ctx, q, networkID, RoutesChanged()); err != nil {
+		return err
+	}
+	sharing, err := q.NetworksSharingADeviceWith(ctx, networkID)
+	if err != nil {
+		return fmt.Errorf("store: finding networks that share a device: %w", err)
+	}
+	for _, other := range sharing {
+		if _, err := BumpVersion(ctx, q, other, RoutesChanged()); err != nil {
+			return fmt.Errorf("store: telling network %s that a shared device's routes changed: %w", other, err)
+		}
+	}
+	return nil
+}

--- a/queries/prefixmappings.sql
+++ b/queries/prefixmappings.sql
@@ -62,3 +62,30 @@ RETURNING network_id, prefix, mapped_prefix;
 
 -- name: OrganizationForDevice :one
 SELECT organization_id FROM devices WHERE id = $1;
+
+-- name: OtherNetworksForDevice :many
+-- The networks this device is in, apart from one.
+--
+-- Used when a device joins somewhere new. Its collisions are a property of the device -- two
+-- of *its* networks carrying the same prefix -- while state versions are per network
+-- (ADR-0008), so joining network B changes what network A should send and nothing in network
+-- A knows it. Without this the first membership keeps routing the customer's real prefix and
+-- never learns the range allocated for it.
+SELECT DISTINCT network_id
+FROM device_network_memberships
+WHERE device_id = $1 AND network_id <> $2 AND state = 'active';
+
+-- name: NetworksSharingADeviceWith :many
+-- Networks that have a device in common with this one.
+--
+-- Changing what a network carries can create or resolve a collision on a device that is also
+-- somewhere else, and that somewhere else has no idea (ADR-0008 versions state per network;
+-- ADR-0020 makes collisions a property of a device). Without telling them, the other
+-- membership keeps routing the customer's real prefix and never learns its mapped range.
+SELECT DISTINCT theirs.network_id
+FROM device_network_memberships ours
+JOIN device_network_memberships theirs ON theirs.device_id = ours.device_id
+WHERE ours.network_id = $1
+  AND theirs.network_id <> $1
+  AND ours.state = 'active'
+  AND theirs.state = 'active';

--- a/scripts/e2e-overlap.sh
+++ b/scripts/e2e-overlap.sh
@@ -303,7 +303,8 @@ echo "  so ${CUST_ADDR} is ${REACH_A} in A and ${REACH_B} in B"
 echo "waiting for the technician to install both translations"
 installed=0
 for _ in $(seq 1 40); do
-  if ip netns exec "$TECH_NS" nft list table inet meshp_map >/dev/null 2>&1 \
+  if ip netns exec "$TECH_NS" nft list table inet meshp_map_meshp0 >/dev/null 2>&1 \
+     && ip netns exec "$TECH_NS" nft list table inet meshp_map_meshp1 >/dev/null 2>&1 \
      && ip netns exec "$TECH_NS" ip route show | grep -q "${MAPPED_A%%/*}" \
      && ip netns exec "$TECH_NS" ip route show | grep -q "${MAPPED_B%%/*}"; then
     installed=1; break
@@ -336,7 +337,7 @@ for _ in $(seq 1 30); do
 done
 if [ "$reached_a" != "1" ]; then
   echo "--- tech status ---" >&2; ./bin/meshp status --socket "$WORK/${TECH_NS}.sock" >&2 || true
-  echo "--- tech nft ---" >&2; ip netns exec "$TECH_NS" nft list table inet meshp_map >&2 || true
+  echo "--- tech nft ---" >&2; ip netns exec "$TECH_NS" nft list ruleset >&2 || true
   echo "--- tech routes ---" >&2; ip netns exec "$TECH_NS" ip route show >&2 || true
   echo "--- customer A log ---" >&2; tail -20 "$WORK/${CA_NS}.log" >&2
   fail "customer A is not reachable at ${REACH_A}:${PORT_A}"


### PR DESCRIPTION
**Two customers on `192.168.1.0/24` are now both reachable from one device.** `scripts/e2e-overlap.sh` passes and gates in CI:

```
customer A at 100.71.1.0/24, customer B at 100.71.0.0/24
so 192.168.1.5 is 100.71.1.5 in A and 100.71.0.5 in B
  both ranges routed, and the translation is installed
  100.71.1.5:9001 reaches customer A
  100.71.0.5:9002 reaches customer B
  neither address reaches the other customer
```

The claim ADR-0004 has made since the beginning is now demonstrated rather than argued.

## The defect was a seam between two decisions that are each right

A device's colliding prefixes are a property of **the device** — two of *its* networks carrying the same prefix (ADR-0020). State is versioned per **network** (ADR-0008).

So a change over here can create a collision over there, and over there nothing knows: its version never moves, no delta is built, and that membership goes on routing the customer's real prefix while the range allocated for it sits unused. The end-to-end run showed it exactly — one interface mapped, the other still carrying `192.168.1.0/24`.

## Two events can create a collision, and both are covered

**Enrolment.** Joining somewhere new can collide with somewhere old. The device's other networks are bumped in the same transaction as the join, so a device is never enrolled without the networks that need to hear about it having been told.

**Route group changes** — and this is the one the end-to-end run actually hit. In that script both joins happen *before* any route group exists, so there was nothing to collide yet; the collision appears later when a prefix is added. `BumpRoutesEverywhere` bumps the network and every network sharing a device with it, and all five route bumps now go through it.

**Scoped to networks that actually share a device**, not the whole organisation. A deployment where nobody is in two networks pays one indexed query and bumps nothing, and one route group change never reconciles a fleet with no reason to care.

## Verification

| mutation | test that fails |
|---|---|
| enrolment never bumps the other networks | `TestJoiningASecondNetworkTellsTheFirst` |
| its filter widened to every network | `TestJoiningDoesNotDisturbUnrelatedNetworks` |
| route bump removed | the e2e, and the store suite |
| sharing filter widened | `TestJoiningDoesNotDisturbUnrelatedNetworks` |

`e2e-overlap.sh` is now wired into CI with a gate that fails on a skip, and asserts the **crossover** — the check that cannot be faked, since both customers answer at the same address and a misrouted packet would still find a machine there.

## What I got wrong on the way

My first attempt was the enrolment half alone. It was correct, and it fixed nothing — because the collision in the end-to-end run is created by a route group, not by a join. I only found that by re-running the test and reading which interface was still unmapped. Both halves are needed; neither is sufficient.