### PR TITLE
feat(api): the audit trail has a reader

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -133,6 +133,26 @@ curl -fsS -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
   their job. Returning is expensive — every connection through the tunnel drops again — so
   the policy is deliberately slower in that direction.
 
+## Why did my outbound IP change?
+
+Ask the audit trail. A device that moves itself between candidates says why, and the control
+plane records it (ADR-0003):
+
+```bash
+curl -fsS -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  "https://control.example.com/api/v1/networks/$NETWORK/audit?limit=20"
+```
+
+Look for `route.switched`. The `metadata` carries the agent's own words in `reason`, the
+candidate it left in `switched_from`, and the one it moved to. `actor_label` is the device
+that decided — the choice is the agent's, not the control plane's, so the trail names the
+machine that made it.
+
+The same endpoint holds enrolments, revocations and policy publications. It pages newest
+first: pass the `next_before` from one response as `?before=` to get the next page. There is
+no page number on purpose — events are only ever appended, so an offset would shift under
+you while you read.
+
 ## An API call is refused and I do not know why
 
 Refusals caused by what you sent carry the reason:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -136,6 +136,12 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	// its cross-tenant roll-up on it, so its shape is not this page's to choose.
 	mux.Handle("GET /api/v1/networks/{networkID}/overview", s.readable(s.handleNetworkOverview))
 
+	// The audit trail, which four subsystems have been writing to and nothing has read
+	// back. Behind the administrative token rather than `readable`: ADR-0022 §5 scopes the
+	// browser's cookie to the endpoints it names, and widening a credential is not
+	// something a new route should do on its own.
+	mux.Handle("GET /api/v1/networks/{networkID}/audit", s.adminOnly(s.handleListAuditEvents))
+
 	// Signing in, which is the only route that takes the administrative token in a body.
 	// Rate limited with the enrolment endpoints: it is the one place a wrong secret can be
 	// guessed at, and while guessing a 32-byte secret is not a real threat, an endpoint

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/google/uuid"
+
+	"github.com/meshpnet/meshp/internal/httpx"
+	dbgen "github.com/meshpnet/meshp/internal/store/gen"
+)
+
+// auditPageParams builds the query's arguments. The network id is a pointer in the
+// generated params because the column is nullable — an event whose network was deleted
+// keeps its record — so it is taken by address here rather than at three call sites.
+func auditPageParams(networkID uuid.UUID, before int64, limit int) dbgen.PageAuditEventsForNetworkParams {
+	return dbgen.PageAuditEventsForNetworkParams{
+		NetworkID: &networkID,
+		Before:    before,
+		PageSize:  int32(limit),
+	}
+}
+
+// Audit page bounds.
+//
+// A default small enough to read and a ceiling that stops one request asking the database
+// for a network's entire history. A caller wanting all of it pages, which is also what makes
+// the response size predictable for the commercial layer reading many networks on a timer.
+const (
+	defaultAuditPage = 50
+	maxAuditPage     = 500
+)
+
+// handleListAuditEvents answers what has happened in a network.
+//
+// Three subsystems have been writing here since the beginning — enrolment, policy
+// publication, revocation — and since #124 a device moving itself between candidates. Only
+// a test had ever read one back, so "auditable" meant "queryable in psql" and the record
+// that answers "why did my outbound IP change?" was reachable only by whoever had the
+// database (ADR-0018).
+//
+// Behind the administrative token rather than the browser's cookie. ADR-0022 §5 scopes that
+// cookie to the read endpoints it names, and widening it is a decision about a credential
+// rather than a route to be added quietly — see the note in the ADR.
+func (s *Server) handleListAuditEvents(w http.ResponseWriter, r *http.Request) {
+	networkID, ok := s.pathUUID(w, r, "networkID")
+	if !ok {
+		return
+	}
+	limit, ok := s.auditLimit(w, r)
+	if !ok {
+		return
+	}
+	before, ok := s.auditCursor(w, r)
+	if !ok {
+		return
+	}
+
+	// One more than asked for, so the response can say whether there is another page
+	// without a second query and without a count over the whole table.
+	rows, err := s.store.Queries().PageAuditEventsForNetwork(r.Context(), auditPageParams(networkID, before, limit+1))
+	if err != nil {
+		s.respondError(w, r, err)
+		return
+	}
+
+	more := len(rows) > limit
+	if more {
+		rows = rows[:limit]
+	}
+
+	out := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		event := map[string]any{
+			"id":         strconv.FormatInt(row.ID, 10),
+			"at":         row.CreatedAt.UTC(),
+			"actor_kind": row.ActorKind,
+			"action":     row.Action,
+		}
+		if row.ActorLabel != "" {
+			event["actor_label"] = row.ActorLabel
+		}
+		if row.ActorID != nil {
+			event["actor_id"] = row.ActorID
+		}
+		if row.ResourceKind != "" {
+			event["resource_kind"] = row.ResourceKind
+		}
+		if row.ResourceID != nil {
+			event["resource_id"] = row.ResourceID
+		}
+		if row.SourceIp != nil {
+			event["source_ip"] = row.SourceIp.String()
+		}
+		// Passed through as the object it is rather than as an escaped string. Every writer
+		// puts a JSON object here, and re-encoding it would hand a reader something it has
+		// to parse twice.
+		if len(row.Metadata) > 0 {
+			event["metadata"] = json.RawMessage(row.Metadata)
+		}
+		out = append(out, event)
+	}
+
+	body := map[string]any{"events": out}
+	if more && len(rows) > 0 {
+		// The cursor for the next page, rather than a page number. Events are only ever
+		// appended, so an offset would shift under a caller reading a busy network — the
+		// one situation where a page of history is most likely to be read.
+		body["next_before"] = strconv.FormatInt(rows[len(rows)-1].ID, 10)
+	}
+	httpx.WriteJSON(w, s.log, http.StatusOK, body)
+}
+
+// auditLimit reads ?limit=.
+func (s *Server) auditLimit(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := r.URL.Query().Get("limit")
+	if raw == "" {
+		return defaultAuditPage, true
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request",
+			"limit must be a positive whole number")
+		return 0, false
+	}
+	if n > maxAuditPage {
+		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request",
+			"limit may be at most "+strconv.Itoa(maxAuditPage))
+		return 0, false
+	}
+	return n, true
+}
+
+// auditCursor reads ?before=, which is an id from a previous response.
+//
+// Refused rather than ignored when it will not parse. A cursor silently treated as "start
+// again from the newest" would make a paging caller loop over the first page forever while
+// looking like it was making progress.
+func (s *Server) auditCursor(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	raw := r.URL.Query().Get("before")
+	if raw == "" {
+		return 0, true
+	}
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || n < 0 {
+		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request",
+			"before must be an id from a previous response")
+		return 0, false
+	}
+	return n, true
+}

--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -1,0 +1,192 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	dbgen "github.com/meshpnet/meshp/internal/store/gen"
+)
+
+// writeAuditEvents puts n events in the network, all in one transaction.
+//
+// One transaction on purpose: created_at defaults to the transaction's timestamp, so every
+// row written here shares it exactly. That is the case a timestamp cursor gets wrong, and it
+// is not contrived — the events this table already holds are written alongside the act they
+// describe, so a revocation and its policy change land together.
+func writeAuditEvents(t *testing.T, h *harness, n int) {
+	t.Helper()
+	netID := h.netID
+	err := h.store.InTx(h.ctx, func(q *dbgen.Queries) error {
+		for i := range n {
+			metadata, _ := json.Marshal(map[string]any{"sequence": i, "reason": "because"})
+			if _, err := q.CreateAuditEvent(h.ctx, dbgen.CreateAuditEventParams{
+				NetworkID:    &netID,
+				ActorKind:    "device",
+				ActorLabel:   fmt.Sprintf("device-%d", i),
+				Action:       "route.switched",
+				ResourceKind: "route_group",
+				Metadata:     metadata,
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type auditPage struct {
+	Events []struct {
+		ID         string          `json:"id"`
+		Action     string          `json:"action"`
+		ActorKind  string          `json:"actor_kind"`
+		ActorLabel string          `json:"actor_label"`
+		Metadata   json.RawMessage `json:"metadata"`
+	} `json:"events"`
+	NextBefore string `json:"next_before"`
+}
+
+func getAudit(t *testing.T, h *harness, query string) auditPage {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet,
+		h.server.URL+"/api/v1/networks/"+h.netID.String()+"/audit"+query, nil)
+	req.Header.Set("Authorization", "Bearer "+testAdminToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET audit%s = %d: %s", query, resp.StatusCode, body)
+	}
+	var page auditPage
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		t.Fatal(err)
+	}
+	return page
+}
+
+// Four subsystems have been writing here since the beginning and only a test ever read one
+// back, so "auditable" meant "queryable in psql".
+func TestTheAuditTrailIsReadable(t *testing.T) {
+	h := newHarness(t)
+	writeAuditEvents(t, h, 3)
+
+	page := getAudit(t, h, "")
+	if len(page.Events) != 3 {
+		t.Fatalf("%d events, want 3", len(page.Events))
+	}
+	if page.Events[0].Action != "route.switched" {
+		t.Errorf("action = %q", page.Events[0].Action)
+	}
+	// Newest first: the last one written comes back first.
+	if page.Events[0].ActorLabel != "device-2" {
+		t.Errorf("first event is %q, want the newest (device-2)", page.Events[0].ActorLabel)
+	}
+	// An object, not a string holding an object. A reader should not have to parse twice.
+	var metadata map[string]any
+	if err := json.Unmarshal(page.Events[0].Metadata, &metadata); err != nil {
+		t.Fatalf("metadata is not an object: %v (%s)", err, page.Events[0].Metadata)
+	}
+	if metadata["reason"] != "because" {
+		t.Errorf("metadata = %v, want the writer's own fields", metadata)
+	}
+}
+
+// Paging repeats nothing and skips nothing, including across events that share a timestamp
+// exactly — which is why the cursor is an id.
+func TestPagingTheAuditTrailLosesNothing(t *testing.T) {
+	h := newHarness(t)
+	writeAuditEvents(t, h, 10)
+
+	seen := map[string]bool{}
+	cursor := ""
+	for pages := 0; ; pages++ {
+		if pages > 10 {
+			t.Fatal("paging did not terminate")
+		}
+		query := "?limit=3"
+		if cursor != "" {
+			query += "&before=" + cursor
+		}
+		page := getAudit(t, h, query)
+		for _, event := range page.Events {
+			if seen[event.ID] {
+				t.Fatalf("event %s came back twice", event.ID)
+			}
+			seen[event.ID] = true
+		}
+		if page.NextBefore == "" {
+			break
+		}
+		cursor = page.NextBefore
+	}
+	if len(seen) != 10 {
+		t.Errorf("saw %d events across every page, want 10", len(seen))
+	}
+}
+
+// The last page says so by omitting the cursor, rather than by returning an empty page after
+// it — a caller should not have to make one more request to learn there was nothing left.
+func TestTheLastPageSaysItIsTheLast(t *testing.T) {
+	h := newHarness(t)
+	writeAuditEvents(t, h, 3)
+
+	if page := getAudit(t, h, "?limit=3"); page.NextBefore != "" {
+		t.Errorf("next_before = %q on a page holding everything, want it absent", page.NextBefore)
+	}
+	if page := getAudit(t, h, "?limit=2"); page.NextBefore == "" {
+		t.Error("next_before is absent while an event remains unread")
+	}
+}
+
+// A cursor that will not parse is refused rather than ignored. Treating it as "start from
+// the newest" would make a paging caller loop over the first page while looking busy.
+func TestABadCursorIsRefused(t *testing.T) {
+	h := newHarness(t)
+	for _, query := range []string{"?before=nonsense", "?before=-1", "?limit=0", "?limit=100000"} {
+		req, _ := http.NewRequest(http.MethodGet,
+			h.server.URL+"/api/v1/networks/"+h.netID.String()+"/audit"+query, nil)
+		req.Header.Set("Authorization", "Bearer "+testAdminToken)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("GET audit%s = %d, want 400", query, resp.StatusCode)
+		}
+	}
+}
+
+// The browser's cookie does not reach this. ADR-0022 §5 scopes it to the endpoints it names,
+// and an audit trail carries more than the overview does — actor labels, source addresses,
+// and the reasons an administrator gave.
+func TestTheAuditTrailNeedsTheAdministrativeToken(t *testing.T) {
+	h := newHarness(t)
+
+	resp, err := http.Get(h.server.URL + "/api/v1/networks/" + h.netID.String() + "/audit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status without a credential = %d, want 401", resp.StatusCode)
+	}
+}
+
+// A network with no history is an empty list, not a 404. "Nothing has happened here" and
+// "there is no such network" read the same to a caller that only sees a status code.
+func TestAnEmptyAuditTrailIsAnEmptyList(t *testing.T) {
+	h := newHarness(t)
+	page := getAudit(t, h, "")
+	if len(page.Events) != 0 {
+		t.Errorf("%d events in a network where nothing has happened", len(page.Events))
+	}
+}

--- a/internal/store/gen/devices.sql.go
+++ b/internal/store/gen/devices.sql.go
@@ -493,6 +493,62 @@ func (q *Queries) ListMembershipsForNetwork(ctx context.Context, networkID uuid.
 	return items, nil
 }
 
+const pageAuditEventsForNetwork = `-- name: PageAuditEventsForNetwork :many
+SELECT id, organization_id, network_id, actor_kind, actor_id, actor_label, action, resource_kind, resource_id, source_ip, metadata, created_at FROM audit_events
+WHERE network_id = $1
+  AND ($2::bigint = 0 OR id < $2::bigint)
+ORDER BY id DESC
+LIMIT $3
+`
+
+type PageAuditEventsForNetworkParams struct {
+	NetworkID *uuid.UUID
+	Before    int64
+	PageSize  int32
+}
+
+// One page of a network's audit trail, newest first.
+//
+// Keyed on the id rather than on a timestamp. created_at has no uniqueness and two events
+// written in the same transaction share it exactly, so a timestamp cursor would either
+// repeat them on the next page or skip them — and this is the one table where a reader
+// silently missing a row defeats the purpose of having it.
+//
+// The id is a bigserial, so ordering by it descending is the same order as by time for
+// everything a caller can observe. A cursor of zero starts at the newest.
+func (q *Queries) PageAuditEventsForNetwork(ctx context.Context, arg PageAuditEventsForNetworkParams) ([]AuditEvent, error) {
+	rows, err := q.db.Query(ctx, pageAuditEventsForNetwork, arg.NetworkID, arg.Before, arg.PageSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []AuditEvent
+	for rows.Next() {
+		var i AuditEvent
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.NetworkID,
+			&i.ActorKind,
+			&i.ActorID,
+			&i.ActorLabel,
+			&i.Action,
+			&i.ResourceKind,
+			&i.ResourceID,
+			&i.SourceIp,
+			&i.Metadata,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const revokeMembership = `-- name: RevokeMembership :one
 UPDATE device_network_memberships m
 SET state = 'revoked', revoked_at = now()

--- a/queries/devices.sql
+++ b/queries/devices.sql
@@ -78,6 +78,22 @@ WHERE network_id = $1
 ORDER BY created_at DESC, id DESC
 LIMIT $2;
 
+-- name: PageAuditEventsForNetwork :many
+-- One page of a network's audit trail, newest first.
+--
+-- Keyed on the id rather than on a timestamp. created_at has no uniqueness and two events
+-- written in the same transaction share it exactly, so a timestamp cursor would either
+-- repeat them on the next page or skip them — and this is the one table where a reader
+-- silently missing a row defeats the purpose of having it.
+--
+-- The id is a bigserial, so ordering by it descending is the same order as by time for
+-- everything a caller can observe. A cursor of zero starts at the newest.
+SELECT * FROM audit_events
+WHERE network_id = $1
+  AND (sqlc.arg(before)::bigint = 0 OR id < sqlc.arg(before)::bigint)
+ORDER BY id DESC
+LIMIT sqlc.arg(page_size);
+
 -- name: RevokeMembership :one
 -- Take a device out of a network, and say which key stopped being a peer.
 --


### PR DESCRIPTION
Four subsystems have written audit events since the beginning — enrolment, policy publication, revocation, and since [#124](https://github.com/meshpnet/meshp/pull/124) a device moving itself between candidates. Only a test had ever read one back, so "auditable" meant "queryable in `psql`".

`GET /api/v1/networks/{id}/audit`, newest first, with `?limit=` and `?before=`.

## The cursor is an id, not a timestamp

`created_at` has no uniqueness, and two events written in the same transaction share it **exactly**. That is not contrived — these are written alongside the act they describe, so a revocation and its state bump land together. A timestamp cursor would either repeat those rows or skip them, and this is the one table where a reader silently missing a row defeats the point of having it.

There is no page number either: events are only ever appended, so an offset shifts under a caller reading a busy network, which is precisely when someone reads a page of history. The paging test writes ten events in one transaction — all sharing a timestamp — and asserts that walking every page repeats nothing and loses nothing.

## A decision worth pushing back on

**This is behind the administrative token, not the browser's cookie.** ADR-0022 §5 scopes that cookie to the read endpoints it names, and an audit trail carries more than the overview does: actor labels, source addresses, and the reasons administrators typed.

So the page cannot show this. That is deliberate, not overlooked — but it is arguably the wrong call, and the argument against me is decent: §5's actual reasoning was about blast radius before real accounts exist ("a stolen browser session reads one network"), and one network's history is within one network. If you want the trail on the page, the honest route is amending §5 to scope the cookie by *kind* (network-scoped reads) rather than by an endpoint list — which would also stop every future read endpoint needing an ADR amendment. I did not want to make that change inside a PR titled "the audit trail has a reader".

## Smaller things

Metadata comes back as the object it is, not a string holding an object — every writer puts JSON there and re-encoding would hand each reader a second parse. A bad cursor is a 400 rather than being ignored: silently treating it as "start from the newest" would make a paging caller loop over page one while looking like it was working. An empty trail is an empty list, not a 404.

`docs/troubleshooting.md` gains a "Why did my outbound IP change?" section, which is the question ADR-0003 and the schema both name as the reason this record exists.

## Verified

Full suite against a local PostgreSQL, lint clean, `make sqlc` produces no diff.