### PR TITLE
fix(forwarding): carry a prefix past a firewall meshp does not own

### DIFF
--- a/internal/nftables/carry.go
+++ b/internal/nftables/carry.go
@@ -1,0 +1,75 @@
+package nftables
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+)
+
+// CarryChainName is the chain meshp owns inside the host's own filter table.
+//
+// A chain of its own, jumped to from FORWARD, rather than rules appended straight into
+// FORWARD. meshp then rebuilds its chain as often as it likes and touches the host's chain
+// exactly once in its whole life — and removal is deleting one jump rule rather than hunting
+// for handles of rules it appended some time ago.
+//
+// This is the DOCKER-USER pattern, for the reason Docker uses it: a tool that has to manage
+// somebody else's chain needs a seam it can own.
+const CarryChainName = "meshp_carry"
+
+// CarryTable is the table this lives in, which is not one of meshp's.
+//
+// `ip filter` is where iptables keeps FORWARD, and on any current distribution `iptables` is
+// iptables-nft, so this is the same chain a foreign FORWARD drop policy lives in (#89).
+//
+// Writing here is a real intrusion and is done for exactly one reason: an accept in meshp's
+// own table cannot undo a drop in this one. Every chain registered at a hook runs, and a drop
+// in any of them ends the packet, so there is no rule meshp can write in a table of its own
+// that survives another table's policy.
+const CarryTable = "ip filter"
+
+// RenderCarry builds the rules that let this host forward what it advertises.
+//
+// The chain only, never the jump. Adding the jump edits a chain meshp does not own, which
+// happens once and is checked first — see the apply path. Keeping the two apart means the
+// part that runs on every reconcile touches nothing but meshp's own chain.
+//
+// Flushed and refilled rather than deleted and recreated, because deleting it would break the
+// jump FORWARD holds to it.
+//
+// No prefixes empties the chain, which is what a device that has stopped carrying needs: the
+// jump stays and lands on nothing (Invariant 20).
+func RenderCarry(iface string, prefixes []netip.Prefix) (string, error) {
+	if !interfaceNamePattern.MatchString(iface) {
+		return "", fmt.Errorf("nftables: %q is not a usable interface name", iface)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "add chain %s %s\n", CarryTable, CarryChainName)
+	fmt.Fprintf(&b, "flush chain %s %s\n", CarryTable, CarryChainName)
+
+	for _, p := range prefixes {
+		if !p.IsValid() || !p.Addr().Is4() {
+			// This is the IPv4 table. An IPv6 prefix belongs in `ip6 filter`, and putting
+			// one here would be a rule that matches nothing while looking correct.
+			continue
+		}
+		// Both directions. A reply that cannot come back is the same outage as a request
+		// that cannot go out, and the foreign policy drops both.
+		fmt.Fprintf(&b, "add rule %s %s iifname \"%s\" ip daddr %s accept\n",
+			CarryTable, CarryChainName, iface, p.Masked())
+		fmt.Fprintf(&b, "add rule %s %s oifname \"%s\" ip saddr %s accept\n",
+			CarryTable, CarryChainName, iface, p.Masked())
+	}
+	return b.String(), nil
+}
+
+// CarryJump is the one rule meshp adds to a chain it does not own.
+//
+// Appended rather than inserted, which the probe behind #89 settled: an appended jump is
+// still reached on a host where Docker has put its own jumps ahead of it, because those
+// chains return rather than ending the packet. Inserting at the top would put meshp ahead of
+// rules an operator wrote deliberately, which is a claim this has no business making.
+func CarryJump() string {
+	return fmt.Sprintf("add rule %s FORWARD jump %s\n", CarryTable, CarryChainName)
+}

--- a/internal/nftables/carry_linux.go
+++ b/internal/nftables/carry_linux.go
@@ -1,0 +1,104 @@
+//go:build linux
+
+package nftables
+
+import (
+	"context"
+	"net/netip"
+	"os/exec"
+	"strings"
+)
+
+// ApplyCarry makes this host forward what it advertises even when something else refuses.
+//
+// Two steps, deliberately separate. The chain is meshp's and is rebuilt every time. The jump
+// lives in a chain meshp does not own, so it is read first and added only when it is missing
+// — an appended rule cannot be made idempotent by rewriting it, and adding a second one every
+// reconcile would grow the host's FORWARD chain without bound.
+//
+// Does nothing where there is nothing to overcome. A host with no `ip filter` table has no
+// foreign policy to survive, and creating that table would mean meshp registering a base
+// chain in somebody else's name — a much larger claim on the machine than adding one jump to
+// a chain that already exists.
+func ApplyCarry(ctx context.Context, iface string, prefixes []netip.Prefix) error {
+	if !carryTableExists(ctx) {
+		return nil
+	}
+
+	script, err := RenderCarry(iface, prefixes)
+	if err != nil {
+		return err
+	}
+	if err := Apply(ctx, script); err != nil {
+		return err
+	}
+	if carryJumpPresent(ctx) {
+		return nil
+	}
+	return Apply(ctx, CarryJump())
+}
+
+// RemoveCarry takes meshp back out of the host's chain.
+//
+// The jump first and the chain second, because a chain cannot be deleted while something
+// still jumps to it. Both are best-effort in the caller: a device tearing down has already
+// removed its interface, so a rule naming an interface that no longer exists matches nothing
+// — untidy rather than dangerous.
+func RemoveCarry(ctx context.Context) error {
+	if !carryTableExists(ctx) {
+		return nil
+	}
+	handle := carryJumpHandle(ctx)
+	if handle != "" {
+		if err := Apply(ctx, "delete rule "+CarryTable+" FORWARD handle "+handle+"\n"); err != nil {
+			return err
+		}
+	}
+	return Apply(ctx, "delete chain "+CarryTable+" "+CarryChainName+"\n")
+}
+
+// carryTableExists reports whether the host keeps an iptables-style filter table.
+func carryTableExists(ctx context.Context) bool {
+	path, err := exec.LookPath("nft")
+	if err != nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(ctx, applyTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, path, "list", "chain", CarryTable, "FORWARD").Run() == nil
+}
+
+// carryJumpPresent reports whether FORWARD already jumps to meshp's chain.
+func carryJumpPresent(ctx context.Context) bool {
+	return strings.Contains(forwardChain(ctx), "jump "+CarryChainName)
+}
+
+// carryJumpHandle finds the handle of that jump, which is what deleting a rule needs.
+func carryJumpHandle(ctx context.Context) string {
+	for _, line := range strings.Split(forwardChain(ctx), "\n") {
+		if !strings.Contains(line, "jump "+CarryChainName) {
+			continue
+		}
+		if i := strings.LastIndex(line, "# handle "); i >= 0 {
+			return strings.TrimSpace(line[i+len("# handle "):])
+		}
+	}
+	return ""
+}
+
+// forwardChain returns the host's FORWARD chain, with handles, or empty when it cannot be
+// read. Empty is treated as "no jump present", which errs towards adding one — a duplicate
+// jump is untidy, and a missing one is an advertiser that carries nothing.
+func forwardChain(ctx context.Context) string {
+	path, err := exec.LookPath("nft")
+	if err != nil {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(ctx, applyTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, path, "-a", "list", "chain", CarryTable, "FORWARD").Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}

--- a/internal/nftables/carry_linux_test.go
+++ b/internal/nftables/carry_linux_test.go
@@ -1,0 +1,156 @@
+//go:build linux
+
+package nftables
+
+import (
+	"context"
+	"net/netip"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The defect in #89, and the proof it is fixed.
+//
+// An advertiser on a host where something else drops forwarded packets rendered a correct
+// ruleset, reported the route group applied, and carried nothing. Every chain registered at a
+// hook runs and a drop in any of them ends the packet, so meshp's accept in its own table
+// never got the chance. Docker leaves exactly this policy on every host it is installed on.
+//
+// Asserted with a real packet across real interfaces, because the whole failure was a ruleset
+// that looked right. The middle step is the one that matters: it must be blocked, or the last
+// step proves nothing.
+func TestAPacketCrossesDespiteAForeignDropPolicy(t *testing.T) {
+	requireMapRoot(t)
+	requireNFT(t)
+	if _, err := exec.LookPath("iptables"); err != nil {
+		t.Skip("needs iptables to install a foreign policy")
+	}
+
+	lan := netip.MustParsePrefix("10.50.0.0/24")
+	carryLAN(t)
+	t.Cleanup(func() { _ = RemoveCarry(context.Background()) })
+
+	if !crossesToLAN(t) {
+		t.Fatal("setup: nothing crossed before any policy was installed")
+	}
+
+	// What Docker leaves behind, and what an advertiser silently died on.
+	mustRun(t, "iptables", "-P", "FORWARD", "DROP")
+	t.Cleanup(func() { _ = exec.Command("iptables", "-P", "FORWARD", "ACCEPT").Run() })
+	if crossesToLAN(t) {
+		t.Fatal("setup: a drop policy did not stop anything, so the test below proves nothing")
+	}
+
+	if err := ApplyCarry(context.Background(), "vethcarry", []netip.Prefix{lan}); err != nil {
+		t.Fatalf("ApplyCarry: %v", err)
+	}
+	if !crossesToLAN(t) {
+		chain, _ := exec.Command("nft", "list", "chain", "ip", "filter", "FORWARD").Output()
+		ours, _ := exec.Command("nft", "list", "chain", "ip", "filter", CarryChainName).Output()
+		t.Fatalf("a carried prefix still does not cross:\n--- FORWARD ---\n%s\n--- ours ---\n%s", chain, ours)
+	}
+}
+
+// The jump goes in once, however many times this runs. FORWARD belongs to the host, and a
+// reconciler that appended to it every tick would grow somebody else's chain without bound.
+func TestTheJumpIsAddedOnlyOnce(t *testing.T) {
+	requireMapRoot(t)
+	requireNFT(t)
+	if _, err := exec.LookPath("iptables"); err != nil {
+		t.Skip("needs iptables")
+	}
+	// The table has to exist for any of this to happen at all.
+	mustRun(t, "iptables", "-L", "FORWARD", "-n")
+	t.Cleanup(func() { _ = RemoveCarry(context.Background()) })
+
+	lan := []netip.Prefix{netip.MustParsePrefix("10.50.0.0/24")}
+	for range 5 {
+		if err := ApplyCarry(context.Background(), "vethcarry", lan); err != nil {
+			t.Fatalf("ApplyCarry: %v", err)
+		}
+	}
+
+	out, err := exec.Command("nft", "list", "chain", "ip", "filter", "FORWARD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(string(out), "jump "+CarryChainName); n != 1 {
+		t.Errorf("FORWARD holds %d jumps to %s after five passes, want 1:\n%s", n, CarryChainName, out)
+	}
+}
+
+// And meshp takes itself back out, or a host keeps a chain and a jump for a daemon that has
+// gone (Invariant 20).
+func TestRemoveTakesMeshpOutOfTheHostsChain(t *testing.T) {
+	requireMapRoot(t)
+	requireNFT(t)
+	if _, err := exec.LookPath("iptables"); err != nil {
+		t.Skip("needs iptables")
+	}
+	mustRun(t, "iptables", "-L", "FORWARD", "-n")
+
+	lan := []netip.Prefix{netip.MustParsePrefix("10.50.0.0/24")}
+	if err := ApplyCarry(context.Background(), "vethcarry", lan); err != nil {
+		t.Fatalf("ApplyCarry: %v", err)
+	}
+	if err := RemoveCarry(context.Background()); err != nil {
+		t.Fatalf("RemoveCarry: %v", err)
+	}
+
+	out, _ := exec.Command("nft", "list", "chain", "ip", "filter", "FORWARD").Output()
+	if strings.Contains(string(out), CarryChainName) {
+		t.Errorf("the host's FORWARD chain still names meshp:\n%s", out)
+	}
+	if exec.Command("nft", "list", "chain", "ip", "filter", CarryChainName).Run() == nil {
+		t.Error("meshp's chain is still in the host's table")
+	}
+}
+
+// --- topology -----------------------------------------------------------------------------
+
+// carryLAN builds a client and a LAN either side of this host, so a packet has to be
+// forwarded to get across.
+func carryLAN(t *testing.T) {
+	t.Helper()
+	for _, ns := range []string{"mpcarrylan", "mpcarrycli"} {
+		_ = exec.Command("ip", "netns", "del", ns).Run()
+	}
+	mapRun(t, "ip", "netns", "add", "mpcarrylan")
+	mapRun(t, "ip", "netns", "add", "mpcarrycli")
+	t.Cleanup(func() {
+		_ = exec.Command("ip", "netns", "del", "mpcarrylan").Run()
+		_ = exec.Command("ip", "netns", "del", "mpcarrycli").Run()
+	})
+
+	mapRun(t, "ip", "link", "add", "vethlan", "type", "veth", "peer", "name", "inlan")
+	mapRun(t, "ip", "link", "add", "vethcarry", "type", "veth", "peer", "name", "incli")
+	t.Cleanup(func() {
+		_ = exec.Command("ip", "link", "del", "vethlan").Run()
+		_ = exec.Command("ip", "link", "del", "vethcarry").Run()
+	})
+
+	mapRun(t, "ip", "link", "set", "inlan", "netns", "mpcarrylan")
+	mapRun(t, "ip", "link", "set", "incli", "netns", "mpcarrycli")
+	mapRun(t, "ip", "addr", "add", "10.50.0.1/24", "dev", "vethlan")
+	mapRun(t, "ip", "addr", "add", "10.60.0.1/24", "dev", "vethcarry")
+	mapRun(t, "ip", "link", "set", "vethlan", "up")
+	mapRun(t, "ip", "link", "set", "vethcarry", "up")
+
+	mapRun(t, "ip", "-n", "mpcarrylan", "addr", "add", "10.50.0.2/24", "dev", "inlan")
+	mapRun(t, "ip", "-n", "mpcarrylan", "link", "set", "inlan", "up")
+	mapRun(t, "ip", "-n", "mpcarrylan", "route", "add", "default", "via", "10.50.0.1")
+	mapRun(t, "ip", "-n", "mpcarrycli", "addr", "add", "10.60.0.2/24", "dev", "incli")
+	mapRun(t, "ip", "-n", "mpcarrycli", "link", "set", "incli", "up")
+	mapRun(t, "ip", "-n", "mpcarrycli", "route", "add", "default", "via", "10.60.0.1")
+
+	if _, err := EnableForwarding(); err != nil {
+		t.Fatalf("EnableForwarding: %v", err)
+	}
+}
+
+func crossesToLAN(t *testing.T) bool {
+	t.Helper()
+	return exec.Command("ip", "netns", "exec", "mpcarrycli",
+		"ping", "-c", "1", "-W", "2", "10.50.0.2").Run() == nil
+}

--- a/internal/nftables/carry_other.go
+++ b/internal/nftables/carry_other.go
@@ -1,0 +1,18 @@
+//go:build !linux
+
+package nftables
+
+import (
+	"context"
+	"net/netip"
+)
+
+// ApplyCarry does nothing off Linux, where meshp does not forward at all.
+//
+// Nil rather than ErrUnsupported: a host that cannot carry a prefix is refused earlier, by
+// Available, so reporting a failure here would put an error in front of an operator about
+// something that was never going to be attempted.
+func ApplyCarry(context.Context, string, []netip.Prefix) error { return nil }
+
+// RemoveCarry likewise has nothing to take back out.
+func RemoveCarry(context.Context) error { return nil }

--- a/internal/nftables/filter.go
+++ b/internal/nftables/filter.go
@@ -2,6 +2,7 @@ package nftables
 
 import (
 	"context"
+	"fmt"
 	"net/netip"
 
 	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
@@ -63,7 +64,41 @@ func (f *Filter) ApplyForward(ctx context.Context, iface string, groups []*meshp
 	if err != nil {
 		return err
 	}
-	return Apply(ctx, script)
+	if err := Apply(ctx, script); err != nil {
+		return err
+	}
+
+	// And a way past anything else that refuses forwarded packets (#89). meshp's own
+	// accept cannot undo another table's drop, so this puts one where it counts. A host
+	// with nothing in the way is untouched: ApplyCarry does nothing when there is no
+	// iptables-style filter table, which is exactly the host with no foreign policy.
+	carried, err := carriedPrefixList(groups)
+	if err != nil {
+		return err
+	}
+	return ApplyCarry(ctx, iface, carried)
+}
+
+// carriedPrefixList is what this device forwards into, as prefixes.
+//
+// A default route is left out. An egress group carries 0.0.0.0/0, and accepting that in the
+// host's own FORWARD chain would turn meshp into a blanket exemption from a policy somebody
+// wrote on purpose — far past what carrying a customer's LAN needs.
+func carriedPrefixList(groups []*meshpv1.AdvertisedRoutes_Group) ([]netip.Prefix, error) {
+	var out []netip.Prefix
+	for _, g := range groups {
+		for _, raw := range g.GetPrefixes() {
+			p, err := netip.ParsePrefix(raw)
+			if err != nil {
+				return nil, fmt.Errorf("nftables: a carried prefix will not parse: %q", raw)
+			}
+			if p.Bits() == 0 {
+				continue
+			}
+			out = append(out, p.Masked())
+		}
+	}
+	return out, nil
 }
 
 // ForwardObstacles names anything else on this host that drops forwarded packets.


### PR DESCRIPTION
Closes #89.

An advertiser on a host where something else drops forwarded packets rendered a correct ruleset, reported the route group applied, said it was reachable, and **carried nothing**. Every chain registered at a hook runs and a drop in any of them ends the packet, so meshp's accept in its own table never got the chance. Docker leaves exactly that policy on every host it is installed on; so do firewalld and several VPN clients.

[#90](https://github.com/meshpnet/meshp/pull/90) made it stop lying. **This makes it work.**

## The shape

meshp keeps a chain of its own inside `ip filter` — the table where iptables keeps FORWARD, and where the drop lives — holding an accept per carried prefix in both directions. FORWARD gets **one jump** to it.

A chain plus a jump, rather than rules appended straight into FORWARD, so meshp rebuilds its own chain as often as it likes while touching the host's chain once in its whole life. Removal is deleting one rule instead of hunting for handles of rules appended some time ago. That is the `DOCKER-USER` pattern, for the reason Docker uses it: a tool that must manage somebody else's chain needs a seam it can own.

**Appended rather than inserted**, which a probe settled rather than reasoning:

```
1. baseline, no foreign policy:              crosses
2. with iptables -P FORWARD DROP:            blocked
3. meshp appends an accept into FORWARD:     crosses
4. with Docker-like jump rules ahead of it:  crosses
```

An appended jump is still reached where Docker has put its own jumps first, because those chains *return* rather than ending the packet. Inserting at the top would put meshp ahead of rules an operator wrote deliberately.

## What it deliberately will not do

- **Nothing happens where there is nothing to overcome.** A host with no `ip filter` table has no foreign policy to survive, and creating that table would mean registering a base chain in somebody else's name — a far larger claim on the machine than one jump into a chain already there.
- **Default routes are excluded.** An egress group carries `0.0.0.0/0`, and accepting that in the host's FORWARD chain would make meshp a blanket exemption from a policy somebody wrote on purpose.
- **A DROP an operator put in `DOCKER-USER` still wins**, and should — that is their firewall, not a bug.

## Verification

A real packet across real interfaces against a real `iptables -P FORWARD DROP`. **The middle assertion is load-bearing**: the test fails if the drop policy does not block first, so it cannot pass vacuously.

| mutation | result |
|---|---|
| never add the jump | killed — nothing crosses |
| add the jump on every pass | killed — the host's chain grows without bound |