### PR TITLE
feat(routes): a device moving between candidates is auditable

### DIFF
--- a/internal/session/reachability.go
+++ b/internal/session/reachability.go
@@ -38,16 +38,6 @@ func (s *Server) handleReachabilityReport(ctx context.Context, sess *Session, re
 		observed = health.SignalOK
 	}
 
-	// The group the device is talking about, so its choice can be written down beside the
-	// health that choice produced. An unparseable id records the health and skips the
-	// assignment rather than dropping the report: the two facts are independent, and losing
-	// a health signal because a newer agent sent a group id this build cannot read would be
-	// the wrong half to discard (ADR-0008).
-	groupID, groupErr := uuid.Parse(report.GetRouteGroupId())
-	if groupErr != nil {
-		groupID = uuid.Nil
-	}
-
 	transition, err := s.store.ObserveAdvertiser(ctx, store.ObserveRequest{
 		NetworkID:    sess.NetworkID,
 		AdvertiserID: advertiserID,
@@ -56,9 +46,14 @@ func (s *Server) handleReachabilityReport(ctx context.Context, sess *Session, re
 		// authority on liveness and says the server records what it chose; this is the
 		// recording, and it is what lets anything answer "which candidate is carrying
 		// this" — a question nothing could answer before.
+		// The membership and the device come from the session rather than the message:
+		// they are the identity this connection proved, and a device may only ever speak
+		// about itself. The group is not passed at all — the store reads it from the
+		// advertiser, which is the only end that can tie the two together.
 		MembershipID: sess.MembershipID,
-		RouteGroupID: groupID,
+		DeviceID:     sess.DeviceID,
 		Reason:       report.GetSwitchReason(),
+		SwitchedFrom: report.GetSwitchedFromAdvertiserId(),
 		Clock:        s.clk,
 	})
 	if err != nil {

--- a/internal/store/assignment_test.go
+++ b/internal/store/assignment_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 
 	"github.com/meshpnet/meshp/internal/clock"
 	"github.com/meshpnet/meshp/internal/health"
+	dbgen "github.com/meshpnet/meshp/internal/store/gen"
 )
 
 // assignmentFor reads back what the control plane recorded about one device's choice.
@@ -41,9 +43,9 @@ func TestAnAgentsChoiceIsRecorded(t *testing.T) {
 
 	if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
 		NetworkID: s.netID, AdvertiserID: advertiserID,
-		MembershipID: membershipID, RouteGroupID: group.ID,
-		Reason:   "first choice, reachable",
-		Observed: health.SignalOK, Clock: clk,
+		MembershipID: membershipID,
+		Reason:       "first choice, reachable",
+		Observed:     health.SignalOK, Clock: clk,
 	}); err != nil {
 		t.Fatalf("ObserveAdvertiser: %v", err)
 	}
@@ -80,9 +82,9 @@ func TestRepeatingTheSameChoiceWritesNothing(t *testing.T) {
 		clk.Advance(time.Minute)
 		if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
 			NetworkID: s.netID, AdvertiserID: advertiserID,
-			MembershipID: membershipID, RouteGroupID: group.ID,
-			Reason:   "still fine",
-			Observed: health.SignalOK, Clock: clk,
+			MembershipID: membershipID,
+			Reason:       "still fine",
+			Observed:     health.SignalOK, Clock: clk,
 		}); err != nil {
 			t.Fatalf("ObserveAdvertiser: %v", err)
 		}
@@ -120,9 +122,9 @@ func TestMovingBetweenCandidatesUpdatesTheRecord(t *testing.T) {
 		clk.Advance(time.Minute)
 		if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
 			NetworkID: s.netID, AdvertiserID: step.advertiser,
-			MembershipID: membershipID, RouteGroupID: group.ID,
-			Reason:   step.reason,
-			Observed: health.SignalOK, Clock: clk,
+			MembershipID: membershipID,
+			Reason:       step.reason,
+			Observed:     health.SignalOK, Clock: clk,
 		}); err != nil {
 			t.Fatalf("ObserveAdvertiser: %v", err)
 		}
@@ -142,7 +144,7 @@ func TestMovingBetweenCandidatesUpdatesTheRecord(t *testing.T) {
 
 // A caller with only an advertiser to talk about records health and nothing else, rather
 // than inventing a membership to attach a choice to.
-func TestAReportWithNoGroupRecordsNoChoice(t *testing.T) {
+func TestAReportWithNoMembershipRecordsNoChoice(t *testing.T) {
 	s, addDevice := seedNetwork(t)
 	ctx := testContext(t)
 	membershipID := addDevice()
@@ -166,7 +168,7 @@ func TestTheOverviewCountsWhoIsUsingEachCandidate(t *testing.T) {
 	s, addDevice := seedNetwork(t)
 	ctx := testContext(t)
 	membershipID := addDevice()
-	group := subnetGroup(t, s, "branch")
+	subnetGroup(t, s, "branch")
 	advertiserID := advertiserFor(t, s, "branch", membershipID)
 
 	before, err := s.NetworkOverview(ctx, s.netID, DefaultOverviewDevices)
@@ -179,8 +181,8 @@ func TestTheOverviewCountsWhoIsUsingEachCandidate(t *testing.T) {
 
 	if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
 		NetworkID: s.netID, AdvertiserID: advertiserID,
-		MembershipID: membershipID, RouteGroupID: group.ID,
-		Observed: health.SignalOK, Clock: clock.NewFake(),
+		MembershipID: membershipID,
+		Observed:     health.SignalOK, Clock: clock.NewFake(),
 	}); err != nil {
 		t.Fatalf("ObserveAdvertiser: %v", err)
 	}
@@ -203,4 +205,147 @@ func inUseFor(overview NetworkOverview, advertiserID uuid.UUID) int64 {
 		}
 	}
 	return -1
+}
+
+// routeSwitches reads the audit trail for moves in this network.
+func routeSwitches(t *testing.T, s seeded) []dbgen.AuditEvent {
+	t.Helper()
+	netID := s.netID
+	events, err := s.Queries().ListAuditEventsForNetwork(testContext(t), dbgen.ListAuditEventsForNetworkParams{
+		NetworkID: &netID, Limit: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []dbgen.AuditEvent
+	for _, e := range events {
+		if e.Action == "route.switched" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// The other half of ADR-0003's sentence: the server records what the agent chose *and emits
+// an audit event*. Only the recording existed; a device could move itself between
+// candidates and the only trace was a log line that rotates away.
+func TestAMoveIsAudited(t *testing.T) {
+	s, addDevice := seedNetwork(t)
+	ctx := testContext(t)
+	clk := clock.NewFake()
+	membershipID := addDevice()
+	otherID := addDevice()
+	subnetGroup(t, s, "branch")
+	first := advertiserFor(t, s, "branch", membershipID)
+	second := advertiserFor(t, s, "branch", otherID)
+
+	deviceID := deviceFor(t, s, membershipID)
+	for _, step := range []struct {
+		advertiser uuid.UUID
+		from       string
+		reason     string
+	}{
+		{first, "", "first choice, reachable"},
+		{second, first.String(), "first choice stopped answering"},
+	} {
+		clk.Advance(time.Minute)
+		if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+			NetworkID: s.netID, AdvertiserID: step.advertiser,
+			MembershipID: membershipID, DeviceID: deviceID,
+			Reason: step.reason, SwitchedFrom: step.from,
+			Observed: health.SignalOK, Clock: clk,
+		}); err != nil {
+			t.Fatalf("ObserveAdvertiser: %v", err)
+		}
+	}
+
+	events := routeSwitches(t, s)
+	// One, not two. The first report is a device recording a choice, which happens on every
+	// enrolment and describes nothing going wrong.
+	if len(events) != 1 {
+		t.Fatalf("%d route.switched events, want 1 (the move, not the first choice)", len(events))
+	}
+	event := events[0]
+	// A device's action, not the control plane's. ADR-0003 gives the choice to the agent.
+	if event.ActorKind != "device" {
+		t.Errorf("actor_kind = %q, want device", event.ActorKind)
+	}
+	if event.ActorID == nil || *event.ActorID != deviceID {
+		t.Errorf("actor_id = %v, want the device that moved (%s)", event.ActorID, deviceID)
+	}
+	if event.ActorLabel == "" {
+		t.Error("actor_label is empty; an audit line of bare UUIDs is one nobody reads")
+	}
+	// The agent's own words, which is what somebody is reading this to find.
+	for _, want := range []string{"first choice stopped answering", first.String(), second.String()} {
+		if !strings.Contains(string(event.Metadata), want) {
+			t.Errorf("metadata does not mention %q: %s", want, event.Metadata)
+		}
+	}
+}
+
+// Repeating a choice is not an event. Reports arrive on every heartbeat, and an audit trail
+// that recorded each one would bury the moves it exists to show.
+func TestRepeatingAChoiceIsNotAudited(t *testing.T) {
+	s, addDevice := seedNetwork(t)
+	ctx := testContext(t)
+	clk := clock.NewFake()
+	membershipID := addDevice()
+	subnetGroup(t, s, "branch")
+	advertiserID := advertiserFor(t, s, "branch", membershipID)
+	deviceID := deviceFor(t, s, membershipID)
+
+	for range 5 {
+		clk.Advance(time.Minute)
+		if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+			NetworkID: s.netID, AdvertiserID: advertiserID,
+			MembershipID: membershipID, DeviceID: deviceID,
+			Observed: health.SignalOK, Clock: clk,
+		}); err != nil {
+			t.Fatalf("ObserveAdvertiser: %v", err)
+		}
+	}
+
+	if events := routeSwitches(t, s); len(events) != 0 {
+		t.Errorf("%d route.switched events after five identical reports, want 0", len(events))
+	}
+}
+
+// The assignment is filed under the advertiser's own group, which is the only end that can
+// tie the two together: nothing in the schema constrains advertiser_id to route_group_id, so
+// a group taken from the agent's message could file a candidate from one group as a device's
+// choice in another, and it would stay wrong.
+func TestTheAssignmentIsFiledUnderTheAdvertisersGroup(t *testing.T) {
+	s, addDevice := seedNetwork(t)
+	ctx := testContext(t)
+	membershipID := addDevice()
+	branch := subnetGroup(t, s, "branch")
+	other := subnetGroup(t, s, "other")
+	advertiserID := advertiserFor(t, s, "branch", membershipID)
+
+	if _, err := s.ObserveAdvertiser(ctx, ObserveRequest{
+		NetworkID: s.netID, AdvertiserID: advertiserID,
+		MembershipID: membershipID, DeviceID: deviceFor(t, s, membershipID),
+		Observed: health.SignalOK, Clock: clock.NewFake(),
+	}); err != nil {
+		t.Fatalf("ObserveAdvertiser: %v", err)
+	}
+
+	if _, _, _, ok := assignmentFor(t, s, membershipID, branch.ID); !ok {
+		t.Error("nothing was filed under the group the advertiser actually belongs to")
+	}
+	if _, _, _, ok := assignmentFor(t, s, membershipID, other.ID); ok {
+		t.Error("something was filed under a group this advertiser is not in")
+	}
+}
+
+// deviceFor is the device behind a membership.
+func deviceFor(t *testing.T, s seeded, membershipID uuid.UUID) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	if err := s.pool.QueryRow(testContext(t),
+		`SELECT device_id FROM device_network_memberships WHERE id = $1`, membershipID).Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	return id
 }

--- a/internal/store/gen/devices.sql.go
+++ b/internal/store/gen/devices.sql.go
@@ -255,6 +255,38 @@ func (q *Queries) CreateWireGuardKey(ctx context.Context, arg CreateWireGuardKey
 	return i, err
 }
 
+const getDevice = `-- name: GetDevice :one
+SELECT id, organization_id, user_id, name, hostname, os, os_version, agent_version, identity_public_key, capabilities, created_at, updated_at, last_seen_at, revoked_at, revoked_reason FROM devices WHERE id = $1
+`
+
+// One device by id, for the places that hold an id and need a name.
+//
+// Unscoped like GetDeviceByIdentityKey, and for the same reason: the caller has already
+// established which network it is acting in, and the id it holds came from a row it read
+// under that scope. A tenant parameter here would suggest a check this cannot perform.
+func (q *Queries) GetDevice(ctx context.Context, id uuid.UUID) (Device, error) {
+	row := q.db.QueryRow(ctx, getDevice, id)
+	var i Device
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.UserID,
+		&i.Name,
+		&i.Hostname,
+		&i.Os,
+		&i.OsVersion,
+		&i.AgentVersion,
+		&i.IdentityPublicKey,
+		&i.Capabilities,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.LastSeenAt,
+		&i.RevokedAt,
+		&i.RevokedReason,
+	)
+	return i, err
+}
+
 const getDeviceByIdentityKey = `-- name: GetDeviceByIdentityKey :one
 SELECT id, organization_id, user_id, name, hostname, os, os_version, agent_version, identity_public_key, capabilities, created_at, updated_at, last_seen_at, revoked_at, revoked_reason FROM devices
 WHERE identity_public_key = $1

--- a/internal/store/gen/routegroups.sql.go
+++ b/internal/store/gen/routegroups.sql.go
@@ -735,7 +735,7 @@ func (q *Queries) UpsertRouteAdvertiser(ctx context.Context, arg UpsertRouteAdve
 	return i, err
 }
 
-const upsertRouteAssignment = `-- name: UpsertRouteAssignment :execrows
+const upsertRouteAssignment = `-- name: UpsertRouteAssignment :one
 INSERT INTO route_assignments (
     membership_id, route_group_id, advertiser_id, reason, decided_locally
 ) VALUES ($1, $2, $3, $4, true)
@@ -746,6 +746,7 @@ SET advertiser_id   = EXCLUDED.advertiser_id,
     version         = route_assignments.version + 1,
     assigned_at     = now()
 WHERE route_assignments.advertiser_id IS DISTINCT FROM EXCLUDED.advertiser_id
+RETURNING version
 `
 
 type UpsertRouteAssignmentParams struct {
@@ -772,16 +773,20 @@ type UpsertRouteAssignmentParams struct {
 // on every heartbeat, and an UPDATE that ran each time would write a row per device per
 // group every twenty-five seconds — the write rate ADR-0012 exists to keep away from the
 // tables holding desired state. Unchanged reports now cost a conflict check and nothing
-// else, and the row count tells the caller whether anything actually moved.
+// else, and no row comes back at all when nothing moved.
+//
+// The version is returned because it says which kind of change this was without a second
+// query: 1 is a device recording a choice for the first time, and anything higher is a
+// device that moved. Only the second is worth an audit event — the first happens on every
+// enrolment and describes nothing going wrong.
 func (q *Queries) UpsertRouteAssignment(ctx context.Context, arg UpsertRouteAssignmentParams) (int64, error) {
-	result, err := q.db.Exec(ctx, upsertRouteAssignment,
+	row := q.db.QueryRow(ctx, upsertRouteAssignment,
 		arg.MembershipID,
 		arg.RouteGroupID,
 		arg.AdvertiserID,
 		arg.Reason,
 	)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+	var version int64
+	err := row.Scan(&version)
+	return version, err
 }

--- a/internal/store/health.go
+++ b/internal/store/health.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -92,17 +93,30 @@ func (s *Store) ObserveAdvertiser(ctx context.Context, req ObserveRequest) (heal
 		// candidates without any advertiser's health moving: an agent that finds its first
 		// choice slow and switches has changed the answer to "what is carrying this" while
 		// changing nobody's health state.
-		if req.MembershipID != uuid.Nil && req.RouteGroupID != uuid.Nil {
-			// The row count says whether anything moved, and is deliberately not returned:
-			// the caller already knows, because the agent tells it which candidate it
-			// switched away from and why.
-			if _, err := q.UpsertRouteAssignment(ctx, dbgen.UpsertRouteAssignmentParams{
+		if req.MembershipID != uuid.Nil {
+			version, err := q.UpsertRouteAssignment(ctx, dbgen.UpsertRouteAssignmentParams{
 				MembershipID: req.MembershipID,
-				RouteGroupID: req.RouteGroupID,
+				RouteGroupID: row.RouteGroupID,
 				AdvertiserID: &req.AdvertiserID,
 				Reason:       req.Reason,
-			}); err != nil {
+			})
+			switch {
+			case errors.Is(err, pgx.ErrNoRows):
+				// The same choice as last time, which is most reports. Nothing moved, so
+				// there is nothing to audit.
+			case err != nil:
 				return fmt.Errorf("store: recording the route assignment: %w", err)
+			case version > 1:
+				// A device moved between candidates. ADR-0003 completes here: the server
+				// records what the agent chose and emits an audit event, treating it as
+				// something that happened rather than as drift to be corrected.
+				//
+				// Version 1 is deliberately not audited. That is a device recording a
+				// choice for the first time, which happens on every enrolment and
+				// describes nothing going wrong.
+				if err := auditRouteSwitch(ctx, q, req, row.RouteGroupID); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -133,20 +147,38 @@ type ObserveRequest struct {
 	// monitor's job, not this call's.
 	Observed health.Signal
 
-	// MembershipID and RouteGroupID name the device doing the reporting and the group it is
-	// reporting about, so its choice can be written down alongside the health it produced.
+	// MembershipID names the device doing the reporting, so its choice can be written down
+	// alongside the health that choice produced.
 	//
 	// Zero on a caller that has only an advertiser to talk about, which skips the recording
 	// rather than guessing at a membership. Recorded in the same transaction as the health
 	// on purpose: the two come from one message, and split across transactions they could
 	// disagree about which candidate a device is using at the moment somebody looks.
+	//
+	// There is deliberately no route group here. The agent names one in its report, and
+	// taking it would let a device file an advertiser from one group as its choice in
+	// another — nothing ties advertiser_id to route_group_id in the schema, so the pair
+	// would simply be wrong and would stay wrong. The group is read from the advertiser
+	// instead, which is scoped to the session's network and is the only version of the
+	// answer this end can vouch for.
 	MembershipID uuid.UUID
-	RouteGroupID uuid.UUID
 
 	// Reason is the agent's own account of why it chose this candidate, kept verbatim. It
 	// is what answers "why did my outbound IP change?" six weeks later, and rewriting it
 	// here would lose the only description that came from the machine that decided.
 	Reason string
+
+	// DeviceID is who is reporting, recorded as the actor when a move is audited. An
+	// agent's failover is a device's action, not the control plane's — ADR-0003 gives the
+	// choice to the agent — so attributing it to "system" would name the wrong actor for
+	// the one decision here that nobody at the control plane made.
+	DeviceID uuid.UUID
+
+	// SwitchedFrom is the candidate the agent says it moved away from, kept for the audit
+	// record. The agent's claim rather than a lookup: the row it replaced is gone by the
+	// time this is written, and the two would agree anyway except in the case where the
+	// agent's account is the interesting one.
+	SwitchedFrom string
 
 	Clock clock.Clock
 }
@@ -163,4 +195,56 @@ func nilIfZero(t time.Time) *time.Time {
 		return nil
 	}
 	return &t
+}
+
+// auditRouteSwitch writes down that a device moved itself between candidates.
+//
+// In the transaction that recorded the move, for the reason revocation gives: a change that
+// committed while its audit record was rolled back is one nobody can account for afterwards.
+//
+// Costs two extra reads, and only ever on a move. Both are lookups this call does not
+// otherwise need — the organisation the event is filed under, and the device's name — and a
+// move is rare enough that paying for them here is cheaper than carrying them through every
+// routine report that changes nothing.
+func auditRouteSwitch(ctx context.Context, q *dbgen.Queries, req ObserveRequest, groupID uuid.UUID) error {
+	network, err := q.GetNetwork(ctx, req.NetworkID)
+	if err != nil {
+		return fmt.Errorf("store: reading the network for a route audit event: %w", err)
+	}
+
+	// The name, so the log reads as "hq-gateway moved" rather than as a pair of UUIDs. An
+	// audit trail nobody can read without three joins is one nobody reads.
+	label := ""
+	if device, err := q.GetDevice(ctx, req.DeviceID); err == nil {
+		label = device.Name
+	}
+
+	metadata, _ := json.Marshal(map[string]any{
+		"advertiser_id":  req.AdvertiserID.String(),
+		"switched_from":  req.SwitchedFrom,
+		"reason":         req.Reason,
+		"membership_id":  req.MembershipID.String(),
+		"route_group_id": groupID.String(),
+	})
+
+	networkID := req.NetworkID
+	actorID := req.DeviceID
+	orgID := network.OrganizationID
+	if _, err := q.CreateAuditEvent(ctx, dbgen.CreateAuditEventParams{
+		OrganizationID: &orgID,
+		NetworkID:      &networkID,
+		// Not "system". The schema's comment on that value predates ADR-0003, which moved
+		// the choice to the agent: this is a device reporting something it did, and filing
+		// it under the control plane would credit the wrong actor.
+		ActorKind:    "device",
+		ActorID:      &actorID,
+		ActorLabel:   label,
+		Action:       "route.switched",
+		ResourceKind: "route_group",
+		ResourceID:   &groupID,
+		Metadata:     metadata,
+	}); err != nil {
+		return fmt.Errorf("store: writing the route switch audit event: %w", err)
+	}
+	return nil
 }

--- a/queries/devices.sql
+++ b/queries/devices.sql
@@ -5,6 +5,14 @@ INSERT INTO devices (
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING *;
 
+-- name: GetDevice :one
+-- One device by id, for the places that hold an id and need a name.
+--
+-- Unscoped like GetDeviceByIdentityKey, and for the same reason: the caller has already
+-- established which network it is acting in, and the id it holds came from a row it read
+-- under that scope. A tenant parameter here would suggest a check this cannot perform.
+SELECT * FROM devices WHERE id = $1;
+
 -- name: GetDeviceByIdentityKey :one
 SELECT * FROM devices
 WHERE identity_public_key = $1;

--- a/queries/routegroups.sql
+++ b/queries/routegroups.sql
@@ -162,7 +162,7 @@ FROM route_advertisers a
 JOIN route_groups g ON g.id = a.route_group_id
 WHERE a.id = $1 AND g.network_id = $2;
 
--- name: UpsertRouteAssignment :execrows
+-- name: UpsertRouteAssignment :one
 -- Record which candidate a device says it is currently using.
 --
 -- An observation, never an instruction. ADR-0003 gives the server authorisation and order
@@ -180,7 +180,12 @@ WHERE a.id = $1 AND g.network_id = $2;
 -- on every heartbeat, and an UPDATE that ran each time would write a row per device per
 -- group every twenty-five seconds — the write rate ADR-0012 exists to keep away from the
 -- tables holding desired state. Unchanged reports now cost a conflict check and nothing
--- else, and the row count tells the caller whether anything actually moved.
+-- else, and no row comes back at all when nothing moved.
+--
+-- The version is returned because it says which kind of change this was without a second
+-- query: 1 is a device recording a choice for the first time, and anything higher is a
+-- device that moved. Only the second is worth an audit event — the first happens on every
+-- enrolment and describes nothing going wrong.
 INSERT INTO route_assignments (
     membership_id, route_group_id, advertiser_id, reason, decided_locally
 ) VALUES ($1, $2, $3, $4, true)
@@ -190,7 +195,8 @@ SET advertiser_id   = EXCLUDED.advertiser_id,
     decided_locally = true,
     version         = route_assignments.version + 1,
     assigned_at     = now()
-WHERE route_assignments.advertiser_id IS DISTINCT FROM EXCLUDED.advertiser_id;
+WHERE route_assignments.advertiser_id IS DISTINCT FROM EXCLUDED.advertiser_id
+RETURNING version;
 
 -- name: CountRouteAssignments :many
 -- How many devices report currently using each candidate, per group.


### PR DESCRIPTION
The other half of ADR-0003's sentence. [#123](https://github.com/meshpnet/meshp/pull/123) built the recording — what is carrying *now* — and left the history with nowhere to live but a log line that rotates away.

## Emitted only on a move

The upsert returns `version`, which separates the two cases without a second query: **1** is a device recording a choice for the first time, which happens on every enrolment and describes nothing going wrong; **anything higher** is a device that moved. No row comes back at all when the choice is unchanged, which is most reports. Both are tested — five identical reports produce no events.

Filed as `actor_kind = 'device'`, not `'system'`. The schema's comment on that value predates ADR-0003 and assumed failover was the control plane's doing; the ADR moved the choice to the agent, so crediting the control plane would name the wrong actor for the one decision here nobody at the control plane made. The device's name goes in `actor_label` — an audit line of bare UUIDs is one nobody reads.

Two extra reads (the organisation to file under, the device's name), and only ever on a move.

## A defect in #123, found writing this

**#123 took the route group from the agent's message.** Nothing in the schema ties `advertiser_id` to `route_group_id`, so a device could have filed an advertiser from one group as its choice in another — and the pair would have stayed wrong, with nothing to notice.

The group now comes from the advertiser row, which `GetAdvertiserForReport` already reads under the session's network scope and is the only end that can tie the two together. `ObserveRequest` no longer takes a group at all, so there is nothing left to pass wrongly. Tested: an assignment lands under the advertiser's own group and not under a second group in the same network.

That one is on me — #123 was merged three commits ago and I wrote the code that trusted the message.

## Not done, and worth saying

**Nothing reads `audit_events` over the API.** Three call sites write there and only a test has ever read one back. This does not widen that gap, but "auditable" currently means "queryable in `psql`", and the honest version of this feature includes somewhere to see it. Separate work — it needs an endpoint, pagination and a decision about who may read another tenant's trail.

## Verified

Full suite against a local PostgreSQL, lint clean, and `make sqlc` produces no diff — which the check added in #123 now enforces.