### PR TITLE
feat(paths): a device says what its tunnel is actually doing

### DIFF
--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -304,6 +304,18 @@ type sessionHandle struct {
 // Explicitly, because a nil *relaylink.Link assigned straight to an interface produces a
 // non-nil interface holding a nil pointer: every `if relay != nil` downstream would be true
 // and the first call would panic. Platforms with no data plane take exactly that path.
+// pathsOrNil hands over the reconciler as a path reporter, or nothing.
+//
+// A typed nil would satisfy the interface and be called, so the nil check has to happen
+// here rather than at the call site — the same trap the control plane's presence hook
+// documents.
+func pathsOrNil(r *tunnel.Reconciler) sessionclient.PathReports {
+	if r == nil {
+		return nil
+	}
+	return r
+}
+
 func relayOrNil(l *relaylink.Link) tunnel.Relay {
 	if l == nil {
 		return nil
@@ -458,7 +470,11 @@ func (a *agent) ensureSession(m agentstate.Membership) {
 		CanFilter:    a.ensureFilter() != nil,
 		Revoked:      &membershipRevoker{agent: a, membershipID: m.MembershipID},
 		Reachability: chooser,
-		Log:          log,
+		// The same reconciler, asked a different question: what the tunnel it configured
+		// actually looks like. Nil on a platform with no data plane, where there is
+		// nothing to observe (#117).
+		Paths: pathsOrNil(applier.reconciler),
+		Log:   log,
 	})
 	a.running[m.MembershipID] = &sessionHandle{
 		cancel: cancel, client: client, applier: applier, relay: relay, started: time.Now().UTC(),

--- a/internal/api/overview.go
+++ b/internal/api/overview.go
@@ -97,6 +97,23 @@ func (s *Server) handleNetworkOverview(w http.ResponseWriter, r *http.Request) {
 			// acknowledgement is in flight, and a reader chasing a device that looks stuck
 			// needs to see which of the two is behind.
 			device["reported_version"] = c.AppliedVersion
+
+			// What the device says about its own data plane, absent until it has said
+			// something. Absent and "no peers" are different answers and only one of them
+			// is worth rendering, so the field is omitted rather than zeroed: a device that
+			// has not reported yet must not read as a device with nothing configured.
+			//
+			// Counts rather than a verdict. Whether this adds up to a problem is #116's
+			// question, and answering it here would settle that by accident.
+			if !c.Tunnel.ReportedAt.IsZero() {
+				device["tunnel"] = map[string]any{
+					"reported_at": c.Tunnel.ReportedAt.UTC(),
+					"peers":       c.Tunnel.Peers,
+					"handshaked":  c.Tunnel.Handshaked,
+					"talking":     c.Tunnel.Talking,
+					"relayed":     c.Tunnel.Relayed,
+				}
+			}
 		}
 		if d.AddressV4 != nil {
 			device["address_v4"] = d.AddressV4.String()

--- a/internal/session/hub.go
+++ b/internal/session/hub.go
@@ -40,6 +40,12 @@ type Session struct {
 	relayTok []byte
 	relayExp time.Time
 
+	// tunnelMu guards what this device last said about its own data plane. Written by the
+	// read loop and read by anything sampling presence, so it needs a lock of its own
+	// rather than riding on the session being reachable only from one goroutine.
+	tunnelMu sync.Mutex
+	tunnel   TunnelState
+
 	ID           string
 	MembershipID uuid.UUID
 	NetworkID    uuid.UUID
@@ -288,6 +294,26 @@ type Connected struct {
 	// database says: an acknowledgement reaches this before it is written, and the two
 	// disagree for as long as that takes.
 	AppliedVersion int64
+
+	// Tunnel is what the device last said about its data plane, zero-valued when it has
+	// said nothing yet. ReportedAt is what distinguishes the two: a device that has
+	// genuinely reported no peers and one that has not reported at all are different, and
+	// only one of them is worth showing.
+	Tunnel TunnelState
+}
+
+// setTunnel records a device's account of its own data plane.
+func (s *Session) setTunnel(state TunnelState) {
+	s.tunnelMu.Lock()
+	defer s.tunnelMu.Unlock()
+	s.tunnel = state
+}
+
+// Tunnel returns it.
+func (s *Session) Tunnel() TunnelState {
+	s.tunnelMu.Lock()
+	defer s.tunnelMu.Unlock()
+	return s.tunnel
 }
 
 // NetworkPresence returns the memberships of one network that are connected right now.
@@ -311,6 +337,7 @@ func (h *Hub) NetworkPresence(networkID uuid.UUID) []Connected {
 			MembershipID:   s.MembershipID,
 			ConnectedAt:    s.ConnectedAt,
 			AppliedVersion: s.AppliedVersion(),
+			Tunnel:         s.Tunnel(),
 		})
 	}
 	return out

--- a/internal/session/pathreport_e2e_test.go
+++ b/internal/session/pathreport_e2e_test.go
@@ -1,0 +1,129 @@
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/sessionclient"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// fakePaths stands in for the tunnel reconciler, and remembers being asked.
+type fakePaths struct {
+	report *meshpv1.PathReport
+	asked  chan struct{}
+}
+
+func (f *fakePaths) Paths() *meshpv1.PathReport {
+	select {
+	case f.asked <- struct{}{}:
+	default:
+	}
+	return f.report
+}
+
+// A path report crosses the wire and comes back out of presence.
+//
+// The mechanism existed before any of this: PathReport has been in the protocol since the
+// first commit, generated into Go, with nothing sending it and nothing handling it. That is
+// the ADR-0018 failure, and unit tests either side of the gap would not have found it —
+// both ends can be perfectly correct while nothing joins them. So this drives a real agent
+// against a real control plane and asks the thing an operator would ask: does the control
+// plane know what this device's tunnel looks like.
+func TestAPathReportReachesPresence(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+	f.enrolDevice("bob")
+
+	paths := &fakePaths{
+		asked: make(chan struct{}, 1),
+		report: &meshpv1.PathReport{Paths: []*meshpv1.PathReport_PeerPath{
+			{
+				PeerPublicKey:     "bob-key",
+				Kind:              meshpv1.PathReport_PeerPath_KIND_RELAY,
+				LastHandshakeUnix: time.Now().Add(-20 * time.Second).Unix(),
+			},
+			{PeerPublicKey: "carol-key", Kind: meshpv1.PathReport_PeerPath_KIND_DIRECT},
+		}},
+	}
+
+	applier := newCapturingApplier()
+	client := sessionclient.New(sessionclient.Options{
+		ControlURL:   f.http.URL,
+		Identity:     alice.identity,
+		MembershipID: alice.membershipID,
+		AgentVersion: "test",
+		Paths:        paths,
+	})
+	ctx, cancel := context.WithCancel(f.ctx)
+	defer cancel()
+	go func() { _ = client.RunOnce(ctx, applier) }()
+
+	// Sent as soon as state is applied rather than only on the heartbeat, so this does not
+	// wait twenty-five seconds for the first tick.
+	waitFor(t, "the agent to be asked for its paths", func() bool {
+		select {
+		case <-paths.asked:
+			return true
+		default:
+			return false
+		}
+	})
+
+	var got TunnelState
+	waitFor(t, "the report to reach presence", func() bool {
+		for _, c := range f.hub.NetworkPresence(f.netID) {
+			if c.MembershipID == alice.membershipID && !c.Tunnel.ReportedAt.IsZero() {
+				got = c.Tunnel
+				return true
+			}
+		}
+		return false
+	})
+
+	if got.Peers != 2 {
+		t.Errorf("Peers = %d, want 2", got.Peers)
+	}
+	if got.Handshaked != 1 {
+		t.Errorf("Handshaked = %d, want 1", got.Handshaked)
+	}
+	if got.Talking != 1 {
+		t.Errorf("Talking = %d, want 1", got.Talking)
+	}
+	if got.Relayed != 1 {
+		t.Errorf("Relayed = %d, want 1", got.Relayed)
+	}
+}
+
+// A device with nothing to say says nothing, and presence can tell that apart from a device
+// reporting an empty data plane.
+func TestAnAgentWithNoDataPlaneSendsNoReport(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+
+	applier := newCapturingApplier()
+	client := sessionclient.New(sessionclient.Options{
+		ControlURL:   f.http.URL,
+		Identity:     alice.identity,
+		MembershipID: alice.membershipID,
+		AgentVersion: "test",
+		Paths:        &fakePaths{asked: make(chan struct{}, 1)}, // returns nil
+	})
+	ctx, cancel := context.WithCancel(f.ctx)
+	defer cancel()
+	go func() { _ = client.RunOnce(ctx, applier) }()
+
+	waitFor(t, "the session to register", func() bool { return f.hub.Count() == 1 })
+	select {
+	case <-applier.applied:
+	case <-time.After(15 * time.Second):
+		t.Fatal("no state was delivered")
+	}
+
+	for _, c := range f.hub.NetworkPresence(f.netID) {
+		if c.MembershipID == alice.membershipID && !c.Tunnel.ReportedAt.IsZero() {
+			t.Errorf("presence holds a tunnel state for a device that reported none: %+v", c.Tunnel)
+		}
+	}
+}

--- a/internal/session/paths.go
+++ b/internal/session/paths.go
@@ -1,0 +1,79 @@
+package session
+
+import (
+	"time"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// pathsFresh is how recent a handshake must be for a peer to count as talking.
+//
+// WireGuard renews a handshake when traffic flows, and every keepalive interval where one
+// is set, so an idle peer with no keepalive goes quiet while being perfectly healthy.
+// Nothing here calls a stale handshake a fault for that reason: this bound describes what
+// is currently talking, and it is several times the keepalive so one missed renewal does
+// not change the answer.
+const pathsFresh = 3 * time.Minute
+
+// TunnelState is what a device last said about its own data plane.
+//
+// A summary rather than the peer list it was computed from. The question this exists to
+// answer is "is this device's tunnel carrying anything", and holding every peer of every
+// device of every network in memory to answer it would be a per-device cost that grows with
+// the square of the network. The detail is in the report; what survives is the count.
+//
+// In memory only, like every other kind of liveness (ADR-0012). Losing it costs one
+// heartbeat's wait, not correctness.
+type TunnelState struct {
+	// ReportedAt is when this arrived, so a reader can tell a current answer from one left
+	// behind by a device that has since gone quiet.
+	ReportedAt time.Time
+
+	// Peers is how many peers the interface holds.
+	Peers int
+
+	// Handshaked is how many have ever completed a handshake. Zero, with peers configured,
+	// is the unambiguous failure: this tunnel has never carried anything. It is the only
+	// count here that is treated as a fault.
+	Handshaked int
+
+	// Talking is how many handshaked within pathsFresh. Informational, never a fault — a
+	// quiet peer is not a broken one.
+	Talking int
+
+	// Relayed is how many are reached through a relay rather than directly. Not a fault
+	// either: meshp is relay-first and a relayed path is a working path (ADR-0002).
+	Relayed int
+}
+
+// summarisePaths reduces a report to what presence keeps.
+func summarisePaths(report *meshpv1.PathReport, now time.Time) TunnelState {
+	state := TunnelState{ReportedAt: now, Peers: len(report.GetPaths())}
+	for _, path := range report.GetPaths() {
+		if path.GetKind() == meshpv1.PathReport_PeerPath_KIND_RELAY {
+			state.Relayed++
+		}
+		last := path.GetLastHandshakeUnix()
+		if last <= 0 {
+			continue
+		}
+		state.Handshaked++
+		// Future timestamps count as fresh rather than being discarded. The agent's clock
+		// is its own and may be ahead of ours; treating that as "never handshaked" would
+		// report a working tunnel as one that has never come up, which is the one verdict
+		// here that is loud.
+		if now.Sub(time.Unix(last, 0)) < pathsFresh {
+			state.Talking++
+		}
+	}
+	return state
+}
+
+// handlePathReport records what a device said about its data plane.
+//
+// Kept in memory and not written to the database. It arrives on every heartbeat from every
+// device, which is precisely the write rate ADR-0012 exists to keep off the rows that hold
+// desired state, and none of it needs to survive a restart.
+func (s *Server) handlePathReport(sess *Session, report *meshpv1.PathReport) {
+	sess.setTunnel(summarisePaths(report, s.clk.Now()))
+}

--- a/internal/session/paths_test.go
+++ b/internal/session/paths_test.go
@@ -1,0 +1,91 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+func path(kind meshpv1.PathReport_PeerPath_Kind, handshake int64) *meshpv1.PathReport_PeerPath {
+	return &meshpv1.PathReport_PeerPath{Kind: kind, LastHandshakeUnix: handshake}
+}
+
+// The counts, and the distinctions between them that the page depends on.
+func TestSummarisingAPathReport(t *testing.T) {
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	fresh := now.Add(-30 * time.Second).Unix()
+	stale := now.Add(-2 * time.Hour).Unix()
+
+	for _, tc := range []struct {
+		name  string
+		paths []*meshpv1.PathReport_PeerPath
+		want  TunnelState
+	}{
+		{
+			name:  "a working tunnel",
+			paths: []*meshpv1.PathReport_PeerPath{path(directKind, fresh), path(relayKind, fresh)},
+			want:  TunnelState{Peers: 2, Handshaked: 2, Talking: 2, Relayed: 1},
+		},
+		{
+			// The case the whole thing exists for: peers configured, nothing ever
+			// established. Reported as a fault; every other row here is not.
+			name:  "a tunnel that has never carried anything",
+			paths: []*meshpv1.PathReport_PeerPath{path(directKind, 0), path(directKind, 0)},
+			want:  TunnelState{Peers: 2},
+		},
+		{
+			// Quiet, not broken. WireGuard renews a handshake when traffic flows, so an
+			// idle peer with no keepalive looks like this and is fine.
+			name:  "a quiet peer still counts as having handshaked",
+			paths: []*meshpv1.PathReport_PeerPath{path(directKind, stale)},
+			want:  TunnelState{Peers: 1, Handshaked: 1},
+		},
+		{
+			// The agent's clock is its own. Counting a future handshake as "never" would
+			// report a working tunnel as one that has never come up, which is the loudest
+			// verdict this produces.
+			name:  "a handshake from the future is not a handshake that never happened",
+			paths: []*meshpv1.PathReport_PeerPath{path(directKind, now.Add(time.Minute).Unix())},
+			want:  TunnelState{Peers: 1, Handshaked: 1, Talking: 1},
+		},
+		{
+			name:  "a device with no peers",
+			paths: nil,
+			want:  TunnelState{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := summarisePaths(&meshpv1.PathReport{Paths: tc.paths}, now)
+			if got.ReportedAt != now {
+				t.Errorf("ReportedAt = %v, want %v", got.ReportedAt, now)
+			}
+			got.ReportedAt = time.Time{}
+			if got != tc.want {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A report that has arrived is distinguishable from one that has not.
+//
+// The API omits the field entirely when ReportedAt is zero, because "has not said" and "has
+// nothing" are different answers and only one of them should render as a device with no
+// peers.
+func TestAnUnreportedTunnelIsDistinguishableFromAnEmptyOne(t *testing.T) {
+	var never TunnelState
+	if !never.ReportedAt.IsZero() {
+		t.Fatal("a zero TunnelState must have a zero ReportedAt")
+	}
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	empty := summarisePaths(&meshpv1.PathReport{}, now)
+	if empty.ReportedAt.IsZero() {
+		t.Error("a device that reported no peers must still be marked as having reported")
+	}
+}
+
+const (
+	directKind = meshpv1.PathReport_PeerPath_KIND_DIRECT
+	relayKind  = meshpv1.PathReport_PeerPath_KIND_RELAY
+)

--- a/internal/session/server.go
+++ b/internal/session/server.go
@@ -359,16 +359,18 @@ func (s *Server) readLoop(ctx context.Context, conn *websocket.Conn, sess *Sessi
 		case *meshpv1.ClientMessage_Heartbeat:
 			s.handleHeartbeat(ctx, sess, payload.Heartbeat)
 
+		case *meshpv1.ClientMessage_PathReport:
+			s.handlePathReport(sess, payload.PathReport)
+
 		case *meshpv1.ClientMessage_Hello:
 			// One hello per connection. A second is either a confused agent or somebody
 			// trying to change identity mid-session.
 			return errors.New("received a second hello on an established session")
 
 		default:
-			// Path reports, reachability reports and signalling arrive here once the
-			// subsystems that consume them exist. Ignoring an unknown payload rather than
-			// closing is deliberate: a newer agent must be able to send something this
-			// server has never heard of (ADR-0008).
+			// Signalling arrives here once the subsystem that consumes it exists.
+			// Ignoring an unknown payload rather than closing is deliberate: a newer agent
+			// must be able to send something this server has never heard of (ADR-0008).
 			s.log.Debug("ignoring an unhandled client message",
 				"session", sess.ID, "type", fmt.Sprintf("%T", msg.Payload))
 		}

--- a/internal/sessionclient/client.go
+++ b/internal/sessionclient/client.go
@@ -77,6 +77,20 @@ type Applier interface {
 	Apply(ctx context.Context, state *peerset.Set) (unapplied []string, err error)
 }
 
+// PathReports is asked what the tunnel currently looks like.
+//
+// Separate from Applier on purpose. Applying is a thing the agent is told to do; this is a
+// thing it is asked about, and the two run on different clocks — the whole point is to hear
+// from a device between reconciles, when nothing has changed and the tunnel has quietly
+// stopped working anyway.
+//
+// Returning nil means "nothing to say", which is not the same as a report with no paths: a
+// membership whose interface has not come up has no data plane to describe, and sending an
+// empty report would tell the control plane its peers are all down.
+type PathReports interface {
+	Paths() *meshpv1.PathReport
+}
+
 // RelayCredentials is whatever needs a relay token, if anything does.
 //
 // The agent asks and the server answers; the server never pushes (ADR-0017). This is the
@@ -151,6 +165,10 @@ type Options struct {
 	// Reachability is asked for advertiser verdicts to send on. Nil on a build with no
 	// data plane, which has nothing to observe and so nothing to say.
 	Reachability ReachabilityReports
+
+	// Paths is asked what this device's data plane looks like. Nil on a build with no
+	// data plane, for the same reason.
+	Paths PathReports
 
 	// CanFilter is whether this host can enforce a packet filter.
 	//
@@ -292,6 +310,30 @@ func (c *Client) sendReachabilityReports(outbound chan<- *meshpv1.ClientMessage)
 			c.opts.Reachability.Requeue(reports[i:])
 			return
 		}
+	}
+}
+
+// sendPathReport passes on what this device's tunnel currently looks like.
+//
+// On the heartbeat only, and dropped rather than queued when the writer is behind. This is
+// the opposite trade to a reachability report: that one is produced when something has
+// already gone wrong and is worth waiting for, while this is a periodic description of a
+// state that will be described again in twenty-five seconds. A report that waits is a
+// report that arrives stale, and a stale one is worse than none — it is the number an
+// operator reads while deciding whether a tunnel is alive.
+func (c *Client) sendPathReport(outbound chan<- *meshpv1.ClientMessage) {
+	if c.opts.Paths == nil {
+		return
+	}
+	report := c.opts.Paths.Paths()
+	if report == nil {
+		return
+	}
+	select {
+	case outbound <- &meshpv1.ClientMessage{
+		Payload: &meshpv1.ClientMessage_PathReport{PathReport: report},
+	}:
+	default:
 	}
 }
 
@@ -491,6 +533,11 @@ func (c *Client) RunOnce(ctx context.Context, applier Applier) error {
 				// with no state delta anywhere near it. Without this, a device on a quiet
 				// network would hold the news of its own failover indefinitely.
 				c.sendReachabilityReports(outbound)
+
+				// And what the data plane looks like, which nothing else reports. An
+				// acknowledgement says a device applied a version; this is the only thing
+				// that says whether the tunnel it configured is carrying anything (#117).
+				c.sendPathReport(outbound)
 			}
 		}
 	}()
@@ -536,6 +583,15 @@ func (c *Client) RunOnce(ctx context.Context, applier Applier) error {
 			// Applying state ran a reconcile, which is what produces a verdict, so this is
 			// the earliest moment there is anything to send.
 			c.sendReachabilityReports(outbound)
+
+			// And the interface has just been configured, so this is the earliest the
+			// control plane can be told what it looks like. Waiting for the next heartbeat
+			// would leave a device that has just joined invisible for up to 25 seconds.
+			//
+			// It will report no handshakes, because there have not been any yet. That is
+			// true and is why the reader applies a grace period before calling it a fault:
+			// a tunnel seconds old has not failed, it has not started.
+			c.sendPathReport(outbound)
 
 		case *meshpv1.ServerMessage_RelayToken:
 			c.handleRelayToken(payload.RelayToken)

--- a/internal/tunnel/paths.go
+++ b/internal/tunnel/paths.go
@@ -1,0 +1,87 @@
+package tunnel
+
+import (
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// Paths reports what this membership's data plane actually looks like.
+//
+// The gap this closes: an acknowledgement says a device applied version N, and a device can
+// apply every version it is sent while passing no traffic at all. Nothing told the control
+// plane the difference, so a laptop with a dead tunnel and a live control session read as
+// healthy (#117). PathReport has been in the protocol since the first commit with nothing
+// sending it and nothing handling it.
+//
+// Read from the kernel on each call rather than remembered from the last reconcile. The
+// numbers are what an operator is looking at while deciding whether something is wrong, and
+// a cached handshake age is a number that stops changing exactly when it matters.
+//
+// Nil when there is nothing to say, which the caller treats as "do not send": a membership
+// whose interface has not come up has no paths to describe, and an empty report would be
+// indistinguishable from one whose peers are all down.
+func (r *Reconciler) Paths() *meshpv1.PathReport {
+	name := r.membership.InterfaceName
+	if name == "" {
+		return nil
+	}
+	observed, err := r.link.Observe(name)
+	if err != nil || !observed.Exists {
+		return nil
+	}
+
+	r.mu.Lock()
+	relayed := r.relayed
+	r.mu.Unlock()
+
+	report := &meshpv1.PathReport{
+		Paths: make([]*meshpv1.PathReport_PeerPath, 0, len(observed.Peers)),
+	}
+	for _, peer := range observed.Peers {
+		key := string(peer.PublicKey)
+		path := &meshpv1.PathReport_PeerPath{
+			PeerPublicKey: key,
+			// How this peer is reached, which is not the same question as whether it is
+			// working. A relayed peer is relayed whether or not it has handshaked
+			// recently; freshness travels separately, below, so a reader can tell "reached
+			// through a relay" from "not reached at all".
+			Kind: meshpv1.PathReport_PeerPath_KIND_DOWN,
+		}
+		switch {
+		case relayed[key]:
+			path.Kind = meshpv1.PathReport_PeerPath_KIND_RELAY
+		case peer.Endpoint != "":
+			path.Kind = meshpv1.PathReport_PeerPath_KIND_DIRECT
+		}
+		if peer.HasHandshake {
+			// Sent as an instant rather than as an age, so it stays true while the message
+			// is in flight and while the server holds it. An age computed here and read
+			// two minutes later is simply wrong, and wrong in the direction that makes a
+			// dead tunnel look recent.
+			path.LastHandshakeUnix = r.now().Add(-peer.HandshakeAge).Unix()
+		}
+		report.Paths = append(report.Paths, path)
+	}
+
+	// discovered_mtu is deliberately left unset. The field means a path MTU somebody
+	// discovered, and nothing in this project discovers one yet — reporting the interface's
+	// configured MTU here would answer a question nobody asked with a number that looks
+	// like an answer to the one they did.
+	return report
+}
+
+// notePaths remembers which peers this state relays, so a report can say how a peer is
+// reached rather than guessing from its endpoint.
+//
+// Guessing would mean treating a loopback endpoint as proof of relaying, which is exactly
+// the inference wgplan refuses to make: the address is a consequence of the decision, not
+// the decision, and reading it backwards would misreport any future arrangement that
+// happens to use one.
+func (r *Reconciler) notePaths(keys []string) {
+	relayed := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		relayed[key] = true
+	}
+	r.mu.Lock()
+	r.relayed = relayed
+	r.mu.Unlock()
+}

--- a/internal/tunnel/paths_test.go
+++ b/internal/tunnel/paths_test.go
@@ -1,0 +1,109 @@
+package tunnel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/wgplan"
+	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
+)
+
+// Nothing to say is said by saying nothing.
+//
+// An empty report would tell the control plane this device's peers are all down, which is a
+// very different claim from "this membership has no interface yet".
+func TestNoInterfaceMeansNoReport(t *testing.T) {
+	link := newFakeLink()
+	r := New(link, membership(), nil, nil, nil)
+
+	if report := r.Paths(); report != nil {
+		t.Errorf("an absent interface produced a report: %v", report)
+	}
+
+	link.observed.Exists = true
+	if report := r.Paths(); report == nil {
+		t.Error("an interface that exists produced no report")
+	}
+}
+
+// How a peer is reached, which is not the same question as whether it is working.
+func TestAPathReportSaysHowEachPeerIsReached(t *testing.T) {
+	link := newFakeLink()
+	link.observed = wgplan.Observed{
+		Exists: true,
+		Peers: []wgplan.Peer{
+			{PublicKey: "relayed-key", Endpoint: "127.0.0.1:51820", HasHandshake: true, HandshakeAge: time.Minute},
+			{PublicKey: "direct-key", Endpoint: "203.0.113.7:51820", HasHandshake: true, HandshakeAge: time.Second},
+			{PublicKey: "nowhere-key"},
+		},
+	}
+	r := New(link, membership(), nil, nil, nil)
+	// What the last applied state said it relays. Read from here rather than inferred from
+	// the loopback endpoint above, which is the inference wgplan refuses to make.
+	r.notePaths([]string{"relayed-key"})
+
+	report := r.Paths()
+	if report == nil {
+		t.Fatal("no report")
+	}
+	got := map[string]meshpv1.PathReport_PeerPath_Kind{}
+	for _, p := range report.GetPaths() {
+		got[p.GetPeerPublicKey()] = p.GetKind()
+	}
+	want := map[string]meshpv1.PathReport_PeerPath_Kind{
+		"relayed-key": meshpv1.PathReport_PeerPath_KIND_RELAY,
+		"direct-key":  meshpv1.PathReport_PeerPath_KIND_DIRECT,
+		// No endpoint at all: there is nowhere to send to, which is what DOWN means here.
+		"nowhere-key": meshpv1.PathReport_PeerPath_KIND_DOWN,
+	}
+	for key, kind := range want {
+		if got[key] != kind {
+			t.Errorf("%s = %v, want %v", key, got[key], kind)
+		}
+	}
+}
+
+// A handshake travels as an instant, not as an age.
+//
+// An age computed here and read a minute later is wrong in the direction that makes a dead
+// tunnel look recent, so the conversion happens once, at the end that knows the clock.
+func TestAHandshakeTravelsAsAnInstant(t *testing.T) {
+	link := newFakeLink()
+	link.observed = wgplan.Observed{
+		Exists: true,
+		Peers: []wgplan.Peer{
+			{PublicKey: "talking", HasHandshake: true, HandshakeAge: 90 * time.Second},
+			{PublicKey: "never"},
+		},
+	}
+	r := New(link, membership(), nil, nil, nil)
+
+	before := time.Now()
+	report := r.Paths()
+	after := time.Now()
+
+	byKey := map[string]*meshpv1.PathReport_PeerPath{}
+	for _, p := range report.GetPaths() {
+		byKey[p.GetPeerPublicKey()] = p
+	}
+	if got := byKey["never"].GetLastHandshakeUnix(); got != 0 {
+		t.Errorf("a peer that never handshaked reported %d, want 0", got)
+	}
+	stamp := time.Unix(byKey["talking"].GetLastHandshakeUnix(), 0)
+	if stamp.Before(before.Add(-91*time.Second)) || stamp.After(after.Add(-89*time.Second)) {
+		t.Errorf("handshake stamp %v is not ~90s before now (%v)", stamp, before)
+	}
+}
+
+// The field means a path MTU somebody discovered, and nothing discovers one yet. Reporting
+// the configured MTU would answer a different question with a number that looks like an
+// answer to this one.
+func TestNoMTUIsClaimed(t *testing.T) {
+	link := newFakeLink()
+	link.observed = wgplan.Observed{Exists: true, MTU: 1420}
+	r := New(link, membership(), nil, nil, nil)
+
+	if got := r.Paths().GetDiscoveredMtu(); got != 0 {
+		t.Errorf("discovered_mtu = %d, want 0: nothing discovers an MTU", got)
+	}
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -175,6 +175,11 @@ type Reconciler struct {
 	lastErr  string
 	appliedV uint64
 	port     int
+
+	// relayed is the peers this membership reaches through a relay, by public key, as of
+	// the last state applied. Kept so a path report can say how a peer is reached without
+	// inferring it from the endpoint address (see notePaths).
+	relayed map[string]bool
 }
 
 // Filter enforces a packet filter on this host.
@@ -391,8 +396,13 @@ func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, e
 	// The port is only knowable here too. A device that has just joined asks the kernel for
 	// any port, so until the interface exists there is no answer to give and inbound
 	// relayed packets have nowhere to be delivered.
+	relayedNow := relayedKeys(want)
+	// Recorded whether or not there is a relay implementation behind it, because the
+	// report describes what this state asked for and a build with no relay simply asks
+	// for none.
+	r.notePaths(relayedNow)
 	if r.relay != nil {
-		r.relay.Retain(relayedKeys(want))
+		r.relay.Retain(relayedNow)
 		r.relay.SetWireGuardPort(port)
 	}
 

--- a/web/app.js
+++ b/web/app.js
@@ -125,8 +125,18 @@ function groupFaults(group) {
   return faults;
 }
 
-/** What is wrong with a device, in words. */
-function deviceFaults(device) {
+/**
+ * How long a control session must have been up before a tunnel with no handshakes counts
+ * as broken rather than as new.
+ *
+ * A device reports its data plane the moment it applies state, and at that point there
+ * have been no handshakes because there has not been time for any. Without this, every
+ * join would flash "has never carried anything" for as long as it took to be wrong.
+ */
+const TUNNEL_GRACE_SECONDS = 120;
+
+/** What is wrong with a device, in words. `asOf` is the server's clock, not this one's. */
+function deviceFaults(device, asOf) {
   const faults = [];
   if (device.state !== "active") return faults;
 
@@ -141,7 +151,40 @@ function deviceFaults(device) {
     // an installation that did not finish rather than a device that has gone away.
     faults.push("has never applied any configuration");
   }
+  // The one thing a path report is allowed to call a fault. A device can apply every
+  // version it is sent and pass no traffic at all, and until it reported its peers nothing
+  // could tell the difference (#117).
+  //
+  // "Never handshaked", not "handshaked a while ago". WireGuard renews a handshake when
+  // traffic flows, so a quiet peer looks stale while being perfectly healthy — but a peer
+  // that has never completed one has never carried a packet, and that is unambiguous.
+  if (device.tunnel && device.tunnel.peers > 0 && device.tunnel.handshaked === 0 && settled(device, asOf)) {
+    faults.push("tunnel has never carried anything: no peer has completed a handshake");
+  }
   return faults;
+}
+
+/**
+ * Whether this device has been connected long enough for "no handshakes" to mean anything.
+ *
+ * Both timestamps come from the server, so this survives a browser whose clock is wrong —
+ * which is the machine somebody is reading this on, and the one whose clock nobody checks.
+ */
+function settled(device, asOf) {
+  if (!device.connected_since || !asOf) return false;
+  const up = (Date.parse(asOf) - Date.parse(device.connected_since)) / 1000;
+  return Number.isFinite(up) && up > TUNNEL_GRACE_SECONDS;
+}
+
+/** How a device's data plane reads, in words. */
+function tunnelSummary(device) {
+  // Absent because the device has not said, which is not the same as having nothing.
+  if (!device.tunnel) return device.connected ? "not reported yet" : "—";
+  const { peers, talking, relayed } = device.tunnel;
+  if (peers === 0) return "no peers";
+  const bits = [`${talking} of ${peers} talking`];
+  if (relayed) bits.push(`${relayed} relayed`);
+  return bits.join(" · ");
 }
 
 // --- rendering ------------------------------------------------------------------------
@@ -238,9 +281,9 @@ function renderGroup(group) {
   );
 }
 
-function renderDevices(devices) {
+function renderDevices(devices, asOf) {
   const rows = devices.map((device) => {
-    const faults = deviceFaults(device);
+    const faults = deviceFaults(device, asOf);
     const addresses = [device.address_v4, device.address_v6].filter(Boolean);
 
     let stateLabel;
@@ -274,6 +317,7 @@ function renderDevices(devices) {
         addresses.length ? el("div", { class: "addr" }, addresses.join("  ")) : null,
       ),
       el("td", {}, dot(stateClass, stateLabel), " ", stateLabel),
+      el("td", { class: "note" }, tunnelSummary(device)),
       el("td", { class: "mono" }, versions),
       el(
         "td",
@@ -302,6 +346,7 @@ function renderDevices(devices) {
         {},
         el("th", {}, "Device"),
         el("th", {}, "Control session"),
+        el("th", {}, "Tunnel"),
         el("th", {}, "Applied version"),
         el("th", {}, "Reported faults"),
       ),
@@ -313,12 +358,12 @@ function renderDevices(devices) {
 
 function renderOverview(data, networks) {
   const groupFaultCount = data.route_groups.reduce((n, g) => n + groupFaults(g).length, 0);
-  const deviceFaultCount = data.devices.reduce((n, d) => n + deviceFaults(d).length, 0);
+  const deviceFaultCount = data.devices.reduce((n, d) => n + deviceFaults(d, data.as_of).length, 0);
 
   // Devices with something wrong first. A list sorted by name buries the one device the
   // page exists to surface somewhere in the middle of forty that are fine.
   const devices = [...data.devices].sort((a, b) => {
-    const byFault = (deviceFaults(b).length > 0) - (deviceFaults(a).length > 0);
+    const byFault = (deviceFaults(b, data.as_of).length > 0) - (deviceFaults(a, data.as_of).length > 0);
     if (byFault) return byFault;
     return a.device_name.localeCompare(b.device_name);
   });
@@ -334,7 +379,7 @@ function renderOverview(data, networks) {
     el(
       "div",
       { class: "panel" },
-      renderDevices(devices),
+      renderDevices(devices, data.as_of),
       data.devices_truncated
         ? el(
             "p",


### PR DESCRIPTION
Closes [#117](https://github.com/meshpnet/meshp/issues/117).

A device can apply every version it is sent and pass no traffic at all. Nothing told the control plane the difference, so a laptop with a dead tunnel and a live control session read as healthy on the page whose whole job is to say whether anything is broken.

## No protocol change

`PathReport` has been in `control.proto` since the first commit — per-peer kind, RTT, last handshake, discovered MTU — generated into Go, with **nothing sending it and nothing handling it**. Same shape as `dns_zones` before ADR-0021 and `unapplied_components` before #113. The agent already reads last-handshake times from the kernel on every reconcile (`peerFromDevice`), so the data was in hand at one end and already had a message to travel in.

The issue offered three options and guessed wrong: it proposed extending the acknowledgement, on the assumption the protocol had no room. It has room.

## The path

`tunnel.Reconciler.Paths()` reads the interface, classifies each peer by how it is reached, and stamps handshakes as instants rather than ages — an age computed on the agent and read a minute later is wrong in the direction that makes a dead tunnel look recent. The agent sends on the heartbeat, and again the moment it has applied state, so a device that has just joined is not invisible for 25 seconds. The server summarises into presence — in memory, because this arrives from every device on every heartbeat and that is exactly the write rate ADR-0012 exists to keep off the rows holding desired state. The overview surfaces counts; the page renders a Tunnel column.

## What is deliberately not a fault

**A stale handshake.** WireGuard renews one when traffic flows, so an idle peer with no keepalive looks dead and is fine. What *is* a fault is a peer that has never completed one: that tunnel has never carried a packet.

**A relayed path.** meshp is relay-first; a relayed path is a working path (ADR-0002).

**A tunnel seconds old.** A device reports the instant it applies state, when there has been no time for a handshake. Without a grace period every join would flash "has never carried anything" until it was wrong. Both timestamps in that comparison come from the server, so it survives a browser whose clock is off — which is the machine somebody is reading this on, and the one whose clock nobody checks.

**`discovered_mtu` stays unset.** The field means a path MTU somebody discovered. Nothing here discovers one, and filling it with the configured MTU would answer a different question with a number that looks like an answer to this one.

The counts go over the wire, not a verdict. Whether they add up to a problem is [#116](https://github.com/meshpnet/meshp/issues/116)'s question, and answering it in the API here would settle that by accident.

## Verified

The end-to-end test drives a real agent against a real control plane and asks whether presence knows what the tunnel looks like. Unit tests either side of a gap cannot see the gap — both ends of `PathReport` were already correct and nothing joined them. Checked by deleting the dispatch case: it times out rather than passing.

Ran the full suite against a local PostgreSQL, since these tests skip without one. Also drove the page against canned responses for all three states — reporting and healthy, reporting nothing handshaked, and connected but not yet reported — and confirmed the grace period suppresses the fault for a fresh connection while the column still honestly reads `0 of 4 talking`.