### PR TITLE
test(install): cover the branch that runs when nobody names a version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ on:
     paths:
       - ".github/workflows/release.yml"
       - "scripts/install.sh"
+      # The test itself, which was missing: a change to the only thing that exercises the
+      # install path did not run the install path. The same mistake the header above
+      # describes, one level further in.
+      - "scripts/install-test.sh"
       - "deploy/systemd/**"
       - ".go-version"
       - "Makefile"

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -45,6 +45,58 @@ done
 /usr/local/bin/meshp --version >/dev/null || fail "the installed binary does not run"
 echo "  binaries and unit installed, and the binary runs"
 
+# --- version resolution ------------------------------------------------------------------
+#
+# The branch that runs when nobody sets MESHP_VERSION: the documented one-liner, and the
+# only path most people will ever take. It had no coverage at all, because every case in
+# this file passes a version explicitly and so never makes `[ "$VERSION" = "latest" ]` true
+# (#112). Publishing v0.1.0 walked straight into it.
+#
+# Both cases are served from files on disk. SimpleHTTPRequestHandler strips the query string
+# before mapping a path, so one file named `releases` answers both requests the script makes
+# — the list at `releases?per_page=1`, and a 404 at `releases/latest`, because `releases` is
+# a file and not a directory. That is exactly the pair GitHub returns for a repository whose
+# only releases are pre-releases.
+
+PRE_TAG="v0.9.0-rc.1"
+mkdir -p /tmp/rel/api-pre
+printf '[{"tag_name": "%s", "prerelease": true}]' "$PRE_TAG" > /tmp/rel/api-pre/releases
+
+echo "a repository with only a pre-release is not installed from"
+# The assignment fails when the script does, which is what is wanted here, so the two are
+# joined with && rather than tested afterwards: set -e would otherwise end the run at the
+# refusal this is asserting.
+out="$(MESHP_DOWNLOAD_BASE="http://127.0.0.1:871" MESHP_API_BASE="http://127.0.0.1:871/api-pre" \
+  sh scripts/install.sh 2>&1)" && fail "a pre-release was installed without being asked for"
+[ -x /usr/local/bin/meshpd ] || fail "the refusal removed an already-installed binary"
+case "$out" in
+  *"$PRE_TAG"*) ;;
+  # A refusal that will not say what it found leaves the reader with two facts that look
+  # contradictory — no latest version, and a release on the releases page — and no way to
+  # see that both are true. That was the whole of #111.
+  *) fail "the refusal does not name the pre-release: ${out}" ;;
+esac
+case "$out" in
+  *MESHP_VERSION*) ;;
+  *) fail "the refusal does not say how to install it deliberately: ${out}" ;;
+esac
+echo "  refused, and the message names ${PRE_TAG} and MESHP_VERSION"
+
+# And the other half: a repository that does have a stable release. Here `releases/latest`
+# is a directory holding an index, which is what turns the 404 above into a served body.
+mkdir -p "/tmp/rel/api-stable/releases/latest"
+printf '{"tag_name": "%s"}' "$VERSION" > "/tmp/rel/api-stable/releases/latest/index.html"
+
+rm -f /usr/local/bin/meshp
+echo "a stable release is resolved and installed with no version given"
+MESHP_DOWNLOAD_BASE="http://127.0.0.1:871" MESHP_API_BASE="http://127.0.0.1:871/api-stable" \
+  sh scripts/install.sh >/dev/null || fail "the latest version could not be resolved"
+# Installing at all is the assertion. The tag has to have been read out of that JSON, since
+# it is the only thing naming the directory the archive is downloaded from — a resolution
+# that produced anything else would have 404ed rather than arriving here.
+[ -x /usr/local/bin/meshp ] || fail "nothing was installed after resolving the latest version"
+echo "  resolved ${VERSION} and installed it"
+
 # The security-critical half. An archive that has been tampered with must not be installed,
 # and this is the only assertion here that anyone would miss if it silently stopped working.
 rm -f /usr/local/bin/meshp
@@ -56,4 +108,4 @@ fi
 echo "  a tampered archive is refused"
 
 echo
-echo "the install path works, and refuses what it should"
+echo "the install path works, resolves a version, and refuses what it should"


### PR DESCRIPTION
Closes [#112](https://github.com/meshpnet/meshp/issues/112).

Every case in `install-test.sh` passed `MESHP_VERSION` explicitly, so `[ "$VERSION" = "latest" ]` was never true. The block that resolves a version — the default path, the one in the documented one-liner — had no coverage, and it is what broke when v0.1.0 was published (#111).

The stub is as small as the issue predicted. `SimpleHTTPRequestHandler` strips the query string before mapping a path, so one file named `releases` answers both requests the script makes: the list at `releases?per_page=1`, and a 404 at `releases/latest`, because `releases` is a file and not a directory. That is precisely the pair GitHub returns for a repository whose only releases are pre-releases. The stable case is the same tree with `releases/latest` as a directory holding an index.

**The assertion is on the message, not just the exit code.** The pre-release case requires the refusal to name the tag *and* to name `MESHP_VERSION`. A refusal that won't say what it found leaves the reader holding two facts that look contradictory — no latest version, and a release sitting on the releases page — with no way to see both are true. That was the whole of #111, and "it exited non-zero" would have passed through it unchanged.

## One thing I found on the way

The release workflow's `pull_request` paths filter listed `scripts/install.sh` but not `scripts/install-test.sh`. A change to the only thing that exercises the install path did not run the install path — the mistake that workflow's own header describes, one level further in. Added to the filter, which is also what makes this PR run it.

## Verified

Ran it in a `golang:1.26` container: both new cases pass alongside the existing ones. Then broke the pre-release lookup and re-ran — it fails with

```
FAIL: the refusal does not name the pre-release: meshp install: could not work out the latest version; set MESHP_VERSION
```

which is verbatim what v0.1.0 shipped.