### PR TITLE
feat(cli): meshp down, and the decision it turns on

### DIFF
--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -105,6 +105,12 @@ func main() {
 	case "doctor":
 		runOrDie(cmdDoctor, args[1:])
 		return
+	case "up":
+		runOrDie(cmdUp, args[1:])
+		return
+	case "down":
+		runOrDie(cmdDown, args[1:])
+		return
 	}
 
 	if contains(bareVerbs, args[0]) {
@@ -230,6 +236,16 @@ func cmdStatus(ctx context.Context, args []string) error {
 		// bound should not have to enrol first to find out.
 		printResolver(status)
 		return nil
+	}
+
+	if status.Paused {
+		// First, and before anything else is described. Somebody reading a status full of
+		// disconnected sessions needs to know they asked for that — otherwise they debug
+		// their own decision, which is the most frustrating kind of outage.
+		fmt.Println("DOWN      this device was taken off the mesh with 'meshp down'")
+		fmt.Println("          traffic is using this machine's ordinary network")
+		fmt.Println("          run 'sudo meshp up' to put it back")
+		fmt.Println()
 	}
 
 	fmt.Printf("enrolled  %d network(s)\n", len(status.Memberships))

--- a/cmd/meshp/updown.go
+++ b/cmd/meshp/updown.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/agentapi"
+)
+
+// cmdDown takes this device off the mesh until somebody puts it back.
+//
+// It releases the fail-closed lock, which is the part worth being explicit about. ADR-0011
+// installs that lock so a device whose tunnel drops stops passing traffic rather than
+// putting the user's real address back on the wire — but that protects against a failure.
+// This is somebody saying they want their ordinary network back, and a command called
+// "down" that left a machine unable to reach anything would manufacture the support ticket
+// that ADR describes out of a deliberate act.
+//
+// So it says what it did. Traffic is not going through the mesh any more, and whoever ran
+// this should know that rather than remember it.
+func cmdDown(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp down", flag.ContinueOnError)
+	socket := fs.String("socket", envOr("MESHP_SOCKET", agentapi.DefaultSocketPath), "meshpd's local socket")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	status, err := agentapi.NewClient(*socket, 30*time.Second).SetRunning(ctx, false)
+	if err != nil {
+		// The same explanation status gives. Somebody who runs this and is told only
+		// "connection refused" has to work out that meshpd is a thing that runs.
+		return describeDaemonError(err, *socket)
+	}
+	if !status.Enrolled {
+		fmt.Println("This device is not in any network, so there was nothing to take down.")
+		return nil
+	}
+
+	fmt.Println("Tunnels are down.")
+	fmt.Println()
+	fmt.Println("Traffic is using this machine's ordinary network again, including anything")
+	fmt.Println("that was going through a full tunnel. Nothing is being carried over the mesh.")
+	fmt.Println()
+	fmt.Println("    sudo meshp up")
+	fmt.Println()
+	fmt.Println("This survives a reboot: the device stays off the mesh until you put it back.")
+	return nil
+}
+
+// cmdUp puts it back.
+func cmdUp(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp up", flag.ContinueOnError)
+	socket := fs.String("socket", envOr("MESHP_SOCKET", agentapi.DefaultSocketPath), "meshpd's local socket")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	status, err := agentapi.NewClient(*socket, 30*time.Second).SetRunning(ctx, true)
+	if err != nil {
+		return describeDaemonError(err, *socket)
+	}
+	if !status.Enrolled {
+		fmt.Println("This device is not in any network yet. Join one first:")
+		fmt.Println()
+		fmt.Println("    sudo meshp join <token>")
+		return nil
+	}
+
+	// Deliberately not "you are connected". Bringing sessions up is asynchronous — the
+	// daemon has started them, and whether they reached a control plane is a different
+	// question, answered by the command that asks.
+	fmt.Println("Tunnels are coming back up; run 'meshp status' to see whether they did.")
+	return nil
+}

--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -400,6 +400,15 @@ func (a *agent) load() error {
 
 // startAll supervises a session for every membership.
 func (a *agent) startAll() {
+	// Nothing starts while this device is deliberately off the mesh. Checked here rather
+	// than at each call site, because the call sites are "the daemon started" and "somebody
+	// ran meshp up", and only one of them knows about pausing.
+	if a.paused() {
+		a.log.Info("staying off the mesh; this device was taken down deliberately",
+			"restore", "meshp up")
+		return
+	}
+
 	a.mu.Lock()
 	memberships := a.membershipsLocked()
 	a.mu.Unlock()
@@ -589,6 +598,7 @@ func (a *agent) Status(_ context.Context) (agentapi.Status, error) {
 		Version:   version.Version(),
 		StartedAt: a.startedAt,
 		Enrolled:  a.state != nil,
+		Paused:    a.state != nil && a.state.Paused,
 	}
 	// Before the enrolment check, because a resolver that is up on a device with no
 	// memberships is still a fact worth reporting — and its absence on a device that has

--- a/cmd/meshpd/pause.go
+++ b/cmd/meshpd/pause.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+
+	"github.com/meshpnet/meshp/internal/agentapi"
+	"github.com/meshpnet/meshp/internal/agentstate"
+	"github.com/meshpnet/meshp/internal/nftables"
+	"github.com/meshpnet/meshp/internal/wglink"
+)
+
+// down takes every tunnel off this device and gives the network back.
+//
+// The fail-closed lock is released, and that is the decision this command turns on.
+// ADR-0011 installs it so a device whose tunnel drops stops passing traffic rather than
+// putting the user's real address back on the wire — but that protects against a *failure*.
+// This is somebody at a keyboard saying they want their ordinary network back. A command
+// called "down" that left a machine unable to reach anything, with no obvious way back,
+// would manufacture the support ticket ADR-0011 predicts out of a deliberate action.
+//
+// So it is released, and the caller is told plainly that traffic is no longer going through
+// the mesh. Somebody who forgets is somebody leaking.
+func (a *agent) down() {
+	a.mu.Lock()
+	handles := make(map[string]*sessionHandle, len(a.running))
+	for id, handle := range a.running {
+		handles[id.String()] = handle
+	}
+	a.mu.Unlock()
+
+	for id, handle := range handles {
+		// The interface before the session, the order revoke uses: tearing down needs the
+		// reconciler, and cancelling first would race the goroutine that closes the relay
+		// link out from under it.
+		if handle.applier != nil && handle.applier.reconciler != nil {
+			if err := handle.applier.reconciler.Teardown(); err != nil {
+				a.log.Error("could not tear down an interface", "membership_id", id, "error", err)
+			}
+		}
+		handle.cancel()
+	}
+
+	a.mu.Lock()
+	clear(a.running)
+	a.mu.Unlock()
+
+	a.releaseEgress()
+	a.setPaused(true)
+	a.log.Warn("tunnels are down and traffic is using this machine's ordinary network",
+		"restore", "meshp up")
+}
+
+// up brings back what down took away.
+func (a *agent) up() {
+	a.setPaused(false)
+	a.startAll()
+	a.log.Info("tunnels are coming back up")
+}
+
+// paused reports whether somebody asked for this device to stay off the mesh.
+func (a *agent) paused() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.state != nil && a.state.Paused
+}
+
+func (a *agent) setPaused(paused bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.state == nil || a.state.Paused == paused {
+		return
+	}
+	a.state.Paused = paused
+	if err := agentstate.Save(a.stateDir, a.state); err != nil {
+		// Reported and not fatal: the tunnels are already down either way. What is lost is
+		// the memory of it, so the next start would bring them back — which is worth
+		// knowing about rather than discovering after a reboot.
+		a.log.Error("could not record that this device was taken off the mesh",
+			"error", err, "consequence", "a restart will bring the tunnels back up")
+	}
+}
+
+// releaseEgress undoes both halves of a full tunnel's claim on this machine.
+//
+// The same two things reclaimEgressLock undoes after a crash, done deliberately here. The
+// routing first, because rules pointing at a table whose tunnel is gone send traffic
+// nowhere.
+func (a *agent) releaseEgress() {
+	if held, err := wglink.EgressHeld(); err == nil && held {
+		if err := wglink.NewRouter().Release(); err != nil {
+			a.log.Error("could not release the default route; this device may have no working routing",
+				"error", err)
+		}
+	}
+
+	filter := a.ensureFilter()
+	if filter == nil || !nftables.LockHeld(a.ctx) {
+		return
+	}
+	if err := filter.ApplyLock(a.ctx, "", nil, nil, false); err != nil {
+		// The worst outcome this project has: a machine with no network and no obvious
+		// cause. Whoever reads this is at a console on a host that cannot reach anything.
+		a.log.Error("could not remove the fail-closed lock; this device still has no egress",
+			"error", err, "fix", "run: nft delete table inet "+nftables.LockTableName)
+	}
+}
+
+// SetRunning is the agentapi.Handler half of `meshp up` and `meshp down`.
+//
+// Idempotent by construction: down() on a device with nothing running tears down nothing
+// and still records the decision, and up() on a running device starts the sessions that are
+// already there, which ensureSession treats as a no-op. Asking for the state you are already
+// in is what the caller wanted.
+func (a *agent) SetRunning(ctx context.Context, running bool) (agentapi.Status, error) {
+	if running {
+		a.up()
+	} else {
+		a.down()
+	}
+	return a.Status(ctx)
+}

--- a/docs/adr/0011-fail-closed.md
+++ b/docs/adr/0011-fail-closed.md
@@ -44,6 +44,19 @@ can ship (Invariant 20).
 
 ## Consequences
 
+*Amended 2026-08-22.* `meshp down` releases the lock. This decision is about what happens
+when a tunnel **fails**: a device that loses one stops passing traffic rather than putting
+the user's real address back on the wire. It is not about what happens when somebody asks
+for their ordinary network back. A command called "down" that left a machine unable to
+reach anything, with no obvious way to undo it, would manufacture the very support ticket
+this record predicts out of a deliberate act — and the person at the keyboard would have
+been told, by the tool, that taking the tunnel down was a thing they could do.
+
+So it is released, and `meshp down` says plainly that traffic is no longer going through
+the mesh, because somebody who forgets is somebody leaking. The state is persisted: a
+reboot does not put a device back on the mesh that its owner took off.
+
+
 Users get the property they actually bought, including across sleep, network
 changes and crashes. Administrators can guarantee it for a fleet.
 

--- a/internal/agentapi/agentapi.go
+++ b/internal/agentapi/agentapi.go
@@ -29,6 +29,14 @@ type Status struct {
 	Version   string    `json:"version"`
 	StartedAt time.Time `json:"started_at"`
 
+	// Paused is true when somebody ran `meshp down`.
+	//
+	// Reported because it is the difference between "nothing is connected because
+	// something is broken" and "nothing is connected because you asked for that", and a
+	// status that could not tell them apart would send people debugging their own
+	// decision.
+	Paused bool `json:"paused"`
+
 	// Enrolled is false when there is no local state at all, which is a normal
 	// condition rather than an error: the agent may be installed before anyone has a
 	// token.

--- a/internal/agentapi/agentapi_test.go
+++ b/internal/agentapi/agentapi_test.go
@@ -24,11 +24,20 @@ type fakeHandler struct {
 	joinResp JoinResponse
 	joinErr  error
 	joined   []JoinRequest
+	running  []bool
 }
 
 func (h *fakeHandler) Status(context.Context) (Status, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	return h.status, nil
+}
+
+func (h *fakeHandler) SetRunning(_ context.Context, running bool) (Status, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.status.Paused = !running
+	h.running = append(h.running, running)
 	return h.status, nil
 }
 
@@ -348,4 +357,35 @@ func structFieldNames(v any) string {
 		b.WriteString(" ")
 	}
 	return b.String()
+}
+
+// `meshp down` and `meshp up` reach the daemon, and both come back with what the device is
+// doing now rather than an empty body — so whoever asked can say what happened instead of
+// assuming it worked.
+func TestUpAndDownReachTheDaemonAndReportBack(t *testing.T) {
+	h := &fakeHandler{status: Status{Enrolled: true}}
+	_, path := serve(t, h, ServerConfig{})
+	client := NewClient(path, 5*time.Second)
+
+	down, err := client.SetRunning(context.Background(), false)
+	if err != nil {
+		t.Fatalf("down: %v", err)
+	}
+	if !down.Paused {
+		t.Error("the status after down does not say the device is paused")
+	}
+
+	up, err := client.SetRunning(context.Background(), true)
+	if err != nil {
+		t.Fatalf("up: %v", err)
+	}
+	if up.Paused {
+		t.Error("the status after up still says the device is paused")
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.running) != 2 || h.running[0] || !h.running[1] {
+		t.Errorf("the daemon was asked for %v, want [false true]", h.running)
+	}
 }

--- a/internal/agentapi/client.go
+++ b/internal/agentapi/client.go
@@ -70,6 +70,19 @@ func (c *Client) Join(ctx context.Context, req JoinRequest) (JoinResponse, error
 	return out, err
 }
 
+// SetRunning takes this device off the mesh, or puts it back.
+func (c *Client) SetRunning(ctx context.Context, running bool) (Status, error) {
+	path := "/v1/down"
+	if running {
+		path = "/v1/up"
+	}
+	var out Status
+	// No body. The path says which way, and a body saying it again is a second place for
+	// the two to disagree.
+	err := c.do(ctx, http.MethodPost, path, nil, &out)
+	return out, err
+}
+
 func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
 	var reader io.Reader
 	if body != nil {

--- a/internal/agentapi/server.go
+++ b/internal/agentapi/server.go
@@ -23,6 +23,13 @@ import (
 type Handler interface {
 	Status(ctx context.Context) (Status, error)
 	Join(ctx context.Context, req JoinRequest) (JoinResponse, error)
+
+	// SetRunning takes this device off the mesh, or puts it back.
+	//
+	// One method rather than two, because the two are the same decision with opposite
+	// answers and a pair would let a caller ask for both. Idempotent: asking for a state
+	// the device is already in is success, since that is what the caller wanted.
+	SetRunning(ctx context.Context, running bool) (Status, error)
 }
 
 // ServerConfig configures the local listener.
@@ -86,6 +93,8 @@ func (s *Server) Listen() error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /v1/status", s.handleStatus)
 	mux.HandleFunc("POST /v1/join", s.handleJoin)
+	mux.HandleFunc("POST /v1/up", s.handleUp)
+	mux.HandleFunc("POST /v1/down", s.handleDown)
 	s.http = &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
@@ -228,6 +237,24 @@ func (s *Server) handleJoin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.respond(w, http.StatusCreated, res)
+}
+
+// handleUp and handleDown put this device on or off the mesh.
+//
+// Both answer with the resulting status rather than an empty body, so whoever asked can say
+// what the machine is doing now instead of assuming it worked.
+func (s *Server) handleUp(w http.ResponseWriter, r *http.Request)   { s.setRunning(w, r, true) }
+func (s *Server) handleDown(w http.ResponseWriter, r *http.Request) { s.setRunning(w, r, false) }
+
+func (s *Server) setRunning(w http.ResponseWriter, r *http.Request, running bool) {
+	status, err := s.handler.SetRunning(r.Context(), running)
+	if err != nil {
+		s.log.Error("could not change whether this device is on the mesh",
+			"running", running, "error", logx.SafeError(err))
+		s.fail(w, http.StatusInternalServerError, "failed", err.Error())
+		return
+	}
+	s.respond(w, http.StatusOK, status)
 }
 
 func (s *Server) respond(w http.ResponseWriter, status int, body any) {

--- a/internal/agentstate/state.go
+++ b/internal/agentstate/state.go
@@ -53,6 +53,13 @@ type State struct {
 
 	Memberships []Membership `json:"memberships"`
 
+	// Paused is set when somebody ran `meshp down`.
+	//
+	// Persisted, because a reboot must not undo it. A device that came back up carrying
+	// traffic its owner had deliberately taken off the mesh would be the opposite of what
+	// they asked for, and they would have no reason to check.
+	Paused bool `json:"paused,omitempty"`
+
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/internal/agentstate/state_test.go
+++ b/internal/agentstate/state_test.go
@@ -303,3 +303,42 @@ func TestRemoveMembershipKeepsTheIdentity(t *testing.T) {
 		t.Error("a forgotten identity still loads")
 	}
 }
+
+// Being taken off the mesh survives a restart.
+//
+// The whole point of `meshp down`: a device that came back up carrying traffic its owner
+// had deliberately taken off the mesh would be the opposite of what they asked for, and
+// they would have no reason to check.
+func TestPausedSurvivesARoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	state := &State{IdentityPublicKey: "pub", IdentityPrivateKey: "priv", Paused: true}
+	if err := Save(dir, state); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !loaded.Paused {
+		t.Error("a device taken off the mesh came back on it after a restart")
+	}
+}
+
+// And the ordinary case stays ordinary: a state written before this field existed loads as
+// running, not as paused. `omitempty` keeps it out of the file entirely.
+func TestAStateWithoutTheFieldIsNotPaused(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := Save(dir, &State{IdentityPublicKey: "pub", IdentityPrivateKey: "priv"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.Paused {
+		t.Error("a device that was never taken down loaded as paused")
+	}
+}


### PR DESCRIPTION
`--help` has advertised `down — Take the tunnel down` since the CLI existed. Running it said `not implemented yet` — honest, but not what the help promised.

## The decision

It hangs entirely on ADR-0011, which installs a fail-closed lock so a device whose tunnel drops stops passing traffic rather than putting the user's real address back on the wire, and is explicit that the lock is system state outliving the process. So: does `down` release it?

**Yes, and the ADR is amended to say so.** ADR-0011 is about what happens when a tunnel *fails*. This is somebody at a keyboard asking for their ordinary network back. A command called "down" that left a machine unable to reach anything, with no obvious way to undo it, would manufacture the very support ticket that record predicts — out of a deliberate act, by a tool that told them this was a thing they could do.

So it releases both halves of a full tunnel's claim (routing first, for the reason the crash-recovery path already gives) and says plainly that traffic is no longer going through the mesh. Someone who forgets is someone leaking.

## Three things that follow

**It persists.** A reboot must not put a device back on a mesh its owner took it off. `startAll` refuses to start anything while paused, and the flag round-trips through `agentstate` — with a test that a state written before the field existed loads as *running*, not paused.

**`meshp status` says it first**, before listing disconnected sessions. Someone reading a status full of dead sessions needs to know they asked for that; debugging your own decision is the most frustrating kind of outage.

**`up` comes with it.** Down without up means the only way back is re-joining or restarting the daemon. That is not a pair of commands, it is a trap.

## Shape

One `SetRunning(running bool)` on the daemon rather than `Up()` and `Down()` — the two are the same decision with opposite answers, and a pair lets a caller ask for both. Both endpoints answer with the resulting status, so the CLI reports what the machine is doing instead of assuming it worked. Failures go through `describeDaemonError`, so `meshp down` with no daemon says how to start one rather than "connection refused".

## Still true after this

`--help` continues to advertise plenty that is not implemented — eleven nouns and two more verbs, all of which say so when run. That is [#65](https://github.com/meshpnet/meshp/issues/65)'s territory and is not made worse here; `up` and `down` have simply stopped being among them.

Full suite against a local PostgreSQL, lint clean.