### PR TITLE
ci(reachability): fail on a mechanism nothing reaches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,6 +388,17 @@ jobs:
       # linked into it, so self-hosters run exactly the binary we run.
       - run: make standalone-check
 
+  reachability:
+    name: everything defined is reached
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # ADR-0018, checked rather than remembered. Three mechanisms have sat unreached for
+      # months apiece and each was found by somebody reading nearby code for another reason
+      # (#121). Needs no toolchain: it reads the schema, the protocol and the queries.
+      - run: ./scripts/reachability-check.sh
+
   vuln:
     name: vulnerabilities
     runs-on: ubuntu-latest
@@ -594,7 +605,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
-    needs: [lint, test, cross, proto, integration, migrations, migrations-immutable, standalone, image, dataplane, vuln, fuzz-seeds, dco]
+    needs: [lint, test, cross, proto, integration, migrations, migrations-immutable, standalone, reachability, image, dataplane, vuln, fuzz-seeds, dco]
     steps:
       - name: report
         run: |

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,10 @@ generate: proto sqlc ## Run all code generation
 
 ## --- invariants -----------------------------------------------------------
 
+.PHONY: reachability
+reachability: ## ADR-0018: fail on a mechanism nothing reaches
+	@./scripts/reachability-check.sh
+
 .PHONY: standalone-check
 standalone-check: ## Invariant 12: the core must not depend on the commercial layer
 	@if grep -rn --include='*.go' 'meshpnet/meshp-cloud' . ; then \

--- a/scripts/reachability-allow
+++ b/scripts/reachability-allow
@@ -1,0 +1,49 @@
+# Mechanisms nothing reaches, and why that is currently correct.
+#
+# Every line here is an exception to scripts/reachability-check.sh. The file is the point of
+# the check: ADR-0018 says a mechanism is not done until something running reaches it, and
+# until now telling "deliberately not yet" from "we forgot" meant reading the history of
+# each one. An entry costs a sentence and a reviewer's attention, which is what "nobody has
+# looked" did not.
+#
+# Format: <kind>:<name> — reason
+# Kinds: table (a schema table no query in queries/ touches)
+#        message (a protocol message the oneofs name and no Go outside proto/gen references)
+#
+# Removing an entry is how a mechanism graduates. Adding one should be uncomfortable.
+
+# --- waiting for the authentication work ---------------------------------------------------
+#
+# ADR-0022 §5 ships the browser view on a cookie derived from the single admin token, and is
+# explicit that per-user accounts become a prerequisite the moment the UI grows a write path.
+# These are the tables that work will read. They have been in the schema since migration 0001.
+table:users            — no accounts exist yet; ADR-0022 §5 defers them and says when they stop being deferrable
+table:roles            — as above
+table:role_bindings    — as above
+table:groups           — as above
+table:group_members    — as above
+
+# --- half-built, and named as such ---------------------------------------------------------
+#
+# ADR-0021 §2 decided admin-entered DNS records travel to the agent as desired state, like
+# everything else. The resolver answers from the peer list it already holds; the records half
+# is not built, so nothing reads these.
+table:dns_zones        — ADR-0021 §2 is only half implemented: names resolve from peers, admin records do not travel yet
+table:dns_records      — as above
+
+# --- configuration overtook the table ------------------------------------------------------
+#
+table:relays           — relays come from MESHP_RELAYS; whether this table should exist at all is an open question
+
+# --- possibly a table that should be dropped rather than read ------------------------------
+#
+# ADR-0003 gives the server the ordered candidate list and the agent the choice, so there may
+# be no single assignment to record. Raised in #121; this entry is a placeholder for that
+# decision, not an answer to it.
+table:route_assignments — ADR-0003 may mean nothing should ever write this; see #121
+
+# --- direct paths -------------------------------------------------------------------------
+#
+# meshp is relay-first (ADR-0002): connectivity never depends on hole punching succeeding, so
+# the absence of signalling costs performance rather than function.
+message:SignalEnvelope  — direct-path signalling is not built; relay-first means nothing depends on it

--- a/scripts/reachability-check.sh
+++ b/scripts/reachability-check.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Fail on a mechanism nothing reaches.
+#
+# ADR-0018 says a mechanism is not done until something running reaches it, and it is the
+# decision this project cites most often. Until now it was enforced by somebody happening to
+# look: dns_zones went unread from the first migration until the DNS work, unapplied_components
+# was written on every acknowledgement and selected by nothing until the overview endpoint, and
+# PathReport sat in the protocol with both ends independently correct and nothing joining them
+# (#121). Each was found by a person reading nearby code for another reason.
+#
+# Two things are cheap to check mechanically, and this checks those two: a schema table no query
+# touches, and a protocol message nothing references.
+#
+# What it does not catch is worth stating, because one of its own motivating examples escapes it.
+# This works at table granularity, and unapplied_components was a *column* on a table that is
+# queried constantly — it appeared only in a RETURNING clause on an insert, where it is always
+# empty. Telling that from a read needs real SQL parsing rather than grep. Nor can this see a
+# message that is sent and handled but whose ends disagree. Both of those are what the
+# end-to-end scripts and image-smoke.sh are for; this is the cheap half, and cheap is the point:
+# it runs on every pull request rather than when somebody happens to look.
+#
+# Exceptions live in scripts/reachability-allow, one per line, each with a reason. That file is
+# the deliverable: it turns "nobody has looked" into something a reviewer has to read.
+set -euo pipefail
+
+ALLOW="${MESHP_REACHABILITY_ALLOW:-scripts/reachability-allow}"
+PROTO="${MESHP_PROTO:-proto/meshp/v1/control.proto}"
+
+found=0
+
+# allowed reports whether <kind>:<name> is excused, matching the name exactly rather than as a
+# prefix — otherwise an entry for `users` would silently excuse `user_sessions` too.
+allowed() {
+  grep -qE "^$1[[:space:]]+—" "$ALLOW"
+}
+
+echo "tables no query touches"
+for table in $(grep -h '^CREATE TABLE' migrations/*.sql \
+  | sed 's/CREATE TABLE IF NOT EXISTS //; s/CREATE TABLE //; s/[ (].*//'); do
+  # The SQL keywords that actually name a table. Matching the bare word anywhere would count
+  # a mention in a comment, which is how three of these looked reachable on first inspection.
+  if grep -qEi "(FROM|JOIN|INTO|UPDATE|TABLE)[[:space:]]+\"?${table}\"?([[:space:]]|,|;|\(|$)" queries/*.sql; then
+    continue
+  fi
+  if allowed "table:${table}"; then
+    continue
+  fi
+  echo "  ${table} — in the schema, and no query in queries/ reads or writes it"
+  found=1
+done
+
+echo "protocol messages nothing references"
+# The payload types of the two oneofs, which is what an agent and a server can actually send.
+# A message reachable only as a nested field of one of these is covered by its parent.
+oneof_types="$(awk '
+  /^message (ClientMessage|ServerMessage) \{/ { inmsg = 1 }
+  inmsg && /^  oneof payload \{/ { inoneof = 1; next }
+  inoneof && /^  \}/ { inoneof = 0; inmsg = 0 }
+  inoneof && NF { print $1 }
+' "$PROTO" | sort -u)"
+
+for message in $oneof_types; do
+  # Outside the generated code, and outside tests. A message only a test constructs is not one
+  # anything running reaches, which is the whole distinction being drawn — and every real case
+  # found so far had neither.
+  hits="$(grep -rl "\b${message}\b" internal/ cmd/ --include='*.go' 2>/dev/null \
+    | grep -v '/gen/' | grep -vc '_test\.go$' || true)"
+  if [ "${hits:-0}" -gt 0 ]; then
+    continue
+  fi
+  if allowed "message:${message}"; then
+    continue
+  fi
+  echo "  ${message} — named in a oneof, and no Go outside proto/gen references it"
+  found=1
+done
+
+if [ "$found" -ne 0 ]; then
+  cat >&2 <<'MSG'
+
+Something is defined and nothing reaches it (ADR-0018).
+
+Either wire it up, or add it to scripts/reachability-allow with a reason somebody
+reading this in six months can act on. "Not yet" is a fine reason; it is not a fine
+absence.
+MSG
+  exit 1
+fi
+
+echo
+echo "everything defined is reached, or excused in ${ALLOW}"


### PR DESCRIPTION
Closes [#121](https://github.com/meshpnet/meshp/issues/121).

ADR-0018 is the decision this repository cites most often, and it was enforced entirely by somebody happening to look. `dns_zones` went unread from migration 0001 until the DNS work. `unapplied_components` was written on every acknowledgement and selected by nothing until #113. `PathReport` sat in the protocol with both ends independently correct and nothing joining them until #118. Each was found by a person reading nearby code for a different reason.

## What it checks

Two things that are cheap by grep: a schema table no query in `queries/` touches, and a message named in the `ClientMessage`/`ServerMessage` oneofs that no Go outside `proto/gen` references. `make reachability`, and a CI job in the required set.

Nine tables and one message are currently unreached. Each has a line in `scripts/reachability-allow` with a reason.

## The allowlist is the point

The check is trivial; the file is the deliverable. It turns "nobody has looked" into something a reviewer has to read, and **an entry without a reason excuses nothing** — the matcher requires the em dash and the sentence after it, so a bare name fails exactly as an absent one does. That is tested.

Two entries are questions rather than exemptions, and writing them down is most of the value:

- **`route_assignments`** may be a table ADR-0003 means should never be written at all. The server sends ordered candidate lists and the agent chooses, so there may be no single assignment to record.
- **`relays`** is unread because relays come from `MESHP_RELAYS` instead — a configuration path with a known silent failure when the line is absent.

The rest are honest deferrals: five tables waiting on the authentication work ADR-0022 §5 defers, and `dns_zones`/`dns_records` waiting on the half of ADR-0021 §2 that is not built — names resolve from the peer list, admin-entered records do not travel yet.

## What it does not catch

Stated in the script's header, because one of its own motivating examples escapes it. This works at table granularity, and `unapplied_components` was a *column* on a table that is queried constantly — it appeared only in a `RETURNING` clause on an insert, where it is always empty. Telling that from a read needs SQL parsing, not grep. Nor can this see a message that is sent and handled but whose two ends disagree. That is what the end-to-end scripts and `image-smoke.sh` are for.

## The third check already existed

#121 also proposed skip accounting. Checking before writing it: the data plane job already fails on a skip, the integration job already fails if the tunnel assertions skip, and there are coverage floors behind both. Nothing to add.

## Verified

Ran it three ways, each confirming it fails when it should: with the `users` entry removed, with the `SignalEnvelope` entry removed, and with an entry stripped of its reason. All three are reported and exit non-zero.