### PR TITLE
feat(routes): record which candidate a device says it is using

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,19 @@ jobs:
       - name: go.mod is tidy
         run: make tidy-check
 
+      # The protos have had this check since the beginning; the database bindings never
+      # did, and were found stale — a query's comments had been edited without
+      # regenerating, so the committed Go described an older version of its own SQL.
+      # ADR-0013 commits generated code so nobody needs the toolchain to build; that only
+      # holds while what is committed is what the generator produces.
+      - name: committed database code matches the queries
+        run: |
+          make sqlc
+          if ! git diff --exit-code -- internal/store/gen/; then
+            echo "internal/store/gen is not what sqlc generates from queries/; run 'make sqlc' and commit the result"
+            exit 1
+          fi
+
   test:
     name: test and coverage
     runs-on: ubuntu-latest

--- a/internal/api/overview.go
+++ b/internal/api/overview.go
@@ -172,6 +172,10 @@ func (s *Server) handleNetworkOverview(w http.ResponseWriter, r *http.Request) {
 				// unusable candidates must not have to derive it a second time and reach a
 				// different answer (ADR-0023 §5).
 				"viable": viableAdvertiser(a),
+				// How many devices report routing through this one. The nearest thing to
+				// "which candidate is carrying" that exists: the agent chooses (ADR-0003),
+				// so this is a count of what agents have said, not a decision anybody made.
+				"in_use_by": a.InUseBy,
 			}
 			if _, live := connected[a.MembershipID]; live {
 				advertiser["connected"] = true

--- a/internal/session/reachability.go
+++ b/internal/session/reachability.go
@@ -38,10 +38,27 @@ func (s *Server) handleReachabilityReport(ctx context.Context, sess *Session, re
 		observed = health.SignalOK
 	}
 
+	// The group the device is talking about, so its choice can be written down beside the
+	// health that choice produced. An unparseable id records the health and skips the
+	// assignment rather than dropping the report: the two facts are independent, and losing
+	// a health signal because a newer agent sent a group id this build cannot read would be
+	// the wrong half to discard (ADR-0008).
+	groupID, groupErr := uuid.Parse(report.GetRouteGroupId())
+	if groupErr != nil {
+		groupID = uuid.Nil
+	}
+
 	transition, err := s.store.ObserveAdvertiser(ctx, store.ObserveRequest{
 		NetworkID:    sess.NetworkID,
 		AdvertiserID: advertiserID,
 		Observed:     observed,
+		// What this device says it is using, and why. ADR-0003 makes the agent the
+		// authority on liveness and says the server records what it chose; this is the
+		// recording, and it is what lets anything answer "which candidate is carrying
+		// this" — a question nothing could answer before.
+		MembershipID: sess.MembershipID,
+		RouteGroupID: groupID,
+		Reason:       report.GetSwitchReason(),
 		Clock:        s.clk,
 	})
 	if err != nil {

--- a/internal/store/assignment_test.go
+++ b/internal/store/assignment_test.go
@@ -1,0 +1,206 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/meshpnet/meshp/internal/clock"
+	"github.com/meshpnet/meshp/internal/health"
+)
+
+// assignmentFor reads back what the control plane recorded about one device's choice.
+func assignmentFor(t *testing.T, s seeded, membershipID, groupID uuid.UUID) (advertiser uuid.UUID, reason string, version int64, ok bool) {
+	t.Helper()
+	var advertiserID *uuid.UUID
+	err := s.pool.QueryRow(testContext(t),
+		`SELECT advertiser_id, reason, version FROM route_assignments
+		 WHERE membership_id = $1 AND route_group_id = $2`,
+		membershipID, groupID).Scan(&advertiserID, &reason, &version)
+	if err != nil {
+		return uuid.Nil, "", 0, false
+	}
+	if advertiserID != nil {
+		advertiser = *advertiserID
+	}
+	return advertiser, reason, version, true
+}
+
+// ADR-0003 splits authority: the server owns authorisation and order, the agent owns
+// liveness, and the server records what the agent chose. Only the first half was ever
+// built — route_assignments sat in the schema from the first migration with nothing
+// writing it, so nothing could answer "which candidate is actually carrying this".
+func TestAnAgentsChoiceIsRecorded(t *testing.T) {
+	s, addDevice := seedNetwork(t)
+	ctx := testContext(t)
+	clk := clock.NewFake()
+	membershipID := addDevice()
+	group := subnetGroup(t, s, "branch")
+	advertiserID := advertiserFor(t, s, "branch", membershipID)
+
+	if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+		NetworkID: s.netID, AdvertiserID: advertiserID,
+		MembershipID: membershipID, RouteGroupID: group.ID,
+		Reason:   "first choice, reachable",
+		Observed: health.SignalOK, Clock: clk,
+	}); err != nil {
+		t.Fatalf("ObserveAdvertiser: %v", err)
+	}
+
+	got, reason, version, ok := assignmentFor(t, s, membershipID, group.ID)
+	if !ok {
+		t.Fatal("nothing was recorded about what this device chose")
+	}
+	if got != advertiserID {
+		t.Errorf("advertiser = %s, want %s", got, advertiserID)
+	}
+	// Kept verbatim: it is the only account of the decision that came from the machine
+	// that made it, and it is what answers "why did my outbound IP change?" later.
+	if reason != "first choice, reachable" {
+		t.Errorf("reason = %q, want the agent's own words", reason)
+	}
+	if version != 1 {
+		t.Errorf("version = %d, want 1", version)
+	}
+}
+
+// Reports arrive from every device on every heartbeat. An update that ran each time would
+// write a row per device per group every twenty-five seconds, against a table in the same
+// database as desired state — the write rate ADR-0012 exists to keep away from it.
+func TestRepeatingTheSameChoiceWritesNothing(t *testing.T) {
+	s, addDevice := seedNetwork(t)
+	ctx := testContext(t)
+	clk := clock.NewFake()
+	membershipID := addDevice()
+	group := subnetGroup(t, s, "branch")
+	advertiserID := advertiserFor(t, s, "branch", membershipID)
+
+	for range 5 {
+		clk.Advance(time.Minute)
+		if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+			NetworkID: s.netID, AdvertiserID: advertiserID,
+			MembershipID: membershipID, RouteGroupID: group.ID,
+			Reason:   "still fine",
+			Observed: health.SignalOK, Clock: clk,
+		}); err != nil {
+			t.Fatalf("ObserveAdvertiser: %v", err)
+		}
+	}
+
+	_, _, version, ok := assignmentFor(t, s, membershipID, group.ID)
+	if !ok {
+		t.Fatal("nothing was recorded")
+	}
+	// The version moves when the choice moves. Five identical reports are one choice.
+	if version != 1 {
+		t.Errorf("version = %d after five identical reports, want 1", version)
+	}
+}
+
+// And when a device does move, the record moves with it — including the reason, which is
+// the whole point of keeping one.
+func TestMovingBetweenCandidatesUpdatesTheRecord(t *testing.T) {
+	s, addDevice := seedNetwork(t)
+	ctx := testContext(t)
+	clk := clock.NewFake()
+	membershipID := addDevice()
+	otherID := addDevice()
+	group := subnetGroup(t, s, "branch")
+	first := advertiserFor(t, s, "branch", membershipID)
+	second := advertiserFor(t, s, "branch", otherID)
+
+	for _, step := range []struct {
+		advertiser uuid.UUID
+		reason     string
+	}{
+		{first, "first choice, reachable"},
+		{second, "first choice stopped answering"},
+	} {
+		clk.Advance(time.Minute)
+		if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+			NetworkID: s.netID, AdvertiserID: step.advertiser,
+			MembershipID: membershipID, RouteGroupID: group.ID,
+			Reason:   step.reason,
+			Observed: health.SignalOK, Clock: clk,
+		}); err != nil {
+			t.Fatalf("ObserveAdvertiser: %v", err)
+		}
+	}
+
+	got, reason, version, _ := assignmentFor(t, s, membershipID, group.ID)
+	if got != second {
+		t.Errorf("advertiser = %s, want the one it moved to (%s)", got, second)
+	}
+	if reason != "first choice stopped answering" {
+		t.Errorf("reason = %q, want the reason for the move", reason)
+	}
+	if version != 2 {
+		t.Errorf("version = %d, want 2 after one move", version)
+	}
+}
+
+// A caller with only an advertiser to talk about records health and nothing else, rather
+// than inventing a membership to attach a choice to.
+func TestAReportWithNoGroupRecordsNoChoice(t *testing.T) {
+	s, addDevice := seedNetwork(t)
+	ctx := testContext(t)
+	membershipID := addDevice()
+	group := subnetGroup(t, s, "branch")
+	advertiserID := advertiserFor(t, s, "branch", membershipID)
+
+	if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+		NetworkID: s.netID, AdvertiserID: advertiserID,
+		Observed: health.SignalOK, Clock: clock.NewFake(),
+	}); err != nil {
+		t.Fatalf("ObserveAdvertiser: %v", err)
+	}
+	if _, _, _, ok := assignmentFor(t, s, membershipID, group.ID); ok {
+		t.Error("a report naming no group recorded a choice anyway")
+	}
+}
+
+// And the count reaches the overview, which is what makes any of this visible. A record
+// nothing reads is the failure this was fixing (ADR-0018).
+func TestTheOverviewCountsWhoIsUsingEachCandidate(t *testing.T) {
+	s, addDevice := seedNetwork(t)
+	ctx := testContext(t)
+	membershipID := addDevice()
+	group := subnetGroup(t, s, "branch")
+	advertiserID := advertiserFor(t, s, "branch", membershipID)
+
+	before, err := s.NetworkOverview(ctx, s.netID, DefaultOverviewDevices)
+	if err != nil {
+		t.Fatalf("NetworkOverview: %v", err)
+	}
+	if n := inUseFor(before, advertiserID); n != 0 {
+		t.Errorf("in use by %d before anything reported, want 0", n)
+	}
+
+	if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+		NetworkID: s.netID, AdvertiserID: advertiserID,
+		MembershipID: membershipID, RouteGroupID: group.ID,
+		Observed: health.SignalOK, Clock: clock.NewFake(),
+	}); err != nil {
+		t.Fatalf("ObserveAdvertiser: %v", err)
+	}
+
+	after, err := s.NetworkOverview(ctx, s.netID, DefaultOverviewDevices)
+	if err != nil {
+		t.Fatalf("NetworkOverview: %v", err)
+	}
+	if n := inUseFor(after, advertiserID); n != 1 {
+		t.Errorf("in use by %d after one device reported, want 1", n)
+	}
+}
+
+func inUseFor(overview NetworkOverview, advertiserID uuid.UUID) int64 {
+	for _, g := range overview.Groups {
+		for _, a := range g.Advertisers {
+			if a.ID == advertiserID {
+				return a.InUseBy
+			}
+		}
+	}
+	return -1
+}

--- a/internal/store/gen/overview.sql.go
+++ b/internal/store/gen/overview.sql.go
@@ -51,12 +51,14 @@ type ListAllNetworksRow struct {
 // transaction. Everything here is deliberately shaped for a consumer that is not this
 // repository's web page: the commercial layer builds its cross-tenant roll-up on the same
 // endpoint (ADR-0009), so these cannot be reshaped to suit whatever one screen needs.
-// Every network this control plane holds, so a view can offer a choice.
+// scope: global the only credential that reaches this is the administrative token, which is
+// a single shared secret granting every route already (ADR-0022 §5), so a tenant parameter
+// here would suggest a constraint that does not exist. The day roles arrive, this is the
+// first query that has to grow a caller, and that is a change to this line as much as to
+// the SQL.
 //
-// Unscoped, because the credential that reaches it is unscoped. That is only defensible
-// while the administrative token is a single shared secret granting everything; the day
-// roles arrive this is the first query that needs a caller, and it is written here in one
-// place so it is found rather than missed.
+// Every network this control plane holds, so a view can offer a choice rather than
+// requiring somebody to paste a UUID.
 func (q *Queries) ListAllNetworks(ctx context.Context) ([]ListAllNetworksRow, error) {
 	rows, err := q.db.Query(ctx, listAllNetworks)
 	if err != nil {

--- a/internal/store/gen/routegroups.sql.go
+++ b/internal/store/gen/routegroups.sql.go
@@ -30,6 +30,55 @@ func (q *Queries) AddRouteGroupPrefix(ctx context.Context, arg AddRouteGroupPref
 	return err
 }
 
+const countRouteAssignments = `-- name: CountRouteAssignments :many
+SELECT
+    r.route_group_id,
+    r.advertiser_id,
+    count(*)::bigint AS devices
+FROM route_assignments r
+JOIN device_network_memberships m ON m.id = r.membership_id
+JOIN devices d ON d.id = m.device_id
+WHERE r.route_group_id = ANY($1::uuid[])
+  AND r.advertiser_id IS NOT NULL
+  -- Revoked devices stop counting. An assignment outlives the membership that made it
+  -- until the cascade catches up, and a candidate shown as carrying for a device that is
+  -- out of the network is worse than no number at all.
+  AND m.state = 'active'
+  AND d.revoked_at IS NULL
+GROUP BY r.route_group_id, r.advertiser_id
+`
+
+type CountRouteAssignmentsRow struct {
+	RouteGroupID uuid.UUID
+	AdvertiserID *uuid.UUID
+	Devices      int64
+}
+
+// How many devices report currently using each candidate, per group.
+//
+// Counts rather than rows. A subnet group in a fifty-device network has fifty assignments
+// and one useful fact — which candidate is carrying — so returning the rows would make the
+// overview grow with the network to say the same thing.
+func (q *Queries) CountRouteAssignments(ctx context.Context, dollar_1 []uuid.UUID) ([]CountRouteAssignmentsRow, error) {
+	rows, err := q.db.Query(ctx, countRouteAssignments, dollar_1)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CountRouteAssignmentsRow
+	for rows.Next() {
+		var i CountRouteAssignmentsRow
+		if err := rows.Scan(&i.RouteGroupID, &i.AdvertiserID, &i.Devices); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const createAddressPool = `-- name: CreateAddressPool :one
 INSERT INTO address_pools (network_id, prefix, family, purpose)
 VALUES ($1, $2, $3, $4)
@@ -684,4 +733,55 @@ func (q *Queries) UpsertRouteAdvertiser(ctx context.Context, arg UpsertRouteAdve
 		&i.Provider,
 	)
 	return i, err
+}
+
+const upsertRouteAssignment = `-- name: UpsertRouteAssignment :execrows
+INSERT INTO route_assignments (
+    membership_id, route_group_id, advertiser_id, reason, decided_locally
+) VALUES ($1, $2, $3, $4, true)
+ON CONFLICT (membership_id, route_group_id) DO UPDATE
+SET advertiser_id   = EXCLUDED.advertiser_id,
+    reason          = EXCLUDED.reason,
+    decided_locally = true,
+    version         = route_assignments.version + 1,
+    assigned_at     = now()
+WHERE route_assignments.advertiser_id IS DISTINCT FROM EXCLUDED.advertiser_id
+`
+
+type UpsertRouteAssignmentParams struct {
+	MembershipID uuid.UUID
+	RouteGroupID uuid.UUID
+	AdvertiserID *uuid.UUID
+	Reason       string
+}
+
+// Record which candidate a device says it is currently using.
+//
+// An observation, never an instruction. ADR-0003 gives the server authorisation and order
+// and the agent the choice, so this is the control plane writing down what it was told —
+// which is the half of that ADR ("the server records it") that was never built. It is what
+// answers "why did my outbound IP change?", and it is where the page finds which advertiser
+// is actually carrying, a question nothing could answer before.
+//
+// decided_locally is always true. The column was written when the control plane was
+// expected to decide sometimes; ADR-0003 settled that it never does, so the flag records a
+// design that no longer exists. Kept rather than dropped because a migration to remove one
+// boolean is not worth the churn, and set honestly rather than left at its default.
+//
+// The WHERE on the conflict is load-bearing. Reachability reports arrive from every device
+// on every heartbeat, and an UPDATE that ran each time would write a row per device per
+// group every twenty-five seconds — the write rate ADR-0012 exists to keep away from the
+// tables holding desired state. Unchanged reports now cost a conflict check and nothing
+// else, and the row count tells the caller whether anything actually moved.
+func (q *Queries) UpsertRouteAssignment(ctx context.Context, arg UpsertRouteAssignmentParams) (int64, error) {
+	result, err := q.db.Exec(ctx, upsertRouteAssignment,
+		arg.MembershipID,
+		arg.RouteGroupID,
+		arg.AdvertiserID,
+		arg.Reason,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }

--- a/internal/store/health.go
+++ b/internal/store/health.go
@@ -84,6 +84,28 @@ func (s *Store) ObserveAdvertiser(ctx context.Context, req ObserveRequest) (heal
 			return fmt.Errorf("store: storing advertiser health: %w", err)
 		}
 
+		// What this device says it is using, which nothing recorded until now. ADR-0003
+		// splits authority — the server owns authorisation and order, the agent owns
+		// liveness — and says the server records what the agent chose. This is that half.
+		//
+		// Written whether or not health changed, because a device can move between
+		// candidates without any advertiser's health moving: an agent that finds its first
+		// choice slow and switches has changed the answer to "what is carrying this" while
+		// changing nobody's health state.
+		if req.MembershipID != uuid.Nil && req.RouteGroupID != uuid.Nil {
+			// The row count says whether anything moved, and is deliberately not returned:
+			// the caller already knows, because the agent tells it which candidate it
+			// switched away from and why.
+			if _, err := q.UpsertRouteAssignment(ctx, dbgen.UpsertRouteAssignmentParams{
+				MembershipID: req.MembershipID,
+				RouteGroupID: req.RouteGroupID,
+				AdvertiserID: &req.AdvertiserID,
+				Reason:       req.Reason,
+			}); err != nil {
+				return fmt.Errorf("store: recording the route assignment: %w", err)
+			}
+		}
+
 		if !out.Changed {
 			return nil
 		}
@@ -110,6 +132,21 @@ type ObserveRequest struct {
 	// devices — so one laptop's broken Wi-Fi is not mistaken for a broken exit — is the
 	// monitor's job, not this call's.
 	Observed health.Signal
+
+	// MembershipID and RouteGroupID name the device doing the reporting and the group it is
+	// reporting about, so its choice can be written down alongside the health it produced.
+	//
+	// Zero on a caller that has only an advertiser to talk about, which skips the recording
+	// rather than guessing at a membership. Recorded in the same transaction as the health
+	// on purpose: the two come from one message, and split across transactions they could
+	// disagree about which candidate a device is using at the moment somebody looks.
+	MembershipID uuid.UUID
+	RouteGroupID uuid.UUID
+
+	// Reason is the agent's own account of why it chose this candidate, kept verbatim. It
+	// is what answers "why did my outbound IP change?" six weeks later, and rewriting it
+	// here would lose the only description that came from the machine that decided.
+	Reason string
 
 	Clock clock.Clock
 }

--- a/internal/store/overview.go
+++ b/internal/store/overview.go
@@ -49,6 +49,10 @@ type OverviewDevice struct {
 
 // OverviewAdvertiser is one device offering to carry a route group's prefixes.
 type OverviewAdvertiser struct {
+	// ID is the advertiser row, which is what an assignment names. Not the membership: one
+	// device can advertise for several groups, so the two are not interchangeable here.
+	ID uuid.UUID
+
 	MembershipID uuid.UUID
 	DeviceName   string
 	Priority     int32
@@ -56,6 +60,17 @@ type OverviewAdvertiser struct {
 	AdminState   string
 	Region       string
 	City         string
+
+	// InUseBy is how many devices currently report routing through this candidate.
+	//
+	// An observation, not an instruction. ADR-0003 gives the agent the choice, so this is
+	// the count of agents that have said what they chose — which is the closest thing to
+	// "which candidate is carrying this" that exists, and it did not exist at all until
+	// something started recording what devices report.
+	//
+	// Zero is not "not carrying". A device that has never sent a reachability report has
+	// nothing recorded, and a group whose devices are all quiet reads as zero everywhere.
+	InUseBy int64
 
 	// Health is what the control plane has been told about this advertiser, and is empty
 	// when it has been told nothing. Empty is not healthy: an advertiser nobody has
@@ -181,9 +196,26 @@ func (s *Store) NetworkOverview(ctx context.Context, networkID uuid.UUID, device
 		if err != nil {
 			return fmt.Errorf("store: listing route advertisers: %w", err)
 		}
+		// How many devices say they are using each candidate. Read in the same transaction
+		// as everything else, so the counts describe the same instant as the health beside
+		// them — a candidate shown as unhealthy and carrying forty devices is a real state,
+		// and one assembled from two instants would not be.
+		assignmentRows, err := q.CountRouteAssignments(ctx, ids)
+		if err != nil {
+			return fmt.Errorf("store: counting route assignments: %w", err)
+		}
+		inUse := make(map[uuid.UUID]int64, len(assignmentRows))
+		for _, row := range assignmentRows {
+			if row.AdvertiserID != nil {
+				inUse[*row.AdvertiserID] = row.Devices
+			}
+		}
+
 		advertisers := make(map[uuid.UUID][]OverviewAdvertiser, len(groups))
 		for _, a := range advertiserRows {
 			entry := OverviewAdvertiser{
+				ID:           a.ID,
+				InUseBy:      inUse[a.ID],
 				MembershipID: a.MembershipID,
 				DeviceName:   a.DeviceName,
 				Priority:     a.Priority,

--- a/queries/routegroups.sql
+++ b/queries/routegroups.sql
@@ -161,3 +161,55 @@ SELECT a.id, a.route_group_id, g.network_id
 FROM route_advertisers a
 JOIN route_groups g ON g.id = a.route_group_id
 WHERE a.id = $1 AND g.network_id = $2;
+
+-- name: UpsertRouteAssignment :execrows
+-- Record which candidate a device says it is currently using.
+--
+-- An observation, never an instruction. ADR-0003 gives the server authorisation and order
+-- and the agent the choice, so this is the control plane writing down what it was told —
+-- which is the half of that ADR ("the server records it") that was never built. It is what
+-- answers "why did my outbound IP change?", and it is where the page finds which advertiser
+-- is actually carrying, a question nothing could answer before.
+--
+-- decided_locally is always true. The column was written when the control plane was
+-- expected to decide sometimes; ADR-0003 settled that it never does, so the flag records a
+-- design that no longer exists. Kept rather than dropped because a migration to remove one
+-- boolean is not worth the churn, and set honestly rather than left at its default.
+--
+-- The WHERE on the conflict is load-bearing. Reachability reports arrive from every device
+-- on every heartbeat, and an UPDATE that ran each time would write a row per device per
+-- group every twenty-five seconds — the write rate ADR-0012 exists to keep away from the
+-- tables holding desired state. Unchanged reports now cost a conflict check and nothing
+-- else, and the row count tells the caller whether anything actually moved.
+INSERT INTO route_assignments (
+    membership_id, route_group_id, advertiser_id, reason, decided_locally
+) VALUES ($1, $2, $3, $4, true)
+ON CONFLICT (membership_id, route_group_id) DO UPDATE
+SET advertiser_id   = EXCLUDED.advertiser_id,
+    reason          = EXCLUDED.reason,
+    decided_locally = true,
+    version         = route_assignments.version + 1,
+    assigned_at     = now()
+WHERE route_assignments.advertiser_id IS DISTINCT FROM EXCLUDED.advertiser_id;
+
+-- name: CountRouteAssignments :many
+-- How many devices report currently using each candidate, per group.
+--
+-- Counts rather than rows. A subnet group in a fifty-device network has fifty assignments
+-- and one useful fact — which candidate is carrying — so returning the rows would make the
+-- overview grow with the network to say the same thing.
+SELECT
+    r.route_group_id,
+    r.advertiser_id,
+    count(*)::bigint AS devices
+FROM route_assignments r
+JOIN device_network_memberships m ON m.id = r.membership_id
+JOIN devices d ON d.id = m.device_id
+WHERE r.route_group_id = ANY($1::uuid[])
+  AND r.advertiser_id IS NOT NULL
+  -- Revoked devices stop counting. An assignment outlives the membership that made it
+  -- until the cascade catches up, and a candidate shown as carrying for a device that is
+  -- out of the network is worse than no number at all.
+  AND m.state = 'active'
+  AND d.revoked_at IS NULL
+GROUP BY r.route_group_id, r.advertiser_id;

--- a/scripts/reachability-allow
+++ b/scripts/reachability-allow
@@ -35,12 +35,6 @@ table:dns_records      — as above
 #
 table:relays           — relays come from MESHP_RELAYS; whether this table should exist at all is an open question
 
-# --- possibly a table that should be dropped rather than read ------------------------------
-#
-# ADR-0003 gives the server the ordered candidate list and the agent the choice, so there may
-# be no single assignment to record. Raised in #121; this entry is a placeholder for that
-# decision, not an answer to it.
-table:route_assignments — ADR-0003 may mean nothing should ever write this; see #121
 
 # --- direct paths -------------------------------------------------------------------------
 #

--- a/web/app.js
+++ b/web/app.js
@@ -157,6 +157,14 @@ function renderGroup(group) {
   const carriers = group.advertisers.map((advertiser) => {
     const health = advertiser.health || "unknown";
     const bits = [`priority ${advertiser.priority}`];
+    // What devices say they are using, which is as close to "chosen" as anything gets: the
+    // server owns the order and the agent owns the choice (ADR-0003), so this is a count of
+    // reports rather than a decision. Shown only when something is using it — zero means
+    // "nothing has reported", not "not carrying", and a column of zeroes would read as the
+    // second.
+    if (advertiser.in_use_by > 0) {
+      bits.unshift(`carrying ${advertiser.in_use_by} device${advertiser.in_use_by === 1 ? "" : "s"}`);
+    }
     if (advertiser.weight !== 1) bits.push(`weight ${advertiser.weight}`);
     bits.push(health === "unknown" ? "never health checked" : health);
     if (advertiser.admin_state !== "enabled") bits.push(advertiser.admin_state);


### PR DESCRIPTION
[#121](https://github.com/meshpnet/meshp/issues/121) flagged `route_assignments` as possibly a table ADR-0003 means should never be written. Reading it settles the opposite.

The schema describes `reason` as what answers *"why did my outbound IP change?"*, and `decided_locally` exists precisely for an agent that moved itself. ADR-0003 says the server records what the agent chose — this is the table it meant, and it was never built. Only the flag is a fossil: it was written when the control plane was expected to decide sometimes, and the ADR settled that it never does, so it is now always `true`.

## It answers a question I said had no answer

Closing [#108](https://github.com/meshpnet/meshp/issues/108) I wrote that no server-side fact exists about which advertiser is currently carrying, so the page must not claim one. That was true, and it was true *because this half of ADR-0003 was missing* — not because the fact is unknowable. The agent already reports the candidate it is using on every reachability report; nothing wrote it down.

The overview now carries `in_use_by` per candidate and the page shows `carrying 3 devices`. A count, not a verdict: the agent chooses, so this is what agents have said. Zero is rendered as nothing at all, because zero means "nothing has reported", not "not carrying", and a column of zeroes would read as the second.

## Two things that needed care

**Write rate.** Reports arrive from every device on every heartbeat. The upsert has a `WHERE ... IS DISTINCT FROM` on the conflict, so an unchanged report costs a conflict check and no write — otherwise this would put a row per device per group every 25 seconds against the database holding desired state, which is what ADR-0012 exists to prevent. Tested: five identical reports leave `version` at 1.

**One transaction.** The assignment is recorded alongside the health the same report produced, so the two cannot disagree about which candidate a device is using at the moment somebody looks.

## Found on the way, and included because it was in the way

`make sqlc` produces a diff on `main`. A query's comments had been edited without regenerating, so the committed Go described an older version of its own SQL. The protos have had a "committed bindings match" check since the beginning; the database bindings never did. ADR-0013 commits generated code so nobody needs the toolchain to build — which only holds while what is committed is what the generator produces. Added to the `lint` job.

## Not done

The other half of ADR-0003's sentence: *"and emits an audit event"*. The assignment record answers what is carrying now; the history of moves still has nowhere to live but the log. Worth its own change rather than being smuggled in here.

## Verified

`route_assignments` is out of `scripts/reachability-allow` and the check passes — which is the proof it is reached, and the first entry to graduate since that file existed. Full suite against a local PostgreSQL, lint clean.