### PR TITLE
feat(web): a page that answers whether anything is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ cmd/meshpd          device agent (privileged, owns the WireGuard key)
 cmd/meshp-control   control plane
 cmd/meshp-relay     encrypted packet relay
 internal/       implementation, grouped by subsystem
+web/            the page a person looks at — hand-written, no build step
 docs/           guides, invariants, and the decision records
 docs/adr/       why things are the way they are — start here
 deploy/docker/  self-hosting

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -159,6 +159,21 @@ discovers direct paths yet, so everything is relayed — that is relay-first wor
 designed rather than a gap (ADR-0002), and a direct path is an optimisation layered on
 later rather than a prerequisite for connectivity.
 
+## Look at it
+
+Open <http://localhost:8080> and sign in with the same `MESHP_ADMIN_TOKEN` you set in step 1.
+
+The page shows one network: every device and whether its control session is up, every
+route group and which devices are offering to carry it, and anything a device reported it
+could not apply. It says at the top whether anything needs attention, and it says in the
+corner how old what you are looking at is — a poll that fails leaves the last answer on
+screen and marks it stale rather than letting old numbers pass for current.
+
+The token is exchanged once for a session cookie that may read and may not write, so the
+page cannot mint a token or revoke a device even if somebody else is sitting at it
+(ADR-0022). Signing in needs TLS anywhere that is not loopback; `localhost` is the
+exception that keeps this quickstart working without a certificate.
+
 ## Where to go next
 
 - [Self-hosting](self-hosting.md) — TLS, systemd, backups: the version you would actually run.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -143,9 +143,9 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	mux.Handle("POST /api/v1/ui/session", s.rateLimited(s.handleUILogin))
 	mux.Handle("DELETE /api/v1/ui/session", http.HandlerFunc(s.handleUILogout))
 
-	// The page itself, last because it is the catch-all: every pattern above is more
-	// specific and wins (ADR-0022 §2).
-	mux.Handle("GET /", http.HandlerFunc(s.handlePage))
+	// The page itself (ADR-0022 §2), registered as one route per embedded file rather
+	// than as a catch-all — see routePage for why that distinction is load-bearing.
+	s.routePage(mux)
 
 	// Its own sub-resource rather than a field on a general network update, because this
 	// is the one setting here that can decide whether a laptop leaks. A PUT that names it

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -143,6 +143,10 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	mux.Handle("POST /api/v1/ui/session", s.rateLimited(s.handleUILogin))
 	mux.Handle("DELETE /api/v1/ui/session", http.HandlerFunc(s.handleUILogout))
 
+	// The page itself, last because it is the catch-all: every pattern above is more
+	// specific and wins (ADR-0022 §2).
+	mux.Handle("GET /", http.HandlerFunc(s.handlePage))
+
 	// Its own sub-resource rather than a field on a general network update, because this
 	// is the one setting here that can decide whether a laptop leaks. A PUT that names it
 	// in the path cannot be made by accident, reads unambiguously in an access log, and

--- a/internal/api/page.go
+++ b/internal/api/page.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/meshpnet/meshp/internal/httpx"
+	"github.com/meshpnet/meshp/web"
+)
+
+// contentSecurityPolicy is what the page is allowed to do.
+//
+// The browser's credential is an HttpOnly cookie, which stops a script reading it — but a
+// script running on this origin can spend it, because the browser attaches it to every
+// request here. So the value of the cookie being HttpOnly depends on no foreign script
+// running, and this is what says so to the browser rather than leaving it to review.
+//
+// 'none' by default and widened one directive at a time. `form-action 'none'` is not
+// decoration: the sign-in form takes the administrative token, and its submit handler
+// cancels the real submission — a policy that forbids form submission entirely means a
+// bug in that handler cannot turn into a token in somebody's access log.
+const contentSecurityPolicy = "default-src 'none'; " +
+	"script-src 'self'; style-src 'self'; connect-src 'self'; img-src 'self' data:; " +
+	"base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
+
+// handlePage serves the view (ADR-0022 §2).
+//
+// From the same binary and the same port as the API it reads, so a self-hoster's
+// deployment stays the one unit deploy/systemd describes rather than gaining a second
+// artefact, a second port and a CORS policy between two halves of one product.
+func (s *Server) handlePage(w http.ResponseWriter, r *http.Request) {
+	// This is the catch-all for GET, so anything under /api/ that matched no route above
+	// arrives here. It must not be answered with HTML: a caller that asked for JSON and
+	// got a page back learns nothing about what it got wrong.
+	if strings.HasPrefix(r.URL.Path, "/api/") {
+		httpx.Error(w, s.log, http.StatusNotFound, "no_such_endpoint", "no such endpoint")
+		return
+	}
+
+	w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	// The files change when the binary does and carry no version in their names, so a
+	// cached copy would outlive an upgrade. no-cache revalidates rather than forbidding
+	// storage; they are three small files and this is not the expensive part of a poll.
+	w.Header().Set("Cache-Control", "no-cache")
+
+	pageServer.ServeHTTP(w, r)
+}
+
+// pageServer serves the embedded files. Built once: it holds no request state, and
+// rebuilding it per request would re-read the FS index every time.
+//
+// There is no history-mode fallback to index.html for unknown paths. The page routes on
+// the fragment, which never reaches a server, so a request for a path that is not a file
+// is a request for something that does not exist — and answering it with the page would
+// turn every typo into a dashboard that silently shows the wrong thing.
+var pageServer = http.FileServerFS(web.FS)

--- a/internal/api/page.go
+++ b/internal/api/page.go
@@ -1,10 +1,9 @@
 package api
 
 import (
+	"io/fs"
 	"net/http"
-	"strings"
 
-	"github.com/meshpnet/meshp/internal/httpx"
 	"github.com/meshpnet/meshp/web"
 )
 
@@ -23,20 +22,46 @@ const contentSecurityPolicy = "default-src 'none'; " +
 	"script-src 'self'; style-src 'self'; connect-src 'self'; img-src 'self' data:; " +
 	"base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
 
-// handlePage serves the view (ADR-0022 §2).
+// routePage registers the view (ADR-0022 §2), one route per embedded file.
+//
+// Explicitly, rather than as a `GET /` catch-all. The catch-all is the obvious way to
+// serve a page and it is wrong here twice over.
+//
+// It panics. A pattern registered without a method conflicts with `GET /` — neither is
+// more specific — and meshp-control registers `/api/v1/` on its mux before the database is
+// up, so the two together take the process down at startup. Every test in this package
+// passed while that was true, because they build a mux holding only these routes.
+//
+// And it over-serves. A catch-all answers /anything-at-all with the page, which turns a
+// mistyped URL into a dashboard that looks like it worked. Registering exactly what is
+// embedded means the served set and the embedded set cannot drift, because they are the
+// same list read once.
+func (s *Server) routePage(mux *http.ServeMux) {
+	entries, err := fs.ReadDir(web.FS, ".")
+	if err != nil {
+		// Unreachable: the FS is built at compile time from a fixed pattern. Logged rather
+		// than ignored, because the failure it would describe is a page that silently is
+		// not there.
+		s.log.Error("could not read the embedded page", "error", err)
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		mux.Handle("GET /"+entry.Name(), http.HandlerFunc(s.handlePage))
+	}
+	// {$} matches the root and nothing below it, so this claims one path rather than the
+	// whole space beneath it.
+	mux.Handle("GET /{$}", http.HandlerFunc(s.handlePage))
+}
+
+// handlePage serves the view.
 //
 // From the same binary and the same port as the API it reads, so a self-hoster's
 // deployment stays the one unit deploy/systemd describes rather than gaining a second
 // artefact, a second port and a CORS policy between two halves of one product.
 func (s *Server) handlePage(w http.ResponseWriter, r *http.Request) {
-	// This is the catch-all for GET, so anything under /api/ that matched no route above
-	// arrives here. It must not be answered with HTML: a caller that asked for JSON and
-	// got a page back learns nothing about what it got wrong.
-	if strings.HasPrefix(r.URL.Path, "/api/") {
-		httpx.Error(w, s.log, http.StatusNotFound, "no_such_endpoint", "no such endpoint")
-		return
-	}
-
 	w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Referrer-Policy", "no-referrer")
@@ -51,8 +76,7 @@ func (s *Server) handlePage(w http.ResponseWriter, r *http.Request) {
 // pageServer serves the embedded files. Built once: it holds no request state, and
 // rebuilding it per request would re-read the FS index every time.
 //
-// There is no history-mode fallback to index.html for unknown paths. The page routes on
-// the fragment, which never reaches a server, so a request for a path that is not a file
-// is a request for something that does not exist — and answering it with the page would
-// turn every typo into a dashboard that silently shows the wrong thing.
+// There is no history-mode fallback to index.html, and no route reaches this for a path
+// that is not an embedded file. The page routes on the fragment, which never reaches a
+// server, so there is nothing for a fallback to serve.
 var pageServer = http.FileServerFS(web.FS)

--- a/internal/api/page_test.go
+++ b/internal/api/page_test.go
@@ -81,27 +81,33 @@ func TestTheAssetsAreServed(t *testing.T) {
 	}
 }
 
-// An unknown API path must answer as an API, not as a page.
+// The regression that took the container down, and the one this package could not see.
 //
-// The page handler is the catch-all for GET, so this is the one that would regress
-// silently: a caller that asked for JSON and was handed HTML with a 404 learns nothing
-// about what it got wrong, and a client library would fail while parsing rather than
-// while checking the status.
-func TestAnUnknownAPIPathAnswersAsAnAPI(t *testing.T) {
-	ts := pageServerFor(t)
+// meshp-control registers `/api/v1/` on its mux while the database is still coming up, so
+// the API's own routes go on beside it. A `GET /` catch-all conflicts with a pattern that
+// names no method — neither is more specific — and ServeMux reports that by panicking at
+// registration. Every test here passed while the shipped binary died at startup, because
+// they all built a mux holding only these routes.
+func TestThePageDoesNotClaimTheWholeURLSpace(t *testing.T) {
+	mux := http.NewServeMux()
+	// What the control plane has already registered by the time the API is wired up.
+	mux.HandleFunc("/api/v1/", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "still starting up", http.StatusServiceUnavailable)
+	})
 
-	status, header, body := get(t, ts.URL+"/api/v1/there-is-no-such-thing")
-	if status != http.StatusNotFound {
-		t.Errorf("status = %d, want 404", status)
+	// Panics on a conflicting pattern, which is the whole assertion.
+	New(nil, nil, nil, Config{}).Routes(mux)
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	// Both still answer: the page at the root, and the bootstrap route for anything under
+	// /api/v1 that the API did not claim.
+	if status, _, _ := get(t, ts.URL+"/"); status != http.StatusOK {
+		t.Errorf("GET / = %d, want 200", status)
 	}
-	if ct := header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
-		t.Errorf("Content-Type = %q, want application/json", ct)
-	}
-	if !strings.Contains(body, "no_such_endpoint") {
-		t.Errorf("body = %q, want it to name the failure", body)
-	}
-	if strings.Contains(body, "<html") {
-		t.Error("an API path was answered with the page")
+	if status, _, body := get(t, ts.URL+"/api/v1/not-a-route"); status != http.StatusServiceUnavailable {
+		t.Errorf("GET /api/v1/not-a-route = %d (%q), want the bootstrap route's 503", status, body)
 	}
 }
 
@@ -113,12 +119,14 @@ func TestAnUnknownAPIPathAnswersAsAnAPI(t *testing.T) {
 func TestAnUnknownPathIsNotThePage(t *testing.T) {
 	ts := pageServerFor(t)
 
-	status, _, body := get(t, ts.URL+"/networks/not-a-route")
-	if status != http.StatusNotFound {
-		t.Errorf("status = %d, want 404", status)
-	}
-	if strings.Contains(body, "/app.js") {
-		t.Error("an unknown path was answered with the page")
+	for _, path := range []string{"/networks/not-a-route", "/api/v1/not-a-route", "/index.html/extra"} {
+		status, _, body := get(t, ts.URL+path)
+		if status != http.StatusNotFound {
+			t.Errorf("GET %s = %d, want 404", path, status)
+		}
+		if strings.Contains(body, "/app.js") {
+			t.Errorf("GET %s was answered with the page", path)
+		}
 	}
 }
 

--- a/internal/api/page_test.go
+++ b/internal/api/page_test.go
@@ -1,0 +1,157 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// pageServerFor builds a server with no database behind it.
+//
+// The page is static, so nothing it serves needs a store — and a test that stood one up
+// would only run where PostgreSQL does, which is the wrong place for the assertions below.
+func pageServerFor(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	New(nil, nil, nil, Config{}).Routes(mux)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// get fetches a URL and returns what the assertions below need.
+//
+// The status, the headers and the body rather than the *http.Response, so the response
+// never escapes this function — which is what lets it be closed in one place instead of in
+// every caller.
+func get(t *testing.T, url string) (int, http.Header, string) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp.StatusCode, resp.Header, string(body)
+}
+
+// The page is reachable, and reachable without a credential.
+//
+// Deliberately so: the page is a static file and holds no data, and requiring a session to
+// fetch the thing whose only job is to ask for one would be a loop. Everything it reads is
+// behind `readable` (ADR-0022 §5), and that is where the credential belongs.
+func TestThePageIsServedWithoutACredential(t *testing.T) {
+	ts := pageServerFor(t)
+
+	status, header, body := get(t, ts.URL+"/")
+	if status != http.StatusOK {
+		t.Fatalf("GET / = %d, want 200", status)
+	}
+	if ct := header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", ct)
+	}
+	if !strings.Contains(body, "/app.js") {
+		t.Error("the page does not load app.js, so nothing would render")
+	}
+}
+
+func TestTheAssetsAreServed(t *testing.T) {
+	ts := pageServerFor(t)
+
+	for _, tc := range []struct{ path, wantType, wantBody string }{
+		{"/app.js", "javascript", "poll_after_seconds"},
+		{"/app.css", "text/css", "--bg"},
+	} {
+		status, header, body := get(t, ts.URL+tc.path)
+		if status != http.StatusOK {
+			t.Errorf("GET %s = %d, want 200", tc.path, status)
+			continue
+		}
+		if ct := header.Get("Content-Type"); !strings.Contains(ct, tc.wantType) {
+			t.Errorf("GET %s Content-Type = %q, want it to name %s", tc.path, ct, tc.wantType)
+		}
+		if !strings.Contains(body, tc.wantBody) {
+			t.Errorf("GET %s does not contain %q", tc.path, tc.wantBody)
+		}
+	}
+}
+
+// An unknown API path must answer as an API, not as a page.
+//
+// The page handler is the catch-all for GET, so this is the one that would regress
+// silently: a caller that asked for JSON and was handed HTML with a 404 learns nothing
+// about what it got wrong, and a client library would fail while parsing rather than
+// while checking the status.
+func TestAnUnknownAPIPathAnswersAsAnAPI(t *testing.T) {
+	ts := pageServerFor(t)
+
+	status, header, body := get(t, ts.URL+"/api/v1/there-is-no-such-thing")
+	if status != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", status)
+	}
+	if ct := header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if !strings.Contains(body, "no_such_endpoint") {
+		t.Errorf("body = %q, want it to name the failure", body)
+	}
+	if strings.Contains(body, "<html") {
+		t.Error("an API path was answered with the page")
+	}
+}
+
+// An unknown path is not quietly answered with the page.
+//
+// The page routes on the fragment, which never reaches a server, so there is no history
+// mode to support and no reason to fall back to index.html. A server that did would turn
+// every mistyped URL into a dashboard, which looks like it worked.
+func TestAnUnknownPathIsNotThePage(t *testing.T) {
+	ts := pageServerFor(t)
+
+	status, _, body := get(t, ts.URL+"/networks/not-a-route")
+	if status != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", status)
+	}
+	if strings.Contains(body, "/app.js") {
+		t.Error("an unknown path was answered with the page")
+	}
+}
+
+// The cookie is HttpOnly, which stops a script reading it — but any script on this origin
+// can spend it, because the browser attaches it here. These headers are what keeps a
+// foreign script off the origin, so they are asserted rather than assumed.
+func TestThePageCarriesItsSecurityHeaders(t *testing.T) {
+	ts := pageServerFor(t)
+
+	_, header, _ := get(t, ts.URL+"/")
+	csp := header.Get("Content-Security-Policy")
+	for _, want := range []string{"default-src 'none'", "script-src 'self'", "frame-ancestors 'none'", "form-action 'none'"} {
+		if !strings.Contains(csp, want) {
+			t.Errorf("Content-Security-Policy = %q, want it to contain %q", csp, want)
+		}
+	}
+	if got := header.Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+}
+
+// Only the three files are embedded.
+//
+// A go:embed pattern is one character away from being much wider than it looks, and the
+// failure is silent: `embed.go` itself, or a stray note left in this directory, would
+// simply start being served. This is what notices.
+func TestOnlyThePageIsEmbedded(t *testing.T) {
+	ts := pageServerFor(t)
+
+	for _, path := range []string{"/embed.go", "/app.js.map", "/.gitignore"} {
+		status, _, _ := get(t, ts.URL+path)
+		if status != http.StatusNotFound {
+			t.Errorf("GET %s = %d, want 404: something beyond the page is embedded", path, status)
+		}
+	}
+}

--- a/web/app.css
+++ b/web/app.css
@@ -1,0 +1,188 @@
+/* One page, two themes, no build step.
+ *
+ * Colour is load-bearing here and cannot be the only signal: a route group nothing is
+ * carrying says so in words as well as in red, because the reader may not see the red. */
+
+:root {
+  color-scheme: light dark;
+
+  --bg: #f6f7f9;
+  --panel: #ffffff;
+  --ink: #16191d;
+  --muted: #5b6472;
+  --line: #dfe3e8;
+
+  --ok: #1a7f4b;
+  --warn: #96631a;
+  --bad: #b3261e;
+  --unknown: #5b6472;
+
+  --radius: 10px;
+  --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #14171b;
+    --panel: #1c2025;
+    --ink: #e8eaed;
+    --muted: #98a2b1;
+    --line: #2b313a;
+
+    --ok: #4ec98a;
+    --warn: #e0b055;
+    --bad: #ff8a80;
+    --unknown: #98a2b1;
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font: 15px/1.5 var(--sans);
+}
+
+.bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.wordmark { font-weight: 600; letter-spacing: 0.02em; }
+.freshness { color: var(--muted); font-size: 13px; margin-left: auto; }
+.freshness.stale { color: var(--warn); font-weight: 600; }
+
+.linkish {
+  background: none;
+  border: none;
+  color: var(--muted);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
+main { max-width: 1100px; margin: 0 auto; padding: 16px; }
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+h1 { font-size: 20px; margin: 0 0 4px; }
+h2 { font-size: 15px; margin: 24px 0 10px; color: var(--muted); font-weight: 600; }
+p { margin: 0 0 12px; }
+
+code, .mono { font-family: var(--mono); font-size: 13px; }
+
+/* The headline. The whole question the page exists to answer, before any scrolling. */
+.verdict {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+  border-left: 4px solid var(--ok);
+}
+.verdict.problems { border-left-color: var(--bad); }
+.verdict h1 { font-size: 22px; }
+.verdict .sub { color: var(--muted); font-size: 14px; }
+
+/* A route group and the devices offering to carry it, side by side, because which
+ * device carries which prefixes is a relationship and reads badly as rows. */
+.group {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) 2fr;
+  gap: 16px;
+  align-items: start;
+}
+@media (max-width: 700px) {
+  .group { grid-template-columns: 1fr; }
+}
+
+.group-id .name { font-weight: 600; }
+.group-id .meta { color: var(--muted); font-size: 13px; }
+.prefixes { margin: 8px 0 0; padding: 0; list-style: none; }
+.prefixes li { font-family: var(--mono); font-size: 13px; }
+
+.carriers { margin: 0; padding: 0; list-style: none; }
+.carrier {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 6px 0;
+  border-top: 1px solid var(--line);
+}
+.carrier:first-child { border-top: none; }
+.carrier .who { font-weight: 500; }
+.carrier .why { color: var(--muted); font-size: 13px; }
+.carrier.not-viable .who { text-decoration: line-through; }
+
+.nobody {
+  color: var(--bad);
+  font-weight: 600;
+}
+
+.scroll { overflow-x: auto; }
+.devices { width: 100%; min-width: 480px; border-collapse: collapse; }
+.devices th {
+  text-align: left;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  border-bottom: 1px solid var(--line);
+  padding: 6px 8px;
+}
+.devices td { padding: 8px; border-bottom: 1px solid var(--line); vertical-align: top; }
+.devices tr.attention td { background: color-mix(in srgb, var(--bad) 7%, transparent); }
+.devices .addr { font-family: var(--mono); font-size: 12px; color: var(--muted); }
+
+.dot { font-size: 11px; }
+.ok { color: var(--ok); }
+.warn { color: var(--warn); }
+.bad { color: var(--bad); }
+.unknown { color: var(--unknown); }
+
+.note { color: var(--muted); font-size: 13px; }
+.faults { margin: 4px 0 0; padding-left: 18px; }
+.faults li { color: var(--bad); font-size: 13px; }
+
+/* Sign-in and the network picker. */
+form.signin { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+input[type="password"], select {
+  font: inherit;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--ink);
+  min-width: 260px;
+}
+button.primary {
+  font: inherit;
+  padding: 8px 14px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: var(--ink);
+  color: var(--panel);
+  cursor: pointer;
+}
+.error { color: var(--bad); }
+
+.picker { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.picker label { color: var(--muted); font-size: 13px; }

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,589 @@
+// The page (ADR-0022). One network, one question: is anything unreachable, and what is
+// carrying for it.
+//
+// Hand-written ES modules, no framework and no build step, so this file is what runs.
+// Three rules it must not break:
+//
+//   1. It never invents a fact the control plane does not have. In particular it does not
+//      say which advertiser is *chosen* — desired state carries an ordered list of
+//      pre-authorised candidates and the agent decides which is alive (ADR-0003), so no
+//      such fact exists server-side to render.
+//   2. It shows its own freshness. A monitoring view that lies about when it last heard
+//      anything is worse than no view, so a failed poll makes the page visibly stale
+//      rather than leaving old numbers looking current.
+//   3. Colour is never the only signal. Anything shown in red says the same thing in words.
+
+const view = document.getElementById("view");
+const freshnessEl = document.getElementById("freshness");
+const signoutEl = document.getElementById("signout");
+
+/** Last successful overview, kept so a failed poll can keep showing it — marked stale. */
+let lastGood = null;
+/** When that arrived, by this browser's clock. `as_of` is the server's. */
+let lastGoodAt = null;
+let pollTimer = null;
+let freshnessTimer = null;
+
+// --- the API -------------------------------------------------------------------------
+
+/**
+ * One call. Errors carry the status and the server's code so a caller can tell an
+ * expired session from a network that has gone away.
+ */
+async function api(path, options = {}) {
+  const res = await fetch(path, {
+    // The credential is an HttpOnly cookie; no script here ever holds a token.
+    credentials: "same-origin",
+    ...options,
+  });
+  const text = await res.text();
+  let body = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = null;
+    }
+  }
+  if (!res.ok) {
+    const err = new Error((body && body.message) || `HTTP ${res.status}`);
+    err.status = res.status;
+    err.code = body && body.error;
+    throw err;
+  }
+  return body;
+}
+
+/**
+ * What to put in front of a person when a call failed.
+ *
+ * A fetch that never reached anything rejects with the browser's own wording — "Failed to
+ * fetch", or something else entirely depending on the browser — which describes the API
+ * this file called rather than what went wrong. Somebody watching a network go down
+ * deserves the sentence that is actually true.
+ */
+function reason(err) {
+  return err.status === undefined ? "cannot reach the control plane" : err.message;
+}
+
+// --- DOM ----------------------------------------------------------------------------
+
+/**
+ * Builds an element. Text always goes in as text, never as markup: device names, group
+ * names and error strings come from devices and from operators, and this page renders
+ * them beside a credential.
+ */
+function el(tag, attrs = {}, ...children) {
+  const node = document.createElement(tag);
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value === null || value === undefined || value === false) continue;
+    if (key === "class") node.className = value;
+    else if (key === "hidden") node.hidden = Boolean(value);
+    else node.setAttribute(key, value);
+  }
+  for (const child of children.flat()) {
+    if (child === null || child === undefined || child === false) continue;
+    node.append(typeof child === "string" ? document.createTextNode(child) : child);
+  }
+  return node;
+}
+
+function show(...nodes) {
+  view.replaceChildren(...nodes);
+}
+
+// --- what counts as broken ------------------------------------------------------------
+
+/**
+ * Whether this candidate could carry anything at all.
+ *
+ * Deliberately not a function of `connected`. That is the control session, and an agent
+ * keeps forwarding from the state it last applied when the control plane is unreachable
+ * (ADR-0008) — so an advertiser whose session has dropped may well still be carrying, and
+ * calling the group broken on that basis would raise an alarm for a control-plane outage
+ * rather than a data-plane one. Disconnection is shown; it is not a fault by itself.
+ *
+ * `unknown` health is not treated as broken either, for the opposite reason: nobody has
+ * reported on it yet, which is not the same as knowing it is down. It is called out as
+ * unproven where it appears.
+ */
+function viable(advertiser) {
+  if (advertiser.admin_state !== "enabled") return false;
+  return advertiser.health !== "unhealthy" && advertiser.health !== "offline";
+}
+
+/** What is wrong with a route group, in words. Empty means nothing is. */
+function groupFaults(group) {
+  const faults = [];
+  if (!group.advertisers.length) {
+    faults.push("nothing is offering to carry this");
+    return faults;
+  }
+  if (!group.advertisers.some(viable)) {
+    faults.push("no candidate can carry this: every advertiser is disabled, draining or unhealthy");
+  }
+  return faults;
+}
+
+/** What is wrong with a device, in words. */
+function deviceFaults(device) {
+  const faults = [];
+  if (device.state !== "active") return faults;
+
+  if (device.unapplied_components && device.unapplied_components.length) {
+    faults.push(`could not apply: ${device.unapplied_components.join(", ")}`);
+  }
+  if (device.last_error) {
+    faults.push(device.last_error);
+  }
+  if (!device.connected && !device.last_ack_at) {
+    // Enrolled and never heard from. Easy to miss in a list of names, and it is usually
+    // an installation that did not finish rather than a device that has gone away.
+    faults.push("has never applied any configuration");
+  }
+  return faults;
+}
+
+// --- rendering ------------------------------------------------------------------------
+
+const HEALTH_CLASS = {
+  healthy: "ok",
+  degraded: "warn",
+  unhealthy: "bad",
+  offline: "bad",
+  unknown: "unknown",
+};
+
+function dot(className, label) {
+  return el("span", { class: `dot ${className}`, title: label, "aria-hidden": "true" }, "●");
+}
+
+function renderVerdict(data, faultCount) {
+  const devices = data.devices.length;
+  const groups = data.route_groups.length;
+  const counted = `${devices} device${devices === 1 ? "" : "s"}, ${groups} route group${groups === 1 ? "" : "s"}`;
+
+  return el(
+    "div",
+    { class: `panel verdict ${faultCount ? "problems" : ""}` },
+    el(
+      "h1",
+      {},
+      faultCount
+        ? `${faultCount} thing${faultCount === 1 ? "" : "s"} need${faultCount === 1 ? "s" : ""} attention`
+        : "No faults reported",
+    ),
+    el(
+      "span",
+      { class: "sub" },
+      faultCount
+        ? counted
+        : // Said precisely. The page knows what devices reported and what health checks
+          // observed; it does not know that every packet is arriving.
+          `${counted} — every device is applying its configuration and every route group has a candidate`,
+    ),
+  );
+}
+
+function renderGroup(group) {
+  const faults = groupFaults(group);
+
+  const carriers = group.advertisers.map((advertiser) => {
+    const health = advertiser.health || "unknown";
+    const bits = [`priority ${advertiser.priority}`];
+    if (advertiser.weight !== 1) bits.push(`weight ${advertiser.weight}`);
+    bits.push(health === "unknown" ? "never health checked" : health);
+    if (advertiser.admin_state !== "enabled") bits.push(advertiser.admin_state);
+    // Named as a control-plane fact, not as an outage, because it is not one.
+    if (!advertiser.connected) bits.push("control session down");
+    const where = [advertiser.city, advertiser.region].filter(Boolean).join(", ");
+    if (where) bits.push(where);
+
+    return el(
+      "li",
+      { class: `carrier ${viable(advertiser) ? "" : "not-viable"}` },
+      dot(HEALTH_CLASS[health] || "unknown", health),
+      el("span", { class: "who" }, advertiser.device_name),
+      el("span", { class: "why" }, bits.join(" · ")),
+    );
+  });
+
+  return el(
+    "div",
+    { class: "panel" },
+    el(
+      "div",
+      { class: "group" },
+      el(
+        "div",
+        { class: "group-id" },
+        el("div", { class: "name" }, group.name || group.slug),
+        el("div", { class: "meta" }, `${group.kind} · ${group.selection_mode}`),
+        el(
+          "ul",
+          { class: "prefixes" },
+          group.prefixes.map((prefix) => el("li", {}, prefix)),
+        ),
+        group.stable_egress_ip ? el("div", { class: "meta mono" }, `egress ${group.stable_egress_ip}`) : null,
+      ),
+      el(
+        "div",
+        {},
+        faults.length ? el("div", { class: "nobody" }, faults.join("; ")) : null,
+        carriers.length
+          ? el("ul", { class: "carriers" }, carriers)
+          : el("div", { class: "note" }, "no advertisers"),
+      ),
+    ),
+  );
+}
+
+function renderDevices(devices) {
+  const rows = devices.map((device) => {
+    const faults = deviceFaults(device);
+    const addresses = [device.address_v4, device.address_v6].filter(Boolean);
+
+    let stateLabel;
+    let stateClass;
+    if (device.state !== "active") {
+      stateLabel = device.state;
+      stateClass = "unknown";
+    } else if (device.connected) {
+      stateLabel = "connected";
+      stateClass = "ok";
+    } else {
+      stateLabel = "control session down";
+      stateClass = "warn";
+    }
+
+    // Both numbers, when they disagree. They differ while an acknowledgement is in
+    // flight, and somebody chasing a device that looks stuck needs to see which of the
+    // two is behind rather than one number that could be either.
+    const versions =
+      device.reported_version !== undefined && device.reported_version !== device.applied_version
+        ? `${device.applied_version} recorded, ${device.reported_version} reported`
+        : String(device.applied_version ?? 0);
+
+    return el(
+      "tr",
+      { class: faults.length ? "attention" : "" },
+      el(
+        "td",
+        {},
+        el("div", {}, device.device_name),
+        addresses.length ? el("div", { class: "addr" }, addresses.join("  ")) : null,
+      ),
+      el("td", {}, dot(stateClass, stateLabel), " ", stateLabel),
+      el("td", { class: "mono" }, versions),
+      el(
+        "td",
+        {},
+        faults.length
+          ? el(
+              "ul",
+              { class: "faults" },
+              faults.map((fault) => el("li", {}, fault)),
+            )
+          : el("span", { class: "note" }, "—"),
+      ),
+    );
+  });
+
+  // Wrapped, so the table scrolls sideways on a narrow screen and the page does not. A
+  // body that shifts under a thumb makes every row harder to read, to save a column.
+  const table = el(
+    "table",
+    { class: "devices" },
+    el(
+      "thead",
+      {},
+      el(
+        "tr",
+        {},
+        el("th", {}, "Device"),
+        el("th", {}, "Control session"),
+        el("th", {}, "Applied version"),
+        el("th", {}, "Reported faults"),
+      ),
+    ),
+    el("tbody", {}, rows),
+  );
+  return el("div", { class: "scroll" }, table);
+}
+
+function renderOverview(data, networks) {
+  const groupFaultCount = data.route_groups.reduce((n, g) => n + groupFaults(g).length, 0);
+  const deviceFaultCount = data.devices.reduce((n, d) => n + deviceFaults(d).length, 0);
+
+  // Devices with something wrong first. A list sorted by name buries the one device the
+  // page exists to surface somewhere in the middle of forty that are fine.
+  const devices = [...data.devices].sort((a, b) => {
+    const byFault = (deviceFaults(b).length > 0) - (deviceFaults(a).length > 0);
+    if (byFault) return byFault;
+    return a.device_name.localeCompare(b.device_name);
+  });
+
+  show(
+    renderNetworkBar(data, networks),
+    renderVerdict(data, groupFaultCount + deviceFaultCount),
+    el("h2", {}, "What is carried, and by what"),
+    data.route_groups.length
+      ? el("div", {}, data.route_groups.map(renderGroup))
+      : el("div", { class: "panel note" }, "This network has no route groups."),
+    el("h2", {}, "Devices"),
+    el(
+      "div",
+      { class: "panel" },
+      renderDevices(devices),
+      data.devices_truncated
+        ? el(
+            "p",
+            { class: "note" },
+            "This network holds more devices than are shown. The list above is cut, not short.",
+          )
+        : null,
+    ),
+  );
+}
+
+function renderNetworkBar(data, networks) {
+  const select = el("select", { id: "network" });
+  for (const network of networks) {
+    const option = el(
+      "option",
+      { value: network.id },
+      `${network.organization_slug} / ${network.slug}`,
+    );
+    if (network.id === data.network.id) option.selected = true;
+    select.append(option);
+  }
+  select.addEventListener("change", () => {
+    location.hash = `#/networks/${select.value}`;
+  });
+
+  return el(
+    "div",
+    { class: "panel picker" },
+    el("label", { for: "network" }, "Network"),
+    select,
+    el("span", { class: "note" }, `state version ${data.network.state_version}`),
+  );
+}
+
+// --- freshness ------------------------------------------------------------------------
+
+/**
+ * Says how old what is on screen is, and says it in the page rather than only in a
+ * console. Recomputed on a timer of its own so the age keeps counting up while a poll is
+ * failing — a number frozen at "2s ago" is exactly the lie this is here to prevent.
+ */
+function renderFreshness(problem) {
+  if (freshnessTimer) clearInterval(freshnessTimer);
+  const paint = () => {
+    if (!lastGoodAt) {
+      freshnessEl.textContent = problem || "";
+      freshnessEl.classList.toggle("stale", Boolean(problem));
+      return;
+    }
+    const age = Math.round((Date.now() - lastGoodAt) / 1000);
+    const ago = age < 2 ? "just now" : `${age}s ago`;
+    freshnessEl.textContent = problem ? `${problem} — last update ${ago}` : `updated ${ago}`;
+    freshnessEl.classList.toggle("stale", Boolean(problem));
+  };
+  paint();
+  freshnessTimer = setInterval(paint, 1000);
+}
+
+// --- sign in --------------------------------------------------------------------------
+
+function renderSignIn(message) {
+  const input = el("input", {
+    type: "password",
+    id: "token",
+    autocomplete: "current-password",
+    placeholder: "administrative token",
+  });
+  const error = el("p", { class: "error" }, message || "");
+
+  const form = el(
+    "form",
+    { class: "signin" },
+    input,
+    el("button", { class: "primary", type: "submit" }, "Sign in"),
+  );
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    error.textContent = "";
+    try {
+      await api("/api/v1/ui/session", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token: input.value }),
+      });
+      input.value = "";
+      start();
+    } catch (err) {
+      error.textContent = err.message;
+    }
+  });
+
+  show(
+    el(
+      "div",
+      { class: "panel" },
+      el("h1", {}, "Sign in"),
+      el(
+        "p",
+        { class: "note" },
+        "The administrative token is exchanged once for a session that may read and may " +
+          "not write. It is not stored in this page.",
+      ),
+      form,
+      error,
+    ),
+  );
+  signoutEl.hidden = true;
+  input.focus();
+}
+
+// --- the loop -------------------------------------------------------------------------
+
+function currentNetworkID() {
+  const match = location.hash.match(/^#\/networks\/([0-9a-fA-F-]{36})$/);
+  return match ? match[1] : null;
+}
+
+function stopPolling() {
+  if (pollTimer) clearTimeout(pollTimer);
+  pollTimer = null;
+}
+
+async function poll(networkID, networks) {
+  try {
+    const data = await api(`/api/v1/networks/${encodeURIComponent(networkID)}/overview`);
+    lastGood = data;
+    lastGoodAt = Date.now();
+    renderOverview(data, networks);
+    renderFreshness(null);
+    // The server decides how often it is asked, so a deployment under load can slow its
+    // pages down without shipping a new one.
+    const wait = Math.max(1, Number(data.poll_after_seconds) || 5) * 1000;
+    pollTimer = setTimeout(() => poll(networkID, networks), wait);
+  } catch (err) {
+    if (err.status === 401) {
+      stopPolling();
+      renderSignIn("That session has expired. Sign in again.");
+      return;
+    }
+    if (err.status === 404) {
+      stopPolling();
+      lastGood = null;
+      lastGoodAt = null;
+      renderFreshness("no such network");
+      show(
+        el(
+          "div",
+          { class: "panel" },
+          el("h1", {}, "No such network"),
+          el("p", { class: "note" }, "It may have been deleted, or the link may be wrong."),
+          el("p", {}, el("a", { href: "#/" }, "Pick another network")),
+        ),
+      );
+      return;
+    }
+    // Anything else: keep what is on screen, say plainly that it is not current, and
+    // keep trying. Blanking the page on a transient failure throws away the last thing
+    // somebody was reading at the moment they most want to look at it.
+    renderFreshness(reason(err));
+    if (!lastGood) {
+      show(el("div", { class: "panel error" }, `Could not read this network: ${reason(err)}`));
+    }
+    pollTimer = setTimeout(() => poll(networkID, networks), 5000);
+  }
+}
+
+function renderPicker(networks) {
+  show(
+    el(
+      "div",
+      { class: "panel" },
+      el("h1", {}, "Pick a network"),
+      networks.length
+        ? el(
+            "ul",
+            {},
+            networks.map((network) =>
+              el(
+                "li",
+                {},
+                el(
+                  "a",
+                  { href: `#/networks/${network.id}` },
+                  `${network.organization_slug} / ${network.slug}`,
+                ),
+                el(
+                  "span",
+                  { class: "note" },
+                  ` — ${network.active_device_count} active device${network.active_device_count === 1 ? "" : "s"}`,
+                ),
+              ),
+            ),
+          )
+        : el(
+            "p",
+            { class: "note" },
+            "This control plane holds no networks yet. Create one with the API or the CLI.",
+          ),
+    ),
+  );
+}
+
+async function start() {
+  stopPolling();
+  let networks;
+  try {
+    const body = await api("/api/v1/networks");
+    networks = body.networks;
+  } catch (err) {
+    if (err.status === 401) {
+      renderSignIn(null);
+      return;
+    }
+    renderFreshness(reason(err));
+    show(el("div", { class: "panel error" }, `Could not list networks: ${reason(err)}`));
+    return;
+  }
+
+  signoutEl.hidden = false;
+  const networkID = currentNetworkID();
+  if (!networkID) {
+    lastGood = null;
+    lastGoodAt = null;
+    renderFreshness(null);
+    // One network and no choice to make: go straight to it rather than asking somebody
+    // to pick from a list of one.
+    if (networks.length === 1) {
+      location.hash = `#/networks/${networks[0].id}`;
+      return;
+    }
+    renderPicker(networks);
+    return;
+  }
+  poll(networkID, networks);
+}
+
+signoutEl.addEventListener("click", async () => {
+  stopPolling();
+  try {
+    await api("/api/v1/ui/session", { method: "DELETE" });
+  } catch {
+    // Logging out of a session the server has already forgotten is still logging out.
+  }
+  lastGood = null;
+  lastGoodAt = null;
+  renderFreshness(null);
+  renderSignIn("Signed out.");
+});
+
+window.addEventListener("hashchange", start);
+start();

--- a/web/embed.go
+++ b/web/embed.go
@@ -1,0 +1,20 @@
+// Package web holds the page a person looks at, and embeds it.
+//
+// The files are hand-written HTML, CSS and ES modules with no build step, and they are
+// embedded exactly as they are written (ADR-0022 §3). There is no bundler, no lockfile and
+// no Node in CI or in the release job — which is a saving worth having while the view is
+// one page answering one question, and stops being one at a size that decision does not
+// try to predict.
+//
+// The embed directive lives here, beside the files, because a go:embed pattern cannot
+// reach upward out of its own directory — the same constraint that puts one in the
+// migrations package rather than in internal/store.
+package web
+
+import "embed"
+
+// FS holds the page. Only the three files are embedded, so this source file and anything
+// else that lands in this directory is not served by accident.
+//
+//go:embed index.html app.css app.js
+var FS embed.FS

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>meshp</title>
+    <link rel="stylesheet" href="/app.css" />
+    <script type="module" src="/app.js"></script>
+  </head>
+  <body>
+    <header class="bar">
+      <span class="wordmark">meshp</span>
+      <span id="freshness" class="freshness"></span>
+      <button id="signout" class="linkish" type="button" hidden>Sign out</button>
+    </header>
+
+    <!-- Everything below is replaced by app.js. What is here is what somebody sees when
+         it has not run: a page that says so, rather than an empty white rectangle that
+         looks like a network with nothing in it. -->
+    <main id="view">
+      <noscript>
+        <div class="panel">
+          <h1>This page needs JavaScript</h1>
+          <p>
+            It polls the control plane and redraws itself, so there is nothing useful to
+            show without it. The same answer is available from the API directly:
+            <code>GET /api/v1/networks/{id}/overview</code>.
+          </p>
+        </div>
+      </noscript>
+      <div class="panel" id="boot">Loading…</div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
Closes the rest of [#108](https://github.com/meshpnet/meshp/issues/108). The read API landed in #113 and #114; nothing could reach it. This is ADR-0022 §2, §3 and §4 — the page.

## What it does

One network, one question. A verdict at the top (`5 things need attention` / `No faults reported`), then route groups shown beside the devices offering to carry them, then devices sorted faults-first. `unapplied_components` is rendered per device — the column that has been written on every acknowledgement since migration 0001 and read by nobody.

## What it refuses to do

**It never says which advertiser is chosen.** No such fact exists server-side: desired state carries an ordered list of pre-authorised candidates and the agent decides which is alive (ADR-0003). The page shows the candidates, their order, their reported health, and whether *any* of them could carry anything.

**A disconnected advertiser is not an outage.** An agent keeps forwarding from the state it last applied when the control plane is unreachable (ADR-0008), so calling a group broken because a control session dropped would raise an alarm for the wrong failure. It is shown, not counted. `unknown` health is not counted as healthy either — nobody has reported on it, which is not the same as knowing it is up.

**It does not let a stale page pass for a current one.** `as_of` is rendered and the age counts up on its own timer, so a failed poll leaves the last answer on screen marked stale rather than frozen at "2s ago".

## Build and serving

No build step, per §3. Four files: `index.html`, `app.css`, `app.js`, `embed.go`. No `package.json`, no bundler, no Node in CI or the release job. `COPY . .` in the Dockerfile and the cross-compile job pick it up with no change.

The page is the GET catch-all, so `internal/api/page.go` answers unknown `/api/` paths as an API rather than handing a client HTML with a 404, and there is no history-mode fallback to `index.html` — the page routes on the fragment, which never reaches a server. Both are tested. So is the CSP, and that only the three files are embedded (a `go:embed` pattern is one character away from serving `embed.go` itself).

## Verified by running it

Go tests prove bytes are served, not that anything appears. I drove the page in a browser against canned API responses covering a healthy group, a group where every candidate is unhealthy or disabled, a group with no advertisers, a device with unapplied components and an error, a device that has never applied anything, and a revoked one. Light and dark, desktop and 375px. The 401, 404 and unreachable-control-plane paths were each exercised deliberately.

Two things that found: the raw `Failed to fetch` was showing as the user-facing reason for an unreachable control plane, and the devices table pushed the whole page sideways on mobile instead of scrolling within itself. Both fixed here.

## One thing worth deciding separately

The rules for *what counts as broken* live in `app.js`. The commercial roll-up builds on the same endpoint (ADR-0009) and would have to reimplement them, and the two can drift — an MSP screen showing all green over a network page showing five faults is the kind of disagreement this project usually refuses. Everything the page derives comes from fields the API states explicitly, so this is not wrong today, but it is a shape worth arguing about. Filing separately rather than extending a contract I just called frozen.

Docs: the quickstart gains a "Look at it" step and the README layout gains `web/`.