### PR TITLE
docs: stop teaching the admin token

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,44 +152,67 @@ git clone https://github.com/meshpnet/meshp.git
 cd meshp
 cp .env.example .env
 
-# Both are required. The control plane refuses to start without a secret key, and
-# leaves the administrative API switched off without an admin token.
+# MESHP_SECRET_KEY is required. MESHP_ADMIN_TOKEN is the bootstrap secret: it makes
+# the first account on a deployment that has none, and gets you back into one that
+# has locked itself out. It is used twice below and then not again.
 #
 # Kept in the shell too, because the commands below need it. Reading it back out of
 # .env does not work: the example declares both keys empty, so appending leaves two
 # lines with the same name — compose takes the last, a grep takes both.
-export MESHP_ADMIN_TOKEN="$(openssl rand -base64 32)"
+export MESHP_BOOTSTRAP="$(openssl rand -base64 32)"
 {
   echo "MESHP_SECRET_KEY=$(openssl rand -base64 32)"
-  echo "MESHP_ADMIN_TOKEN=$MESHP_ADMIN_TOKEN"
+  echo "MESHP_ADMIN_TOKEN=$MESHP_BOOTSTRAP"
 } >> .env
 
 make build
 docker compose up -d
 ```
 
-Then enrol a device. All of it is API calls:
+Then give yourself an account, and use it. All of it is API calls:
 
 ```bash
+# The bootstrap secret makes an organisation and the first account. The first person
+# in an organisation is its owner: somebody has to be able to grant a role, and on a
+# fresh organisation there is nobody who can.
 ORG=$(curl -fsS -X POST \
-  -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H "Authorization: Bearer $MESHP_BOOTSTRAP" \
   -H 'Content-Type: application/json' \
   -d '{"slug":"acme","name":"Acme"}' \
   http://localhost:8080/api/v1/organizations | jq -r .organization_id)
 
-NETWORK=$(curl -fsS -X POST \
-  -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+curl -fsS -X POST \
+  -H "Authorization: Bearer $MESHP_BOOTSTRAP" \
   -H 'Content-Type: application/json' \
-  -d "{\"organization_id\":\"$ORG\",\"slug\":\"hq\",\"name\":\"HQ\",
-       \"address_pools\":[\"100.90.0.0/24\",\"fd7c:6d65:7368::/120\"]}" \
+  -d '{"email":"you@example.com","name":"You","password":"a passphrase you will remember"}' \
+  "http://localhost:8080/api/v1/organizations/$ORG/users" >/dev/null
+
+# From here on you are a person. Sign in, then mint a token for your scripts: it is
+# yours, it carries only the permissions you name, and it is revocable on its own.
+curl -fsS -c meshp-cookies.txt -o /dev/null -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"you@example.com","password":"a passphrase you will remember"}' \
+  http://localhost:8080/api/v1/ui/session
+
+MESHP_TOKEN=$(curl -fsS -b meshp-cookies.txt -X POST \
+  -H "Origin: http://localhost:8080" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"readme","permissions":["organization.networks.create","network.enrollment_tokens.write"]}' \
+  http://localhost:8080/api/v1/me/tokens | jq -r .token)
+
+# No organisation_id: a token acts within its owner's, and you belong to one.
+NETWORK=$(curl -fsS -X POST \
+  -H "Authorization: Bearer $MESHP_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"slug":"hq","name":"HQ",
+       "address_pools":["100.90.0.0/24","fd7c:6d65:7368::/120"]}' \
   http://localhost:8080/api/v1/networks | jq -r .network_id)
 
 TOKEN=$(curl -fsS -X POST \
-  -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H "Authorization: Bearer $MESHP_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"max_uses":1,"expires_in_seconds":600}' \
-  "http://localhost:8080/api/v1/networks/$NETWORK/enrollment-tokens" \
-  | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+  "http://localhost:8080/api/v1/networks/$NETWORK/enrollment-tokens" | jq -r .token)
 
 sudo ./bin/meshpd &                # holds the keys and the sessions
 sudo ./bin/meshp join "$TOKEN"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,70 @@ deploy it. The data plane is Linux-only. Reports are still welcome and will be h
 above — but a finding that a half-built feature is half-built is not one, and there are
 several of those in the open issues already.
 
+## Accounts, credentials and what happens to them
+
+This is worth its own section because the threat model changed. Until ADR-0024 landed there
+was one credential, a shared secret in an environment variable, and the worst case was that
+it leaked. There are now passwords in a database, and that is a liability this project did
+not previously have.
+
+**Passwords** are hashed with Argon2id at 64 MiB, two passes, one lane, stored in PHC
+string format so the parameters travel with the hash and can be raised later. Verification
+is constant-time, and an address that does not exist is put through the same work as one
+that does — so the time a sign-in takes does not say whether the account is real.
+
+**Every way a sign-in can fail looks the same**: no such address, wrong password, suspended,
+deleted, an organisation that does not exist. One status, one message, one log line. Being
+able to tell "no such account" from "wrong password" would let a stranger enumerate who has
+an account here, which is worth more to them than the specificity is worth to the person
+typing, who already knows which of the two they got wrong.
+
+**Sessions** live in PostgreSQL, one row per sign-in, so they are revocable rather than
+merely expiring. What the database holds is a SHA-256 of what the browser presents, so a
+backup does not hand somebody a live session. A sliding idle window of 12 hours keeps a
+dashboard somebody is watching alive; a fixed 30-day ceiling that no amount of use raises
+means a page left open on a wall does not hold a credential forever.
+
+**Changing a password ends every session, including the one that changed it.** A password is
+usually changed because somebody else may have seen it, and the change would be worth much
+less if it left their session running. Suspending an account ends its sessions too, and
+stops its API tokens working immediately.
+
+**API tokens** carry the permissions of the person who minted them, intersected with a scope
+chosen at creation, and that intersection is evaluated *at every use*. Demoting somebody
+demotes their tokens on the next request rather than whenever they happen to sign out. A
+token cannot mint another token, and cannot change its owner's password. Tokens expire —
+ninety days by default, a year at most, with no unexpiring option.
+
+**Permissions are read per request**, for the same reason: a role revoked in one tab takes
+effect on the next request made in another.
+
+**Writes from a browser are defended twice.** `SameSite=Strict` means a browser does not
+attach the session cookie to a request another site caused; behind that, any unsafe method
+authenticated by cookie must carry an `Origin` naming this host.
+
+### What we know is missing
+
+Said plainly, because a security policy that only lists strengths is not one:
+
+- **There is no lockout after repeated failures, and no per-account rate limit.** Sign-in
+  is throttled, but by the same per-address limiter the enrolment endpoints use, which is
+  deliberately generous — so it bounds a flood from one host and does nothing about a slow
+  distributed attempt on one account. Argon2id at 64 MiB makes online guessing expensive
+  rather than impossible. ADR-0024 names this as work its own decision creates; it is
+  tracked in [#148](https://github.com/meshpnet/meshp/issues/148).
+- **There is no second factor.** The `mfa_enrolled_at` column exists and nothing writes it.
+  ADR-0024 §1 commits to TOTP in the open core rather than as a paid feature.
+- **There is no password reset flow yet.** An administrator sets a password directly. The
+  design (ADR-0024 §6) is a link rather than an email, so that running meshp never requires
+  running a mail server.
+- **The bootstrap secret still exists**, deliberately: it is how a locked-out deployment
+  gets back in. Every use of it is audited as itself and logged at warning level once an
+  account exists.
+
+Reports about any of the above are welcome and will be treated as reports about a known gap
+rather than a discovery — see the note on half-built features in Scope.
+
 ## What is not a vulnerability here
 
 Three behaviours look like faults and are the product working as designed. Each has a

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,7 +8,7 @@ deployment — it runs the control plane over plaintext on loopback and uses a t
 database. [Self-hosting](self-hosting.md) is the version you would put in front of real
 devices.
 
-Every command on this page has been run. Steps 1 to 4 were executed exactly as written
+Every command on this page has been run. Steps 1 to 6 were executed exactly as written
 against a fresh checkout; the tunnel coming up is covered by `make e2e-tunnel` in CI, on
 Linux, because that is the only place it can be. If something here does not work, that is a
 bug and worth an issue.
@@ -29,24 +29,29 @@ cd meshp
 cp .env.example .env
 ```
 
-Two secrets, both required. The control plane refuses to start without a secret key, and
-leaves its administrative API switched off — returning 503 rather than running open —
-without an admin token.
+Two secrets. `MESHP_SECRET_KEY` is required — the control plane refuses to start without
+it. `MESHP_ADMIN_TOKEN` is the **bootstrap secret**: it exists to create the first account
+on a deployment that has none, and to get back into one that has locked itself out. It is
+used twice on this page and then not again.
 
 ```bash
-export MESHP_ADMIN_TOKEN="$(openssl rand -base64 32)"
+export MESHP_BOOTSTRAP="$(openssl rand -base64 32)"
 {
   echo "MESHP_SECRET_KEY=$(openssl rand -base64 32)"
-  echo "MESHP_ADMIN_TOKEN=$MESHP_ADMIN_TOKEN"
+  echo "MESHP_ADMIN_TOKEN=$MESHP_BOOTSTRAP"
 } >> .env
 ```
 
-Kept in the shell as well as written to the file, because the rest of this page uses it.
+Kept in a shell variable as well as written to the file, because steps 2 and 3 use it.
 Reading it back out of `.env` is the obvious thing and it does not work: the example file
 already declares both keys empty, so appending leaves two lines with the same name.
 Compose takes the last one and is fine; a `grep`-and-`cut` takes both, and the resulting
 `Authorization` header has a newline in the middle of it — which the server rejects as a
 malformed request, with no hint that the token was the problem.
+
+It is called `MESHP_BOOTSTRAP` in the shell here to keep it visible that this is not the
+credential you will be using. A shared secret that can do everything, with no identity
+behind it, is the thing accounts exist to replace (ADR-0024).
 
 ```bash
 docker compose up -d
@@ -60,53 +65,125 @@ until curl -fsS http://localhost:8080/readyz >/dev/null 2>&1; do sleep 1; done
 echo "control plane is ready"
 ```
 
-## 2. Make a network
+## 2. Make an organisation and give yourself an account
 
-A network needs an organisation to belong to, so make one. The slug is what appears in
-URLs and in the page's network picker; the name is what people read.
+Both with the bootstrap secret, because there is nobody yet who could do it otherwise.
+This is the whole of what that secret is for.
+
+An organisation is the tenant a network belongs to. The slug is what appears in URLs and
+in the page's network picker; the name is what people read.
 
 ```bash
 ORG=$(curl -fsS -X POST \
-  -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H "Authorization: Bearer $MESHP_BOOTSTRAP" \
   -H 'Content-Type: application/json' \
   -d '{"slug":"acme","name":"Acme"}' \
   http://localhost:8080/api/v1/organizations | jq -r .organization_id)
 ```
 
-Now the network, with the addresses its devices will be given. A network with no address
-pool enrols nobody, so this is refused rather than defaulted — the failure would otherwise
-surface much later, as an enrolment that cannot allocate an address.
+Now an account for yourself. **The first person in an organisation becomes its owner** —
+somebody has to be able to grant a role, and on a fresh organisation there is nobody who
+can. Everybody you add afterwards is an administrator unless you say otherwise.
+
+```bash
+curl -fsS -X POST \
+  -H "Authorization: Bearer $MESHP_BOOTSTRAP" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"you@example.com","name":"You","password":"a passphrase you will remember"}' \
+  "http://localhost:8080/api/v1/organizations/$ORG/users" | jq -r '.email + " is the " + .role'
+```
+
+That is the last time the bootstrap secret appears on this page. From here on you are a
+person, and everything is done as you.
+
+## 3. Sign in and mint a token for your scripts
+
+Sign in, keeping the session cookie:
+
+```bash
+curl -fsS -c meshp-cookies.txt -o /dev/null -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"you@example.com","password":"a passphrase you will remember"}' \
+  http://localhost:8080/api/v1/ui/session
+```
+
+Then mint an API token. This is the credential the rest of this page uses, and the one to
+put in a script or a CI job: it belongs to you, it carries the permissions you name and
+never more than you hold, and it can be revoked on its own without touching your password.
+
+```bash
+MESHP_TOKEN=$(curl -fsS -b meshp-cookies.txt \
+  -H "Origin: http://localhost:8080" \
+  -H 'Content-Type: application/json' \
+  -X POST -d '{
+    "name": "quickstart",
+    "permissions": [
+      "organization.networks.create", "organization.networks.read",
+      "network.read", "network.devices.read", "network.enrollment_tokens.write"
+    ]
+  }' \
+  http://localhost:8080/api/v1/me/tokens | jq -r .token)
+
+echo "token: ${MESHP_TOKEN:0:18}..."
+```
+
+Three things about that request are worth a sentence each.
+
+**`Origin` is required**, and only for a cookie. Anything that changes something and
+authenticates with a session cookie has to say which site it came from — a browser always
+does, and `curl` has to be told. A request carrying a bearer token instead, like every
+other command on this page, needs no such header.
+
+**Permissions are named, not implied.** A credential minted without saying what it is for
+ends up being used for everything, and this is the one moment somebody is thinking about
+the question. `GET /api/v1/permissions` lists what there is to choose from.
+
+**The token is shown once.** The control plane stores only a hash, so if you lose it you
+mint another and revoke this one — which is `DELETE /api/v1/me/tokens/{id}`, and
+`GET /api/v1/me/tokens` lists what you have out.
+
+## 4. Make a network
+
+With your token now. Note that you do not name the organisation: a token acts within its
+owner's, and you belong to exactly one.
 
 ```bash
 NETWORK=$(curl -fsS -X POST \
-  -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H "Authorization: Bearer $MESHP_TOKEN" \
   -H 'Content-Type: application/json' \
-  -d "{\"organization_id\":\"$ORG\",\"slug\":\"hq\",\"name\":\"HQ\",
-       \"address_pools\":[\"100.90.0.0/24\",\"fd7c:6d65:7368::/120\"]}" \
+  -d '{"slug":"hq","name":"HQ",
+       "address_pools":["100.90.0.0/24","fd7c:6d65:7368::/120"]}' \
   http://localhost:8080/api/v1/networks | jq -r .network_id)
 
 echo "network: $NETWORK"
 ```
 
+A network with no address pool enrols nobody, so this is refused rather than defaulted —
+the failure would otherwise surface much later, as an enrolment that cannot allocate an
+address.
+
 Pick addresses that do not collide with anything your devices already reach. `100.90.0.0/24`
 sits inside the carrier-grade NAT range, which is unusual enough on a LAN to be a
 reasonable default and is what the rest of these docs assume.
 
-## 3. Mint an enrolment token
+## 5. Mint an enrolment token
 
 ```bash
 TOKEN=$(curl -fsS -X POST \
-  -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H "Authorization: Bearer $MESHP_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"max_uses":1,"expires_in_seconds":600}' \
   "http://localhost:8080/api/v1/networks/$NETWORK/enrollment-tokens" | jq -r .token)
 ```
 
-The token is the credential a device that has nothing yet presents to prove it is allowed
-in. It is shown once, it is single-use here, and it expires in ten minutes. Treat it like
-a password.
+Two kinds of token, and they are not interchangeable. `MESHP_TOKEN` is yours and
+authenticates you to the API; this one is a device's, it is presented once by a machine
+that has nothing yet, and it is spent on use. The prefixes tell them apart at a glance:
+`meshp_api_` and `meshp_tok_`.
 
-## 4. Join a device
+It is single-use here and expires in ten minutes. Treat it like a password.
+
+## 6. Join a device
 
 Build the binaries, or install a release:
 
@@ -134,13 +211,13 @@ traffic goes.
 `meshp status` should show a live session and an applied state version that matches the
 network's. With one device there are no peers yet, which is correct rather than broken.
 
-## 5. Join a second device
+## 7. Join a second device
 
 Mint another token — tokens here are single-use, so the first one is spent:
 
 ```bash
 TOKEN2=$(curl -fsS -X POST \
-  -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+  -H "Authorization: Bearer $MESHP_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"max_uses":1,"expires_in_seconds":600}' \
   "http://localhost:8080/api/v1/networks/$NETWORK/enrollment-tokens" | jq -r .token)
@@ -164,7 +241,7 @@ later rather than a prerequisite for connectivity.
 
 ## Look at it
 
-Open <http://localhost:8080> and sign in with the same `MESHP_ADMIN_TOKEN` you set in step 1.
+Open <http://localhost:8080> and sign in with the email address and password from step 2.
 
 The page shows one network: every device and whether its control session is up, every
 route group and which devices are offering to carry it, and anything a device reported it
@@ -172,10 +249,30 @@ could not apply. It says at the top whether anything needs attention, and it say
 corner how old what you are looking at is — a poll that fails leaves the last answer on
 screen and marks it stale rather than letting old numbers pass for current.
 
-The token is exchanged once for a session cookie that may read and may not write, so the
-page cannot mint a token or revoke a device even if somebody else is sitting at it
-(ADR-0022). Signing in needs TLS anywhere that is not loopback; `localhost` is the
-exception that keeps this quickstart working without a certificate.
+**What you can change there is what your role allows.** As the owner you get a button to
+create an enrolment token and a button to revoke a device — the same two things steps 5 and
+6 did by hand. Somebody signed in as a reader sees the same network and no buttons at all,
+because a control that would be refused is never drawn.
+
+Anything you do there is recorded against your name, and shown on the same page: revoke a
+device and the history panel below says who did it.
+
+Signing in needs TLS anywhere that is not loopback; `localhost` is the exception that keeps
+this quickstart working without a certificate.
+
+## What to do with the bootstrap secret
+
+Leave it configured, and stop using it.
+
+It is how you get back in if everybody forgets their password or the last owner leaves, and
+a self-hosted deployment has no support line to call — so removing it would mean the only
+recovery was editing the database by hand. What it should not be is the credential in your
+scripts: it has no identity, so the audit trail can only ever say "the bootstrap secret did
+this", and it cannot be scoped or revoked without locking out whatever else is using it.
+
+Once an account exists, every use of it is logged at warning level for exactly that reason.
+If you see that line, something is still reaching for the shared secret when it could be
+using an account.
 
 ## Where to go next
 

--- a/docs/route-groups.md
+++ b/docs/route-groups.md
@@ -13,10 +13,16 @@ Every command here has been run against a live control plane.
 Set up first:
 
 ```bash
-export MESHP_ADMIN_TOKEN=...            # the admin token from your .env
-export NETWORK=...                      # the network id
+export MESHP_TOKEN=...     # an API token of yours; the quickstart shows how to mint one
+export NETWORK=...         # the network id
 BASE="http://localhost:8080/api/v1/networks/$NETWORK"
 ```
+
+The permissions this page needs are `network.routes.read` and `network.routes.write`, plus
+`network.devices.read` to find a membership id. Changing which advertiser carries a prefix —
+the failover section below — is `network.routes.failover`, which an operator holds as well:
+it is what somebody does at two in the morning when a link is down, and it is deliberately
+separate from being able to change which routes exist at all.
 
 ## Carrying an office LAN
 
@@ -24,7 +30,7 @@ A branch office has `192.168.10.0/24` behind it. One machine there — a small s
 router running Linux — joins the network and offers to carry it.
 
 ```bash
-curl -fsS -X POST -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+curl -fsS -X POST -H "Authorization: Bearer $MESHP_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"slug":"branch-lan","name":"Branch LAN","kind":"subnet",
        "prefixes":["192.168.10.0/24"]}' \
@@ -34,9 +40,9 @@ curl -fsS -X POST -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
 Nothing carries it yet. Find the membership id of the device that will, then offer it:
 
 ```bash
-curl -fsS -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" "$BASE/devices"
+curl -fsS -H "Authorization: Bearer $MESHP_TOKEN" "$BASE/devices"
 
-curl -fsS -X POST -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+curl -fsS -X POST -H "Authorization: Bearer $MESHP_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"membership_id":"<the branch router>","priority":1}' \
   "$BASE/route-groups/branch-lan/advertisers"
@@ -55,7 +61,7 @@ back out of the same machine is at best a loop and at worst takes the site off t
 A second machine at the same site, at a lower priority:
 
 ```bash
-curl -fsS -X POST -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+curl -fsS -X POST -H "Authorization: Bearer $MESHP_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"membership_id":"<the backup>","priority":2}' \
   "$BASE/route-groups/branch-lan/advertisers"
@@ -72,7 +78,7 @@ exactly when it is most likely to need to.
 ## Failover: how patient a device should be
 
 ```bash
-curl -fsS -X PUT -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+curl -fsS -X PUT -H "Authorization: Bearer $MESHP_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"enabled":true,
        "fail_threshold":2,
@@ -117,7 +123,7 @@ Probe targets fix that. The device dials them *through the tunnel* and requires 
 answer:
 
 ```bash
-curl -fsS -X PUT -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+curl -fsS -X PUT -H "Authorization: Bearer $MESHP_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"enabled":true,
        "fail_threshold":2,
@@ -164,7 +170,7 @@ An exit node is a route group of kind `egress`. It carries the default route, so
 prefixes of its own — and the store refuses one that tries:
 
 ```bash
-curl -fsS -X POST -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+curl -fsS -X POST -H "Authorization: Bearer $MESHP_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"slug":"exit-lon","name":"London exit","kind":"egress"}' \
   "$BASE/route-groups"
@@ -190,14 +196,14 @@ discovery.
 To turn it off for a whole network:
 
 ```bash
-curl -fsS -X PUT -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+curl -fsS -X PUT -H "Authorization: Bearer $MESHP_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"enforced":false}' \
   "$BASE/egress-fail-closed"
 ```
 
 ```bash
-curl -fsS -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" "$BASE/egress-fail-closed"
+curl -fsS -H "Authorization: Bearer $MESHP_TOKEN" "$BASE/egress-fail-closed"
 ```
 
 `enforced` must be stated. A body that leaves it out is refused rather than read as false,
@@ -217,7 +223,7 @@ a broken path is a better outcome than a working path from an address that will 
 ## Draining a machine for maintenance
 
 ```bash
-curl -fsS -X POST -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+curl -fsS -X POST -H "Authorization: Bearer $MESHP_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"membership_id":"<the one going down>","priority":1,"admin_state":"draining"}' \
   "$BASE/route-groups/branch-lan/advertisers"
@@ -231,7 +237,7 @@ what draining is for. `disabled` stops it outright.
 To remove it entirely:
 
 ```bash
-curl -fsS -X DELETE -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+curl -fsS -X DELETE -H "Authorization: Bearer $MESHP_TOKEN" \
   "$BASE/route-groups/branch-lan/advertisers/<membership id>"
 ```
 
@@ -261,7 +267,7 @@ problem rather than a routing one (ADR-0019).
 ## Reading it back
 
 ```bash
-curl -fsS -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" "$BASE/route-groups"
+curl -fsS -H "Authorization: Bearer $MESHP_TOKEN" "$BASE/route-groups"
 ```
 
 Each group comes back with its prefixes, selection mode and full failover policy.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -48,14 +48,60 @@ derived from. The control plane refuses to start without it. **Changing it inval
 outstanding challenge and session**, so agents reconnect — survivable, but not something to
 do casually.
 
-`MESHP_ADMIN_TOKEN` gates the administrative API. Left empty, those endpoints answer 503
-rather than running open: a control plane that will mint enrolment tokens for anyone who
-asks is worse than one whose admin API is switched off.
+`MESHP_ADMIN_TOKEN` is the **bootstrap secret**, and it has exactly two jobs (ADR-0024 §5):
 
-Be clear-eyed about what that token is. It is a single shared secret with no identity, no
-scoping and no audit trail beyond "the admin token was used". It is a bootstrap mechanism
-that exists so tokens can be minted before users and sessions are built, and it should be
-treated as a root credential for every network on this control plane.
+- it creates the first account on a deployment that has none, which is the only way a fresh
+  deployment can have one;
+- it is how you get back in when nobody else can — the last owner left, everybody forgot
+  their password — because a self-hosted deployment has no support line to call.
+
+It is not the credential to run anything with. It is a single shared secret with no
+identity, so the audit trail can only ever record that "the bootstrap secret" did
+something; it cannot be scoped to one network; and it cannot be revoked without locking out
+whatever else was using it. Treat it as a root credential for every network on this control
+plane, keep it somewhere you would keep a root password, and use an account for everything
+else.
+
+**Once an account exists, every use of it is logged at warning level.** That line means
+something is still reaching for the shared secret when it could be using an account — an
+old script, usually. It is throttled to at most one an hour, so it is a nudge rather than
+noise.
+
+Leaving it unset is supported and is the right end state for a deployment whose people all
+have accounts. What you lose is the way back in, so do not unset it until somebody other
+than you holds the owner role, and be aware that a deployment with no accounts *and* no
+bootstrap secret cannot be administered at all without editing the database.
+
+### Accounts, roles and API tokens
+
+Every person gets an account, and what they can do is what their role allows. The four
+built-in roles nest:
+
+| Role | What it is for |
+| --- | --- |
+| `reader` | Sees everything this control plane shows and changes nothing. |
+| `operator` | Adds and removes devices, and moves traffic between advertisers when a link dies. Cannot change the access policy, DNS, or which routes exist. |
+| `administrator` | Configures networks completely. Cannot create accounts, grant roles, or revoke anybody else's credentials. |
+| `owner` | Everything, including deciding who may act. |
+
+A role can be granted across the whole organisation, or narrowed to a single network — which
+is what a technician who looks after one customer needs. A grant narrowed to a network never
+carries an organisation-wide permission, so somebody given a role inside one network cannot
+create accounts across the organisation it belongs to.
+
+`GET /api/v1/permissions` lists the catalogue;
+`GET /api/v1/organizations/{id}/roles` lists what this deployment can grant.
+
+**Scripts and CI use API tokens, not passwords and not the bootstrap secret.** A token
+belongs to the person who minted it, carries the permissions they name — intersected with
+what they hold *at the time it is used*, so demoting somebody demotes their tokens — and is
+revoked on its own without touching their password. Mint one at `POST /api/v1/me/tokens`,
+list them at `GET /api/v1/me/tokens`, and revoke one at `DELETE /api/v1/me/tokens/{id}`.
+An owner can see and revoke everybody's at
+`/api/v1/organizations/{id}/tokens`, which is what you want the day somebody leaves.
+
+Tokens expire: ninety days by default, a year at most, and there is no unexpiring one. That
+is deliberate — a bearer secret that never expires outlives the reason it was made.
 
 ### TLS
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -53,7 +53,7 @@ If the decision was wrong for the whole network rather than for one machine, tur
 centrally and let the agents pick it up:
 
 ```bash
-curl -fsS -X PUT -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+curl -fsS -X PUT -H "Authorization: Bearer $MESHP_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"enforced":false}' \
   "https://control.example.com/api/v1/networks/$NETWORK/egress-fail-closed"
@@ -119,7 +119,7 @@ See [self-hosting](self-hosting.md#relays).
 Read the group's failover policy back:
 
 ```bash
-curl -fsS -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+curl -fsS -H "Authorization: Bearer $MESHP_TOKEN" \
   "https://control.example.com/api/v1/networks/$NETWORK/route-groups"
 ```
 
@@ -140,7 +140,7 @@ Device names come from the peer list and need nothing written down. Names for an
 administrator writes:
 
 ```bash
-curl -fsS -X POST -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+curl -fsS -X POST -H "Authorization: Bearer $MESHP_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"name": "git", "type": "A", "value": "10.80.0.30"}' \
   "https://control.example.com/api/v1/networks/$NETWORK/dns-records"
@@ -166,7 +166,7 @@ Ask the audit trail. A device that moves itself between candidates says why, and
 plane records it (ADR-0003):
 
 ```bash
-curl -fsS -H "Authorization: Bearer $MESHP_ADMIN_TOKEN" \
+curl -fsS -H "Authorization: Bearer $MESHP_TOKEN" \
   "https://control.example.com/api/v1/networks/$NETWORK/audit?limit=20"
 ```
 
@@ -192,8 +192,23 @@ A bare `{"error":"internal"}` means something the server did not expect, and the
 its log rather than the response — deliberately, because an error whose text nobody has
 reviewed could name a table, a path or a peer.
 
-`503` with `admin_disabled` means `MESHP_ADMIN_TOKEN` is unset, so the administrative
-endpoints are switched off rather than running open.
+`401` with `unauthorized` means the request carried no credential this control plane
+recognises: no session cookie, no API token, and not the bootstrap secret. On a deployment
+with no accounts yet and no `MESHP_ADMIN_TOKEN` set, everything answers this — see the
+[quickstart](quickstart.md) for making the first account.
+
+`403` with `forbidden` means the opposite: you are who you say you are and may not do this.
+The message names the permission you would need, so it is something to hand to whoever
+administers your organisation rather than something to retry.
+
+`403` with `cross_origin` means a request that changes something arrived with a session
+cookie and no `Origin` header naming this site. Browsers always send one; `curl` does not,
+so add `-H "Origin: https://your-control-plane"` — or use an API token, which needs no such
+header.
+
+`403` with `person_required` means an API token tried to do something only a person may:
+mint another token, or change its owner's password. A token that could mint a token would
+survive its own revocation.
 
 ## Reporting a bug
 

--- a/internal/api/apitokens_test.go
+++ b/internal/api/apitokens_test.go
@@ -283,3 +283,36 @@ func TestATokenHoldsNothingInAnotherOrganisation(t *testing.T) {
 		t.Errorf("a token reading another organisation's people = %d, want 403", status)
 	}
 }
+
+// A machine acting within its owner's organisation does not have to name it.
+//
+// Found by writing the quickstart rather than by reading the code: the route derives the
+// organisation from the caller, and until now "the caller" meant a person. A token holding
+// organization.networks.create was refused for not naming an organisation the guard had
+// already scoped it to — a permission it could hold and could not use.
+func TestATokenCreatesANetworkInItsOwnersOrganisation(t *testing.T) {
+	h := newHarness(t)
+	createUser(t, h, "alice@example.com")
+	cookie := signIn(t, h, "alice@example.com", testPassword)
+	secret, _ := mintAPIToken(t, h, cookie, map[string]any{
+		"name":        "ci",
+		"permissions": []string{string(authz.OrganizationNetworksCreate)},
+	})
+
+	status, body := h.withToken(http.MethodPost, "/api/v1/networks", secret, map[string]any{
+		"slug": "branch", "name": "Branch", "address_pools": []string{"100.91.0.0/24"},
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("a token creating a network = %d: %v", status, body)
+	}
+
+	// And it landed in the owner's organisation rather than nowhere.
+	var org string
+	if err := h.store.Pool().QueryRow(h.ctx,
+		`SELECT organization_id::text FROM networks WHERE slug = 'branch'`).Scan(&org); err != nil {
+		t.Fatal(err)
+	}
+	if org != orgOf(t, h).String() {
+		t.Errorf("the network landed in %s, want the owner's organisation", org)
+	}
+}

--- a/internal/api/routegroup.go
+++ b/internal/api/routegroup.go
@@ -220,22 +220,23 @@ func (s *Server) handleCreateNetwork(w http.ResponseWriter, r *http.Request) {
 		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
+	// A person belongs to one organisation and a machine acts within its owner's, so
+	// neither has to name one. Only the administrative token does, because it belongs to
+	// no organisation at all.
+	mine := callerOrganization(callerFrom(r))
 	orgID, err := uuid.Parse(body.OrganizationID)
-	if body.OrganizationID == "" {
-		// A person belongs to one organisation, so they do not have to name it. The
-		// administrative token belongs to none and does.
-		if user := callerFrom(r).user; user != nil {
-			orgID, err = user.OrganizationID, nil
-		}
+	if body.OrganizationID == "" && mine != nil {
+		orgID, err = *mine, nil
 	}
 	if err != nil {
-		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request", "organization_id must be a UUID")
+		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request",
+			"organization_id must be a UUID, or omitted to use your own organisation")
 		return
 	}
 	// The permission that got this request here was held over the caller's own organisation,
 	// so it authorises a network in that one and no other. Without this check the guard would
 	// be asking about one tenant and the handler writing to another.
-	if user := callerFrom(r).user; user != nil && orgID != user.OrganizationID {
+	if mine != nil && orgID != *mine {
 		httpx.Error(w, s.log, http.StatusForbidden, "forbidden",
 			"you may only create networks in your own organisation")
 		return

--- a/internal/api/usersession.go
+++ b/internal/api/usersession.go
@@ -34,10 +34,10 @@ func (s *Server) sessionUser(r *http.Request) *store.User {
 
 // signInWithPassword opens a session for a person.
 //
-// The other half of handleUILogin. Which path a request takes is decided by whether it
-// carries an email, not by a separate endpoint: there is one cookie, one sign-in URL, and
-// one thing a browser has to know about. When ADR-0024's later slices remove the
-// administrative token from this endpoint, what is left is this function and no new route.
+// The whole of handleUILogin now. It used to be one of two paths, chosen by whether the
+// request carried an email — the other took the administrative token — and the prediction
+// written here was that removing that path would leave this function and no new route.
+// That is what happened.
 func (s *Server) signInWithPassword(w http.ResponseWriter, r *http.Request, email, plain, orgSlug string) {
 	// Named by slug rather than id, because somebody typing this into a sign-in form has a
 	// slug and would have to look an id up. Resolved before the password is checked, and a
@@ -300,9 +300,16 @@ func (s *Server) warnBootstrapTokenUsed(r *http.Request) {
 		// database will be reported by the request that actually needed it.
 		return
 	}
+	// The hint says what to do, not that something is odd. Whoever reads this line is
+	// running a script they wrote months ago and has no reason to know what replaced the
+	// credential in it, so a warning that only reports a smell costs them a search.
 	s.log.Warn("the bootstrap administrative token was used on a deployment that has accounts",
 		"path", logx.Safe(r.URL.Path),
 		"remote", logx.Safe(clientKey(r)),
-		"hint", "sign in as a user instead; this token is the way back in when nobody can, "+
-			"and every use of it is recorded as nobody in particular")
+		"what_to_do", "replace this credential with an API token: sign in at POST /api/v1/ui/session, "+
+			"then mint one at POST /api/v1/me/tokens naming the permissions it needs",
+		"why", "the bootstrap secret has no identity, so the audit trail can only record that it was used "+
+			"and not by whom; it cannot be scoped to one network, and revoking it locks out everything else "+
+			"still using it",
+		"keep_it", "it is still how you get back in when nobody can sign in — see docs/self-hosting.md")
 }


### PR DESCRIPTION
Closes #139. Last slice of ADR-0024, after #147.

`MESHP_ADMIN_TOKEN` appeared **32 times** across the README and `docs/`. Every quickstart, runbook and recipe handed somebody a credential that can do everything, because until now there was nothing else to hand them.

It appears **7 times** now, and every survivor is either the environment variable's real name — you cannot set one without naming it — or a description of what it is. Nothing in the docs uses it for work any more.

## The quickstart's shape changed

Two calls with the bootstrap secret make an organisation and the first account. That account signs in and mints an API token. Everything after uses the token. The secret is exported as `MESHP_BOOTSTRAP` in the shell so it stays visible that it is **not** the credential you will be using — the env var it is written to keeps its real name.

Three things about minting get a sentence each, because each is surprising the first time: `Origin` is required for a cookie and not for a bearer token; permissions are named rather than implied; the token is shown once.

## I ran the docs rather than reading them

Steps 2–5 of the quickstart and the README's block were **extracted from the files with a script and executed verbatim** against a fresh control plane. Both pages claim every command on them has been run; this makes that true again rather than historically true.

That found a bug the code review did not:

**`handleCreateNetwork` derived the organisation from `caller.user`, which is nil for a machine.** A token holding `organization.networks.create` got a 400 for not naming an organisation the guard had *already scoped it to* — a permission it could hold and could not use. Both callers now go through `callerOrganization`, and there is a test named after where it was found.

It also found a stale claim: `docs/troubleshooting.md` documented a `503` with `admin_disabled`, which no route has been able to return since #147 removed the read-only middleware. It now documents the four refusals that actually happen, including the two this work introduced — `cross_origin` and `person_required` — with what to do about each.

And I verified the permission claims I added to `docs/route-groups.md` rather than asserting them:

```
failover PUT with network.routes.failover: 400   (reached the handler)
the same PUT without it:                  403   (the guard refused)
```

## SECURITY.md

The threat model changed from "a shared secret leaked" to "a password database leaked", so it gets a section: the Argon2id parameters, why an unknown address is put through the same work as a known one, why every sign-in failure looks identical, what ends a session, and why a token's permissions are read at use rather than baked in at creation.

It also states **four things that are missing** — no lockout after repeated failures, no second factor, no password reset flow, and the bootstrap secret still existing — so somebody reporting one is told it is known rather than thanked for a discovery. I filed #148 for the lockout gap rather than leaving "this is tracked" as an unbacked claim; ADR-0024 named it as work its own decision creates, and it is the one of the four with a genuine design question in it (lockout is a denial-of-service vector aimed at the account holder).

I also corrected a self-contradiction I had written into that list on the first pass — it said there was no rate limit on sign-in and then said sign-in shares the enrolment limiter. Sign-in *is* throttled; what is missing is anything per-account.

## Also

`docs/self-hosting.md` gains a table of the four built-in roles and a paragraph on API tokens, since that is where somebody looks when setting up for real.

The warning logged when the bootstrap secret is used on a deployment that has accounts now says **what to do**, not just that something is odd — whoever reads that line is running a script they wrote months ago and has no reason to know what replaced the credential in it.

## That is ADR-0024 finished

Six slices: accounts (#140), attribution (#141), permissions (#142), API tokens (#143), the page (#147), and the documentation. Five tables left `scripts/reachability-allow` along the way. What remains of that record is `groups` and `group_members`, which it deliberately did not settle.