### PR TITLE
docs: point contributors at the toolchain file, not the language version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,10 @@ commits, make `make ci` pass, and expect to rebase.
 
 ## Local requirements
 
-- Go as specified in [`go.mod`](go.mod). The build downloads the required
+- Go as pinned in [`.go-version`](.go-version). The build downloads the required
   toolchain automatically; nothing else needs installing for the lint, test,
-  and build targets.
+  and build targets. (`go.mod` names the *language* version, which is older on
+  purpose — following it gets you the wrong compiler.)
 - GNU Make. `make help` lists every target, and the `##` comments are the
   source of truth.
 - PostgreSQL is only needed for the control-plane database targets


### PR DESCRIPTION
Follow-up to #75, as promised in the review thread there.

`CONTRIBUTING.md` sent people to `go.mod` for the Go version:

| file | says | is |
|---|---|---|
| `go.mod` | `go 1.25.0` | the **language** version |
| `.go-version` | `1.26.6` | the **toolchain**, which CI actually uses |

Every `setup-go` step in the workflows reads `.go-version`, and the Makefile hands it to the Dockerfile. A contributor following the old line installs the wrong compiler and then wonders why their build differs from CI's.

The distinction is not obvious, so the line now says which is which rather than only naming the right file.

Done as a follow-up rather than a change requested on #75: that contribution had been waiting two days on a one-line correction, which is not a fair trade for somebody's first pull request.