### PR TITLE
feat(web): the page stops being read-only

### DIFF
--- a/docs/adr/0022-web-view-in-the-control-plane.md
+++ b/docs/adr/0022-web-view-in-the-control-plane.md
@@ -107,65 +107,83 @@ page visibly stale rather than leaving old data on screen looking current. A mon
 view that lies about when it last heard anything is worse than no view, in the same way
 that a tunnel silently failing open is worse than one that refuses traffic (ADR-0011).
 
-### 5. A browser gets a cookie, and the cookie can only read
+### 5. A browser gets a cookie, and the cookie is a person
 
-> **Superseded in substance by ADR-0024.** That record gives the browser a real user
-> session with a real identity, at which point the read-only restriction below stops being
-> necessary — it exists only because a credential derived from a shared secret has nothing
-> to attach permissions to. This section describes what ships today and should be rewritten
-> rather than amended again when users land.
->
-> **What the derived session now holds.** ADR-0024's permission slice replaced the list of
-> endpoints below with a rule: the cookie minted from the administrative token holds every
-> permission whose action is a read, and none that writes. That is wider than the two
-> endpoints this section enumerated — it now reaches the device list, the policy, DNS
-> records, the route groups and the enrolment token metadata. The widening is deliberate and
-> it is the point of recording it here: a rule somebody can hold in their head is worth more
-> than a list, and this section had to be amended twice because it was a list. Nothing it
-> reaches was out of reach of the secret it is derived from.
+*Rewritten 2026-08-24, when ADR-0024's permission slices landed. What this section said
+before is at the end, because how it was wrong is the useful part.*
 
-`POST /api/v1/ui/session` takes the administrative token once and returns a session
-cookie: `HttpOnly`, `Secure`, `SameSite=Strict`, short-lived, revocable server-side.
-`DELETE` on the same path logs out. The token itself never reaches JavaScript and is never
-stored in the browser.
+`POST /api/v1/ui/session` takes an email address and a password and returns a session
+cookie: `HttpOnly`, `Secure`, `SameSite=Strict`, sliding idle window, fixed ceiling,
+revocable server-side because it names a row in `user_sessions`. `DELETE` on the same path
+signs out. No credential ever reaches JavaScript.
 
-**The cookie authorises reads, and nothing else.** It is a strictly weaker credential
-derived from the administrative one: every route that creates or changes something keeps
-requiring the bearer token.
+**What the cookie authorises is what the person holds.** There is no separate browser
+credential and no separate rule about what a browser may do: the session identifies a user,
+the user has role bindings, and every route checks a permission against them (ADR-0024 §4).
+A reader signs in and sees a page with no buttons on it. An owner signs in and sees the same
+page with buttons. The middleware that used to mean "reads only" is gone, because there is
+nothing left for it to distinguish.
 
-Two reads it deliberately does not reach, because they are not about a network at all: the
-organisation endpoints, which describe tenants rather than anything inside one. The network
-*list* it does reach, and that is a cross-tenant read — names, slugs and device counts for
-every network this control plane holds. It is there because a page reachable only by pasting
-a UUID is not a product, and it is the one place this credential sees past a single network.
-Worth stating rather than leaving to be discovered, because it is the seam where a
-future per-user scope will have to bite first.
+**The page asks what it may do before it renders.** `GET /api/v1/me/permissions?network=`
+answers for the caller, in that scope. This is never enforcement — the API refuses
+regardless, and a page that believed itself would be one edit away from being the security
+boundary — it is so that a control that would be refused is never drawn. A button that
+returns 403 teaches somebody the product is broken rather than that they lack a permission.
 
-That is what makes shipping this before real user accounts defensible, and it is the whole
-of the justification: a stolen browser session reads one network. The moment the UI grows
-a write path, per-user accounts stop being a follow-up and become a prerequisite — the
-tables are already in the schema waiting for a reader.
+**Writes are defended twice, and the two fail independently.** `SameSite=Strict` means a
+browser does not attach the cookie to a request another site caused; this is the strong one
+and the browser enforces it. Behind it, an unsafe method authenticated by cookie must carry
+an `Origin` naming this host — a cross-origin form POST cannot suppress that header, and a
+cross-origin `fetch` that sets an acceptable one cannot get past a preflight this server
+never answers. Hosts are compared and schemes are not, because a TLS-terminating proxy
+leaves `r.TLS` nil and this package refuses to take `X-Forwarded-Proto` on trust; scheme
+downgrade is the cookie's problem, and the cookie is `Secure`.
 
-*Amended 2026-08-21.* This originally named the endpoints in Decision 1 and nothing else,
-which was the wrong granularity and showed it the first time another read arrived: the
-audit trail (#125) shipped behind the administrative token purely because it was not on a
-list, leaving the page unable to answer "why did my outbound IP change?" while the record
-that answers it sat one route away. The boundary that carries the argument is read against
-write, not which reads — a list makes every future read endpoint an ADR amendment, and an
-amendment made to unblock a feature is one nobody weighs properly. Scoping by kind keeps
-the property that matters, which is that this credential cannot change anything and cannot
-see past the network it was opened on.
+While the credential could only read, `SameSite` alone was adequate — the worst a forged
+request could achieve was making somebody's browser read something on their behalf. A cookie
+that can revoke a device is a different proposition, and a defence with one layer is one
+nobody has asked what happens if it fails.
 
-What that admits: the audit trail carries more than the overview does — actor labels,
-source addresses, the reasons administrators typed. A stolen session now reads one
-network's history as well as its state. That is a real widening, accepted because it is the
-same kind of exposure rather than a new one, and because the alternative was a product that
-cannot show an operator why their traffic moved.
+**The page writes two things, and deliberately only two.** Minting an enrolment token, and
+revoking a device: the two halves of a device's life, which is what this page is already
+about and what an operator otherwise reaches for `curl` to do. Publishing an access policy
+and editing DNS records are not here — they are documents somebody composes rather than
+buttons, and a form that got them subtly wrong would be worse than the command it replaced.
 
-The login endpoint refuses to mint a cookie over plaintext to anything but loopback. TLS
-is already supported both ways (`MESHP_TLS_CERT`, or `MESHP_TLS_DOMAINS` for automatic
-certificates); this makes configuring it a requirement for any deployment somebody
-actually browses to.
+**A minted token pauses the page.** The control plane stores only a hash, so the moment
+after minting is the only moment that secret exists; the view is replaced wholesale on every
+poll, which would wipe a half-made text selection. So polling stops while it is on screen and
+the page says that it has, which is the same rule about freshness as everywhere else.
+
+The login endpoint still refuses to mint a cookie over plaintext to anything but loopback,
+which makes configuring TLS a requirement for any deployment somebody actually browses to.
+
+**What is gone.** The in-memory session store, the credential derived from the
+administrative token, and the read-only middleware. A deployment with no user accounts
+cannot sign in to this page at all, which is correct: it has nothing to look at until
+somebody creates the first account, and creating one is an API call the bootstrap secret
+still makes (ADR-0024 §5).
+
+#### What this section used to say, and how it was wrong
+
+It said the cookie was minted from the administrative token and could only read, and that
+this was what made shipping a UI before user accounts defensible. That was true and it was
+also a bound with no principle underneath it — there was nothing to attach permissions to,
+so "reads only" was the only honest thing to say.
+
+It was amended twice in two days and wrong once, both times for the same reason: it
+enumerated. Naming the endpoints meant the audit trail (#125) shipped behind the
+administrative token purely because it was not on the list, leaving the page unable to
+answer "why did my outbound IP change?" while the record that answers it sat one route away.
+Replacing the endpoints with a rule — read against write — fixed the granularity, but the
+*next* amendment claimed the cookie could not read across networks, which had not been true
+since `GET /api/v1/networks` shipped in #113.
+
+The lesson worth keeping is not "check your claims", though that too. It is that a section
+describing a credential in terms of the routes it reaches will go stale every time a route
+is added, and nobody weighs an amendment made to unblock a feature. A credential described
+in terms of what its holder is does not have that failure mode, which is why this rewrite
+describes a person rather than a list.
 
 ## Consequences
 
@@ -245,6 +263,11 @@ can write everything into a place XSS can read, with no revocation and no expiry
 the price of admission for a read-only page: it is a larger project than the view, and it
 would keep the product invisible for the length of it. Decision 5 is what makes deferring
 it honest rather than merely convenient.
+
+> *Two weeks later, done.* ADR-0024 built exactly this, and Decision 5 above is now written
+> in terms of it. The deferral turned out to be worth what it cost — the page shipped, was
+> used, and the shape of what it needed from accounts was clearer for having had it — but
+> the estimate was right too: it was a larger project than the view, in four slices.
 
 **Three endpoints, polled separately.** Resource-shaped, more RESTful, and each one
 simpler. Rejected for the reason in the Context: the page would render an instant that

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -74,9 +74,6 @@ type Server struct {
 	// with no presence reads as disconnected, which is what it is.
 	presence Presence
 
-	// ui holds the browser sessions minted from the administrative token (ADR-0022 §5).
-	ui *uiSessions
-
 	// bootstrapWarnedAt is when the administrative token was last complained about, so the
 	// complaint is occasional rather than per request. See warnBootstrapTokenUsed.
 	bootstrapWarnedAt atomic.Pointer[time.Time]
@@ -104,7 +101,6 @@ func New(st *store.Store, svc *enroll.Service, sess *session.Server, cfg Config)
 		cfg:     cfg,
 		log:     cfg.Log,
 		limit:   newLimiter(cfg.EnrolRatePerSecond, cfg.EnrolBurst, 10_000, cfg.Clock),
-		ui:      newUISessions(cfg.Clock),
 	}
 	// Taken through the interface rather than held as a *Hub, so the thing that replaces
 	// it for multi-replica deployments (ADR-0012) has one place to arrive. A typed nil
@@ -293,6 +289,12 @@ func (s *Server) routes() []route {
 		{pattern: "POST /api/v1/me/password", handler: s.handleChangeOwnPassword, kind: guardSignedIn},
 		{pattern: "GET /api/v1/permissions", handler: s.handleListPermissions, kind: guardSignedIn},
 
+		// What this caller may do, here — which is what the page loads before deciding
+		// which controls exist. Behind no permission of its own: it answers a question
+		// about the caller, and refusing to tell somebody what they may do would leave a
+		// page guessing.
+		{pattern: "GET /api/v1/me/permissions", handler: s.handleListOwnPermissions, kind: guardSignedIn},
+
 		// Credentials for machines (ADR-0024 §2). Your own, which is why they hang off /me
 		// and are behind no permission: minting and pruning your own credentials is like
 		// changing your own password, and needing to be granted the right to do it would
@@ -394,6 +396,17 @@ func (s *Server) gate(rt route) http.Handler {
 		}
 		r = r.WithContext(withCaller(r.Context(), c))
 
+		// A browser session that is about to change something must have been sent by this
+		// site. See sameOrigin: the page can now revoke a device, so the defence is an
+		// argument rather than an inherited assumption.
+		if c.user != nil && !safeMethod(r.Method) && !sameOrigin(r) {
+			s.log.Warn("a cross-origin write was refused",
+				"path", logx.Safe(r.URL.Path), "origin", logx.Safe(r.Header.Get("Origin")))
+			httpx.Error(w, s.log, http.StatusForbidden, "cross_origin",
+				"this request did not come from this site")
+			return
+		}
+
 		switch rt.kind {
 		case guardSignedIn:
 			rt.handler(w, r)
@@ -443,18 +456,23 @@ func (s *Server) gate(rt route) http.Handler {
 			rt.handler(w, r)
 
 		case guardCallerOrganization:
-			// The administrative token belongs to no organisation and holds everything,
-			// so there is nothing to resolve for it.
-			if c.user == nil {
-				held := s.callerPermissions(c)
-				if !held.Allows(rt.perm) {
-					s.refuse(w, r, c, held, rt.perm)
-					return
-				}
+			// The administrative token belongs to no organisation and holds everything, so
+			// there is nothing to resolve for it. A token belongs to its owner's, which is
+			// the one permissionsInOrganization asks about below.
+			if c.bootstrap {
 				rt.handler(w, r)
 				return
 			}
-			held, err := s.permissionsInOrganization(r, c, c.user.OrganizationID)
+			org := callerOrganization(c)
+			if org == nil {
+				// Unreachable: identify returns bootstrap, a person or a token, and the
+				// first is handled above. Answered rather than dereferenced, because the
+				// alternative is a panic that only shows up when it is wrong.
+				httpx.Error(w, s.log, http.StatusForbidden, "forbidden",
+					"this caller belongs to no organisation")
+				return
+			}
+			held, err := s.permissionsInOrganization(r, c, *org)
 			if err != nil {
 				s.respondError(w, r, err)
 				return
@@ -471,14 +489,6 @@ func (s *Server) gate(rt route) http.Handler {
 				"the request could not be completed")
 		}
 	})
-}
-
-// callerPermissions is what a credential that is not a person holds, everywhere.
-func (s *Server) callerPermissions(c caller) authz.Set {
-	if c.bootstrap {
-		return authz.All()
-	}
-	return authz.ReadOnly()
 }
 
 func bearer(r *http.Request) string {

--- a/internal/api/authz.go
+++ b/internal/api/authz.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/subtle"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -36,12 +38,6 @@ type caller struct {
 	// bootstrap is the administrative token itself: the deployment's root credential, which
 	// holds every permission including ones that do not exist yet (ADR-0024 §5).
 	bootstrap bool
-
-	// readOnly is a browser session minted from the administrative token (ADR-0022 §5).
-	// Strictly weaker than the secret it came from: it holds every permission that only
-	// reads and nothing else, which is the whole argument for having shipped a page before
-	// there were accounts. Nothing mints these once people sign in with their own accounts.
-	readOnly bool
 }
 
 type callerKey struct{}
@@ -94,11 +90,6 @@ func (s *Server) identify(r *http.Request) (caller, bool) {
 		return caller{token: &token}, true
 	}
 
-	if s.cfg.AdminToken != "" {
-		if cookie, err := r.Cookie(uiCookieName); err == nil && s.ui.valid(cookie.Value) {
-			return caller{readOnly: true}, true
-		}
-	}
 	return caller{}, false
 }
 
@@ -112,8 +103,6 @@ func (s *Server) permissionsInNetwork(r *http.Request, c caller, networkID uuid.
 	switch {
 	case c.bootstrap:
 		return authz.All(), nil
-	case c.readOnly:
-		return authz.ReadOnly(), nil
 	case c.token != nil:
 		return s.store.TokenPermissions(r.Context(), *c.token, &networkID)
 	default:
@@ -130,8 +119,6 @@ func (s *Server) permissionsInOrganization(r *http.Request, c caller, orgID uuid
 	switch {
 	case c.bootstrap:
 		return authz.All(), nil
-	case c.readOnly:
-		return authz.ReadOnly(), nil
 	case c.token != nil:
 		if c.token.OrganizationID != orgID {
 			// A token belongs to one organisation, as its owner does. Asked about another,
@@ -184,4 +171,63 @@ func (s *Server) unauthenticated(w http.ResponseWriter, r *http.Request) {
 		"path", logx.Safe(r.URL.Path), "remote", logx.Safe(clientKey(r)))
 	httpx.Error(w, s.log, http.StatusUnauthorized, "unauthorized",
 		"sign in, or present a valid administrative token")
+}
+
+// callerOrganization is the one organisation this caller belongs to, or nil for the
+// administrative token, which belongs to none.
+func callerOrganization(c caller) *uuid.UUID {
+	switch {
+	case c.user != nil:
+		return &c.user.OrganizationID
+	case c.token != nil:
+		return &c.token.OrganizationID
+	default:
+		return nil
+	}
+}
+
+// safeMethod reports whether a request only reads.
+func safeMethod(method string) bool {
+	return method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions
+}
+
+// sameOrigin reports whether an unsafe request came from this site.
+//
+// The cross-site request forgery defence, and it is written down rather than assumed because
+// what it is defending changed. While the browser's credential could only read, SameSite=Strict
+// carried the whole burden and that was adequate: the worst a forged request could achieve was
+// to make somebody's browser read something on their behalf. A cookie that can revoke a device
+// deserves an argument.
+//
+// Two things now stand in the way, and they fail independently:
+//
+//   - SameSite=Strict, so a browser does not attach the cookie to a request another site
+//     caused at all. This is the strong one and it is enforced by the browser.
+//   - This check, which is what remains if that is bypassed — by a browser that does not
+//     implement it, or by a bug in one. A cross-origin form POST cannot suppress the Origin
+//     header, and a cross-origin fetch that sets one this endpoint would accept cannot get
+//     past the preflight, because nothing here answers with CORS headers.
+//
+// Hosts are compared and schemes are not. A TLS-terminating proxy in front leaves r.TLS nil
+// while the browser sends an https Origin, and this package deliberately does not consult
+// X-Forwarded-Proto — a header a client can set should not decide whether a write is allowed.
+// Scheme downgrade is the cookie's problem and the cookie is Secure, so it never travels over
+// plaintext to be replayed.
+//
+// Only cookie-authenticated requests are checked. A bearer token is not attached by a browser
+// to anything, so there is nothing to forge; and requiring an Origin from `curl`, which sends
+// none, would break every machine caller to defend against an attack they cannot suffer.
+func sameOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		// Absent, on an unsafe method, from a request carrying a cookie. Every browser
+		// sends it for POST, PUT and DELETE, so this is not one — and a request that is
+		// not a browser has no business using the browser's credential.
+		return false
+	}
+	parsed, err := url.Parse(origin)
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	return strings.EqualFold(parsed.Host, r.Host)
 }

--- a/internal/api/csrf_test.go
+++ b/internal/api/csrf_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+)
+
+// asCookie makes a request with a browser session and whatever Origin the caller names,
+// including none.
+func (h *harness) asCookie(method, path string, cookie *http.Cookie, origin string) int {
+	h.t.Helper()
+	req, _ := http.NewRequest(method, h.server.URL+path, bytes.NewReader([]byte("{}")))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: cookie.Name, Value: cookie.Value})
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	return resp.StatusCode
+}
+
+// A write a browser was tricked into making from another site is refused.
+//
+// SameSite=Strict is the strong defence and the browser enforces it, so this never runs in a
+// browser that implements it correctly. That is exactly why it is here: it is what remains
+// when that one is bypassed, and a defence with a single layer is one that has never been
+// asked what happens if it fails.
+//
+// Until permissions arrived the browser's credential could only read, and the worst a forged
+// request could achieve was making somebody read something. A cookie that can revoke a
+// device deserves the second layer.
+func TestAWriteFromAnotherSiteIsRefused(t *testing.T) {
+	h := newHarness(t)
+	cookie := h.loginAs("owner")
+	path := "/api/v1/networks/" + h.netID.String() + "/enrollment-tokens"
+
+	for _, tc := range []struct {
+		name   string
+		origin string
+	}{
+		{"another site entirely", "https://attacker.example"},
+		{"a lookalike host", "https://" + h.server.Listener.Addr().String() + ".attacker.example"},
+		{"no origin at all", ""},
+		{"not a URL", "null"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := h.asCookie(http.MethodPost, path, cookie, tc.origin); got != http.StatusForbidden {
+				t.Errorf("a write with Origin %q = %d, want 403", tc.origin, got)
+			}
+		})
+	}
+
+	// And the same request from this site works, or the check would be refusing everything
+	// and this test would pass for the wrong reason.
+	if got := h.asCookie(http.MethodPost, path, cookie, h.server.URL); got != http.StatusCreated {
+		t.Errorf("a write from this site = %d, want 201", got)
+	}
+}
+
+// Reads are not checked, because there is nothing to forge: a cross-site read the browser
+// would have attached the cookie to is one SameSite already stopped, and refusing a GET
+// without an Origin would break every page load, which sends none.
+func TestAReadNeedsNoOrigin(t *testing.T) {
+	h := newHarness(t)
+	cookie := h.loginAs("reader")
+
+	if got := h.asCookie(http.MethodGet, "/api/v1/networks", cookie, ""); got != http.StatusOK {
+		t.Errorf("a read with no Origin = %d, want 200", got)
+	}
+}
+
+// A machine is not checked, because a bearer token is not something a browser attaches to a
+// request another site caused. Requiring an Origin here would break every caller that is not
+// a browser — `curl` sends none — to defend against an attack they cannot suffer.
+func TestAMachineNeedsNoOrigin(t *testing.T) {
+	h := newHarness(t)
+
+	req, _ := http.NewRequest(http.MethodPost,
+		h.server.URL+"/api/v1/networks/"+h.netID.String()+"/enrollment-tokens",
+		bytes.NewReader([]byte("{}")))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testAdminToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("the administrative token writing with no Origin = %d, want 201", resp.StatusCode)
+	}
+}

--- a/internal/api/organization.go
+++ b/internal/api/organization.go
@@ -58,25 +58,17 @@ func (s *Server) handleCreateOrganization(w http.ResponseWriter, r *http.Request
 // The administrative token belongs to no organisation and sees them all, which is what it is
 // for and is the only way a deployment operator can find a tenant to work in.
 func (s *Server) handleListOrganizations(w http.ResponseWriter, r *http.Request) {
-	// A browser session minted from the administrative token is refused, and not as a
-	// special case: this endpoint answers "which organisation am I in", and a credential
-	// with no identity has no answer. Returning every tenant to it would hand a page
-	// derived from one shared secret a list of every customer on the deployment, which is
-	// the thing ADR-0022 §5 was amended about.
-	if callerFrom(r).readOnly {
-		httpx.Error(w, s.log, http.StatusForbidden, "forbidden",
-			"this asks which organisation you are in, and this session is not a person; sign in")
-		return
-	}
-
 	orgs, err := s.store.ListOrganizations(r.Context())
 	if err != nil {
 		s.respondError(w, r, err)
 		return
 	}
-	if user := callerFrom(r).user; user != nil {
+	// A person sees their own organisation; a token sees its owner's. The administrative
+	// token belongs to none and sees them all, which is the only way a deployment operator
+	// can find a tenant to work in.
+	if mine := callerOrganization(callerFrom(r)); mine != nil {
 		orgs = slices.DeleteFunc(orgs, func(org store.Organization) bool {
-			return org.ID != user.OrganizationID
+			return org.ID != *mine
 		})
 	}
 	out := make([]map[string]any, 0, len(orgs))

--- a/internal/api/organization_test.go
+++ b/internal/api/organization_test.go
@@ -112,21 +112,37 @@ func TestTheSameOrganisationTwiceIsRefused(t *testing.T) {
 	}
 }
 
-// The browser credential minted from the administrative token reaches neither half of this.
+// A signed-in person sees their own organisation and no other, and cannot create one.
 //
-// Reading is refused because the endpoint answers "which organisation am I in", and that
-// session is not a person — returning every tenant to a page derived from one shared secret
-// is the leak ADR-0022 §5 was amended about. Writing is refused because creating a tenant is
-// deployment administration and needs the token itself.
-func TestOrganisationsAreNotBrowserReadable(t *testing.T) {
+// This used to assert that the browser's credential reached neither half, because that
+// credential was derived from a shared secret and had no identity. It has one now, so the
+// interesting question changed: reading is allowed and *scoped*, because knowing which
+// organisation you are in is not a privilege — /api/v1/me already answers it — while
+// creating a tenant stays deployment administration and needs the token itself.
+func TestAPersonSeesTheirOwnOrganisationAndCannotCreateOne(t *testing.T) {
 	h := newHarness(t)
-	cookie := h.login()
 
-	for _, method := range []string{http.MethodGet, http.MethodPost} {
-		resp := h.withCookie(method, "/api/v1/organizations", cookie)
-		_ = resp.Body.Close()
-		if resp.StatusCode != http.StatusForbidden {
-			t.Errorf("%s with a browser session = %d, want 403", method, resp.StatusCode)
-		}
+	// A second tenant, so "their own" is a real restriction rather than a list of one.
+	if status, body := postOrg(t, h, map[string]any{"slug": "globex", "name": "Globex"}, true); status != http.StatusCreated {
+		t.Fatalf("creating a second organisation = %d: %v", status, body)
+	}
+
+	cookie := h.login()
+	status, _, body := doJSONWithCookie(t, h, http.MethodGet, "/api/v1/organizations", cookie)
+	if status != http.StatusOK {
+		t.Fatalf("reading = %d: %v", status, body)
+	}
+	orgs, _ := body["organizations"].([]any)
+	if len(orgs) != 1 {
+		t.Fatalf("%d organisations, want only their own", len(orgs))
+	}
+	if first, _ := orgs[0].(map[string]any); first["slug"] != "acme" {
+		t.Errorf("they see %v, want their own organisation", first["slug"])
+	}
+
+	resp := h.withCookie(http.MethodPost, "/api/v1/organizations", cookie)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("creating an organisation with a browser session = %d, want 403", resp.StatusCode)
 	}
 }

--- a/internal/api/roles.go
+++ b/internal/api/roles.go
@@ -47,6 +47,71 @@ func scopeOf(p authz.Permission) string {
 	return "organization"
 }
 
+// handleListOwnPermissions answers what this caller may do, here.
+//
+// The endpoint the page loads before it renders anything, because what it may show is now
+// per-person: a reader and an owner see the same network and a different set of controls. A
+// page that renders a button the API then refuses is worse than one that never rendered it —
+// it teaches somebody that the product is broken rather than that they lack a permission.
+//
+// Deliberately not a field on the overview. That response describes a network and is shared
+// surface the commercial layer builds on (ADR-0023); this describes the caller, and mixing
+// the two would make one response's correctness depend on who asked for it.
+//
+// ?network= scopes the answer to one network, which is where a `network.` permission is
+// held. Without it the answer is the caller's organisation-wide permissions — the set that a
+// grant narrowed to a single network never contributes to.
+func (s *Server) handleListOwnPermissions(w http.ResponseWriter, r *http.Request) {
+	c := callerFrom(r)
+
+	var (
+		held authz.Set
+		err  error
+	)
+	if raw := r.URL.Query().Get("network"); raw != "" {
+		networkID, parseErr := uuid.Parse(raw)
+		if parseErr != nil {
+			httpx.Error(w, s.log, http.StatusBadRequest, "bad_request", "network must be a UUID")
+			return
+		}
+		held, err = s.permissionsInNetwork(r, c, networkID)
+	} else {
+		org := callerOrganization(c)
+		if org == nil {
+			// The administrative token belongs to no organisation, so there is nothing to
+			// resolve against. It holds everything.
+			held = authz.All()
+		} else {
+			held, err = s.permissionsInOrganization(r, c, *org)
+		}
+	}
+	if err != nil {
+		s.respondError(w, r, err)
+		return
+	}
+
+	permissions := held.Sorted()
+	if held.Unlimited() {
+		// The administrative token, which holds what has not been invented yet and which no
+		// list describes honestly. The whole catalogue is sent so a page has something to
+		// render, and `unlimited` says why the list is not the whole truth — an empty array
+		// would otherwise read as "allowed nothing", which is its exact opposite.
+		permissions = everyPermission()
+	}
+	httpx.WriteJSON(w, s.log, http.StatusOK, map[string]any{
+		"permissions": permissions,
+		"unlimited":   held.Unlimited(),
+	})
+}
+
+func everyPermission() []string {
+	out := make([]string, 0, len(authz.Catalogue))
+	for _, e := range authz.Catalogue {
+		out = append(out, string(e.Name))
+	}
+	return out
+}
+
 // handleListRoles answers what roles this organisation can grant.
 func (s *Server) handleListRoles(w http.ResponseWriter, r *http.Request) {
 	orgID, ok := s.pathUUID(w, r, "organizationID")

--- a/internal/api/roles_test.go
+++ b/internal/api/roles_test.go
@@ -288,3 +288,67 @@ func doJSONWithBody(t *testing.T, h *harness, method, path string, body any, coo
 	t.Helper()
 	return doJSON(t, method, h.server.URL+path, body, cookie, false)
 }
+
+// The page asks what it may do before deciding what to render, so the answer has to be
+// scoped the same way the guards are: per network for a `network.` permission, organisation
+// wide for an `organization.` one.
+func TestACallerCanAskWhatTheyMayDoHere(t *testing.T) {
+	h := newHarness(t)
+	other := h.secondNetwork(t)
+
+	tech := createUser(t, h, "tech@example.com")
+	takeAwayEveryRole(t, h, tech)
+	grantRole(t, h, tech, map[string]any{
+		"role": authz.RoleOperator, "network_id": h.netID.String(),
+	})
+	cookie := signIn(t, h, "tech@example.com", testPassword)
+
+	held := func(query string) map[string]bool {
+		t.Helper()
+		status, _, body := doJSONWithCookie(t, h, http.MethodGet, "/api/v1/me/permissions"+query, cookie)
+		if status != http.StatusOK {
+			t.Fatalf("asking what I may do%s = %d: %v", query, status, body)
+		}
+		if body["unlimited"] != false {
+			t.Errorf("a person reads as unlimited: %v", body)
+		}
+		out := map[string]bool{}
+		for _, p := range body["permissions"].([]any) {
+			out[p.(string)] = true
+		}
+		return out
+	}
+
+	mine := held("?network=" + h.netID.String())
+	if !mine[string(authz.NetworkDevicesRevoke)] {
+		t.Error("an operator is not told they may revoke a device on their own network")
+	}
+
+	theirs := held("?network=" + other.String())
+	if len(theirs) != 0 {
+		t.Errorf("they are told they may do %v on a network they hold nothing on", theirs)
+	}
+
+	// And organisation-wide, where a grant narrowed to one network contributes nothing —
+	// so a page must not render an organisation-level control for this person.
+	across := held("")
+	if len(across) != 0 {
+		t.Errorf("a grant narrowed to one network was reported as %v across the organisation", across)
+	}
+}
+
+// The administrative token holds what has not been invented yet, and no list describes that
+// honestly. It says so rather than sending an array a consumer would read as a limit.
+func TestTheAdministrativeTokenSaysItIsUnlimited(t *testing.T) {
+	h := newHarness(t)
+	status, _, body := doJSON(t, http.MethodGet, h.server.URL+"/api/v1/me/permissions", nil, nil, true)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if body["unlimited"] != true {
+		t.Errorf("unlimited = %v, want true", body["unlimited"])
+	}
+	if got := len(body["permissions"].([]any)); got != len(authz.Catalogue) {
+		t.Errorf("%d permissions, want the whole catalogue of %d", got, len(authz.Catalogue))
+	}
+}

--- a/internal/api/uisession.go
+++ b/internal/api/uisession.go
@@ -1,179 +1,40 @@
 package api
 
 import (
-	"crypto/rand"
-	"crypto/sha256"
-	"crypto/subtle"
-	"encoding/base64"
-	"errors"
 	"net"
 	"net/http"
 	"net/netip"
 	"strings"
-	"sync"
-	"time"
 
-	"github.com/meshpnet/meshp/internal/clock"
 	"github.com/meshpnet/meshp/internal/httpx"
-	"github.com/meshpnet/meshp/internal/logx"
 )
 
-// The browser's credential, and the whole of what makes a UI defensible before user
-// accounts exist (ADR-0022 §5).
+// The browser's credential (ADR-0022 §5, rewritten by ADR-0024).
 //
-// It is derived from the administrative token and strictly weaker than it: it authorises
-// the two read endpoints and nothing else, so a stolen browser session reads a network and
-// cannot mint an enrolment token, publish a policy or revoke a device. That asymmetry is
-// the entire justification for shipping a page against a single shared secret, and it stops
-// being sufficient the moment the UI grows a write path — at which point per-user accounts
-// are a prerequisite rather than a follow-up. The users, roles and role_bindings tables
-// have been in the schema since the first migration, waiting for a reader.
+// It used to be derived from the administrative token and bounded by being unable to write,
+// because a credential minted from a shared secret has no identity to attach permissions to.
+// That is over: the cookie now names a row in `user_sessions`, belonging to a person, and
+// what it may do is what that person may do. There is no separate browser credential left in
+// this file — what remains is the sign-in that mints one and the sign-out that ends it.
 const (
 	// uiCookieName is prefixed because the prefix is enforced by the browser: a cookie
 	// named __Host- may only be set over TLS, with no Domain, and Path=/. A page that
 	// somehow reached this over plaintext could not have its cookie set at all rather
 	// than having it set insecurely.
 	uiCookieName = "__Host-meshp_ui"
-
-	// uiSessionIdle is how long a session survives without being used.
-	//
-	// Sliding, because the page this exists for polls every few seconds: a dashboard
-	// somebody is watching never expires under them, and one abandoned on an unlocked
-	// laptop is dead within the window. A fixed lifetime would have to choose between
-	// those two and would get one of them wrong.
-	uiSessionIdle = 30 * time.Minute
-
-	// uiSessionMaxAge is the ceiling that no amount of use extends.
-	//
-	// Without it a page left open on a wall holds a credential derived from the
-	// deployment's root password forever, and "revocable server-side" would mean
-	// "revocable if somebody remembers".
-	uiSessionMaxAge = 12 * time.Hour
-
-	// maxUISessions bounds the store. Logins are rare and each entry is small, so this is
-	// not a capacity decision — it is what stops an endpoint that allocates on success
-	// from being a way to grow the heap once somebody has the token.
-	maxUISessions = 1024
 )
 
-// uiSession is one logged-in browser.
-type uiSession struct {
-	// idleDeadline moves forward on use; absoluteDeadline never does.
-	idleDeadline     time.Time
-	absoluteDeadline time.Time
-}
-
-// uiSessions holds them, in memory and in this process only.
+// handleUILogin signs a person in.
 //
-// Deliberately not in PostgreSQL. A browser session is ephemeral by the same argument
-// ADR-0012 makes for presence — losing it costs a login, not correctness — and writing one
-// row per page load into the tables that hold desired state would be the wrong trade. The
-// consequence is that a restart logs everybody out, and that multi-replica does not work,
-// which is already true of this control plane for other reasons ADR-0022 sets out.
-type uiSessions struct {
-	clk clock.Clock
-
-	mu sync.Mutex
-	// Keyed by the SHA-256 of the token rather than by the token. The value a browser
-	// presents is then not sitting in this process's memory, so a heap dump or a core file
-	// does not hand somebody a live session.
-	byHash map[[32]byte]uiSession
-}
-
-// errTooManySessions means the store is full. Refusing is deliberate: evicting somebody
-// else's session instead would make a flood of sign-ins a way to log out whoever is
-// actually watching.
-var errTooManySessions = errors.New("api: too many browser sessions")
-
-func newUISessions(clk clock.Clock) *uiSessions {
-	if clk == nil {
-		clk = clock.System{}
-	}
-	return &uiSessions{clk: clk, byHash: make(map[[32]byte]uiSession)}
-}
-
-// create mints a session and returns the value the browser will present.
-func (u *uiSessions) create() (string, time.Time, error) {
-	raw := make([]byte, 32)
-	if _, err := rand.Read(raw); err != nil {
-		return "", time.Time{}, err
-	}
-	token := base64.RawURLEncoding.EncodeToString(raw)
-
-	now := u.clk.Now()
-	absolute := now.Add(uiSessionMaxAge)
-
-	u.mu.Lock()
-	defer u.mu.Unlock()
-	// Swept here rather than on a timer: logins are the only thing that grows this map, so
-	// they are the only moment it needs tidying, and a goroutine per server for a map that
-	// is usually empty is not worth owning.
-	u.sweepLocked(now)
-	if len(u.byHash) >= maxUISessions {
-		// Refusing rather than evicting somebody else's session. Eviction would make a
-		// flood of logins a way to log out whoever is actually watching.
-		return "", time.Time{}, errTooManySessions
-	}
-	u.byHash[sha256.Sum256([]byte(token))] = uiSession{
-		idleDeadline:     now.Add(uiSessionIdle),
-		absoluteDeadline: absolute,
-	}
-	return token, absolute, nil
-}
-
-// valid reports whether a presented token names a live session, and extends it if so.
-func (u *uiSessions) valid(token string) bool {
-	if token == "" {
-		return false
-	}
-	key := sha256.Sum256([]byte(token))
-	now := u.clk.Now()
-
-	u.mu.Lock()
-	defer u.mu.Unlock()
-	session, ok := u.byHash[key]
-	if !ok {
-		return false
-	}
-	if now.After(session.idleDeadline) || now.After(session.absoluteDeadline) {
-		delete(u.byHash, key)
-		return false
-	}
-	// The idle window moves; the ceiling does not, and the new window is clamped to it so
-	// a busy page cannot walk past the absolute deadline one poll at a time.
-	session.idleDeadline = now.Add(uiSessionIdle)
-	if session.idleDeadline.After(session.absoluteDeadline) {
-		session.idleDeadline = session.absoluteDeadline
-	}
-	u.byHash[key] = session
-	return true
-}
-
-// revoke ends one session. Ending a session that does not exist is success: a browser
-// logging out with a cookie this process has already forgotten has got what it asked for.
-func (u *uiSessions) revoke(token string) {
-	if token == "" {
-		return
-	}
-	u.mu.Lock()
-	defer u.mu.Unlock()
-	delete(u.byHash, sha256.Sum256([]byte(token)))
-}
-
-func (u *uiSessions) sweepLocked(now time.Time) {
-	for key, session := range u.byHash {
-		if now.After(session.idleDeadline) || now.After(session.absoluteDeadline) {
-			delete(u.byHash, key)
-		}
-	}
-}
-
-// handleUILogin exchanges the administrative token for a cookie.
+// An email address and a password, and no longer the administrative token: a browser session
+// is a person now, and a shared secret is not one. A deployment with no accounts yet cannot
+// sign in here at all, which is correct — it has nothing to look at until somebody creates
+// the first user, and creating one is an API call the bootstrap secret still makes
+// (ADR-0024 §5).
 //
-// The token arrives in the body rather than in a header, because that is what a login form
-// produces and the point of this endpoint is that the token is typed once and never stored.
-// What reaches the browser afterwards is HttpOnly, so no script on the page can read it
-// back out, and the token itself never becomes something JavaScript holds between requests.
+// The credential arrives in the body rather than in a header because that is what a login
+// form produces. What reaches the browser afterwards is HttpOnly, so no script on the page
+// can read it back out.
 func (s *Server) handleUILogin(w http.ResponseWriter, r *http.Request) {
 	if !s.canSetSecureCookie(r) {
 		// Refused rather than downgraded. A cookie without Secure over a plaintext hop is
@@ -187,76 +48,31 @@ func (s *Server) handleUILogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		Token string `json:"token"`
+		Email    string `json:"email"`
+		Password string `json:"password"`
 
-		// A person signing in with their own account (ADR-0024). Which path this request
-		// takes is decided by whether it carries an email rather than by a separate
-		// endpoint: one cookie, one sign-in URL, one thing a browser has to know about.
-		Email        string `json:"email"`
-		Password     string `json:"password"`
+		// Organization narrows the search when one address exists in several. Almost every
+		// deployment has one, so almost nobody sends it — the sign-in form asks for it only
+		// after being told the address is ambiguous.
 		Organization string `json:"organization"`
 	}
 	if err := decode(w, r, &body); err != nil {
 		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
-
-	if body.Email != "" {
-		s.signInWithPassword(w, r, body.Email, body.Password, body.Organization)
+	if body.Email == "" {
+		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request",
+			"sign in with an email address and password")
 		return
 	}
-
-	// The administrative token, which is the bootstrap path and is on its way out. ADR-0024
-	// §5 keeps it working — a deployment that has locked itself out has no other way back —
-	// and stops teaching it.
-	if s.cfg.AdminToken == "" {
-		httpx.Error(w, s.log, http.StatusServiceUnavailable, "admin_disabled",
-			"sign in with an email address and password, or set MESHP_ADMIN_TOKEN to bootstrap the first account")
-		return
-	}
-	// Constant time, for the reason adminOnly gives: otherwise the secret can be learned
-	// one byte at a time from how long this takes.
-	if subtle.ConstantTimeCompare([]byte(body.Token), []byte(s.cfg.AdminToken)) != 1 {
-		s.log.Warn("a browser sign-in was refused", "remote", logx.Safe(clientKey(r)))
-		httpx.Error(w, s.log, http.StatusUnauthorized, "unauthorized",
-			"that is not the administrative token")
-		return
-	}
-
-	token, expires, err := s.ui.create()
-	if err != nil {
-		s.log.Error("could not mint a browser session", "error", err)
-		httpx.Error(w, s.log, http.StatusServiceUnavailable, "unavailable",
-			"could not start a session; try again")
-		return
-	}
-
-	http.SetCookie(w, &http.Cookie{
-		Name:  uiCookieName,
-		Value: token,
-		Path:  "/",
-		// HttpOnly so no script reads it, Secure so it never crosses a plaintext hop, and
-		// SameSite=Strict so another origin cannot make a browser spend it — which is also
-		// what stands in for a CSRF token on the sign-out route below.
-		HttpOnly: true,
-		Secure:   true,
-		SameSite: http.SameSiteStrictMode,
-		Expires:  expires,
-		MaxAge:   int(uiSessionMaxAge / time.Second),
-	})
-	httpx.WriteJSON(w, s.log, http.StatusCreated, map[string]any{
-		"expires_at": expires.UTC(),
-		// Said out loud so a consumer is not left to infer it from a 401 later.
-		"authorises": []string{"read"},
-	})
+	s.signInWithPassword(w, r, body.Email, body.Password, body.Organization)
 }
 
 // handleUILogout ends the session and clears the cookie.
 func (s *Server) handleUILogout(w http.ResponseWriter, r *http.Request) {
 	if cookie, err := r.Cookie(uiCookieName); err == nil {
-		// Both stores, because one cookie now names either kind of session and this end
-		// cannot tell which without asking. Ending one that does not exist is free.
-		s.ui.revoke(cookie.Value)
+		// Ending a session that does not exist is success: a browser signing out with a
+		// cookie this deployment has already forgotten has got what it asked for.
 		if err := s.store.SignOut(r.Context(), cookie.Value); err != nil {
 			// Logged and not returned: the cookie is cleared below either way, and telling
 			// a browser its sign-out failed would leave somebody clicking it again.

--- a/internal/api/uisession_test.go
+++ b/internal/api/uisession_test.go
@@ -3,19 +3,22 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/meshpnet/meshp/internal/authz"
-	"github.com/meshpnet/meshp/internal/clock"
 )
 
-// login exchanges the administrative token for a browser session and returns the cookie.
+// login signs in as a reader and returns the cookie.
+//
+// A reader, because that is the successor to the credential these tests were written for: a
+// browser session that reads everything and writes nothing. That used to be a property of
+// the credential itself, derived from the administrative token and bounded by having no
+// identity to attach permissions to. It is now a property of the person holding it, which
+// is the whole of what ADR-0024 changed here.
 //
 // The cookie is carried by hand rather than by a cookie jar, because Go's jar honours the
 // Secure attribute and would refuse to send it back over the test server's plaintext
@@ -23,37 +26,30 @@ import (
 // about. What is under test is the server's side of it.
 func (h *harness) login() *http.Cookie {
 	h.t.Helper()
-	resp := h.loginWith(testAdminToken)
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusCreated {
-		h.t.Fatalf("signing in returned %d", resp.StatusCode)
-	}
-	for _, c := range resp.Cookies() {
-		if c.Name == uiCookieName {
-			return c
-		}
-	}
-	h.t.Fatalf("signing in set no %s cookie", uiCookieName)
-	return nil
+	return h.loginAs("reader")
 }
 
-func (h *harness) loginWith(token string) *http.Response {
+// loginAs signs in as somebody holding exactly one built-in role.
+func (h *harness) loginAs(role string) *http.Cookie {
 	h.t.Helper()
-	body, _ := json.Marshal(map[string]string{"token": token})
-	req, _ := http.NewRequest(http.MethodPost, h.server.URL+"/api/v1/ui/session", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		h.t.Fatal(err)
-	}
-	return resp
+	email := role + "@example.com"
+	user := createUser(h.t, h, email)
+	takeAwayEveryRole(h.t, h, user)
+	grantRole(h.t, h, user, map[string]any{"role": role})
+	return signIn(h.t, h, email, testPassword)
 }
 
 // withCookie makes a request carrying the browser session and no bearer token.
+//
+// Origin is set because a browser sets it on every unsafe method, and the cross-site request
+// forgery check refuses a cookie-authenticated write without it. A test helper that omitted
+// it would make every write in this file fail for the wrong reason — and would hide whether
+// the permission underneath was ever checked.
 func (h *harness) withCookie(method, path string, cookie *http.Cookie) *http.Response {
 	h.t.Helper()
 	req, _ := http.NewRequest(method, h.server.URL+path, bytes.NewReader([]byte("{}")))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", h.server.URL)
 	if cookie != nil {
 		req.AddCookie(&http.Cookie{Name: cookie.Name, Value: cookie.Value})
 	}
@@ -87,8 +83,8 @@ func TestSigningInSetsAHardenedCookie(t *testing.T) {
 	if cookie.Value == "" {
 		t.Error("the cookie carries no value")
 	}
-	if cookie.Value == testAdminToken {
-		t.Fatal("the cookie carries the administrative token itself, which is the one thing it must never do")
+	if strings.Contains(cookie.Value, testPassword) {
+		t.Fatal("the cookie carries the password, which is the one thing it must never do")
 	}
 }
 
@@ -204,92 +200,12 @@ func (h *harness) fillPath(pattern, membership string) string {
 	return pattern
 }
 
-// A wrong token mints nothing. Otherwise the endpoint is a way to turn a guess into a
-// credential that outlives the guessing.
-func TestSigningInWithTheWrongToken(t *testing.T) {
-	h := newHarness(t)
-
-	resp := h.loginWith("not-the-admin-token")
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Fatalf("returned %d, want 401", resp.StatusCode)
-	}
-	for _, c := range resp.Cookies() {
-		if c.Name == uiCookieName && c.Value != "" {
-			t.Fatal("a refused sign-in still set a session cookie")
-		}
-	}
-}
-
-// Signing out is what "revocable server-side" means, so the cookie has to stop working
-// even though the browser still holds it.
-func TestSigningOutRevokesTheSession(t *testing.T) {
-	h := newHarness(t)
-	cookie := h.login()
-
-	out := h.withCookie(http.MethodDelete, "/api/v1/ui/session", cookie)
-	_ = out.Body.Close()
-	if out.StatusCode != http.StatusNoContent {
-		t.Fatalf("signing out returned %d, want 204", out.StatusCode)
-	}
-
-	resp := h.withCookie(http.MethodGet, "/api/v1/networks", cookie)
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("the cookie still reads after signing out, returned %d", resp.StatusCode)
-	}
-}
-
-// A page nobody is watching stops being able to read. A page somebody is watching does not.
-func TestTheSessionExpiresWhenIdleAndIsHeldOpenByUse(t *testing.T) {
-	h := newHarness(t)
-	cookie := h.login()
-
-	// Used well inside the idle window, repeatedly, past the point a fixed lifetime of one
-	// idle window would have ended it. A dashboard polling every few seconds must not log
-	// itself out.
-	for range 4 {
-		h.clk.Advance(uiSessionIdle - time.Minute)
-		resp := h.withCookie(http.MethodGet, "/api/v1/networks", cookie)
-		_ = resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("a session in use returned %d, want 200", resp.StatusCode)
-		}
-	}
-
-	h.clk.Advance(uiSessionIdle + time.Minute)
-	resp := h.withCookie(http.MethodGet, "/api/v1/networks", cookie)
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("an idle session still reads, returned %d", resp.StatusCode)
-	}
-}
-
-// Use extends the idle window but never the ceiling, so a page left open on a wall does not
-// hold a credential derived from the deployment's root password indefinitely.
-func TestTheSessionHasACeilingUseDoesNotRaise(t *testing.T) {
-	h := newHarness(t)
-	cookie := h.login()
-
-	// Polled continuously, so the idle window is refreshed every time and only the absolute
-	// deadline can end this.
-	for range int(uiSessionMaxAge/(uiSessionIdle-time.Minute)) + 2 {
-		h.clk.Advance(uiSessionIdle - time.Minute)
-		resp := h.withCookie(http.MethodGet, "/api/v1/networks", cookie)
-		_ = resp.Body.Close()
-		if resp.StatusCode == http.StatusUnauthorized {
-			return // the ceiling ended it, which is the point
-		}
-	}
-	t.Errorf("a continuously polled session outlived its %s ceiling", uiSessionMaxAge)
-}
-
 // Signing in over plaintext to something that is not loopback is refused rather than
 // downgraded, so configuring TLS is a requirement for any deployment somebody browses to.
 func TestSigningInIsRefusedOverPlaintextToARemoteHost(t *testing.T) {
 	h := newHarness(t)
 
-	body, _ := json.Marshal(map[string]string{"token": testAdminToken})
+	body, _ := json.Marshal(map[string]string{"email": "alice@example.com", "password": testPassword})
 	req, _ := http.NewRequest(http.MethodPost, h.server.URL+"/api/v1/ui/session", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	// The connection is still loopback; what the server can see of where the browser
@@ -311,8 +227,8 @@ func TestSigningInIsRefusedOverPlaintextToARemoteHost(t *testing.T) {
 	}
 }
 
-// A forged or stale cookie is not a session. The store is keyed by a hash of what the
-// browser presents, so this also covers the case of somebody who has seen the map.
+// A forged or stale cookie is not a session. What the database holds is a hash of what the
+// browser presents, so this also covers somebody who has read the table.
 func TestAnInventedCookieIsNotASession(t *testing.T) {
 	h := newHarness(t)
 	h.login() // so there is a real session in the store to be confused with
@@ -325,40 +241,53 @@ func TestAnInventedCookieIsNotASession(t *testing.T) {
 	}
 }
 
-// The store's own bounds, exercised directly because the HTTP path cannot reach them
-// without a thousand sign-ins.
-func TestTheSessionStoreSweepsAndRefusesToGrowWithoutBound(t *testing.T) {
-	clk := clock.NewFake()
-	store := newUISessions(clk)
+// The administrative token no longer signs anybody in to the page.
+//
+// It still works on the API, because a locked-out deployment needs a way back (ADR-0024 §5).
+// What it does not do any more is mint a browser session — there is no credential-without-an
+// identity left for one to be. Asserted rather than assumed, because restoring that path
+// would be a two-line change that reintroduces a shared secret to the one surface people
+// actually look at, and nothing else would fail.
+func TestSigningInNoLongerTakesTheAdministrativeToken(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"token": testAdminToken})
+	h := newHarness(t)
 
-	first, _, err := store.create()
+	req, _ := http.NewRequest(http.MethodPost, h.server.URL+"/api/v1/ui/session", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !store.valid(first) {
-		t.Fatal("a fresh session is not valid")
-	}
+	defer func() { _ = resp.Body.Close() }()
 
-	// Expired entries go on the next sign-in rather than lingering, so an abandoned page
-	// does not hold a slot against the bound below.
-	clk.Advance(uiSessionMaxAge + time.Hour)
-	if _, _, err := store.create(); err != nil {
-		t.Fatalf("creating a session after everything expired: %v", err)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("signing in with the administrative token = %d, want 400", resp.StatusCode)
 	}
-	if store.valid(first) {
-		t.Error("an expired session is still valid")
-	}
-	if got := len(store.byHash); got != 1 {
-		t.Errorf("the store holds %d sessions, want 1 — the expired one was not swept", got)
-	}
-
-	for range maxUISessions {
-		if _, _, err := store.create(); err != nil {
-			if !errors.Is(err, errTooManySessions) {
-				t.Fatalf("creating a session: %v", err)
-			}
-			return // refused rather than growing, which is the point
+	for _, c := range resp.Cookies() {
+		if c.Name == uiCookieName && c.Value != "" {
+			t.Fatal("the administrative token still mints a browser session")
 		}
 	}
-	t.Errorf("the store grew past %d sessions without refusing", maxUISessions)
+}
+
+// A deployment with no accounts cannot sign in here at all, and that is correct: there is
+// nothing to look at until somebody creates the first account, and creating one is an API
+// call the bootstrap secret still makes.
+func TestADeploymentWithNoAccountsCannotSignIn(t *testing.T) {
+	h := newHarness(t)
+
+	body, _ := json.Marshal(map[string]string{
+		"email": "nobody@example.com", "password": testPassword,
+	})
+	req, _ := http.NewRequest(http.MethodPost, h.server.URL+"/api/v1/ui/session", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("signing in to a deployment with no accounts = %d, want 401", resp.StatusCode)
+	}
 }

--- a/internal/api/users_test.go
+++ b/internal/api/users_test.go
@@ -6,9 +6,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	neturl "net/url"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/meshpnet/meshp/internal/store"
 )
 
 const testPassword = "correct horse battery staple"
@@ -43,6 +47,12 @@ func doJSON(t *testing.T, method, url string, body any, cookie *http.Cookie, tok
 	}
 	if cookie != nil {
 		req.AddCookie(&http.Cookie{Name: cookie.Name, Value: cookie.Value})
+		// What a browser sends on every unsafe method, and what the cross-site request
+		// forgery check requires of a cookie-authenticated write. Set from the request's
+		// own URL so it is right whatever host the test server got.
+		if parsed, err := neturl.Parse(url); err == nil {
+			req.Header.Set("Origin", parsed.Scheme+"://"+parsed.Host)
+		}
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -343,4 +353,80 @@ func auditFor(t *testing.T, h *harness, action string) []map[string]any {
 		}
 	}
 	return out
+}
+
+// A page nobody is watching stops reading. A page somebody is watching does not.
+//
+// The sliding half of the session's lifetime. This was tested against the in-memory browser
+// sessions until ADR-0024 removed them; the database sessions have the same shape and had no
+// test, so the property moved here rather than being lost with the code that used to hold it.
+//
+// The clock is not advanced — the store reads the wall clock — so the rows are aged with SQL
+// instead, which is the same thing from the query's point of view.
+func TestASessionExpiresWhenIdleAndIsHeldOpenByUse(t *testing.T) {
+	h := newHarness(t)
+	createUser(t, h, "alice@example.com")
+	cookie := signIn(t, h, "alice@example.com", testPassword)
+
+	// Aged past the point where SessionUser will extend it, then used. A dashboard polling
+	// for hours must not log itself out.
+	for range 3 {
+		ageSession(t, h, store.SessionIdle-time.Minute)
+		resp := h.withCookie(http.MethodGet, "/api/v1/networks", cookie)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("a session in use returned %d, want 200", resp.StatusCode)
+		}
+	}
+
+	// And then left alone past the window.
+	ageSession(t, h, store.SessionIdle+time.Minute)
+	resp := h.withCookie(http.MethodGet, "/api/v1/networks", cookie)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("an idle session still reads, returned %d", resp.StatusCode)
+	}
+}
+
+// Use extends the idle window and never the ceiling, so a page left open on a wall does not
+// hold a credential forever.
+func TestASessionHasACeilingThatUseDoesNotRaise(t *testing.T) {
+	h := newHarness(t)
+	createUser(t, h, "alice@example.com")
+	cookie := signIn(t, h, "alice@example.com", testPassword)
+
+	// Continuously polled, so only the fixed deadline can end this. The clamp in
+	// TouchUserSession is what makes it terminate: without it the idle window would walk
+	// past the ceiling one request at a time.
+	if _, err := h.store.Pool().Exec(h.ctx,
+		`UPDATE user_sessions SET expires_at = now() + interval '1 second'`); err != nil {
+		t.Fatal(err)
+	}
+	resp := h.withCookie(http.MethodGet, "/api/v1/networks", cookie)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("a session inside its ceiling returned %d, want 200", resp.StatusCode)
+	}
+
+	if _, err := h.store.Pool().Exec(h.ctx,
+		`UPDATE user_sessions SET expires_at = now() - interval '1 second'`); err != nil {
+		t.Fatal(err)
+	}
+	after := h.withCookie(http.MethodGet, "/api/v1/networks", cookie)
+	defer func() { _ = after.Body.Close() }()
+	if after.StatusCode != http.StatusUnauthorized {
+		t.Errorf("a session past its ceiling returned %d, want 401 — use raised the ceiling",
+			after.StatusCode)
+	}
+}
+
+// ageSession moves every session's idle deadline backwards by d, which is what the passage
+// of that much time looks like to the query.
+func ageSession(t *testing.T, h *harness, d time.Duration) {
+	t.Helper()
+	if _, err := h.store.Pool().Exec(h.ctx,
+		`UPDATE user_sessions SET idle_expires_at = idle_expires_at - $1::interval`,
+		d.String()); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -171,22 +171,6 @@ type Set struct {
 // All is every permission, including ones that do not exist yet.
 func All() Set { return Set{all: true} }
 
-// ReadOnly is every permission that only reads.
-//
-// What the browser session minted from the administrative token holds (ADR-0022 §5). It is
-// derived from a credential that can do everything and is strictly weaker than it, which is
-// the entire argument for having shipped a page before accounts existed. Once a deployment
-// signs people in with their own accounts this stops being reached.
-func ReadOnly() Set {
-	s := Set{have: make(map[Permission]struct{}, len(Catalogue))}
-	for _, e := range Catalogue {
-		if IsRead(e.Name) {
-			s.have[e.Name] = struct{}{}
-		}
-	}
-	return s
-}
-
 // NewSet collects permissions, ignoring any string this control plane does not recognise.
 //
 // Ignored rather than refused, because the strings come from a table an operator may have
@@ -210,6 +194,14 @@ func (s Set) Allows(p Permission) bool {
 	_, ok := s.have[p]
 	return ok
 }
+
+// Unlimited reports whether this caller holds everything, including permissions that do not
+// exist yet.
+//
+// Worth asking rather than inferring from Sorted() being empty, which is what a caller
+// holding nothing also looks like. The two are opposites and a consumer that confused them
+// would render the most powerful credential in the deployment as the least.
+func (s Set) Unlimited() bool { return s.all }
 
 // Empty reports whether this caller holds nothing at all.
 //

--- a/internal/authz/authz_test.go
+++ b/internal/authz/authz_test.go
@@ -145,22 +145,6 @@ func TestAnOwnerHoldsTheWholeCatalogue(t *testing.T) {
 	}
 }
 
-// The browser session minted from the administrative token reads and does nothing else. That
-// asymmetry is the whole argument ADR-0022 §5 makes for having shipped a page before there
-// were accounts, and it is now a property of this set rather than of a list of two routes.
-func TestTheReadOnlySetOnlyReads(t *testing.T) {
-	ro := ReadOnly()
-	for _, e := range Catalogue {
-		allowed := ro.Allows(e.Name)
-		if IsRead(e.Name) != allowed {
-			t.Errorf("read-only %v %q", map[bool]string{true: "allows", false: "refuses"}[allowed], e.Name)
-		}
-	}
-	if ro.Empty() {
-		t.Error("the read-only set is empty, so a browser session would be allowed nothing")
-	}
-}
-
 // A caller holding everything holds what has not been invented yet. The bootstrap secret is
 // the deployment's root credential and a list would describe it wrongly the moment the
 // catalogue grew.

--- a/web/app.css
+++ b/web/app.css
@@ -163,8 +163,12 @@ code, .mono { font-family: var(--mono); font-size: 13px; }
 .faults li { color: var(--bad); font-size: 13px; }
 
 /* Sign-in and the network picker. */
-form.signin { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
-input[type="password"], select {
+/* A column, since sign-in became two labelled fields and sometimes three. The single
+   token field this used to hold sat happily on one row beside its button; three do not,
+   and a wrapped row puts a label under the input it names. */
+form.signin { display: flex; flex-direction: column; gap: 2px; align-items: stretch; }
+form.signin button.primary { margin-top: 14px; align-self: flex-start; }
+input[type="password"], input[type="email"], input[type="text"], select {
   font: inherit;
   padding: 8px 10px;
   border: 1px solid var(--line);
@@ -202,3 +206,68 @@ button.primary {
 .event .when { color: var(--muted); font-size: 12px; white-space: nowrap; }
 .event .who { font-weight: 500; }
 .event .why { color: var(--muted); font-size: 13px; }
+
+/* --- doing something ------------------------------------------------------------------ */
+
+/* The actions column stays narrow and never pushes the columns that carry the answer. */
+td.actions,
+th.actions {
+  width: 1%;
+  white-space: nowrap;
+  text-align: right;
+}
+
+button.danger {
+  background: transparent;
+  border: 1px solid var(--bad);
+  color: var(--bad);
+  border-radius: 4px;
+  padding: 0.2rem 0.6rem;
+  font: inherit;
+  cursor: pointer;
+}
+
+button.danger:hover:not(:disabled) {
+  background: var(--bad);
+  color: var(--bg);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+/* Shown once and never again, so it is easy to select and hard to miss. */
+code.token {
+  display: block;
+  margin: 0.6rem 0;
+  padding: 0.6rem;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  font-family: var(--mono);
+  /* Long, and it must stay selectable in one gesture rather than scrolling sideways. */
+  word-break: break-all;
+  user-select: all;
+}
+
+.error.inline {
+  margin-left: 0.5rem;
+  font-size: 0.9em;
+}
+
+form.signin label {
+  margin-top: 10px;
+  font-size: 0.9em;
+  color: var(--muted);
+}
+
+button.quiet {
+  font: inherit;
+  padding: 6px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+}

--- a/web/app.js
+++ b/web/app.js
@@ -17,8 +17,42 @@ const view = document.getElementById("view");
 const freshnessEl = document.getElementById("freshness");
 const signoutEl = document.getElementById("signout");
 
+/**
+ * What this person may do in the network being shown.
+ *
+ * Fetched once per network rather than per poll — a role changes rarely and the answer is
+ * about the caller, not about the network — and used only to decide which controls exist.
+ * It is never the enforcement: the API refuses regardless, and a page that believed itself
+ * would be a page one edit away from being the security boundary.
+ *
+ * Empty until it has been read, so a control is absent while the answer is unknown rather
+ * than flickering into existence. Absent-then-present is a page loading; present-then-gone
+ * is a page that lied.
+ */
+let permissions = new Set();
+let unlimited = false;
+
+/** Whether this person may do something here. */
+function may(permission) {
+  return unlimited || permissions.has(permission);
+}
+
+/**
+ * A token this page has just minted, held here rather than in the DOM.
+ *
+ * The view is replaced wholesale by every poll, and the control plane stores only a hash, so
+ * a secret drawn straight into the page would be unrecoverable within a few seconds of
+ * existing — and somebody would click again, minting another credential nobody can use.
+ */
+let mintedToken = null;
+/** Which network that token was minted for, so moving away clears it. */
+let shownFor = null;
+
 /** Last successful overview, kept so a failed poll can keep showing it — marked stale. */
 let lastGood = null;
+/** What was rendered beside it, so the page can redraw itself without polling again. */
+let lastNetworks = [];
+let lastHistory = null;
 /** When that arrived, by this browser's clock. `as_of` is the server's. */
 let lastGoodAt = null;
 let pollTimer = null;
@@ -88,8 +122,16 @@ function el(tag, attrs = {}, ...children) {
   return node;
 }
 
+/**
+ * Replaces the view.
+ *
+ * Nullish children are dropped, the same way el() drops them — and for a reason that only
+ * appeared once the page had controls that are absent for some people. `replaceChildren`
+ * stringifies what it is given, so a panel that renders as null for somebody without the
+ * permission for it put the word "null" on their screen.
+ */
 function show(...nodes) {
-  view.replaceChildren(...nodes);
+  view.replaceChildren(...nodes.filter((node) => node !== null && node !== undefined && node !== false));
 }
 
 // --- what counts as broken ------------------------------------------------------------
@@ -261,6 +303,10 @@ function renderDevices(devices) {
             )
           : el("span", { class: "note" }, "—"),
       ),
+      // Empty for somebody who may not act, rather than absent: a column that appears and
+      // disappears between people makes two screenshots of the same page look like two
+      // different products.
+      el("td", { class: "actions" }, revokeButton(device)),
     );
   });
 
@@ -280,11 +326,160 @@ function renderDevices(devices) {
         el("th", {}, "Tunnel"),
         el("th", {}, "Applied version"),
         el("th", {}, "Reported faults"),
+        el("th", { class: "actions" }, ""),
       ),
     ),
     el("tbody", {}, rows),
   );
   return el("div", { class: "scroll" }, table);
+}
+
+// --- doing something ---------------------------------------------------------------------
+//
+// Two write paths, and deliberately only two (ADR-0022 §5, as rewritten by ADR-0024). They
+// are the two halves of a device's life — getting one on, and getting one off — which is
+// what this page is already about and what an operator otherwise reaches for `curl` to do.
+// Publishing a policy and editing DNS are not here: they are text somebody composes, not a
+// button, and a form that got them subtly wrong would be worse than the curl it replaced.
+
+/**
+ * Runs a write.
+ *
+ * `refresh` is opt-in, and the two callers below want opposite things. Revoking a device
+ * must refresh: a page that changed something and kept showing the old state makes somebody
+ * click twice, and on a revoke the second click is the one that does damage. Minting a token
+ * must not: the poll re-renders this whole view every few seconds, so anything drawn here
+ * and not held in state is gone within one tick — which for a secret shown exactly once
+ * means a person clicking again and leaking another credential nobody can use.
+ */
+async function act(node, run, { refresh = false } = {}) {
+  const previous = node.textContent;
+  node.disabled = true;
+  node.textContent = "…";
+  try {
+    await run();
+    if (refresh) restart();
+    else {
+      node.disabled = false;
+      node.textContent = previous;
+    }
+  } catch (err) {
+    node.disabled = false;
+    node.textContent = previous;
+    // Shown against the control that failed rather than at the top of the page, because
+    // by the time somebody has scrolled to a device the top is not where they are looking.
+    const message = el("span", { class: "error inline" }, ` ${reason(err)}`);
+    node.after(message);
+    setTimeout(() => message.remove(), 8000);
+  }
+}
+
+/** The button that throws a device off the network. */
+function revokeButton(device) {
+  if (!may("network.devices.revoke") || device.state !== "active") return null;
+
+  const button = el("button", { class: "danger", type: "button" }, "Revoke");
+  button.addEventListener("click", () => {
+    // Confirmed, because this is not undoable: the device has to enrol again with a fresh
+    // token, and its addresses go back to the pool. A one-click version of that beside a
+    // device somebody is already worried about is a trap.
+    if (!window.confirm(`Revoke ${device.device_name}? It will lose access immediately and must enrol again.`)) {
+      return;
+    }
+    act(
+      button,
+      () =>
+        api(
+          `/api/v1/networks/${encodeURIComponent(currentNetworkID())}` +
+            `/devices/${encodeURIComponent(device.membership_id)}`,
+          { method: "DELETE" },
+        ),
+      { refresh: true },
+    );
+  });
+  return button;
+}
+
+/** The panel that mints an enrolment token, and shows it exactly once. */
+function renderAddDevice() {
+  if (!may("network.enrollment_tokens.write")) return null;
+
+  const button = el("button", { class: "primary", type: "button" }, "Create an enrolment token");
+  button.addEventListener("click", () => {
+    mintedToken = null;
+    act(button, async () => {
+      const body = await api(
+        `/api/v1/networks/${encodeURIComponent(currentNetworkID())}/enrollment-tokens`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          // One device, one hour. Deliberately the narrowest thing that is useful: a
+          // token minted from a page somebody left open should not outlive the afternoon,
+          // and anybody who needs a wider one is already using the API.
+          body: JSON.stringify({ max_uses: 1, expires_in_seconds: 3600 }),
+        },
+      );
+      // Into module state, not into the DOM. This view is replaced wholesale by the next
+      // poll, and the control plane stores only a hash — so a token drawn straight into
+      // the page would be unrecoverable within a few seconds of existing.
+      mintedToken = body.token;
+      // Polling stops while it is on screen. Every poll replaces this view wholesale, which
+      // would wipe a half-made text selection — and the whole point of showing a secret once
+      // is that somebody selects it and copies it. A dashboard that refreshes out from under
+      // the one thing it asked you to copy is worse than one that pauses and says so.
+      stopPolling();
+      renderFromLastGood();
+    });
+  });
+
+  return el(
+    "div",
+    { class: "panel" },
+    el("h3", {}, "Add a device"),
+    button,
+    mintedToken ? renderMintedToken() : null,
+  );
+}
+
+/** The one showing of a token, kept across re-renders until it is dismissed. */
+function renderMintedToken() {
+  const done = el("button", { class: "quiet", type: "button" }, "Done");
+  done.addEventListener("click", () => {
+    mintedToken = null;
+    // Which also starts the page updating again.
+    restart();
+  });
+
+  return el(
+    "div",
+    {},
+    el(
+      "p",
+      { class: "note" },
+      "Copy this now — it is not shown again, and it is good for one device for an hour.",
+    ),
+    el("code", { class: "token" }, mintedToken),
+    el(
+      "p",
+      { class: "note" },
+      "On the device: ",
+      el("span", { class: "mono" }, `meshp up --token ${mintedToken}`),
+    ),
+    // Said rather than left to be noticed. The page's own rule is that it never lies about
+    // its freshness, and it is deliberately not updating right now.
+    el("p", { class: "note" }, "This page has paused while the token is shown."),
+    done,
+  );
+}
+
+/**
+ * Redraws from the last good poll, without waiting for the next one.
+ *
+ * For state that is this page's own rather than the control plane's — whether a minted token
+ * is on screen — where asking the server again would answer a question it was never asked.
+ */
+function renderFromLastGood() {
+  if (lastGood) renderOverview(lastGood, lastNetworks, lastHistory);
 }
 
 function renderOverview(data, networks, history) {
@@ -305,6 +500,7 @@ function renderOverview(data, networks, history) {
       ? el("div", {}, data.route_groups.map(renderGroup))
       : el("div", { class: "panel note" }, "This network has no route groups."),
     el("h2", {}, "Devices"),
+    renderAddDevice(),
     el(
       "div",
       { class: "panel" },
@@ -329,6 +525,10 @@ const ACTIONS = {
   "device.revoked": "was removed from the network",
   "policy.published": "published a policy",
   "route.switched": "moved to another candidate",
+  "role.granted": "was given a role",
+  "role.revoked": "had a role taken away",
+  "api_token.minted": "created an API token",
+  "api_token.revoked": "revoked an API token",
 };
 
 /** The audit trail, newest first. */
@@ -420,34 +620,77 @@ function renderFreshness(problem) {
 
 // --- sign in --------------------------------------------------------------------------
 
-function renderSignIn(message) {
-  const input = el("input", {
+function renderSignIn(message, options = {}) {
+  const email = el("input", {
+    type: "email",
+    id: "email",
+    name: "email",
+    autocomplete: "username",
+    placeholder: "you@example.com",
+    required: "required",
+  });
+  const password = el("input", {
     type: "password",
-    id: "token",
+    id: "password",
+    name: "password",
     autocomplete: "current-password",
-    placeholder: "administrative token",
+    placeholder: "password",
+    required: "required",
+  });
+  // Asked for only after the server says the address is ambiguous. Almost every deployment
+  // has one organisation, so asking everybody up front would be a field almost nobody needs
+  // and everybody has to read.
+  const organization = el("input", {
+    type: "text",
+    id: "organization",
+    name: "organization",
+    autocomplete: "organization",
+    placeholder: "organisation",
   });
   const error = el("p", { class: "error" }, message || "");
+
+  const fields = [
+    el("label", { for: "email" }, "Email"),
+    email,
+    el("label", { for: "password" }, "Password"),
+    password,
+  ];
+  if (options.needsOrganization) {
+    fields.push(el("label", { for: "organization" }, "Organisation"), organization);
+  }
 
   const form = el(
     "form",
     { class: "signin" },
-    input,
+    ...fields,
     el("button", { class: "primary", type: "submit" }, "Sign in"),
   );
   form.addEventListener("submit", async (event) => {
+    // Always, and first. The CSP sets form-action 'none' so a native submit cannot leave
+    // this origin at all, but a native submit would also put the password in a URL if the
+    // form ever gained a GET method by accident.
     event.preventDefault();
     error.textContent = "";
     try {
       await api("/api/v1/ui/session", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ token: input.value }),
+        body: JSON.stringify({
+          email: email.value,
+          password: password.value,
+          organization: organization.value || undefined,
+        }),
       });
-      input.value = "";
+      password.value = "";
       start();
     } catch (err) {
+      if (err.code === "ambiguous_sign_in") {
+        renderSignIn(err.message, { needsOrganization: true });
+        return;
+      }
       error.textContent = err.message;
+      password.value = "";
+      password.focus();
     }
   });
 
@@ -459,15 +702,15 @@ function renderSignIn(message) {
       el(
         "p",
         { class: "note" },
-        "The administrative token is exchanged once for a session that may read and may " +
-          "not write. It is not stored in this page.",
+        "Sign in with your own account. What you can see and change here is what your " +
+          "role allows.",
       ),
       form,
       error,
     ),
   );
   signoutEl.hidden = true;
-  input.focus();
+  email.focus();
 }
 
 // --- the loop -------------------------------------------------------------------------
@@ -505,12 +748,33 @@ async function fetchHistory(networkID) {
   }
 }
 
+/**
+ * Reads what this person may do here.
+ *
+ * Failing is not fatal and leaves the set empty, which renders a page with no controls
+ * rather than no page. Somebody who can see that a device is unreachable and cannot click
+ * anything is worse off than before this slice; somebody staring at an error where the
+ * network used to be is worse off than that.
+ */
+async function fetchPermissions(networkID) {
+  try {
+    const body = await api(`/api/v1/me/permissions?network=${encodeURIComponent(networkID)}`);
+    permissions = new Set(body.permissions || []);
+    unlimited = Boolean(body.unlimited);
+  } catch {
+    permissions = new Set();
+    unlimited = false;
+  }
+}
+
 async function poll(networkID, networks) {
   try {
     const data = await api(`/api/v1/networks/${encodeURIComponent(networkID)}/overview`);
     lastGood = data;
     lastGoodAt = Date.now();
-    renderOverview(data, networks, await fetchHistory(networkID));
+    lastNetworks = networks;
+    lastHistory = await fetchHistory(networkID);
+    renderOverview(data, networks, lastHistory);
     renderFreshness(null);
     // The server decides how often it is asked, so a deployment under load can slow its
     // pages down without shipping a new one.
@@ -616,7 +880,28 @@ async function start() {
     renderPicker(networks);
     return;
   }
+  // Before the first render, so a control is never absent-then-present on a page somebody
+  // is already reading — and never present-then-absent, which would be worse.
+  await fetchPermissions(networkID);
+  if (networkID !== shownFor) {
+    // A token minted for one network must not still be on screen while another is shown.
+    mintedToken = null;
+    shownFor = networkID;
+  }
   poll(networkID, networks);
+}
+
+/**
+ * Reloads after a write.
+ *
+ * Goes through start() rather than poking the poll timer, because a write can change what
+ * comes next in more ways than one: revoking the last device changes the verdict, and a
+ * person whose role was changed in another tab should find that out here rather than by
+ * clicking something that fails.
+ */
+function restart() {
+  stopPolling();
+  start();
 }
 
 signoutEl.addEventListener("click", async () => {
@@ -628,6 +913,13 @@ signoutEl.addEventListener("click", async () => {
   }
   lastGood = null;
   lastGoodAt = null;
+  // Forgotten explicitly. A page that kept the last person's permissions in memory would
+  // render their controls for whoever signs in next, for as long as it took the next fetch
+  // to come back.
+  permissions = new Set();
+  unlimited = false;
+  mintedToken = null;
+  shownFor = null;
   renderFreshness(null);
   renderSignIn("Signed out.");
 });


### PR DESCRIPTION
Closes #138. Fifth slice of ADR-0024, after #143.

The browser's credential was derived from the administrative token and bounded by being unable to write. That bound had no principle underneath it — a credential minted from a shared secret has no identity to attach permissions to, so "reads only" was the only honest thing to say. It has an identity now.

## What is gone

The in-memory session store, the derived credential, the read-only middleware, and `authz.ReadOnly`. `POST /api/v1/ui/session` takes an email and a password and nothing else, and a test asserts the administrative token no longer mints a session — restoring that path would be a two-line change that reintroduces a shared secret to the one surface people actually look at, and nothing else would fail.

A deployment with no accounts cannot sign in to the page at all. That is correct: it has nothing to look at until somebody creates the first account, and creating one is an API call the bootstrap secret still makes (ADR-0024 §5).

Removing the in-memory store also removes one of the multi-replica blockers filed in #145 — user sessions were already in PostgreSQL for exactly that reason.

## What the page may do is per-person

`GET /api/v1/me/permissions?network=` answers for the caller, in that scope, and the page asks before it renders. This is **never** enforcement — the API refuses regardless, and a page that believed itself would be one edit away from being the security boundary. It is so that a control which would be refused is never drawn: a button that returns 403 teaches somebody the product is broken rather than that they lack a permission.

Two write paths, deliberately two: **minting an enrolment token** and **revoking a device** — the two halves of a device's life, which is what this page is already about and what an operator otherwise reaches for `curl` to do. Publishing a policy and editing DNS are documents somebody composes rather than buttons; a form that got them subtly wrong would be worse than the command it replaced.

## CSRF, with an argument rather than an assumption

Two defences that fail independently:

- **`SameSite=Strict`** — the browser does not attach the cookie to a request another site caused. The strong one.
- **An `Origin` naming this host** on any cookie-authenticated unsafe method. What remains if the first is bypassed. A cross-origin form POST cannot suppress the header, and a cross-origin `fetch` that sets an acceptable one cannot get past a preflight this server never answers.

Hosts are compared and schemes are not: a TLS-terminating proxy leaves `r.TLS` nil while the browser sends an `https` Origin, and this package refuses to take `X-Forwarded-Proto` on trust. Scheme downgrade is the cookie's problem, and the cookie is `Secure`. Machines are exempt — a bearer token is not something a browser attaches to anything, and requiring an Origin from `curl` would break every machine caller to defend against an attack they cannot suffer.

While the credential could only read, `SameSite` alone was adequate. A cookie that can revoke a device is a different proposition.

## Three bugs I found by using the page, not by reasoning about it

1. **Minting a token then refreshing destroyed it.** `act()` refreshed on success; the refresh re-renders the view wholesale; the control plane stores only a hash. So the secret existed for about 200ms and then never again — and a person seeing nothing would click again, leaking another unusable credential each time. The token now lives in module state, and polling **pauses** while it is on screen, because a poll would wipe a half-made text selection. The page says it has paused, which is the same freshness rule as everywhere else.
2. **`show()` did not filter nullish children the way `el()` does.** `replaceChildren(null)` stringifies, so a reader — for whom the write panel correctly renders as `null` — got the word **"null"** on their screen.
3. **`guardCallerOrganization` dereferenced `c.token` before checking for a user**, panicking on every request a signed-in person made to `/api/v1/networks`. Caught by the existing tests the moment I ran them.

The first two only appear if you sign in and click, once as an owner and once as a reader.

## Verified end to end

Against a real `meshp-control`, signed in as an owner and then as a reader:

- Owner: "Add a device" present, token minted and displayed with a paste-ready `meshp up --token …`, page paused while shown.
- Reader: no "Add a device", no Revoke column content, and no stray `null`.
- Revoked a device from the page → state went to `revoked`, the fault cleared, `state_version` bumped 1 → 2, and the history panel on that same page now reads **`alice@example.com — was removed from the network`**.

That last one is the whole ADR-0024 arc landing in one screen: a person did a thing through the page, and the trail names them.

## ADR-0022 §5

Rewritten, not amended a fourth time, and it keeps a short section on **how it was wrong**: it described a credential in terms of the routes it reached, which goes stale every time a route is added, and nobody weighs an amendment made to unblock a feature. A credential described in terms of what its holder *is* does not have that failure mode.

The "build real user accounts first" alternative it rejected now carries a note saying it was built two weeks later, and that the estimate was right — it was a larger project than the view, in four slices.

## Also

Ported the two session-lifetime tests that covered the in-memory store to the database sessions, which have the same shape and had no test. They would otherwise have been deleted along with the code they exercised.

Filed #146 for the underlying issue the token pause works around: the page re-renders wholesale every poll, which was harmless when nothing on it was interactive.

## Not in this slice

The documentation (#139), which is now the last of ADR-0024.