### PR TITLE
feat(api): the overview says what is wrong, not only what is true

### DIFF
--- a/docs/adr/0023-the-overview-says-what-is-wrong.md
+++ b/docs/adr/0023-the-overview-says-what-is-wrong.md
@@ -1,0 +1,123 @@
+# ADR-0023: The overview says what is wrong, not only what is true
+
+- **Status:** accepted
+- **Date:** 2026-08-21
+
+## Context
+
+`GET /api/v1/networks/{id}/overview` returns facts. A device's `unapplied_components`, an
+advertiser's `health` and `admin_state`, whether a control session is up, how many peers
+have ever handshaked. It says nothing about whether any of that amounts to a problem.
+
+The page decided that for itself, in JavaScript. Four rules for devices and two for route
+groups, plus a threshold — how long a control session must have been up before "no
+handshakes" means a dead tunnel rather than a new one.
+
+Three things make that the wrong place for them.
+
+**There are two consumers, and the second one is not ours.** ADR-0009 requires the
+commercial layer to build its cross-tenant roll-up on this same endpoint. To render "Acme:
+5 problems" it has to reach the same conclusions, which today means reimplementing six
+rules in another repository in another language. They will drift, and the failure that
+produces — an MSP roll-up showing a customer green while that customer's own page shows
+five faults — is the silent disagreement this project refuses for colliding prefixes
+(ADR-0020) and for ambiguous names (ADR-0021).
+
+**The rules cannot be tested where they are.** ADR-0022 §3 decided there is no JavaScript
+toolchain, deliberately and with a stated expiry. The consequence went unstated: the logic
+that decides whether an operator is alarmed is the only logic in this repository with no
+tests. Every rule below has an edge — a stale handshake that is not a fault, a revoked
+membership that is not a device in trouble, a clock that runs backwards — and none of them
+had a test that could fail.
+
+**The surface grew before it shrank.** #118 added tunnel reporting and with it a second set
+of judgements, including the first threshold. Each new signal makes the duplicated rules
+larger and the drift more expensive, so the moment to move them is before the roll-up
+exists rather than after.
+
+## Decision
+
+**The overview computes faults, and consumers render them.**
+
+### 1. A fault is a code and a message
+
+```json
+{"code": "tunnel_never_carried",
+ "message": "tunnel has never carried anything: no peer has completed a handshake"}
+```
+
+The code is a stable identifier for a consumer that counts, groups or alerts. The message is
+English for a person, and is the same sentence the page shows — this project already treats
+the wording of a failure as part of the product (ADR-0011), and the wording belongs beside
+the rule that produced it rather than in whichever client happens to be rendering.
+
+The same shape as the error envelope this API already returns, for the same reason: a
+caller should never have to parse prose to find out what happened.
+
+### 2. Faults hang off the thing that has them, and are counted once
+
+Each device and each route group carries `faults`, always present and always a list. The
+response carries `fault_count` for the whole network, so a roll-up rendering forty tiles
+does not have to walk forty device lists to draw one number.
+
+### 3. Thresholds are the server's, and so is the clock
+
+The grace period before an unhandshaked tunnel is called dead is applied here, against
+`as_of` and the session's own start time. Both come from the same clock. A client comparing
+a server timestamp against its own would be wrong by whatever its clock is wrong by, on the
+machine somebody is reading this on.
+
+### 4. An unknown code is not an error
+
+Consumers must render or count a fault whose code they do not recognise, using the message.
+New rules will be added, and a client that failed on one would make every rule addition a
+breaking change — the opposite of what naming them is for.
+
+### 5. The page holds no rules
+
+It renders `faults` and sorts by whether the list is empty. Any rule that reappears there is
+a bug, because it can only ever be a second opinion.
+
+## Consequences
+
+**"What counts as broken" is public API now.** Refining a rule changes what every consumer
+reports, and removing a code is a breaking change. Decision 4 keeps additions cheap;
+nothing makes removals cheap, which is the price of the endpoint being shared.
+
+**The rules get tests, and immediately earn them.** Every edge in these six rules is a
+table row now: a revoked membership is not a device in trouble; a stale handshake is not a
+dead tunnel; a tunnel seconds old is neither.
+
+**Messages are English in a JSON body.** A deployment wanting another language has the code
+to key a catalogue on, and would have to supply its own wording. Not solved here, and
+honest about that: nothing else in this API is localised either.
+
+**The API is opinionated, and a deployment cannot argue with it.** An operator who thinks a
+draining advertiser should not count as a fault has no knob. That is a real loss and the
+deliberate trade — a knob would mean two deployments disagreeing about what "broken" means,
+which is the drift this ADR exists to prevent, reintroduced as configuration.
+
+**The page gets smaller.** Roughly sixty lines of judgement leave it, which is most of what
+was hard to review in a file with no tests.
+
+## Alternatives considered
+
+**Publish the rules as a specification and let each consumer implement them.** No API
+change, and each client renders exactly what it wants. Rejected because a specification two
+implementations follow is a specification they drift from, and nothing would notice: there
+is no test that can compare a private repository's TypeScript against this one's JavaScript.
+
+**Leave them in the page.** What we had. Rejected for the three reasons in the Context, of
+which the untestability is the one that would have bitten first.
+
+**A separate `/health` endpoint returning verdicts.** Keeps the facts endpoint pure, which
+is tidy. Rejected because two calls means two instants: a page that read facts from one and
+verdicts from another would render a device shown as healthy beside a verdict saying it is
+not. That is precisely the failure the single-snapshot decision in ADR-0022 §1 exists to
+prevent, and it would be reintroduced by the endpoint meant to describe it.
+
+**Return a severity or an overall status** (`healthy` / `degraded` / `down`) instead of a
+list. Smaller responses and an obvious thing to colour a tile with. Rejected for now
+because collapsing several faults into one word discards which ones, and the page's whole
+argument is that the broken thing should be obvious without clicking. A severity per fault
+can be added later without removing anything, which is the right order.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,6 +31,7 @@ deliberate act with a written reason rather than a drift nobody noticed.
 | [0020](0020-colliding-prefixes-are-mapped-on-the-device.md) | Colliding prefixes are mapped, by the control plane that can see them |
 | [0021](0021-names-resolve-on-the-device.md) | Names resolve on the device, from desired state |
 | [0022](0022-web-view-in-the-control-plane.md) | The web view ships inside the control plane and polls one snapshot |
+| [0023](0023-the-overview-says-what-is-wrong.md) | The overview says what is wrong, not only what is true |
 
 ## Format
 

--- a/internal/api/faults.go
+++ b/internal/api/faults.go
@@ -1,0 +1,136 @@
+package api
+
+import (
+	"strings"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/session"
+	"github.com/meshpnet/meshp/internal/store"
+)
+
+// Fault is something wrong with a device or a route group (ADR-0023).
+//
+// A code and a message, for the two readers this endpoint has. The code is a stable
+// identifier for a consumer that counts or alerts; the message is the sentence a person
+// reads, and it lives beside the rule that produced it rather than in whichever client
+// happens to be rendering — this project treats the wording of a failure as part of the
+// product (ADR-0011), and a wording maintained in two places is a wording that disagrees
+// with itself.
+//
+// Consumers must handle a code they do not recognise by rendering the message. Rules will
+// be added, and a client that failed on an unknown one would make every addition a
+// breaking change.
+type Fault struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// Fault codes. Stable: a consumer may key alerts on these.
+const (
+	// faultUnapplied is the component list a device said it could not apply.
+	faultUnapplied = "unapplied_components"
+	// faultLastError is whatever the agent reported alongside it.
+	faultLastError = "last_error"
+	// faultNeverApplied is an enrolled device that has never acknowledged anything.
+	faultNeverApplied = "never_applied"
+	// faultTunnelNeverCarried is a data plane with peers and no handshake, ever.
+	faultTunnelNeverCarried = "tunnel_never_carried"
+
+	// faultNoAdvertisers is a route group nobody offers to carry.
+	faultNoAdvertisers = "no_advertisers"
+	// faultNoViableAdvertiser is one where every candidate is out of action.
+	faultNoViableAdvertiser = "no_viable_advertiser"
+)
+
+// tunnelGrace is how long a control session must have been up before a tunnel with no
+// handshakes is called dead rather than new.
+//
+// A device reports its data plane the moment it applies state, when there has been no time
+// for a handshake. Without this every join would report a dead tunnel until it stopped
+// being wrong. Applied here, against this server's own clock at both ends, because a client
+// comparing our timestamp against its own would be wrong by however wrong its clock is.
+const tunnelGrace = 2 * time.Minute
+
+// deviceFaults is what is wrong with one device.
+//
+// Only an active membership can be in trouble. A revoked or suspended one is doing exactly
+// what was asked of it, and reporting it as broken would put an operator's own decision in
+// front of them as a fault to investigate.
+func deviceFaults(d store.OverviewDevice, live *session.Connected, now time.Time) []Fault {
+	faults := make([]Fault, 0, 2)
+	if d.State != "active" {
+		return faults
+	}
+
+	if len(d.Unapplied) > 0 {
+		faults = append(faults, Fault{
+			Code:    faultUnapplied,
+			Message: "could not apply: " + strings.Join(d.Unapplied, ", "),
+		})
+	}
+	if d.LastError != "" {
+		// The agent's own words, passed through. Rewriting them here would lose the only
+		// account of the failure that came from the machine it happened on.
+		faults = append(faults, Fault{Code: faultLastError, Message: d.LastError})
+	}
+	if live == nil && d.LastAckAt == nil {
+		// Enrolled and never heard from. Easy to miss in a list of names, and usually an
+		// installation that did not finish rather than a device that has gone away.
+		faults = append(faults, Fault{
+			Code:    faultNeverApplied,
+			Message: "has never applied any configuration",
+		})
+	}
+
+	// The one thing a path report is allowed to call a fault (#117). A device can apply
+	// every version it is sent and pass no traffic at all.
+	//
+	// "Never handshaked", not "handshaked a while ago". WireGuard renews a handshake when
+	// traffic flows, so a quiet peer with no keepalive looks stale while being perfectly
+	// healthy — but a peer that has never completed one has never carried a packet.
+	if live != nil && live.Tunnel.Peers > 0 && live.Tunnel.Handshaked == 0 &&
+		now.Sub(live.ConnectedAt) > tunnelGrace {
+		faults = append(faults, Fault{
+			Code:    faultTunnelNeverCarried,
+			Message: "tunnel has never carried anything: no peer has completed a handshake",
+		})
+	}
+	return faults
+}
+
+// groupFaults is what is wrong with one route group.
+func groupFaults(g store.OverviewGroup) []Fault {
+	faults := make([]Fault, 0, 1)
+	if len(g.Advertisers) == 0 {
+		return append(faults, Fault{
+			Code:    faultNoAdvertisers,
+			Message: "nothing is offering to carry this",
+		})
+	}
+	for _, a := range g.Advertisers {
+		if viableAdvertiser(a) {
+			return faults
+		}
+	}
+	return append(faults, Fault{
+		Code:    faultNoViableAdvertiser,
+		Message: "no candidate can carry this: every advertiser is disabled, draining or unhealthy",
+	})
+}
+
+// viableAdvertiser reports whether this candidate could carry anything at all.
+//
+// Deliberately not a function of whether its control session is up. An agent keeps
+// forwarding from the state it last applied when the control plane is unreachable
+// (ADR-0008), so an advertiser whose session has dropped may well still be carrying, and
+// calling the group broken on that basis would raise an alarm for a control-plane outage
+// rather than a data-plane one.
+//
+// Unknown health is not treated as broken either, for the opposite reason: nobody has
+// reported on it yet, which is not the same as knowing it is down.
+func viableAdvertiser(a store.OverviewAdvertiser) bool {
+	if a.AdminState != "enabled" {
+		return false
+	}
+	return a.Health != "unhealthy" && a.Health != "offline"
+}

--- a/internal/api/faults_test.go
+++ b/internal/api/faults_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/meshpnet/meshp/internal/session"
+	"github.com/meshpnet/meshp/internal/store"
+)
+
+func codes(faults []Fault) []string {
+	out := make([]string, 0, len(faults))
+	for _, f := range faults {
+		out = append(out, f.Code)
+	}
+	return out
+}
+
+func same(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// The rules that decide whether somebody is alarmed. They had no tests at all while they
+// lived in the page, because there is no JavaScript toolchain to run any (ADR-0023).
+func TestWhatCountsAsABrokenDevice(t *testing.T) {
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	ackedAt := now.Add(-time.Minute)
+
+	settled := func(tunnel session.TunnelState) *session.Connected {
+		return &session.Connected{ConnectedAt: now.Add(-time.Hour), Tunnel: tunnel}
+	}
+
+	for _, tc := range []struct {
+		name   string
+		device store.OverviewDevice
+		live   *session.Connected
+		want   []string
+	}{
+		{
+			name:   "a device with nothing wrong",
+			device: store.OverviewDevice{State: "active", LastAckAt: &ackedAt},
+			live:   settled(session.TunnelState{Peers: 3, Handshaked: 3, Talking: 3}),
+			want:   nil,
+		},
+		{
+			name: "components it could not apply",
+			device: store.OverviewDevice{
+				State: "active", LastAckAt: &ackedAt, Unapplied: []string{"route-groups", "dns"},
+			},
+			live: settled(session.TunnelState{Peers: 1, Handshaked: 1}),
+			want: []string{faultUnapplied},
+		},
+		{
+			name:   "enrolled and never heard from",
+			device: store.OverviewDevice{State: "active"},
+			live:   nil,
+			want:   []string{faultNeverApplied},
+		},
+		{
+			// A revoked membership is doing what was asked of it. Reporting it as broken
+			// would put an operator's own decision in front of them as a fault.
+			name:   "a revoked membership is not a device in trouble",
+			device: store.OverviewDevice{State: "revoked"},
+			live:   nil,
+			want:   nil,
+		},
+		{
+			name:   "a tunnel that has never carried anything",
+			device: store.OverviewDevice{State: "active", LastAckAt: &ackedAt},
+			live:   settled(session.TunnelState{Peers: 4}),
+			want:   []string{faultTunnelNeverCarried},
+		},
+		{
+			// WireGuard renews a handshake when traffic flows, so a quiet peer looks stale
+			// and is fine. Only "never" is a fault.
+			name:   "a quiet tunnel is not a dead one",
+			device: store.OverviewDevice{State: "active", LastAckAt: &ackedAt},
+			live:   settled(session.TunnelState{Peers: 4, Handshaked: 4}),
+			want:   nil,
+		},
+		{
+			// A device reports its data plane the moment it applies state, before there
+			// has been time for a handshake. Without the grace every join would report a
+			// dead tunnel until it stopped being wrong.
+			name:   "a tunnel seconds old has not failed, it has not started",
+			device: store.OverviewDevice{State: "active", LastAckAt: &ackedAt},
+			live:   &session.Connected{ConnectedAt: now.Add(-5 * time.Second), Tunnel: session.TunnelState{Peers: 4}},
+			want:   nil,
+		},
+		{
+			// Connected, so it is applying state; it just has no peers to talk to.
+			name:   "a device alone in its network is not broken",
+			device: store.OverviewDevice{State: "active", LastAckAt: &ackedAt},
+			live:   settled(session.TunnelState{}),
+			want:   nil,
+		},
+		{
+			name: "several things at once",
+			device: store.OverviewDevice{
+				State: "active", LastAckAt: &ackedAt,
+				Unapplied: []string{"peers"}, LastError: "nftables: could not carry 192.168.1.0/24",
+			},
+			live: settled(session.TunnelState{Peers: 2}),
+			want: []string{faultUnapplied, faultLastError, faultTunnelNeverCarried},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := codes(deviceFaults(tc.device, tc.live, now))
+			if len(tc.want) == 0 && len(got) == 0 {
+				return
+			}
+			if !same(got, tc.want) {
+				t.Errorf("faults = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func advertiser(admin, health string) store.OverviewAdvertiser {
+	return store.OverviewAdvertiser{MembershipID: uuid.New(), AdminState: admin, Health: health}
+}
+
+func TestWhatCountsAsABrokenRouteGroup(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		advertisers []store.OverviewAdvertiser
+		want        []string
+	}{
+		{
+			name:        "nobody is offering to carry it",
+			advertisers: nil,
+			want:        []string{faultNoAdvertisers},
+		},
+		{
+			name:        "one healthy candidate is enough",
+			advertisers: []store.OverviewAdvertiser{advertiser("enabled", "healthy"), advertiser("disabled", "healthy")},
+			want:        nil,
+		},
+		{
+			// Nobody has reported on it, which is not the same as knowing it is down.
+			name:        "an unproven candidate still counts as a candidate",
+			advertisers: []store.OverviewAdvertiser{advertiser("enabled", "")},
+			want:        nil,
+		},
+		{
+			// Degraded is carrying, badly. The group is not out.
+			name:        "a degraded candidate still counts",
+			advertisers: []store.OverviewAdvertiser{advertiser("enabled", "degraded")},
+			want:        nil,
+		},
+		{
+			name: "every candidate is out of action",
+			advertisers: []store.OverviewAdvertiser{
+				advertiser("enabled", "unhealthy"), advertiser("draining", "healthy"),
+				advertiser("disabled", "healthy"), advertiser("enabled", "offline"),
+			},
+			want: []string{faultNoViableAdvertiser},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := codes(groupFaults(store.OverviewGroup{Advertisers: tc.advertisers}))
+			if len(tc.want) == 0 && len(got) == 0 {
+				return
+			}
+			if !same(got, tc.want) {
+				t.Errorf("faults = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// An advertiser whose control session has dropped may still be carrying, because an agent
+// keeps forwarding from the state it last applied (ADR-0008). Calling the group broken on
+// that basis would raise an alarm for a control-plane outage rather than a data-plane one.
+func TestADroppedControlSessionDoesNotBreakARouteGroup(t *testing.T) {
+	group := store.OverviewGroup{Advertisers: []store.OverviewAdvertiser{advertiser("enabled", "healthy")}}
+	if faults := groupFaults(group); len(faults) != 0 {
+		t.Errorf("faults = %v, want none: liveness is not part of this rule", codes(faults))
+	}
+}

--- a/internal/api/overview.go
+++ b/internal/api/overview.go
@@ -76,6 +76,12 @@ func (s *Server) handleNetworkOverview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// One instant for the whole response: as_of, and whatever the fault rules compare
+	// against. Calling the clock twice would let a device be judged against a moment the
+	// response does not claim to describe.
+	now := s.cfg.Clock.Now().UTC()
+	faultCount := 0
+
 	devices := make([]map[string]any, 0, len(overview.Devices))
 	for _, d := range overview.Devices {
 		device := map[string]any{
@@ -130,6 +136,18 @@ func (s *Server) handleNetworkOverview(w http.ResponseWriter, r *http.Request) {
 		if d.LastError != "" {
 			device["last_error"] = d.LastError
 		}
+
+		// What is wrong with it, decided here rather than by whoever is rendering
+		// (ADR-0023). Always present and always a list, so a consumer never has to tell
+		// absent from empty before it can decide whether to raise an alarm.
+		var live *session.Connected
+		if c, ok := connected[d.MembershipID]; ok {
+			live = &c
+		}
+		faults := deviceFaults(d, live, now)
+		device["faults"] = faults
+		faultCount += len(faults)
+
 		devices = append(devices, device)
 	}
 
@@ -149,6 +167,11 @@ func (s *Server) handleNetworkOverview(w http.ResponseWriter, r *http.Request) {
 				// as healthy would make a group that has never worked look fine.
 				"health":    healthOrUnknown(a.Health),
 				"connected": false,
+				// Whether this candidate could carry anything at all, decided by the same
+				// rule that decides whether the group has a fault. A consumer marking
+				// unusable candidates must not have to derive it a second time and reach a
+				// different answer (ADR-0023 §5).
+				"viable": viableAdvertiser(a),
 			}
 			if _, live := connected[a.MembershipID]; live {
 				advertiser["connected"] = true
@@ -166,7 +189,11 @@ func (s *Server) handleNetworkOverview(w http.ResponseWriter, r *http.Request) {
 		for _, p := range g.Prefixes {
 			prefixes = append(prefixes, p.String())
 		}
+		groupTrouble := groupFaults(g)
+		faultCount += len(groupTrouble)
+
 		group := map[string]any{
+			"faults":         groupTrouble,
 			"id":             g.ID,
 			"slug":           g.Slug,
 			"name":           g.Name,
@@ -184,7 +211,7 @@ func (s *Server) handleNetworkOverview(w http.ResponseWriter, r *http.Request) {
 	httpx.WriteJSON(w, s.log, http.StatusOK, map[string]any{
 		// The instant everything below describes. Rendered by the page, so a poll that
 		// failed makes it visibly stale rather than leaving old numbers looking current.
-		"as_of": s.cfg.Clock.Now().UTC(),
+		"as_of": now,
 		"network": map[string]any{
 			"id":            overview.NetworkID,
 			"slug":          overview.Slug,
@@ -194,6 +221,9 @@ func (s *Server) handleNetworkOverview(w http.ResponseWriter, r *http.Request) {
 		"devices":           devices,
 		"devices_truncated": overview.DevicesTruncated,
 		"route_groups":      groups,
+		// Every fault in the network, counted once. A roll-up drawing forty tiles should
+		// not have to walk forty device lists to put a number on each one (ADR-0023).
+		"fault_count": faultCount,
 		// The server decides how often it is asked, so a deployment under load can slow
 		// its pages down without shipping a new one.
 		"poll_after_seconds": int(overviewPollInterval / time.Second),

--- a/web/app.js
+++ b/web/app.js
@@ -93,88 +93,11 @@ function show(...nodes) {
 }
 
 // --- what counts as broken ------------------------------------------------------------
-
-/**
- * Whether this candidate could carry anything at all.
- *
- * Deliberately not a function of `connected`. That is the control session, and an agent
- * keeps forwarding from the state it last applied when the control plane is unreachable
- * (ADR-0008) — so an advertiser whose session has dropped may well still be carrying, and
- * calling the group broken on that basis would raise an alarm for a control-plane outage
- * rather than a data-plane one. Disconnection is shown; it is not a fault by itself.
- *
- * `unknown` health is not treated as broken either, for the opposite reason: nobody has
- * reported on it yet, which is not the same as knowing it is down. It is called out as
- * unproven where it appears.
- */
-function viable(advertiser) {
-  if (advertiser.admin_state !== "enabled") return false;
-  return advertiser.health !== "unhealthy" && advertiser.health !== "offline";
-}
-
-/** What is wrong with a route group, in words. Empty means nothing is. */
-function groupFaults(group) {
-  const faults = [];
-  if (!group.advertisers.length) {
-    faults.push("nothing is offering to carry this");
-    return faults;
-  }
-  if (!group.advertisers.some(viable)) {
-    faults.push("no candidate can carry this: every advertiser is disabled, draining or unhealthy");
-  }
-  return faults;
-}
-
-/**
- * How long a control session must have been up before a tunnel with no handshakes counts
- * as broken rather than as new.
- *
- * A device reports its data plane the moment it applies state, and at that point there
- * have been no handshakes because there has not been time for any. Without this, every
- * join would flash "has never carried anything" for as long as it took to be wrong.
- */
-const TUNNEL_GRACE_SECONDS = 120;
-
-/** What is wrong with a device, in words. `asOf` is the server's clock, not this one's. */
-function deviceFaults(device, asOf) {
-  const faults = [];
-  if (device.state !== "active") return faults;
-
-  if (device.unapplied_components && device.unapplied_components.length) {
-    faults.push(`could not apply: ${device.unapplied_components.join(", ")}`);
-  }
-  if (device.last_error) {
-    faults.push(device.last_error);
-  }
-  if (!device.connected && !device.last_ack_at) {
-    // Enrolled and never heard from. Easy to miss in a list of names, and it is usually
-    // an installation that did not finish rather than a device that has gone away.
-    faults.push("has never applied any configuration");
-  }
-  // The one thing a path report is allowed to call a fault. A device can apply every
-  // version it is sent and pass no traffic at all, and until it reported its peers nothing
-  // could tell the difference (#117).
-  //
-  // "Never handshaked", not "handshaked a while ago". WireGuard renews a handshake when
-  // traffic flows, so a quiet peer looks stale while being perfectly healthy — but a peer
-  // that has never completed one has never carried a packet, and that is unambiguous.
-  if (device.tunnel && device.tunnel.peers > 0 && device.tunnel.handshaked === 0 && settled(device, asOf)) {
-    faults.push("tunnel has never carried anything: no peer has completed a handshake");
-  }
-  return faults;
-}
-
-/**
- * Whether this device has been connected long enough for "no handshakes" to mean anything.
- *
- * Both timestamps come from the server, so this survives a browser whose clock is wrong —
- * which is the machine somebody is reading this on, and the one whose clock nobody checks.
- */
-function settled(device, asOf) {
-  if (!device.connected_since || !asOf) return false;
-  const up = (Date.parse(asOf) - Date.parse(device.connected_since)) / 1000;
-  return Number.isFinite(up) && up > TUNNEL_GRACE_SECONDS;
-}
+//
+// Nothing here decides that. The control plane does, and sends `faults` on every device and
+// every route group (ADR-0023): there are two consumers of that endpoint and rules kept
+// here could only ever be a second opinion that drifts from the commercial layer's. Any
+// rule that reappears in this file is a bug.
 
 /** How a device's data plane reads, in words. */
 function tunnelSummary(device) {
@@ -229,7 +152,7 @@ function renderVerdict(data, faultCount) {
 }
 
 function renderGroup(group) {
-  const faults = groupFaults(group);
+  const faults = group.faults || [];
 
   const carriers = group.advertisers.map((advertiser) => {
     const health = advertiser.health || "unknown";
@@ -244,7 +167,7 @@ function renderGroup(group) {
 
     return el(
       "li",
-      { class: `carrier ${viable(advertiser) ? "" : "not-viable"}` },
+      { class: `carrier ${advertiser.viable ? "" : "not-viable"}` },
       dot(HEALTH_CLASS[health] || "unknown", health),
       el("span", { class: "who" }, advertiser.device_name),
       el("span", { class: "why" }, bits.join(" · ")),
@@ -272,7 +195,7 @@ function renderGroup(group) {
       el(
         "div",
         {},
-        faults.length ? el("div", { class: "nobody" }, faults.join("; ")) : null,
+        faults.length ? el("div", { class: "nobody" }, faults.map((f) => f.message).join("; ")) : null,
         carriers.length
           ? el("ul", { class: "carriers" }, carriers)
           : el("div", { class: "note" }, "no advertisers"),
@@ -281,9 +204,9 @@ function renderGroup(group) {
   );
 }
 
-function renderDevices(devices, asOf) {
+function renderDevices(devices) {
   const rows = devices.map((device) => {
-    const faults = deviceFaults(device, asOf);
+    const faults = device.faults || [];
     const addresses = [device.address_v4, device.address_v6].filter(Boolean);
 
     let stateLabel;
@@ -326,7 +249,7 @@ function renderDevices(devices, asOf) {
           ? el(
               "ul",
               { class: "faults" },
-              faults.map((fault) => el("li", {}, fault)),
+              faults.map((fault) => el("li", {}, fault.message)),
             )
           : el("span", { class: "note" }, "—"),
       ),
@@ -357,20 +280,18 @@ function renderDevices(devices, asOf) {
 }
 
 function renderOverview(data, networks) {
-  const groupFaultCount = data.route_groups.reduce((n, g) => n + groupFaults(g).length, 0);
-  const deviceFaultCount = data.devices.reduce((n, d) => n + deviceFaults(d, data.as_of).length, 0);
 
   // Devices with something wrong first. A list sorted by name buries the one device the
   // page exists to surface somewhere in the middle of forty that are fine.
   const devices = [...data.devices].sort((a, b) => {
-    const byFault = (deviceFaults(b, data.as_of).length > 0) - (deviceFaults(a, data.as_of).length > 0);
+    const byFault = ((b.faults || []).length > 0) - ((a.faults || []).length > 0);
     if (byFault) return byFault;
     return a.device_name.localeCompare(b.device_name);
   });
 
   show(
     renderNetworkBar(data, networks),
-    renderVerdict(data, groupFaultCount + deviceFaultCount),
+    renderVerdict(data, data.fault_count || 0),
     el("h2", {}, "What is carried, and by what"),
     data.route_groups.length
       ? el("div", {}, data.route_groups.map(renderGroup))
@@ -379,7 +300,7 @@ function renderOverview(data, networks) {
     el(
       "div",
       { class: "panel" },
-      renderDevices(devices, data.as_of),
+      renderDevices(devices),
       data.devices_truncated
         ? el(
             "p",


### PR DESCRIPTION
Closes [#116](https://github.com/meshpnet/meshp/issues/116). ADR-0023 records the decision and its cost.

## The argument that actually settled it

The issue framed this as drift: six rules in `app.js`, a commercial roll-up building on the same endpoint per ADR-0009, two implementations that would disagree. That's real, but it's a future problem.

The present one is that **the rules had no tests and could not have any.** ADR-0022 §3 decided there is no JavaScript toolchain — deliberately, with a stated expiry — and the consequence went unstated: the logic deciding whether an operator gets alarmed was the only logic in this repository nothing could test. Moving it to Go produced fourteen table rows on the first pass, each an edge that was previously assertable only by reading carefully:

- a revoked membership is not a device in trouble — it is doing what was asked of it
- a quiet tunnel is not a dead one — WireGuard only renews a handshake when traffic flows
- a tunnel seconds old has not failed, it has not started
- an unproven advertiser still counts as a candidate; nobody having reported is not the same as knowing it is down
- a degraded advertiser is carrying, badly — the group is not out
- a dropped control session does not break a route group (ADR-0008)
- a device alone in its network is not broken

## The shape

Every device and route group carries `faults`, always present, always a list. Each fault is a stable `code` and the `message` a person reads — the same envelope this API already uses for errors, so nobody parses prose to find out what happened. The response carries `fault_count` so a roll-up drawing forty tiles doesn't walk forty device lists.

Advertisers gained `viable`. The page struck through unusable candidates, and deriving that client-side is the same second opinion one layer down.

**The grace period moved too**, and this one was a latent bug: the page compared `as_of` against `connected_since` using `Date.parse` on the browser's clock. Correct only where that clock is right — on the machine somebody is reading this on, and the one nobody checks. It is now computed server-side against one instant, sampled once for the whole response.

## What it costs

ADR-0023 is explicit. What counts as broken is public API now: refining a rule changes what every consumer reports, and removing a code is breaking. Consumers must render an unrecognised code using its message, so *adding* rules stays cheap — that is written into the ADR as a requirement, not left as an assumption.

And a deployment that disagrees with a rule has no knob. Deliberate: a knob would mean two deployments disagreeing about what "broken" means, which is exactly the drift this removes, reintroduced as configuration.

## Verified

Full suite against a local PostgreSQL, since the overview tests skip without one. Drove the page against the new response shape and confirmed it renders identically to before — same verdict count, same group messages, same strike-throughs — with every judgement now arriving from the server. `web/app.js` loses 94 lines and gains none.