### PR TITLE
feat(audit): the trail names who did it

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -17,6 +17,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"sync/atomic"
+	"time"
 
 	"github.com/meshpnet/meshp/internal/clock"
 	"github.com/meshpnet/meshp/internal/enroll"
@@ -68,6 +70,10 @@ type Server struct {
 
 	// ui holds the browser sessions minted from the administrative token (ADR-0022 §5).
 	ui *uiSessions
+
+	// bootstrapWarnedAt is when the administrative token was last complained about, so the
+	// complaint is occasional rather than per request. See warnBootstrapTokenUsed.
+	bootstrapWarnedAt atomic.Pointer[time.Time]
 }
 
 // New builds a Server. store and svc may not be nil; the caller waits until the
@@ -235,6 +241,7 @@ func (s *Server) adminOnly(next http.HandlerFunc) http.Handler {
 				"a valid administrative token is required")
 			return
 		}
+		s.warnBootstrapTokenUsed(r)
 		next(w, r)
 	})
 }

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -76,10 +76,10 @@ func (s *Server) handlePublishPolicy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req := store.PublishPolicyRequest{
-		NetworkID:  networkID,
-		Document:   doc,
-		ActorLabel: "admin token",
-		SourceIP:   sourceAddr(r),
+		NetworkID: networkID,
+		Document:  doc,
+		Actor:     s.actor(r),
+		SourceIP:  sourceAddr(r),
 	}
 	if network, err := s.store.Queries().GetNetwork(r.Context(), networkID); err == nil {
 		req.OrganizationID = &network.OrganizationID

--- a/internal/api/revoke.go
+++ b/internal/api/revoke.go
@@ -48,7 +48,7 @@ func (s *Server) handleRevokeMembership(w http.ResponseWriter, r *http.Request) 
 		NetworkID:    networkID,
 		MembershipID: membershipID,
 		Reason:       body.Reason,
-		ActorLabel:   "admin token",
+		Actor:        s.actor(r),
 		SourceIP:     sourceAddr(r),
 	}
 	// Best effort: the organisation only labels the audit row, and failing to read it is

--- a/internal/api/revoke_test.go
+++ b/internal/api/revoke_test.go
@@ -211,6 +211,7 @@ func TestARevokedDeviceIsStillListed(t *testing.T) {
 func TestRevokingAnUnknownMembership(t *testing.T) {
 	h := newHarness(t)
 	_, err := h.store.RevokeMembership(h.ctx, store.RevokeRequest{
+		Actor:        store.BootstrapActor(),
 		NetworkID:    h.netID,
 		MembershipID: uuid.New(),
 	})

--- a/internal/api/users_test.go
+++ b/internal/api/users_test.go
@@ -266,3 +266,81 @@ func TestSigningOutEndsTheSession(t *testing.T) {
 		t.Errorf("the cookie still works after signing out: %d", status)
 	}
 }
+
+// The point of the slice: an administrative action done by a signed-in person names them.
+//
+// Four subsystems have written audit events since the first migration, and every one landed
+// as `api_token` with no id — the trail could say what happened and never who.
+func TestAnActionByAPersonNamesThem(t *testing.T) {
+	h := newHarness(t)
+	createUser(t, h, "alice@example.com")
+	cookie := signIn(t, h, "alice@example.com", testPassword)
+
+	// Publishing a policy is an audited administrative act, done here as Alice.
+	status, _, body := doJSON(t, http.MethodPut,
+		h.server.URL+"/api/v1/networks/"+h.netID.String()+"/acl",
+		map[string]any{"version": 1, "rules": []any{}}, cookie, false)
+	if status != http.StatusOK && status != http.StatusCreated {
+		t.Fatalf("publishing a policy as a signed-in person = %d: %v", status, body)
+	}
+
+	events := auditFor(t, h, "policy.published")
+	if len(events) == 0 {
+		t.Fatal("publishing a policy wrote no audit event")
+	}
+	event := events[0]
+	if event["actor_kind"] != "user" {
+		t.Errorf("actor_kind = %v, want user", event["actor_kind"])
+	}
+	if event["actor_label"] != "alice@example.com" {
+		t.Errorf("actor_label = %v, want the address", event["actor_label"])
+	}
+	if event["actor_id"] == nil {
+		t.Error("the event names no actor id, so the trail cannot be joined to a person")
+	}
+}
+
+// The same action done with the bootstrap secret says that it was the bootstrap secret. It
+// still cannot name a person — a shared secret has no identity — but "somebody used the root
+// credential" stops being something you infer from an empty column.
+func TestAnActionByTheBootstrapSecretSaysSo(t *testing.T) {
+	h := newHarness(t)
+
+	status, _, body := doJSON(t, http.MethodPut,
+		h.server.URL+"/api/v1/networks/"+h.netID.String()+"/acl",
+		map[string]any{"version": 1, "rules": []any{}}, nil, true)
+	if status != http.StatusOK && status != http.StatusCreated {
+		t.Fatalf("publishing a policy with the token = %d: %v", status, body)
+	}
+
+	events := auditFor(t, h, "policy.published")
+	if len(events) == 0 {
+		t.Fatal("publishing a policy wrote no audit event")
+	}
+	if events[0]["actor_kind"] != "api_token" {
+		t.Errorf("actor_kind = %v, want api_token", events[0]["actor_kind"])
+	}
+	label, _ := events[0]["actor_label"].(string)
+	if label == "" {
+		t.Error("the bootstrap secret is still anonymous in the trail")
+	}
+}
+
+// auditFor reads the trail and returns the events of one kind, newest first.
+func auditFor(t *testing.T, h *harness, action string) []map[string]any {
+	t.Helper()
+	status, _, body := doJSON(t, http.MethodGet,
+		h.server.URL+"/api/v1/networks/"+h.netID.String()+"/audit?limit=50", nil, nil, true)
+	if status != http.StatusOK {
+		t.Fatalf("reading the audit trail = %d: %v", status, body)
+	}
+	raw, _ := body["events"].([]any)
+	var out []map[string]any
+	for _, item := range raw {
+		event, _ := item.(map[string]any)
+		if event["action"] == action {
+			out = append(out, event)
+		}
+	}
+	return out
+}

--- a/internal/api/usersession.go
+++ b/internal/api/usersession.go
@@ -204,3 +204,59 @@ func requestAddr(r *http.Request) *netip.Addr {
 	addr := addrPort.Addr().Unmap()
 	return &addr
 }
+
+// actor is who this request is, for the audit trail.
+//
+// A signed-in person where there is one; the bootstrap secret otherwise. There is no third
+// answer: a request that reached an audited handler got past adminOnly, which accepts
+// exactly those two things.
+//
+// The label for a person is their email rather than their display name, because an audit
+// line is read months later by somebody trying to reach whoever did it, and a display name
+// is not a way to reach anyone.
+func (s *Server) actor(r *http.Request) store.Actor {
+	if user := s.sessionUser(r); user != nil {
+		return store.UserActor(*user)
+	}
+	return store.BootstrapActor()
+}
+
+// warnBootstrapTokenUsed says, at most occasionally, that the administrative token was used
+// on a deployment that has accounts.
+//
+// ADR-0024 §5 keeps the token working — a deployment locked out of its own control plane has
+// no other way back — and asks that using it stop being invisible. Once an account exists,
+// reaching for the shared secret means somebody is using it *instead of* an account, and
+// that is a fact an operator should be able to see in a log rather than infer.
+//
+// Throttled hard, and for two reasons rather than one. The obvious one is log noise: the
+// commercial layer polls with a bearer token and would otherwise write a line per request.
+// The less obvious one is the query behind it — "does this deployment have accounts" is a
+// count, and asking it per request would put a scan of the users table in front of every
+// administrative call to save a message nobody reads more than once an hour.
+func (s *Server) warnBootstrapTokenUsed(r *http.Request) {
+	const every = time.Hour
+
+	now := s.cfg.Clock.Now()
+	last := s.bootstrapWarnedAt.Load()
+	if last != nil && now.Sub(*last) < every {
+		return
+	}
+	if !s.bootstrapWarnedAt.CompareAndSwap(last, &now) {
+		// Another request got there first. One of us logs; it does not matter which.
+		return
+	}
+
+	accounts, err := s.store.AnyUsers(r.Context())
+	if err != nil || !accounts {
+		// No accounts is the ordinary bootstrap state and says nothing worth logging. A
+		// failed count is not worth a second message either — whatever is wrong with the
+		// database will be reported by the request that actually needed it.
+		return
+	}
+	s.log.Warn("the bootstrap administrative token was used on a deployment that has accounts",
+		"path", logx.Safe(r.URL.Path),
+		"remote", logx.Safe(clientKey(r)),
+		"hint", "sign in as a user instead; this token is the way back in when nobody can, "+
+			"and every use of it is recorded as nobody in particular")
+}

--- a/internal/enroll/service.go
+++ b/internal/enroll/service.go
@@ -309,19 +309,19 @@ func (s *Service) Redeem(ctx context.Context, req RedeemRequest) (RedeemResult, 
 			"agent_version":  req.AgentVersion,
 			"token_id":       tok.ID,
 		})
-		if _, err := q.CreateAuditEvent(ctx, dbgen.CreateAuditEventParams{
+		// The device is the actor: it presented a token and enrolled itself. Through the
+		// store's helper rather than the query directly, so this shares the refusal that
+		// stops any audited action being written without saying who acted.
+		if err := store.WriteAudit(ctx, q, store.DeviceActor(device.ID, device.Name), dbgen.CreateAuditEventParams{
 			OrganizationID: &tok.OrganizationID,
 			NetworkID:      &tok.NetworkID,
-			ActorKind:      "device",
-			ActorID:        &device.ID,
-			ActorLabel:     device.Name,
 			Action:         "device.enrolled",
 			ResourceKind:   "membership",
 			ResourceID:     &membership.ID,
 			SourceIp:       req.SourceIP,
 			Metadata:       metadata,
 		}); err != nil {
-			return fmt.Errorf("enroll: writing audit event: %w", err)
+			return err
 		}
 
 		result = RedeemResult{

--- a/internal/session/filter_test.go
+++ b/internal/session/filter_test.go
@@ -11,9 +11,9 @@ import (
 func (f *fixture) publish(rules ...acl.Rule) {
 	f.t.Helper()
 	if _, err := f.store.PublishPolicy(f.ctx, store.PublishPolicyRequest{
-		NetworkID:  f.netID,
-		Document:   acl.Document{Version: acl.Version, Rules: rules},
-		ActorLabel: "test",
+		NetworkID: f.netID,
+		Document:  acl.Document{Version: acl.Version, Rules: rules},
+		Actor:     store.BootstrapActor(),
 	}); err != nil {
 		f.t.Fatalf("publishing a policy: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestARevokedDeviceLeavesEveryFilter(t *testing.T) {
 	}
 
 	if _, err := f.store.RevokeMembership(f.ctx, store.RevokeRequest{
-		NetworkID: f.netID, MembershipID: bob.membershipID,
+		NetworkID: f.netID, MembershipID: bob.membershipID, Actor: store.BootstrapActor(),
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/session/routes_test.go
+++ b/internal/session/routes_test.go
@@ -185,6 +185,7 @@ func TestARevokedAdvertiserLeavesTheCandidates(t *testing.T) {
 	f.advertise("branch-lan", backup, 2)
 
 	if _, err := f.store.RevokeMembership(f.ctx, store.RevokeRequest{
+		Actor:     store.BootstrapActor(),
 		NetworkID: f.netID, MembershipID: primary.membershipID,
 	}); err != nil {
 		t.Fatal(err)

--- a/internal/store/actor.go
+++ b/internal/store/actor.go
@@ -1,0 +1,93 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	dbgen "github.com/meshpnet/meshp/internal/store/gen"
+)
+
+// Actor is who did something, for the audit trail.
+//
+// A type rather than three loose fields on every request, because the failure this is
+// guarding against is quiet: an audited action whose author forgot to say who was acting
+// writes a row that looks like every other row and answers nothing. One value is one thing
+// to remember, and writeAudit below refuses a zero one — so forgetting is a compile-time
+// omission that fails at the first test rather than a blank column somebody notices in six
+// months.
+type Actor struct {
+	// Kind is one of the values audit_events.actor_kind allows: user, device, system or
+	// api_token.
+	Kind string
+
+	// ID names the row this actor is, where there is one. Nil for the bootstrap secret,
+	// which is nobody in particular — that being the whole problem with it.
+	ID *uuid.UUID
+
+	// Label is what a person reads. An audit line of bare UUIDs is one nobody reads.
+	Label string
+}
+
+// ErrNoActor means an audited action did not say who was acting.
+//
+// Returned rather than defaulted. A default would be a guess written into a record whose
+// entire purpose is not guessing.
+var ErrNoActor = errors.New("store: an audited action must say who was acting")
+
+// UserActor is a signed-in person.
+func UserActor(user User) Actor {
+	id := user.ID
+	return Actor{Kind: "user", ID: &id, Label: user.Email}
+}
+
+// DeviceActor is a machine acting for itself — an agent choosing a candidate, or a device
+// completing its own enrolment.
+func DeviceActor(deviceID uuid.UUID, name string) Actor {
+	id := deviceID
+	return Actor{Kind: "device", ID: &id, Label: name}
+}
+
+// BootstrapActor is the administrative token.
+//
+// Named rather than left blank, which is what it was: every administrative action in this
+// system has been recorded as `api_token` with no id and no label, so the trail could say
+// that something happened and never who. It still cannot say who — a shared secret has no
+// identity, which is ADR-0024's whole argument — but it can at least say that the shared
+// secret was what did it, so "somebody used the root credential" is visible rather than
+// inferred from the absence of anything else.
+func BootstrapActor() Actor {
+	return Actor{Kind: "api_token", Label: "the bootstrap admin token"}
+}
+
+// Valid reports whether this actor says anything.
+func (a Actor) Valid() bool {
+	switch a.Kind {
+	case "user", "device", "system", "api_token":
+		return a.Label != "" || a.ID != nil
+	default:
+		return false
+	}
+}
+
+// WriteAudit records that something happened, and refuses to record it anonymously.
+//
+// Every audited action goes through here, including the ones in other packages — which is
+// why it is exported rather than kept private to this one. The check is the point: an
+// audit_events row with no actor is worse than no row, because it looks like a record and
+// answers none of the question a record is for.
+func WriteAudit(ctx context.Context, q *dbgen.Queries, actor Actor, params dbgen.CreateAuditEventParams) error {
+	if !actor.Valid() {
+		return ErrNoActor
+	}
+	params.ActorKind = actor.Kind
+	params.ActorID = actor.ID
+	params.ActorLabel = actor.Label
+
+	if _, err := q.CreateAuditEvent(ctx, params); err != nil {
+		return fmt.Errorf("store: writing the audit event: %w", err)
+	}
+	return nil
+}

--- a/internal/store/actor_test.go
+++ b/internal/store/actor_test.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// An audited action that does not say who acted is refused rather than recorded.
+//
+// The guard is the point of the type. Four subsystems write audit events and every one of
+// them recorded `api_token` with no id, so the trail could say that something happened and
+// never who — and nothing failed, which is why it stayed that way from the first migration
+// until now.
+func TestAnActorThatSaysNothingIsRefused(t *testing.T) {
+	id := uuid.New()
+
+	for _, tc := range []struct {
+		name  string
+		actor Actor
+		valid bool
+	}{
+		{"nothing at all", Actor{}, false},
+		{"a kind and nothing else", Actor{Kind: "user"}, false},
+		{"a kind the schema does not allow", Actor{Kind: "robot", Label: "hal"}, false},
+		{"a label with no id", BootstrapActor(), true},
+		{"an id and a label", UserActor(User{ID: id, Email: "alice@example.com"}), true},
+		{"a device", DeviceActor(id, "hq-gateway"), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.actor.Valid(); got != tc.valid {
+				t.Errorf("Valid() = %v, want %v", got, tc.valid)
+			}
+		})
+	}
+}
+
+// A person is named by their email, not their display name. An audit line is read months
+// later by somebody trying to reach whoever did it, and a display name is not a way to
+// reach anyone.
+func TestAPersonIsNamedByTheirAddress(t *testing.T) {
+	actor := UserActor(User{ID: uuid.New(), Email: "alice@example.com", Name: "Alice"})
+	if actor.Kind != "user" {
+		t.Errorf("kind = %q, want user", actor.Kind)
+	}
+	if actor.Label != "alice@example.com" {
+		t.Errorf("label = %q, want the address", actor.Label)
+	}
+	if actor.ID == nil {
+		t.Error("a person has no id in the trail")
+	}
+}
+
+// The bootstrap secret is nobody in particular, and says so. It still cannot name a person —
+// a shared secret has no identity, which is ADR-0024's whole argument — but "somebody used
+// the root credential" becomes visible rather than inferred from an empty column.
+func TestTheBootstrapSecretNamesItself(t *testing.T) {
+	actor := BootstrapActor()
+	if actor.ID != nil {
+		t.Error("the bootstrap secret claims to be a particular somebody")
+	}
+	if actor.Label == "" {
+		t.Error("the bootstrap secret is anonymous, which is what this was fixing")
+	}
+	if !actor.Valid() {
+		t.Error("the bootstrap secret cannot write an audit event")
+	}
+}

--- a/internal/store/gen/users.sql.go
+++ b/internal/store/gen/users.sql.go
@@ -13,6 +13,21 @@ import (
 	"github.com/google/uuid"
 )
 
+const countUsers = `-- name: CountUsers :one
+SELECT count(*)::bigint FROM users WHERE deleted_at IS NULL
+`
+
+// scope: global whether this deployment has any accounts at all is a property of the
+// deployment, not of a tenant. It is asked so the control plane can say, when somebody uses
+// the bootstrap secret, that there is now an account they could be using instead — a
+// question no organisation owns.
+func (q *Queries) CountUsers(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, countUsers)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const createUser = `-- name: CreateUser :one
 
 INSERT INTO users (organization_id, email, name, password_hash)

--- a/internal/store/health.go
+++ b/internal/store/health.go
@@ -228,23 +228,16 @@ func auditRouteSwitch(ctx context.Context, q *dbgen.Queries, req ObserveRequest,
 	})
 
 	networkID := req.NetworkID
-	actorID := req.DeviceID
 	orgID := network.OrganizationID
-	if _, err := q.CreateAuditEvent(ctx, dbgen.CreateAuditEventParams{
+	// Not "system". The schema's comment on that value predates ADR-0003, which moved the
+	// choice to the agent: this is a device reporting something it did, and filing it under
+	// the control plane would credit the wrong actor.
+	return WriteAudit(ctx, q, DeviceActor(req.DeviceID, label), dbgen.CreateAuditEventParams{
 		OrganizationID: &orgID,
 		NetworkID:      &networkID,
-		// Not "system". The schema's comment on that value predates ADR-0003, which moved
-		// the choice to the agent: this is a device reporting something it did, and filing
-		// it under the control plane would credit the wrong actor.
-		ActorKind:    "device",
-		ActorID:      &actorID,
-		ActorLabel:   label,
-		Action:       "route.switched",
-		ResourceKind: "route_group",
-		ResourceID:   &groupID,
-		Metadata:     metadata,
-	}); err != nil {
-		return fmt.Errorf("store: writing the route switch audit event: %w", err)
-	}
-	return nil
+		Action:         "route.switched",
+		ResourceKind:   "route_group",
+		ResourceID:     &groupID,
+		Metadata:       metadata,
+	})
 }

--- a/internal/store/policy.go
+++ b/internal/store/policy.go
@@ -111,18 +111,16 @@ func (s *Store) PublishPolicy(ctx context.Context, req PublishPolicyRequest) (Po
 			"rules":          len(req.Document.Rules),
 		})
 		networkID := req.NetworkID
-		if _, err := q.CreateAuditEvent(ctx, dbgen.CreateAuditEventParams{
+		if err := WriteAudit(ctx, q, req.Actor, dbgen.CreateAuditEventParams{
 			OrganizationID: req.OrganizationID,
 			NetworkID:      &networkID,
-			ActorKind:      "api_token",
-			ActorLabel:     req.ActorLabel,
 			Action:         "policy.published",
 			ResourceKind:   "acl_policy",
 			ResourceID:     &row.ID,
 			SourceIp:       req.SourceIP,
 			Metadata:       metadata,
 		}); err != nil {
-			return fmt.Errorf("store: writing the policy audit event: %w", err)
+			return err
 		}
 
 		out = Policy{
@@ -147,8 +145,9 @@ type PublishPolicyRequest struct {
 
 	OrganizationID  *uuid.UUID
 	CreatedByUserID *uuid.UUID
-	ActorLabel      string
-	SourceIP        *netip.Addr
+	// Actor is who is publishing. Required, like every audited action here.
+	Actor    Actor
+	SourceIP *netip.Addr
 }
 
 // PolicyDevices returns everything the compiler needs about a network's members.

--- a/internal/store/policy_test.go
+++ b/internal/store/policy_test.go
@@ -89,6 +89,7 @@ func TestPublishAndReadBack(t *testing.T) {
 	ctx := testContext(t)
 
 	published, err := s.PublishPolicy(ctx, PublishPolicyRequest{
+		Actor:     BootstrapActor(),
 		NetworkID: s.netID, Document: simplePolicy(), OrganizationID: &s.orgID,
 	})
 	if err != nil {
@@ -118,6 +119,7 @@ func TestVersionsAlwaysMoveForward(t *testing.T) {
 
 	for want := int32(1); want <= 3; want++ {
 		got, err := s.PublishPolicy(ctx, PublishPolicyRequest{
+			Actor:     BootstrapActor(),
 			NetworkID: s.netID, Document: simplePolicy(),
 		})
 		if err != nil {
@@ -143,6 +145,7 @@ func TestVersionsAlwaysMoveForward(t *testing.T) {
 func TestPublishingRefusesAnInvalidDocument(t *testing.T) {
 	s, _ := seedNetwork(t)
 	_, err := s.PublishPolicy(testContext(t), PublishPolicyRequest{
+		Actor:     BootstrapActor(),
 		NetworkID: s.netID,
 		Document:  acl.Document{Version: 99},
 	})
@@ -198,6 +201,7 @@ func TestPolicyDevicesResolvesMembers(t *testing.T) {
 	// A revoked member leaves the list, or its address would stay in every other device's
 	// filter granting access to something no longer in the network.
 	if _, err := s.RevokeMembership(ctx, RevokeRequest{
+		Actor:     BootstrapActor(),
 		NetworkID: s.netID, MembershipID: first,
 	}); err != nil {
 		t.Fatal(err)
@@ -250,18 +254,21 @@ func TestRevokingWhatIsNotThere(t *testing.T) {
 	membershipID := addDevice()
 
 	if _, err := s.RevokeMembership(ctx, RevokeRequest{
+		Actor:     BootstrapActor(),
 		NetworkID: s.netID, MembershipID: uuid.New(),
 	}); !errors.Is(err, ErrNotAMember) {
 		t.Errorf("unknown membership: error = %v, want ErrNotAMember", err)
 	}
 
 	if _, err := s.RevokeMembership(ctx, RevokeRequest{
+		Actor:     BootstrapActor(),
 		NetworkID: uuid.New(), MembershipID: membershipID,
 	}); !errors.Is(err, ErrNotAMember) {
 		t.Errorf("wrong network: error = %v, want ErrNotAMember", err)
 	}
 
 	revoked, err := s.RevokeMembership(ctx, RevokeRequest{
+		Actor:     BootstrapActor(),
 		NetworkID: s.netID, MembershipID: membershipID,
 	})
 	if err != nil {
@@ -272,6 +279,7 @@ func TestRevokingWhatIsNotThere(t *testing.T) {
 	}
 
 	if _, err := s.RevokeMembership(ctx, RevokeRequest{
+		Actor:     BootstrapActor(),
 		NetworkID: s.netID, MembershipID: membershipID,
 	}); !errors.Is(err, ErrNotAMember) {
 		t.Errorf("revoking twice: error = %v, want ErrNotAMember", err)

--- a/internal/store/revoke.go
+++ b/internal/store/revoke.go
@@ -72,18 +72,16 @@ func (s *Store) RevokeMembership(ctx context.Context, req RevokeRequest) (Revoke
 		})
 		networkID := req.NetworkID
 		membershipID := row.MembershipID
-		if _, err := q.CreateAuditEvent(ctx, dbgen.CreateAuditEventParams{
+		if err := WriteAudit(ctx, q, req.Actor, dbgen.CreateAuditEventParams{
 			OrganizationID: req.OrganizationID,
 			NetworkID:      &networkID,
-			ActorKind:      "api_token",
-			ActorLabel:     req.ActorLabel,
 			Action:         "device.revoked",
 			ResourceKind:   "membership",
 			ResourceID:     &membershipID,
 			SourceIp:       req.SourceIP,
 			Metadata:       metadata,
 		}); err != nil {
-			return fmt.Errorf("store: writing the revocation audit event: %w", err)
+			return err
 		}
 
 		out = Revoked{
@@ -110,7 +108,9 @@ type RevokeRequest struct {
 
 	// Reason is recorded and also sent to the device, so it is written by an administrator
 	// and read by whoever finds the machine. Optional.
-	Reason     string
-	ActorLabel string
-	SourceIP   *netip.Addr
+	Reason string
+	// Actor is who is doing this. Required: writeAudit refuses a zero one rather than
+	// recording a revocation nobody can be asked about.
+	Actor    Actor
+	SourceIP *netip.Addr
 }

--- a/internal/store/routegroup_test.go
+++ b/internal/store/routegroup_test.go
@@ -108,6 +108,7 @@ func TestARevokedAdvertiserIsNotOffered(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := s.RevokeMembership(ctx, RevokeRequest{
+		Actor:     BootstrapActor(),
 		NetworkID: s.netID, MembershipID: membershipID,
 	}); err != nil {
 		t.Fatal(err)

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -408,3 +408,17 @@ func hashSessionToken(token string) []byte {
 	sum := sha256.Sum256([]byte(token))
 	return sum[:]
 }
+
+// AnyUsers reports whether this deployment has any accounts.
+//
+// Asked so the control plane can tell somebody using the bootstrap secret that there is now
+// an account they could be using instead (ADR-0024 §5). It is a count rather than a flag on
+// the server because a second replica, or a user created by hand, must change the answer
+// without a restart.
+func (s *Store) AnyUsers(ctx context.Context) (bool, error) {
+	n, err := s.Queries().CountUsers(ctx)
+	if err != nil {
+		return false, fmt.Errorf("store: counting users: %w", err)
+	}
+	return n > 0, nil
+}

--- a/queries/users.sql
+++ b/queries/users.sql
@@ -95,3 +95,10 @@ DELETE FROM user_sessions WHERE user_id = $1;
 -- nobody and is removed on everybody's behalf, so scoping this to one organisation would
 -- leave every other organisation's dead rows behind and make the sweep a per-tenant chore.
 DELETE FROM user_sessions WHERE expires_at < now() OR idle_expires_at < now();
+
+-- name: CountUsers :one
+-- scope: global whether this deployment has any accounts at all is a property of the
+-- deployment, not of a tenant. It is asked so the control plane can say, when somebody uses
+-- the bootstrap secret, that there is now an account they could be using instead — a
+-- question no organisation owns.
+SELECT count(*)::bigint FROM users WHERE deleted_at IS NULL;


### PR DESCRIPTION
Second slice of ADR-0024, closing [#135](https://github.com/meshpnet/meshp/issues/135).

Four subsystems have written audit events since migration 0001. Every administrative one landed as `actor_kind = 'api_token'` with **no id and no label** — the record could say what happened and never who, which is half of what an audit trail is for.

## The design question, answered differently than the issue framed it

[#135](https://github.com/meshpnet/meshp/issues/135) posed it as explicit request fields versus request context. It turned out to be neither.

There is now a `store.Actor` — one value rather than three loose fields — and a `WriteAudit` that **refuses a zero one**. Context would have made the omission invisible again, exactly as it is today. Explicit fields make it forgettable, which is how four subsystems ended up anonymous. A required value that fails loudly makes it neither: forgetting is a test failure at the first run rather than a blank column somebody notices in six months.

**The refusal immediately found five call sites in the existing tests that had never said who was acting** — the same silence the production code had been keeping, and a fair demonstration that the guard is the part worth having.

## What changes in the trail

A signed-in person: `actor_kind = 'user'`, a real id, and their **email** as the label — an audit line is read months later by somebody trying to reach whoever did it, and a display name is not a way to reach anyone.

The bootstrap token now names itself. It still cannot name a person — a shared secret has no identity, which is ADR-0024's whole argument — but *"somebody used the root credential"* becomes something an operator reads rather than infers from an empty column.

## The warning, and why it is throttled to an hour

ADR-0024 §5 keeps the token working and asks that using it stop being invisible. Once the deployment has accounts, reaching for the shared secret means somebody is using it *instead of* one.

Throttled for two reasons rather than one. The obvious: the commercial layer polls with a bearer token and would write a line per request. The less obvious: the query behind it is a count of the users table, and asking per request would put a scan in front of every administrative call to produce a message nobody reads twice.

Full suite against a local PostgreSQL, lint, reachability, `make sqlc` clean.