### PR TITLE
docs(reachability): say why the relays table is unread

### DIFF
--- a/scripts/reachability-allow
+++ b/scripts/reachability-allow
@@ -23,9 +23,19 @@ table:role_bindings    — as above
 table:groups           — as above
 table:group_members    — as above
 
-# --- configuration overtook the table ------------------------------------------------------
+# --- deferred with a stated trigger --------------------------------------------------------
 #
-table:relays           — relays come from MESHP_RELAYS; whether this table should exist at all is an open question
+# Not forgotten and not an open question, which is what this entry used to claim. The
+# decision is recorded where the code makes it, in ParseRelays: "Configuration rather than a
+# database table for now. A table is right eventually — relays will have regions and health —
+# but a deployment with one relay should not need a migration to name it."
+#
+# Neither half of that trigger exists: nothing reads a relay's region, and there is no relay
+# health at all, which is why last_seen_at has no writer either. What the deferral costs is
+# worth knowing before somebody picks this up: taking a relay out of service means editing
+# MESHP_RELAYS and restarting the control plane, all-or-nothing, because 'draining' lives in
+# this table and nothing reads it. Tracked in #128.
+table:relays           — configuration overtook it, deliberately; see ParseRelays and #128
 
 
 # --- direct paths -------------------------------------------------------------------------


### PR DESCRIPTION
The allowlist entry for `relays` said "whether this table should exist at all is an open question". It is not open. `ParseRelays` records the decision where the code makes it:

> Configuration rather than a database table for now. A table is right eventually — relays will have regions and health — but a deployment with one relay should not need a migration to name it.

**I wrote that entry in [#122](https://github.com/meshpnet/meshp/pull/122) without reading the parser**, which is the exact failure the allowlist exists to prevent. An entry whose reason is a guess is worse than no entry, because it looks like somebody checked.

The entry now cites the reason, names the trigger — regions and health, neither of which exists — and records what the deferral costs: taking a relay out of service means editing `MESHP_RELAYS` and restarting the control plane, all-or-nothing, because `draining` lives in the unread table.

Tracked as [#128](https://github.com/meshpnet/meshp/issues/128), so the deferral lives somewhere findable rather than in a comment and an allowlist line — which is how "eventually" becomes "never".

## Why not build the registry

Asked to do what is best for the product, and this is it. A registry adds public API surface that ADR-0009 makes the commercial layer's to depend on, and ADR-0023 has just established such surface cannot be reshaped freely afterwards — for a capability nobody needs yet, in a pre-alpha project whose README says not to deploy it and whose deployments run one relay.

Today's other work removed five mechanisms that were built ahead of their consumers. Building this one now would be the same mistake with better intentions.

One thing found while deciding: `RelayConfig.Relay.public_key` is never set and never read either, so the proto field is ahead of its code the same way the table is. Nothing is broken by that today; it is noted in #128 because it means the whole relay area is written ahead of use rather than behind it.