### PR TITLE
feat(web): the page shows why something moved

### DIFF
--- a/docs/adr/0022-web-view-in-the-control-plane.md
+++ b/docs/adr/0022-web-view-in-the-control-plane.md
@@ -114,14 +114,31 @@ cookie: `HttpOnly`, `Secure`, `SameSite=Strict`, short-lived, revocable server-s
 `DELETE` on the same path logs out. The token itself never reaches JavaScript and is never
 stored in the browser.
 
-**The cookie authorises the read endpoints in Decision 1 and nothing else.** It is a
-strictly weaker credential derived from the administrative one. Every existing route keeps
-requiring the bearer token.
+**The cookie authorises reads scoped to a network, and nothing else.** It is a strictly
+weaker credential derived from the administrative one. Every route that creates or changes
+something keeps requiring the bearer token, and so does anything that reads across networks
+or across organisations.
 
 That is what makes shipping this before real user accounts defensible, and it is the whole
 of the justification: a stolen browser session reads one network. The moment the UI grows
 a write path, per-user accounts stop being a follow-up and become a prerequisite — the
 tables are already in the schema waiting for a reader.
+
+*Amended 2026-08-21.* This originally named the endpoints in Decision 1 and nothing else,
+which was the wrong granularity and showed it the first time another read arrived: the
+audit trail (#125) shipped behind the administrative token purely because it was not on a
+list, leaving the page unable to answer "why did my outbound IP change?" while the record
+that answers it sat one route away. The boundary that carries the argument is read against
+write, not which reads — a list makes every future read endpoint an ADR amendment, and an
+amendment made to unblock a feature is one nobody weighs properly. Scoping by kind keeps
+the property that matters, which is that this credential cannot change anything and cannot
+see past the network it was opened on.
+
+What that admits: the audit trail carries more than the overview does — actor labels,
+source addresses, the reasons administrators typed. A stolen session now reads one
+network's history as well as its state. That is a real widening, accepted because it is the
+same kind of exposure rather than a new one, and because the alternative was a product that
+cannot show an operator why their traffic moved.
 
 The login endpoint refuses to mint a cookie over plaintext to anything but loopback. TLS
 is already supported both ways (`MESHP_TLS_CERT`, or `MESHP_TLS_DOMAINS` for automatic

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -136,11 +136,10 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	// its cross-tenant roll-up on it, so its shape is not this page's to choose.
 	mux.Handle("GET /api/v1/networks/{networkID}/overview", s.readable(s.handleNetworkOverview))
 
-	// The audit trail, which four subsystems have been writing to and nothing has read
-	// back. Behind the administrative token rather than `readable`: ADR-0022 §5 scopes the
-	// browser's cookie to the endpoints it names, and widening a credential is not
-	// something a new route should do on its own.
-	mux.Handle("GET /api/v1/networks/{networkID}/audit", s.adminOnly(s.handleListAuditEvents))
+	// The audit trail. Readable by the browser as of the amendment to ADR-0022 §5: the
+	// cookie is scoped to reads within one network, and this is one — it carries more than
+	// the overview does, and it carries it about the same network.
+	mux.Handle("GET /api/v1/networks/{networkID}/audit", s.readable(s.handleListAuditEvents))
 
 	// Signing in, which is the only route that takes the administrative token in a body.
 	// Rate limited with the enrolment endpoints: it is the one place a wrong secret can be

--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -165,10 +165,9 @@ func TestABadCursorIsRefused(t *testing.T) {
 	}
 }
 
-// The browser's cookie does not reach this. ADR-0022 §5 scopes it to the endpoints it names,
-// and an audit trail carries more than the overview does — actor labels, source addresses,
-// and the reasons an administrator gave.
-func TestTheAuditTrailNeedsTheAdministrativeToken(t *testing.T) {
+// Some credential is required. The trail carries actor labels, source addresses and the
+// reasons administrators typed, and none of that is public.
+func TestTheAuditTrailNeedsACredential(t *testing.T) {
 	h := newHarness(t)
 
 	resp, err := http.Get(h.server.URL + "/api/v1/networks/" + h.netID.String() + "/audit")
@@ -178,6 +177,43 @@ func TestTheAuditTrailNeedsTheAdministrativeToken(t *testing.T) {
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("status without a credential = %d, want 401", resp.StatusCode)
+	}
+}
+
+// And the browser's cookie is one of them, as of the amendment to ADR-0022 §5: that cookie
+// is scoped to reads within one network, and this is one. It shipped behind the
+// administrative token in #125 purely because §5 named endpoints rather than a kind, which
+// left the page unable to answer "why did my outbound IP change?" while the record that
+// answers it sat one route away.
+func TestABrowserSessionReachesTheAuditTrail(t *testing.T) {
+	h := newHarness(t)
+	writeAuditEvents(t, h, 1)
+
+	resp := h.withCookie(http.MethodGet, "/api/v1/networks/"+h.netID.String()+"/audit", h.login())
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("a browser session reading the audit trail = %d, want 200", resp.StatusCode)
+	}
+
+	var page auditPage
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Events) != 1 {
+		t.Errorf("%d events, want 1", len(page.Events))
+	}
+}
+
+// The widening is to reads within one network and no further. Everything that changes
+// something still needs the bearer token, which is the property the whole of §5 rests on.
+func TestABrowserSessionStillCannotWrite(t *testing.T) {
+	h := newHarness(t)
+
+	resp := h.withCookie(http.MethodPost,
+		"/api/v1/networks/"+h.netID.String()+"/enrollment-tokens", h.login())
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("a browser session minting an enrolment token = %d, want 401", resp.StatusCode)
 	}
 }
 

--- a/migrations/0008_audit_paging_index.sql
+++ b/migrations/0008_audit_paging_index.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+
+-- The audit trail is paged by id, and nothing indexed that.
+--
+-- The existing index is on (network_id, created_at DESC), which was right while the only
+-- reader was a `LIMIT` on the newest few. Paging keys on the id instead, because created_at
+-- has no uniqueness and events written in one transaction share it exactly — so a timestamp
+-- cursor repeats or skips rows. That left `ORDER BY id DESC` filtering by network through
+-- one index and then sorting, which is fine on a young deployment and is the wrong shape to
+-- leave behind: this table only grows, and the page now reads it on every poll.
+CREATE INDEX audit_events_network_id_idx ON audit_events (network_id, id DESC);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS audit_events_network_id_idx;

--- a/web/app.css
+++ b/web/app.css
@@ -186,3 +186,19 @@ button.primary {
 
 .picker { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
 .picker label { color: var(--muted); font-size: 13px; }
+
+/* The audit trail. A list rather than a table: the interesting column is the last one, and
+   a table would give equal width to a timestamp nobody reads twice. */
+.events { margin: 0; padding: 0; list-style: none; }
+.event {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: baseline;
+  padding: 7px 0;
+  border-top: 1px solid var(--line);
+}
+.event:first-child { border-top: none; }
+.event .when { color: var(--muted); font-size: 12px; white-space: nowrap; }
+.event .who { font-weight: 500; }
+.event .why { color: var(--muted); font-size: 13px; }

--- a/web/app.js
+++ b/web/app.js
@@ -287,7 +287,7 @@ function renderDevices(devices) {
   return el("div", { class: "scroll" }, table);
 }
 
-function renderOverview(data, networks) {
+function renderOverview(data, networks, history) {
 
   // Devices with something wrong first. A list sorted by name buries the one device the
   // page exists to surface somewhere in the middle of forty that are fine.
@@ -316,6 +316,56 @@ function renderOverview(data, networks) {
             "This network holds more devices than are shown. The list above is cut, not short.",
           )
         : null,
+    ),
+    el("h2", {}, "What has happened"),
+    renderHistory(history),
+  );
+}
+
+// What an action is, in words. Unknown codes render as themselves rather than being hidden
+// or guessed at: a new one is a line somebody should see, not a line that quietly vanishes.
+const ACTIONS = {
+  "device.enrolled": "joined the network",
+  "device.revoked": "was removed from the network",
+  "policy.published": "published a policy",
+  "route.switched": "moved to another candidate",
+};
+
+/** The audit trail, newest first. */
+function renderHistory(history) {
+  if (history === null) {
+    return el("div", { class: "panel note" }, "The history could not be read just now.");
+  }
+  if (!history.length) {
+    return el("div", { class: "panel note" }, "Nothing has been recorded for this network yet.");
+  }
+
+  const rows = history.map((event) => {
+    const metadata = event.metadata || {};
+    const bits = [];
+    // The agent's own account of why it moved, which is the whole reason this record
+    // exists — the schema describes it as what answers "why did my outbound IP change?".
+    if (metadata.reason) bits.push(metadata.reason);
+    if (metadata.switched_from) bits.push("was on another candidate");
+
+    return el(
+      "li",
+      { class: "event" },
+      el("span", { class: "when mono" }, new Date(event.at).toLocaleString()),
+      el("span", { class: "who" }, event.actor_label || event.actor_kind),
+      el("span", {}, ACTIONS[event.action] || event.action),
+      bits.length ? el("span", { class: "why" }, bits.join(" · ")) : null,
+    );
+  });
+
+  return el(
+    "div",
+    { class: "panel" },
+    el("ul", { class: "events" }, rows),
+    el(
+      "p",
+      { class: "note" },
+      "The ten most recent. The whole trail is at /api/v1/networks/{id}/audit, newest first.",
     ),
   );
 }
@@ -432,12 +482,35 @@ function stopPolling() {
   pollTimer = null;
 }
 
+/**
+ * The audit trail is read separately from the overview, and that is not the mistake
+ * ADR-0022 §1 rules out.
+ *
+ * That rule is about current state: devices from one instant beside route groups from
+ * another render a network that never existed. History cannot do that. Events are appended
+ * and never change, so a page of them read a moment later than the state beside it says the
+ * same thing it would have said a moment earlier — the two panels do not describe one
+ * instant and are not presented as though they do.
+ *
+ * Failing is not fatal. The question this page exists to answer is in the overview; the
+ * history is context, and losing it should not blank a screen somebody is reading during an
+ * outage.
+ */
+async function fetchHistory(networkID) {
+  try {
+    const body = await api(`/api/v1/networks/${encodeURIComponent(networkID)}/audit?limit=10`);
+    return body.events || [];
+  } catch {
+    return null;
+  }
+}
+
 async function poll(networkID, networks) {
   try {
     const data = await api(`/api/v1/networks/${encodeURIComponent(networkID)}/overview`);
     lastGood = data;
     lastGoodAt = Date.now();
-    renderOverview(data, networks);
+    renderOverview(data, networks, await fetchHistory(networkID));
     renderFreshness(null);
     // The server decides how often it is asked, so a deployment under load can slow its
     // pages down without shipping a new one.


### PR DESCRIPTION
Amends ADR-0022 §5 and puts the audit trail on the page, as discussed on [#125](https://github.com/meshpnet/meshp/pull/125).

## The amendment

§5 scoped the browser's cookie to "the read endpoints in Decision 1 and nothing else". That was the wrong granularity, and it showed the first time another read arrived: #125 shipped the audit trail behind the administrative token purely because it was not on a list — leaving the page unable to answer *"why did my outbound IP change?"* while the record that answers it sat one route away.

The boundary that carries §5's argument is **read against write**, not which reads. A list makes every future read endpoint an ADR amendment, and an amendment made to unblock a feature is one nobody weighs properly.

The cookie is now scoped to reads within one network. **What that admits is written into the ADR rather than left implied:** the trail carries actor labels, source addresses and the reasons administrators typed, so a stolen browser session now reads one network's history as well as its state. That is a real widening, accepted because it is the same kind of exposure rather than a new one. Everything that changes something still needs the bearer token, and there is a test asserting a browser session cannot mint an enrolment token.

## Two reads, and why that is not the thing §1 forbids

ADR-0022 §1 requires one snapshot from one transaction because a page assembling **current state** from several polls renders a network that never existed — a device down beside the route group it advertises for shown healthy.

History cannot do that. Events are appended and never change, so a page of them read a moment later says exactly what it would have said a moment earlier. The two panels are not presented as describing one instant. A failed history read leaves the rest of the page alone: the question this page exists to answer is in the overview, and losing context should not blank a screen somebody is reading during an outage.

## Migration 0008

Paging keys on the event id, because `created_at` has no uniqueness. The existing index is on `(network_id, created_at DESC)`, so `ORDER BY id DESC` was filtering through one index and then sorting — fine on a young deployment, and the wrong shape to leave on a table that only grows and is now read on every poll. Round trip verified with `make migrate-check`.

## Smaller things

An unknown action renders as its own code rather than being hidden or guessed at — a new one is a line somebody should see. Verified in the browser with a deliberately unrecognised action alongside the four real ones; `route.switched` reads as "moved to another candidate" followed by the agent's own reason.

## Verified

Full suite against a local PostgreSQL, `make migrate-check`, lint, and the reachability check. Drove the page against canned responses covering all four known actions, an unknown one, and a failed history read.