### PR TITLE
fix(prefixmap): a mapped range must not land on a reachable network

### DIFF
--- a/internal/store/gen/prefixmappings.sql.go
+++ b/internal/store/gen/prefixmappings.sql.go
@@ -228,7 +228,24 @@ UNION ALL
 SELECT mapped_prefix AS prefix
 FROM prefix_mappings
 WHERE organization_id = $1
+UNION ALL
+SELECT DISTINCT rgp.prefix
+FROM route_group_prefixes rgp
+JOIN route_groups rg ON rg.id = rgp.route_group_id
+JOIN networks n ON n.id = rg.network_id
+WHERE n.organization_id = $1
+  AND n.deleted_at IS NULL
+  -- Egress groups excluded for the reason CarriedPrefixesForDevice gives: the default route
+  -- overlaps everything, so counting it here would reserve the whole block and leave nothing
+  -- to allocate.
+  AND rg.kind <> 'egress'
+  AND rgp.prefix && $2::cidr
 `
+
+type SpokenForRangesInOrganizationParams struct {
+	OrganizationID uuid.UUID
+	Block          netip.Prefix
+}
 
 // Everything in this organisation a mapped range must not land on.
 //
@@ -236,11 +253,22 @@ WHERE organization_id = $1
 // a mapped range on top of one would be the same collision a level up with nothing left to
 // resolve it. Existing mapped ranges are the obvious other half.
 //
-// The customers' own prefixes are deliberately absent: they are the thing being mapped away
-// from, they already collide with each other, and refusing to allocate near them would rule
-// out the whole of RFC 1918 for no gain.
-func (q *Queries) SpokenForRangesInOrganization(ctx context.Context, organizationID uuid.UUID) ([]netip.Prefix, error) {
-	rows, err := q.db.Query(ctx, spokenForRangesInOrganization, organizationID)
+// The customers' own prefixes are mostly absent, and that is still deliberate: they are the
+// thing being mapped away from, they already collide with each other, and refusing to
+// allocate near them would rule out the whole of RFC 1918 for no gain.
+//
+// Mostly. A carried prefix that overlaps the mapped block itself is the exception, and it
+// was missed: the block is in CGNAT space (RFC 6598), so no RFC 1918 prefix can overlap it
+// and the argument above is untouched — but a customer already running something that uses
+// 100.64.0.0/10 has LANs exactly there. Allocating on top of one produces a mapped range
+// that shadows a network the device can genuinely reach, and the device cannot tell the
+// difference: both are prefixes it was told to route.
+//
+// Filtered by overlap rather than reserved wholesale, which is what keeps the first
+// paragraph true. A 10.0.0.0/8 carried by every customer in the organisation never reaches
+// this list.
+func (q *Queries) SpokenForRangesInOrganization(ctx context.Context, arg SpokenForRangesInOrganizationParams) ([]netip.Prefix, error) {
+	rows, err := q.db.Query(ctx, spokenForRangesInOrganization, arg.OrganizationID, arg.Block)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/prefixmap.go
+++ b/internal/store/prefixmap.go
@@ -109,7 +109,14 @@ func (s *Store) EnsureMappings(ctx context.Context, deviceID uuid.UUID, block ne
 	if err != nil {
 		return nil, fmt.Errorf("store: reading the device's organisation: %w", err)
 	}
-	spoken, err := q.SpokenForRangesInOrganization(ctx, org)
+	spoken, err := q.SpokenForRangesInOrganization(ctx, dbgen.SpokenForRangesInOrganizationParams{
+		OrganizationID: org,
+		// The block is passed so the query can reserve only the carried prefixes that could
+		// actually land on it. A customer LAN in RFC 1918 cannot overlap a block in CGNAT
+		// space and is not reserved; one inside 100.64.0.0/10 is, because a mapped range on
+		// top of it would shadow a network this device can genuinely reach.
+		Block: block,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("store: reading what is already spoken for: %w", err)
 	}

--- a/internal/store/prefixmap_test.go
+++ b/internal/store/prefixmap_test.go
@@ -248,3 +248,60 @@ func TestAnInactiveMembershipDoesNotCollide(t *testing.T) {
 		t.Errorf("mappings = %+v; only one network is live", got)
 	}
 }
+
+// A mapped range must not land on a network somebody can genuinely reach.
+//
+// The block is in CGNAT space, which is fine until a customer uses CGNAT space too — a
+// customer already running something built on 100.64.0.0/10 has LANs exactly there. A
+// mapped range allocated on top of one shadows a reachable network, and the device cannot
+// tell the two apart: both are prefixes it was told to route, and the mapping wins.
+//
+// RFC 1918 is deliberately not reserved, which the second half of this test holds in place:
+// reserving every carried prefix would rule out the whole private space for no gain.
+func TestAMappedRangeAvoidsACarriedPrefixInsideTheBlock(t *testing.T) {
+	w := seedMapWorld(t)
+	w.join(t, w.device, w.netA, "meshp0", "tech", "100.90.0.10/32")
+	w.join(t, w.device, w.netB, "meshp1", "tech", "100.90.1.10/32")
+
+	// The collision that needs mapping, in ordinary private space.
+	w.carry(t, w.netA, "lan-a", "192.168.1.0/24")
+	w.carry(t, w.netB, "lan-b", "192.168.1.0/24")
+
+	// And a third network in the same organisation whose LAN is inside the mapped block.
+	// Nothing about it collides; it is simply somewhere a mapped range must not go.
+	netC := w.network(t, "customer-c")
+	w.carry(t, netC, "lan-c", "100.71.0.0/24")
+
+	for _, mapping := range w.ensure(t) {
+		if mapping.Mapped.Overlaps(netip.MustParsePrefix("100.71.0.0/24")) {
+			t.Errorf("allocated %s, which lands on a customer LAN that is genuinely reachable",
+				mapping.Mapped)
+		}
+	}
+}
+
+// The RFC 1918 half of the same rule: a carried prefix that cannot overlap the block is not
+// reserved, so the allocator is not slowly starved by every customer LAN in the deployment.
+func TestPrivatePrefixesDoNotNarrowTheBlock(t *testing.T) {
+	w := seedMapWorld(t)
+	w.join(t, w.device, w.netA, "meshp0", "tech", "100.90.0.10/32")
+	w.join(t, w.device, w.netB, "meshp1", "tech", "100.90.1.10/32")
+	w.carry(t, w.netA, "lan-a", "192.168.1.0/24")
+	w.carry(t, w.netB, "lan-b", "192.168.1.0/24")
+
+	// A third customer carrying a very large private range. If this were reserved, it would
+	// take out nothing here — but the query that reserves it would be the wrong shape, and
+	// the assertion below is what says the filter is by overlap rather than wholesale.
+	netC := w.network(t, "customer-c")
+	w.carry(t, netC, "lan-c", "10.0.0.0/8")
+
+	got := w.ensure(t)
+	if len(got) == 0 {
+		t.Fatal("nothing was allocated for a real collision")
+	}
+	for _, mapping := range got {
+		if !DefaultMappedBlock.Overlaps(mapping.Mapped) {
+			t.Errorf("allocated %s, which is outside the block", mapping.Mapped)
+		}
+	}
+}

--- a/queries/prefixmappings.sql
+++ b/queries/prefixmappings.sql
@@ -36,9 +36,20 @@ ORDER BY network_id, prefix;
 -- a mapped range on top of one would be the same collision a level up with nothing left to
 -- resolve it. Existing mapped ranges are the obvious other half.
 --
--- The customers' own prefixes are deliberately absent: they are the thing being mapped away
--- from, they already collide with each other, and refusing to allocate near them would rule
--- out the whole of RFC 1918 for no gain.
+-- The customers' own prefixes are mostly absent, and that is still deliberate: they are the
+-- thing being mapped away from, they already collide with each other, and refusing to
+-- allocate near them would rule out the whole of RFC 1918 for no gain.
+--
+-- Mostly. A carried prefix that overlaps the mapped block itself is the exception, and it
+-- was missed: the block is in CGNAT space (RFC 6598), so no RFC 1918 prefix can overlap it
+-- and the argument above is untouched — but a customer already running something that uses
+-- 100.64.0.0/10 has LANs exactly there. Allocating on top of one produces a mapped range
+-- that shadows a network the device can genuinely reach, and the device cannot tell the
+-- difference: both are prefixes it was told to route.
+--
+-- Filtered by overlap rather than reserved wholesale, which is what keeps the first
+-- paragraph true. A 10.0.0.0/8 carried by every customer in the organisation never reaches
+-- this list.
 SELECT p.prefix
 FROM address_pools p
 JOIN networks n ON n.id = p.network_id
@@ -46,7 +57,19 @@ WHERE n.organization_id = $1 AND n.deleted_at IS NULL
 UNION ALL
 SELECT mapped_prefix AS prefix
 FROM prefix_mappings
-WHERE organization_id = $1;
+WHERE organization_id = $1
+UNION ALL
+SELECT DISTINCT rgp.prefix
+FROM route_group_prefixes rgp
+JOIN route_groups rg ON rg.id = rgp.route_group_id
+JOIN networks n ON n.id = rg.network_id
+WHERE n.organization_id = $1
+  AND n.deleted_at IS NULL
+  -- Egress groups excluded for the reason CarriedPrefixesForDevice gives: the default route
+  -- overlaps everything, so counting it here would reserve the whole block and leave nothing
+  -- to allocate.
+  AND rg.kind <> 'egress'
+  AND rgp.prefix && sqlc.arg(block)::cidr;
 
 -- name: InsertPrefixMapping :one
 -- Records where a colliding prefix is reached.


### PR DESCRIPTION
`EnsureMappings` built its reserved set from the organisation's address pools and the ranges already mapped. It did not include the prefixes customers actually carry — and the comment saying so gave a good reason:

> The customers' own prefixes are deliberately absent: they are the thing being mapped away from, they already collide with each other, and refusing to allocate near them would rule out the whole of RFC 1918 for no gain.

**That reasoning survives this change.** What it missed is the single case where a carried prefix can overlap the block at all.

The block is `100.71.0.0/16`, in CGNAT space (RFC 6598). No RFC 1918 prefix can overlap it, which is why reserving them wholesale would be pure loss. But a customer already running something built on `100.64.0.0/10` has LANs exactly there — and allocating on top of one produces a mapped range that **shadows a network the device can genuinely reach**. The device cannot tell the two apart: both are prefixes it was told to route, and the mapping wins. Silent, and only visible inside someone else's network.

## The fix keeps the original argument intact

Carried prefixes are reserved **filtered by overlap with the block**, not wholesale. A `10.0.0.0/8` carried by every customer in the deployment never reaches the list. There is a test asserting exactly that, because the obvious over-correction here is to reserve everything and slowly starve the allocator instead.

Egress groups are excluded for the reason `CarriedPrefixesForDevice` already gives: the default route overlaps everything, so counting it would reserve the whole block.

## Verified against the bug

Reverted the query arm and re-ran: the test allocates `100.71.0.0/24` — the customer's LAN — because the allocator hands out the lowest free range and that is it.

```
prefixmap_test.go:277: allocated 100.71.0.0/24, which lands on a customer LAN that is genuinely reachable
```

Full suite against a local PostgreSQL, lint, `make sqlc` clean.

## Not addressed

A deployment that has **already** allocated a range on top of a customer LAN keeps it. Detecting and re-allocating one is a repair job that needs a decision about devices holding the old mapping — worth doing separately rather than smuggling a migration in here.