### PR TITLE
fix(install): a pre-release is an answer, not a missing version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,8 +145,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" dist/* \
-            --repo "${GITHUB_REPOSITORY}" \
-            --title "${GITHUB_REF_NAME}" \
-            --generate-notes \
+          set -euo pipefail
+          # Everything before v1.0.0 publishes as a pre-release, which is what keeps
+          # /releases/latest empty. install.sh reads that endpoint and refuses rather than
+          # installing something this project does not yet offer as ready.
+          args=(
+            --repo "${GITHUB_REPOSITORY}"
+            --title "${GITHUB_REF_NAME}"
+            --generate-notes
             --verify-tag
+          )
+          case "${GITHUB_REF_NAME}" in
+            v0.*) args+=(--prerelease) ;;
+          esac
+          gh release create "${GITHUB_REF_NAME}" dist/* "${args[@]}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,9 +55,27 @@ esac
 # certain to come from the same release. Asking twice for "latest" could straddle a
 # publication and produce a mismatch that looks like tampering.
 if [ "$VERSION" = "latest" ]; then
-  VERSION="$(curl -fsSL "${API_BASE}/releases/latest" \
-    | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)"
-  [ -n "$VERSION" ] || die "could not work out the latest version; set MESHP_VERSION"
+  # GitHub excludes pre-releases from this endpoint, so a repository whose only releases
+  # are pre-releases answers 404 here. That is the honest answer to "what is the latest
+  # stable version" and it must not be turned into an install: somebody piping this to sh
+  # is asking for the version offered as ready, and there is not one yet.
+  #
+  # -f makes the 404 a failure rather than a body, which is what separates it from a
+  # release whose JSON could not be parsed.
+  if latest="$(curl -fsSL "${API_BASE}/releases/latest" 2>/dev/null)"; then
+    VERSION="$(printf '%s' "$latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)"
+    [ -n "$VERSION" ] || die "could not read a version out of the latest release; set MESHP_VERSION"
+  else
+    # Naming the pre-release rather than only refusing. "Could not work out the latest
+    # version" while a release sits on the releases page is a dead end, and the reader has
+    # no way to know the two facts are compatible.
+    pre="$(curl -fsSL "${API_BASE}/releases?per_page=1" 2>/dev/null \
+      | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)"
+    [ -n "$pre" ] || die "could not work out the latest version; set MESHP_VERSION"
+    die "there is no stable release yet: the newest is the pre-release ${pre}.
+  Install it deliberately, having read what it is not ready for:
+    MESHP_VERSION=${pre} sh install.sh"
+  fi
 fi
 
 archive="meshp_${VERSION}_${os}_${arch}.tar.gz"


### PR DESCRIPTION
Found by publishing v0.1.0, which is what publishing it was for.

## The bug

GitHub excludes pre-releases from `/releases/latest`, so that endpoint returns **404** while v0.1.0 sits on the releases page. `install.sh` read the empty result as a parse failure:

```
meshp install: could not work out the latest version; set MESHP_VERSION
```

That is a dead end. The reader has no way to know that "no latest version" and "there is a release right there" are compatible statements, and the fix — `MESHP_VERSION=v0.1.0` — is not discoverable from it.

Verified live: `curl https://api.github.com/repos/meshpnet/meshp/releases/latest` → 404 right now.

## The fix

`install.sh` tells the 404 apart from an unparseable release, looks for the newest release of any kind, and names it:

```
meshp install: there is no stable release yet: the newest is the pre-release v0.1.0.
  Install it deliberately, having read what it is not ready for:
    MESHP_VERSION=v0.1.0 sh install.sh
```

It still **refuses to install a pre-release on its own**. Somebody piping this to `sh` is asking for the version offered as ready, and there is not one yet.

`release.yml` publishes every `v0.x` tag as a pre-release rather than leaving it to be remembered afterwards — which is also what keeps `/releases/latest` empty and the refusal above correct. `v1.0.0` onward publishes as a release. Checked: `v0.1.0`/`v0.9.3` get the flag, `v1.0.0`/`v1.2.0` do not.

## Why CI missed it

`install-test.sh` builds a release, serves it over loopback and installs from it — it never touches the GitHub API, so the version-resolution branch was never exercised against a real releases page. Worth closing separately; this fixes the behaviour it missed rather than the gap that hid it.

This PR touches both paths in the release workflow's `pull_request` trigger, so it rebuilds every artifact and reruns the install test.