### PR TITLE
feat(api): a browser gets a cookie, and the cookie can only read

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -65,6 +65,9 @@ type Server struct {
 	// how the read endpoints stay usable in a test that does not stand one up: a device
 	// with no presence reads as disconnected, which is what it is.
 	presence Presence
+
+	// ui holds the browser sessions minted from the administrative token (ADR-0022 §5).
+	ui *uiSessions
 }
 
 // New builds a Server. store and svc may not be nil; the caller waits until the
@@ -89,6 +92,7 @@ func New(st *store.Store, svc *enroll.Service, sess *session.Server, cfg Config)
 		cfg:     cfg,
 		log:     cfg.Log,
 		limit:   newLimiter(cfg.EnrolRatePerSecond, cfg.EnrolBurst, 10_000, cfg.Clock),
+		ui:      newUISessions(cfg.Clock),
 	}
 	// Taken through the interface rather than held as a *Hub, so the thing that replaces
 	// it for multi-replica deployments (ADR-0012) has one place to arrive. A typed nil
@@ -125,12 +129,19 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	mux.Handle("GET /api/v1/networks/{networkID}/acl/versions", s.adminOnly(s.handleListPolicyVersions))
 
 	mux.Handle("POST /api/v1/networks", s.adminOnly(s.handleCreateNetwork))
-	mux.Handle("GET /api/v1/networks", s.adminOnly(s.handleListNetworks))
+	mux.Handle("GET /api/v1/networks", s.readable(s.handleListNetworks))
 
 	// The one read endpoint (ADR-0022). Everything else under /api/v1 creates or changes
 	// something; this answers a question about a network, and the commercial layer builds
 	// its cross-tenant roll-up on it, so its shape is not this page's to choose.
-	mux.Handle("GET /api/v1/networks/{networkID}/overview", s.adminOnly(s.handleNetworkOverview))
+	mux.Handle("GET /api/v1/networks/{networkID}/overview", s.readable(s.handleNetworkOverview))
+
+	// Signing in, which is the only route that takes the administrative token in a body.
+	// Rate limited with the enrolment endpoints: it is the one place a wrong secret can be
+	// guessed at, and while guessing a 32-byte secret is not a real threat, an endpoint
+	// that allocates on success should not be free to hammer.
+	mux.Handle("POST /api/v1/ui/session", s.rateLimited(s.handleUILogin))
+	mux.Handle("DELETE /api/v1/ui/session", http.HandlerFunc(s.handleUILogout))
 
 	// Its own sub-resource rather than a field on a general network update, because this
 	// is the one setting here that can decide whether a laptop leaks. A PUT that names it

--- a/internal/api/uisession.go
+++ b/internal/api/uisession.go
@@ -1,0 +1,312 @@
+package api
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/clock"
+	"github.com/meshpnet/meshp/internal/httpx"
+	"github.com/meshpnet/meshp/internal/logx"
+)
+
+// The browser's credential, and the whole of what makes a UI defensible before user
+// accounts exist (ADR-0022 §5).
+//
+// It is derived from the administrative token and strictly weaker than it: it authorises
+// the two read endpoints and nothing else, so a stolen browser session reads a network and
+// cannot mint an enrolment token, publish a policy or revoke a device. That asymmetry is
+// the entire justification for shipping a page against a single shared secret, and it stops
+// being sufficient the moment the UI grows a write path — at which point per-user accounts
+// are a prerequisite rather than a follow-up. The users, roles and role_bindings tables
+// have been in the schema since the first migration, waiting for a reader.
+const (
+	// uiCookieName is prefixed because the prefix is enforced by the browser: a cookie
+	// named __Host- may only be set over TLS, with no Domain, and Path=/. A page that
+	// somehow reached this over plaintext could not have its cookie set at all rather
+	// than having it set insecurely.
+	uiCookieName = "__Host-meshp_ui"
+
+	// uiSessionIdle is how long a session survives without being used.
+	//
+	// Sliding, because the page this exists for polls every few seconds: a dashboard
+	// somebody is watching never expires under them, and one abandoned on an unlocked
+	// laptop is dead within the window. A fixed lifetime would have to choose between
+	// those two and would get one of them wrong.
+	uiSessionIdle = 30 * time.Minute
+
+	// uiSessionMaxAge is the ceiling that no amount of use extends.
+	//
+	// Without it a page left open on a wall holds a credential derived from the
+	// deployment's root password forever, and "revocable server-side" would mean
+	// "revocable if somebody remembers".
+	uiSessionMaxAge = 12 * time.Hour
+
+	// maxUISessions bounds the store. Logins are rare and each entry is small, so this is
+	// not a capacity decision — it is what stops an endpoint that allocates on success
+	// from being a way to grow the heap once somebody has the token.
+	maxUISessions = 1024
+)
+
+// uiSession is one logged-in browser.
+type uiSession struct {
+	// idleDeadline moves forward on use; absoluteDeadline never does.
+	idleDeadline     time.Time
+	absoluteDeadline time.Time
+}
+
+// uiSessions holds them, in memory and in this process only.
+//
+// Deliberately not in PostgreSQL. A browser session is ephemeral by the same argument
+// ADR-0012 makes for presence — losing it costs a login, not correctness — and writing one
+// row per page load into the tables that hold desired state would be the wrong trade. The
+// consequence is that a restart logs everybody out, and that multi-replica does not work,
+// which is already true of this control plane for other reasons ADR-0022 sets out.
+type uiSessions struct {
+	clk clock.Clock
+
+	mu sync.Mutex
+	// Keyed by the SHA-256 of the token rather than by the token. The value a browser
+	// presents is then not sitting in this process's memory, so a heap dump or a core file
+	// does not hand somebody a live session.
+	byHash map[[32]byte]uiSession
+}
+
+// errTooManySessions means the store is full. Refusing is deliberate: evicting somebody
+// else's session instead would make a flood of sign-ins a way to log out whoever is
+// actually watching.
+var errTooManySessions = errors.New("api: too many browser sessions")
+
+func newUISessions(clk clock.Clock) *uiSessions {
+	if clk == nil {
+		clk = clock.System{}
+	}
+	return &uiSessions{clk: clk, byHash: make(map[[32]byte]uiSession)}
+}
+
+// create mints a session and returns the value the browser will present.
+func (u *uiSessions) create() (string, time.Time, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", time.Time{}, err
+	}
+	token := base64.RawURLEncoding.EncodeToString(raw)
+
+	now := u.clk.Now()
+	absolute := now.Add(uiSessionMaxAge)
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	// Swept here rather than on a timer: logins are the only thing that grows this map, so
+	// they are the only moment it needs tidying, and a goroutine per server for a map that
+	// is usually empty is not worth owning.
+	u.sweepLocked(now)
+	if len(u.byHash) >= maxUISessions {
+		// Refusing rather than evicting somebody else's session. Eviction would make a
+		// flood of logins a way to log out whoever is actually watching.
+		return "", time.Time{}, errTooManySessions
+	}
+	u.byHash[sha256.Sum256([]byte(token))] = uiSession{
+		idleDeadline:     now.Add(uiSessionIdle),
+		absoluteDeadline: absolute,
+	}
+	return token, absolute, nil
+}
+
+// valid reports whether a presented token names a live session, and extends it if so.
+func (u *uiSessions) valid(token string) bool {
+	if token == "" {
+		return false
+	}
+	key := sha256.Sum256([]byte(token))
+	now := u.clk.Now()
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	session, ok := u.byHash[key]
+	if !ok {
+		return false
+	}
+	if now.After(session.idleDeadline) || now.After(session.absoluteDeadline) {
+		delete(u.byHash, key)
+		return false
+	}
+	// The idle window moves; the ceiling does not, and the new window is clamped to it so
+	// a busy page cannot walk past the absolute deadline one poll at a time.
+	session.idleDeadline = now.Add(uiSessionIdle)
+	if session.idleDeadline.After(session.absoluteDeadline) {
+		session.idleDeadline = session.absoluteDeadline
+	}
+	u.byHash[key] = session
+	return true
+}
+
+// revoke ends one session. Ending a session that does not exist is success: a browser
+// logging out with a cookie this process has already forgotten has got what it asked for.
+func (u *uiSessions) revoke(token string) {
+	if token == "" {
+		return
+	}
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	delete(u.byHash, sha256.Sum256([]byte(token)))
+}
+
+func (u *uiSessions) sweepLocked(now time.Time) {
+	for key, session := range u.byHash {
+		if now.After(session.idleDeadline) || now.After(session.absoluteDeadline) {
+			delete(u.byHash, key)
+		}
+	}
+}
+
+// handleUILogin exchanges the administrative token for a cookie.
+//
+// The token arrives in the body rather than in a header, because that is what a login form
+// produces and the point of this endpoint is that the token is typed once and never stored.
+// What reaches the browser afterwards is HttpOnly, so no script on the page can read it
+// back out, and the token itself never becomes something JavaScript holds between requests.
+func (s *Server) handleUILogin(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.AdminToken == "" {
+		httpx.Error(w, s.log, http.StatusServiceUnavailable, "admin_disabled",
+			"the administrative API is not configured; set MESHP_ADMIN_TOKEN")
+		return
+	}
+	if !s.canSetSecureCookie(r) {
+		// Refused rather than downgraded. A cookie without Secure over a plaintext hop is
+		// a credential on the wire, and one that silently worked would make configuring TLS
+		// optional for a deployment somebody browses to (ADR-0022 §5).
+		httpx.Error(w, s.log, http.StatusBadRequest, "tls_required",
+			"signing in needs TLS: set MESHP_TLS_CERT and MESHP_TLS_KEY, or MESHP_TLS_DOMAINS "+
+				"for automatic certificates. A TLS-terminating proxy in front is not visible "+
+				"from here and is not assumed; reach this over loopback to sign in without one.")
+		return
+	}
+
+	var body struct {
+		Token string `json:"token"`
+	}
+	if err := decode(w, r, &body); err != nil {
+		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	// Constant time, for the reason adminOnly gives: otherwise the secret can be learned
+	// one byte at a time from how long this takes.
+	if subtle.ConstantTimeCompare([]byte(body.Token), []byte(s.cfg.AdminToken)) != 1 {
+		s.log.Warn("a browser sign-in was refused", "remote", logx.Safe(clientKey(r)))
+		httpx.Error(w, s.log, http.StatusUnauthorized, "unauthorized",
+			"that is not the administrative token")
+		return
+	}
+
+	token, expires, err := s.ui.create()
+	if err != nil {
+		s.log.Error("could not mint a browser session", "error", err)
+		httpx.Error(w, s.log, http.StatusServiceUnavailable, "unavailable",
+			"could not start a session; try again")
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:  uiCookieName,
+		Value: token,
+		Path:  "/",
+		// HttpOnly so no script reads it, Secure so it never crosses a plaintext hop, and
+		// SameSite=Strict so another origin cannot make a browser spend it — which is also
+		// what stands in for a CSRF token on the sign-out route below.
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+		Expires:  expires,
+		MaxAge:   int(uiSessionMaxAge / time.Second),
+	})
+	httpx.WriteJSON(w, s.log, http.StatusCreated, map[string]any{
+		"expires_at": expires.UTC(),
+		// Said out loud so a consumer is not left to infer it from a 401 later.
+		"authorises": []string{"read"},
+	})
+}
+
+// handleUILogout ends the session and clears the cookie.
+func (s *Server) handleUILogout(w http.ResponseWriter, r *http.Request) {
+	if cookie, err := r.Cookie(uiCookieName); err == nil {
+		s.ui.revoke(cookie.Value)
+	}
+	// Cleared whether or not there was a session to end, so a browser holding a cookie this
+	// process has forgotten does not keep presenting it.
+	http.SetCookie(w, &http.Cookie{
+		Name:     uiCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+		MaxAge:   -1,
+	})
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// readable gates an endpoint on either the administrative token or a browser session.
+//
+// The only middleware that accepts a cookie, and it is applied only to the endpoints that
+// answer questions. Everything that creates or changes something stays on adminOnly, which
+// is what keeps the browser's credential strictly weaker than the one it came from.
+func (s *Server) readable(next http.HandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.cfg.AdminToken == "" {
+			httpx.Error(w, s.log, http.StatusServiceUnavailable, "admin_disabled",
+				"the administrative API is not configured; set MESHP_ADMIN_TOKEN")
+			return
+		}
+		if subtle.ConstantTimeCompare([]byte(bearer(r)), []byte(s.cfg.AdminToken)) == 1 {
+			next(w, r)
+			return
+		}
+		if cookie, err := r.Cookie(uiCookieName); err == nil && s.ui.valid(cookie.Value) {
+			next(w, r)
+			return
+		}
+		httpx.Error(w, s.log, http.StatusUnauthorized, "unauthorized",
+			"a valid administrative token or browser session is required")
+	})
+}
+
+// canSetSecureCookie reports whether this request may be given a Secure cookie.
+//
+// TLS on this connection, or loopback. X-Forwarded-Proto is deliberately not consulted:
+// this package already refuses to trust X-Forwarded-For for rate limiting, on the grounds
+// that a client can set it, and a header that decides whether a credential may be issued
+// is a worse thing to take on trust than one that decides a rate-limit bucket.
+//
+// Loopback is allowed because every current browser treats localhost as a secure context
+// and will store a Secure cookie set over http there, which is what keeps the quickstart
+// working without a certificate.
+func (s *Server) canSetSecureCookie(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	return isLoopbackRequest(r)
+}
+
+func isLoopbackRequest(r *http.Request) bool {
+	host := r.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	addr, err := netip.ParseAddr(strings.Trim(host, "[]"))
+	if err != nil {
+		return false
+	}
+	return addr.IsLoopback()
+}

--- a/internal/api/uisession_test.go
+++ b/internal/api/uisession_test.go
@@ -1,0 +1,304 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/clock"
+)
+
+// login exchanges the administrative token for a browser session and returns the cookie.
+//
+// The cookie is carried by hand rather than by a cookie jar, because Go's jar honours the
+// Secure attribute and would refuse to send it back over the test server's plaintext
+// loopback — which is the browser behaviour this cookie wants and not what these tests are
+// about. What is under test is the server's side of it.
+func (h *harness) login() *http.Cookie {
+	h.t.Helper()
+	resp := h.loginWith(testAdminToken)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		h.t.Fatalf("signing in returned %d", resp.StatusCode)
+	}
+	for _, c := range resp.Cookies() {
+		if c.Name == uiCookieName {
+			return c
+		}
+	}
+	h.t.Fatalf("signing in set no %s cookie", uiCookieName)
+	return nil
+}
+
+func (h *harness) loginWith(token string) *http.Response {
+	h.t.Helper()
+	body, _ := json.Marshal(map[string]string{"token": token})
+	req, _ := http.NewRequest(http.MethodPost, h.server.URL+"/api/v1/ui/session", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	return resp
+}
+
+// withCookie makes a request carrying the browser session and no bearer token.
+func (h *harness) withCookie(method, path string, cookie *http.Cookie) *http.Response {
+	h.t.Helper()
+	req, _ := http.NewRequest(method, h.server.URL+path, bytes.NewReader([]byte("{}")))
+	req.Header.Set("Content-Type", "application/json")
+	if cookie != nil {
+		req.AddCookie(&http.Cookie{Name: cookie.Name, Value: cookie.Value})
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	return resp
+}
+
+// The cookie is what the page will actually hold, so it has to carry the flags that make
+// holding it safe. Asserted here rather than trusted, because every one of them is a silent
+// failure: a cookie that works identically without HttpOnly is readable by any script that
+// gets onto the page.
+func TestSigningInSetsAHardenedCookie(t *testing.T) {
+	h := newHarness(t)
+	cookie := h.login()
+
+	if !cookie.HttpOnly {
+		t.Error("the cookie is not HttpOnly, so a script on the page can read it")
+	}
+	if !cookie.Secure {
+		t.Error("the cookie is not Secure, so it can cross a plaintext hop")
+	}
+	if cookie.SameSite != http.SameSiteStrictMode {
+		t.Errorf("SameSite = %v, want Strict — it is what stands in for a CSRF token", cookie.SameSite)
+	}
+	if cookie.Path != "/" {
+		t.Errorf("Path = %q, want /", cookie.Path)
+	}
+	if cookie.Value == "" {
+		t.Error("the cookie carries no value")
+	}
+	if cookie.Value == testAdminToken {
+		t.Fatal("the cookie carries the administrative token itself, which is the one thing it must never do")
+	}
+}
+
+// The whole point: it reads.
+func TestTheCookieReadsTheOverview(t *testing.T) {
+	h := newHarness(t)
+	h.enrol("a-device")
+	cookie := h.login()
+
+	resp := h.withCookie(http.MethodGet, h.netPath("/overview"), cookie)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("reading the overview with a browser session returned %d", resp.StatusCode)
+	}
+
+	listing := h.withCookie(http.MethodGet, "/api/v1/networks", cookie)
+	defer func() { _ = listing.Body.Close() }()
+	if listing.StatusCode != http.StatusOK {
+		t.Errorf("listing networks with a browser session returned %d", listing.StatusCode)
+	}
+}
+
+// And the whole point of the point: it does nothing else.
+//
+// This is the test that makes shipping a UI against a single shared secret defensible, so
+// it walks every route that changes something rather than sampling one. A stolen browser
+// session must read a network and be unable to mint a token, publish a policy, revoke a
+// device or touch a route group.
+func TestTheCookieCannotReachAnythingThatWrites(t *testing.T) {
+	h := newHarness(t)
+	membership := h.enrol("a-device").MembershipID.String()
+	cookie := h.login()
+
+	writes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, h.netPath("/enrollment-tokens")},
+		{http.MethodGet, h.netPath("/enrollment-tokens")},
+		{http.MethodGet, h.netPath("/devices")},
+		{http.MethodDelete, h.netPath("/devices/" + membership)},
+		{http.MethodGet, h.netPath("/acl")},
+		{http.MethodPut, h.netPath("/acl")},
+		{http.MethodPost, "/api/v1/networks"},
+		{http.MethodGet, h.netPath("/route-groups")},
+		{http.MethodPost, h.netPath("/route-groups")},
+		{http.MethodDelete, h.netPath("/route-groups/anything")},
+		{http.MethodPost, h.netPath("/route-groups/anything/advertisers")},
+	}
+	for _, route := range writes {
+		resp := h.withCookie(route.method, route.path, cookie)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("%s %s with only a browser session returned %d, want 401 — the cookie is "+
+				"not weaker than the token it came from", route.method, route.path, resp.StatusCode)
+		}
+	}
+}
+
+// A wrong token mints nothing. Otherwise the endpoint is a way to turn a guess into a
+// credential that outlives the guessing.
+func TestSigningInWithTheWrongToken(t *testing.T) {
+	h := newHarness(t)
+
+	resp := h.loginWith("not-the-admin-token")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("returned %d, want 401", resp.StatusCode)
+	}
+	for _, c := range resp.Cookies() {
+		if c.Name == uiCookieName && c.Value != "" {
+			t.Fatal("a refused sign-in still set a session cookie")
+		}
+	}
+}
+
+// Signing out is what "revocable server-side" means, so the cookie has to stop working
+// even though the browser still holds it.
+func TestSigningOutRevokesTheSession(t *testing.T) {
+	h := newHarness(t)
+	cookie := h.login()
+
+	out := h.withCookie(http.MethodDelete, "/api/v1/ui/session", cookie)
+	_ = out.Body.Close()
+	if out.StatusCode != http.StatusNoContent {
+		t.Fatalf("signing out returned %d, want 204", out.StatusCode)
+	}
+
+	resp := h.withCookie(http.MethodGet, "/api/v1/networks", cookie)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("the cookie still reads after signing out, returned %d", resp.StatusCode)
+	}
+}
+
+// A page nobody is watching stops being able to read. A page somebody is watching does not.
+func TestTheSessionExpiresWhenIdleAndIsHeldOpenByUse(t *testing.T) {
+	h := newHarness(t)
+	cookie := h.login()
+
+	// Used well inside the idle window, repeatedly, past the point a fixed lifetime of one
+	// idle window would have ended it. A dashboard polling every few seconds must not log
+	// itself out.
+	for range 4 {
+		h.clk.Advance(uiSessionIdle - time.Minute)
+		resp := h.withCookie(http.MethodGet, "/api/v1/networks", cookie)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("a session in use returned %d, want 200", resp.StatusCode)
+		}
+	}
+
+	h.clk.Advance(uiSessionIdle + time.Minute)
+	resp := h.withCookie(http.MethodGet, "/api/v1/networks", cookie)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("an idle session still reads, returned %d", resp.StatusCode)
+	}
+}
+
+// Use extends the idle window but never the ceiling, so a page left open on a wall does not
+// hold a credential derived from the deployment's root password indefinitely.
+func TestTheSessionHasACeilingUseDoesNotRaise(t *testing.T) {
+	h := newHarness(t)
+	cookie := h.login()
+
+	// Polled continuously, so the idle window is refreshed every time and only the absolute
+	// deadline can end this.
+	for range int(uiSessionMaxAge/(uiSessionIdle-time.Minute)) + 2 {
+		h.clk.Advance(uiSessionIdle - time.Minute)
+		resp := h.withCookie(http.MethodGet, "/api/v1/networks", cookie)
+		_ = resp.Body.Close()
+		if resp.StatusCode == http.StatusUnauthorized {
+			return // the ceiling ended it, which is the point
+		}
+	}
+	t.Errorf("a continuously polled session outlived its %s ceiling", uiSessionMaxAge)
+}
+
+// Signing in over plaintext to something that is not loopback is refused rather than
+// downgraded, so configuring TLS is a requirement for any deployment somebody browses to.
+func TestSigningInIsRefusedOverPlaintextToARemoteHost(t *testing.T) {
+	h := newHarness(t)
+
+	body, _ := json.Marshal(map[string]string{"token": testAdminToken})
+	req, _ := http.NewRequest(http.MethodPost, h.server.URL+"/api/v1/ui/session", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// The connection is still loopback; what the server can see of where the browser
+	// thinks it is, is the Host header, and that is what decides.
+	req.Host = "control.example.net"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("returned %d, want 400", resp.StatusCode)
+	}
+	for _, c := range resp.Cookies() {
+		if c.Name == uiCookieName && c.Value != "" {
+			t.Error("a refused sign-in over plaintext still set a session cookie")
+		}
+	}
+}
+
+// A forged or stale cookie is not a session. The store is keyed by a hash of what the
+// browser presents, so this also covers the case of somebody who has seen the map.
+func TestAnInventedCookieIsNotASession(t *testing.T) {
+	h := newHarness(t)
+	h.login() // so there is a real session in the store to be confused with
+
+	resp := h.withCookie(http.MethodGet, "/api/v1/networks",
+		&http.Cookie{Name: uiCookieName, Value: "made-up"})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("an invented cookie returned %d, want 401", resp.StatusCode)
+	}
+}
+
+// The store's own bounds, exercised directly because the HTTP path cannot reach them
+// without a thousand sign-ins.
+func TestTheSessionStoreSweepsAndRefusesToGrowWithoutBound(t *testing.T) {
+	clk := clock.NewFake()
+	store := newUISessions(clk)
+
+	first, _, err := store.create()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !store.valid(first) {
+		t.Fatal("a fresh session is not valid")
+	}
+
+	// Expired entries go on the next sign-in rather than lingering, so an abandoned page
+	// does not hold a slot against the bound below.
+	clk.Advance(uiSessionMaxAge + time.Hour)
+	if _, _, err := store.create(); err != nil {
+		t.Fatalf("creating a session after everything expired: %v", err)
+	}
+	if store.valid(first) {
+		t.Error("an expired session is still valid")
+	}
+	if got := len(store.byHash); got != 1 {
+		t.Errorf("the store holds %d sessions, want 1 — the expired one was not swept", got)
+	}
+
+	for range maxUISessions {
+		if _, _, err := store.create(); err != nil {
+			if !errors.Is(err, errTooManySessions) {
+				t.Fatalf("creating a session: %v", err)
+			}
+			return // refused rather than growing, which is the point
+		}
+	}
+	t.Errorf("the store grew past %d sessions without refusing", maxUISessions)
+}


### PR DESCRIPTION
Decision 5 of ADR-0022, and the gate on shipping any page at all — without it the only way for a browser to authenticate is to put the administrative token in JavaScript.

`POST /api/v1/ui/session` takes the token once and returns a session. `DELETE` ends it.

## The part that matters is the asymmetry, not the hardening

The cookie authorises the **two read endpoints and nothing else**. A stolen browser session reads a network and cannot mint an enrolment token, publish a policy, revoke a device or touch a route group.

Only `GET /networks` and `GET /networks/{id}/overview` moved to the new `readable` middleware. Every other route stays on `adminOnly`. `TestTheCookieCannotReachAnythingThatWrites` walks **all eleven** of them rather than sampling one, because this is the property the whole decision rests on.

When the UI grows a write path this stops being sufficient and per-user accounts become a prerequisite rather than a follow-up.

## Decisions worth reviewing

- **Sliding expiry with a ceiling.** A dashboard polling every few seconds must not log itself out; one abandoned on an unlocked laptop must not stay open. One fixed lifetime cannot do both. Use moves a 30-minute idle window and never the 12-hour cap. Both bounds are tested.
- **Sessions are in memory, keyed by SHA-256 of the presented value.** A heap dump does not hand out live sessions. A restart signs everybody out — costs a login, not correctness, which is the argument ADR-0012 already makes for presence. Consistent with multi-replica being unsupported.
- **`__Host-` cookie prefix.** Browser-enforced: it may only be set over TLS, with no `Domain`, and `Path=/`. A page that somehow reached this over plaintext could not have its cookie set at all rather than having it set insecurely.
- **The token arrives in the body**, not a header — that is what a login form produces, and the point is that it is typed once and never stored.
- **X-Forwarded-Proto is deliberately not consulted.** This package already declines to trust `X-Forwarded-For` for rate limiting because a client can set it; a header deciding whether a *credential is issued* is worse to take on trust than one deciding a rate-limit bucket. So a TLS-terminating proxy is not detectable from here, and the refusal message says so instead of leaving somebody to guess. If someone needs it, that is an explicit flag, not a default.
- **A full store refuses rather than evicting.** Eviction would make a flood of sign-ins a way to log out whoever is actually watching.

## Tests

Eleven. Cookie flags asserted individually (each is a silent failure), the read path, the write boundary across every mutating route, wrong token mints nothing, sign-out revokes server-side, idle expiry, the ceiling that use does not raise, plaintext-to-a-remote-host refused, an invented cookie, and the store's sweep and bound directly.

Grepped `cmd/` per ADR-0018: `meshp-control` → `api.New` (constructs the store) → `Routes` (registers both routes and the two `readable` gates).

With this, decisions 1 and 5 are done and the remaining work in #108 is 2, 3 and 4 — `embed.FS`, the hand-written page, and polling, which the endpoint already advertises via `poll_after_seconds`.