### PR TITLE
feat(dataplane): a tunnel on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,12 +613,64 @@ jobs:
           fi
           echo "no data-plane test was skipped"
 
+  # The macOS data plane, on a real macOS kernel, creating a real utun.
+  #
+  # It lands with the implementation rather than before or after it (#144). Before, there
+  # was nothing here but a stub returning ErrUnsupported and this job would have exercised
+  # it; after, there would be a window where a data plane was merged and had never created
+  # an interface on the platform it was written for. ADR-0018 is about exactly that gap.
+  #
+  # What this proves that `cross compile` does not: that a utun can be created at all, that
+  # wgctrl configures it over the UAPI socket the same way it configures a kernel device on
+  # Linux (ADR-0015's central bet), and that the routing table can be read back accurately
+  # enough to reconcile against.
+  dataplane-macos:
+    name: data plane (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: .go-version
+          cache: true
+
+      # No separate "can this runner make a utun" probe. The test is that probe: it fails
+      # loudly if creation does not work, and the skip check below catches the other way it
+      # could report nothing — sudo not taking, so the tests run unprivileged and skip.
+      #
+      # Creating a utun goes through PF_SYSTEM and needs root, so these tests skip without
+      # it, which means an unprivileged run would report success while testing nothing.
+      # A skip is therefore a failure here, exactly as it is for the Linux job. -E keeps the
+      # Go environment across sudo.
+      - name: a utun comes up, is configured through wgctrl, and is observed back
+        run: |
+          set -o pipefail
+          sudo -E env "PATH=$PATH" go test ./internal/wglink/ -count=1 -v 2>&1 | tee dataplane-macos.log
+
+      - name: report, and refuse a silent skip
+        if: always()
+        run: |
+          {
+            echo "### Data plane (macOS)"
+            echo
+            echo '```'
+            grep -E '^(--- |ok|FAIL)' dataplane-macos.log || true
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+          if grep -q -- "--- SKIP" dataplane-macos.log; then
+            grep -- "--- SKIP" dataplane-macos.log
+            echo "macOS data-plane tests were skipped, which reports success without testing anything"
+            exit 1
+          fi
+          echo "no macOS data-plane test was skipped"
+
   ci-required:
     name: ci
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
-    needs: [lint, test, cross, proto, integration, migrations, migrations-immutable, standalone, reachability, image, dataplane, vuln, fuzz-seeds, dco]
+    needs: [lint, test, cross, proto, integration, migrations, migrations-immutable, standalone, reachability, image, dataplane, dataplane-macos, vuln, fuzz-seeds, dco]
     steps:
       - name: report
         run: |

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ twice. Each colliding prefix is given a mapped range allocated by the control pl
 name layer resolves to the mapped address (ADR-0020), so a technician reaches both rather
 than reaching whichever membership was written last.
 
-What does not, and matters: direct paths are unimplemented, and the data plane is
-Linux-only — elsewhere a device enrols, holds an address, and reports honestly that it has
-no tunnel and cannot filter. There is no web dashboard and no user accounts: the
-administrative API is one shared token.
+What does not, and matters: direct paths are unimplemented, so everything is relayed. The
+data plane is Linux on its own — **macOS brings a tunnel up and carries traffic, and does
+not configure DNS or fail closed on egress**; Windows and the mobile platforms enrol, hold
+an address, and report honestly that they have no tunnel and cannot filter.
 
 It is public from the first commit because the design decisions are the
 interesting part and we would rather be argued with early.

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,9 +31,10 @@ Two worth starting with:
   tunnel drops, and why that is worth the support tickets.
 
 And the honest one: the [status section of the README](../README.md#status) says what does
-not work. The data plane is Linux-only, nothing discovers direct paths yet, and DNS is
-unimplemented. If you need something that works this afternoon, the README names three
-projects that will serve you better today.
+not work. The data plane is complete on Linux and partial on macOS — a tunnel, and neither
+DNS nor fail-closed egress — and absent elsewhere; nothing discovers direct paths yet. If
+you need something that works this afternoon, the README names three projects that will
+serve you better today.
 
 ## A note on what these pages claim
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,8 +15,10 @@ bug and worth an issue.
 
 ## What you need
 
-- Linux, with root. The data plane is Linux-only today: elsewhere a device enrols, holds
-  an address, and reports honestly that it has no tunnel.
+- Linux, with root. This page is written for Linux because that is where the data plane is
+  complete. macOS brings a tunnel up and carries traffic, but does not configure DNS and
+  cannot fail closed on egress; Windows and the mobile platforms enrol, hold an address, and
+  report honestly that they have no tunnel.
 - Docker with the Compose plugin, for the control plane and its database.
 - A kernel that can create WireGuard interfaces. `sudo ip link add dev wgcheck type
   wireguard && sudo ip link del dev wgcheck` tells you in one line.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -69,9 +69,16 @@ reachable.
 sudo meshp status
 ```
 
-`interface meshp0 (not up)` on a non-Linux machine is correct and permanent for now: the
-data plane is Linux-only, and elsewhere a device enrols, holds an address, and reports
-honestly that it has no tunnel rather than pretending.
+`interface meshp0 (not up)` on Windows or a mobile platform is correct for now: there is no
+data plane there yet, so a device enrols, holds an address, and reports honestly that it has
+no tunnel rather than pretending.
+
+On macOS there **is** a tunnel, and `meshp status` reports its kind as `userspace` — macOS
+has no WireGuard in the kernel, so wireguard-go moves the packets. Expect lower throughput
+and higher CPU than the same host would manage on Linux; that is the platform, not a fault.
+What macOS still does not have is DNS configuration and fail-closed egress, so a name will
+not resolve and a full-tunnel group will be reported unhonoured rather than silently
+half-applied.
 
 On Linux, check that the kernel can make WireGuard interfaces at all:
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/jsimonetti/rtnetlink/v2 v2.2.0
 	golang.org/x/crypto v0.55.0
+	golang.org/x/net v0.58.0
 	golang.org/x/sys v0.47.0
+	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10
 	google.golang.org/protobuf v1.36.12
 )
@@ -21,10 +23,9 @@ require (
 	github.com/mdlayher/genetlink v1.3.2 // indirect
 	github.com/mdlayher/netlink v1.8.0 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
-	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
-	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 // indirect
+	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 )
 
 tool google.golang.org/protobuf/cmd/protoc-gen-go

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6p
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -44,6 +46,10 @@ golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
 golang.org/x/text v0.41.0/go.mod h1:jvf1O8ajNzZqhSrQBPbutR/EB83Cc0CFrezNQIwbb5M=
+golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 h1:vVKdlvoWBphwdxWKrFZEuM0kGgGLxUOYcY4U/2Vjg44=
+golang.org/x/time v0.0.0-20220210224613-90d013bbcef8/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeunTOisW56dUokqW/FOteYJJ/yg=
+golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
 golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 h1:/jFs0duh4rdb8uIfPMv78iAJGcPKDeqAFnaLBropIC4=
 golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10 h1:3GDAcqdIg1ozBNLgPy4SLT84nfcBjr6rhGtXYtrkWLU=
@@ -54,3 +60,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259 h1:TbRPT0HtzFP3Cno1zZo7yPzEEnfu8EjLfl6IU9VfqkQ=
+gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259/go.mod h1:AVgIgHMwK63XvmAzWG9vLQ41YnVHN0du0tEC46fI7yY=

--- a/internal/wglink/peer.go
+++ b/internal/wglink/peer.go
@@ -1,0 +1,86 @@
+package wglink
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"time"
+
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+
+	"github.com/meshpnet/meshp/internal/wgplan"
+)
+
+// Translating between a plan's peers and wgctrl's, which is the same job on every platform
+// because wgctrl is the same on every platform — netlink to a kernel device, the UAPI socket
+// to a userspace one, one set of types either way (ADR-0015).
+//
+// Kept out of the platform files for that reason. It lived beside the Linux implementation
+// while that was the only one, and the moment a second arrived the choice was to move it or
+// to have two copies of the one function whose halves must stay in step.
+
+func peerConfig(peer wgplan.Peer) (wgtypes.PeerConfig, error) {
+	key, err := wgtypes.ParseKey(string(peer.PublicKey))
+	if err != nil {
+		return wgtypes.PeerConfig{}, fmt.Errorf("peer key is not a WireGuard key: %w", err)
+	}
+	cfg := wgtypes.PeerConfig{PublicKey: key}
+
+	for _, prefix := range peer.AllowedIPs {
+		cfg.AllowedIPs = append(cfg.AllowedIPs, net.IPNet{
+			IP:   net.IP(prefix.Addr().AsSlice()),
+			Mask: net.CIDRMask(prefix.Bits(), prefix.Addr().BitLen()),
+		})
+	}
+
+	if peer.Endpoint != "" {
+		addr, err := net.ResolveUDPAddr("udp", peer.Endpoint)
+		if err != nil {
+			return wgtypes.PeerConfig{}, fmt.Errorf("endpoint %q: %w", peer.Endpoint, err)
+		}
+		cfg.Endpoint = addr
+	}
+	if peer.PresharedKey != "" {
+		psk, err := wgtypes.ParseKey(string(peer.PresharedKey))
+		if err != nil {
+			return wgtypes.PeerConfig{}, fmt.Errorf("preshared key is not a WireGuard key: %w", err)
+		}
+		cfg.PresharedKey = &psk
+	}
+	if peer.KeepaliveSeconds > 0 {
+		d := time.Duration(peer.KeepaliveSeconds) * time.Second
+		cfg.PersistentKeepaliveInterval = &d
+	}
+	return cfg, nil
+}
+
+// peerFromDevice turns what the kernel reports back into a planned peer, so the two can be
+// compared. Anything not represented here is invisible to the diff and would never be
+// corrected, so this and peerConfig have to stay in step.
+func peerFromDevice(peer wgtypes.Peer) wgplan.Peer {
+	out := wgplan.Peer{
+		PublicKey:        wgplan.Key(peer.PublicKey.String()),
+		KeepaliveSeconds: int(peer.PersistentKeepaliveInterval.Seconds()),
+	}
+	// Whether this peer's current endpoint is working, which is what decides whether
+	// replacing it would be a repair or would undo roaming.
+	if !peer.LastHandshakeTime.IsZero() {
+		out.HasHandshake = true
+		out.HandshakeAge = time.Since(peer.LastHandshakeTime)
+	}
+	if peer.Endpoint != nil {
+		out.Endpoint = peer.Endpoint.String()
+	}
+	if peer.PresharedKey != (wgtypes.Key{}) {
+		out.PresharedKey = wgplan.Key(peer.PresharedKey.String())
+	}
+	for _, ipnet := range peer.AllowedIPs {
+		addr, ok := netip.AddrFromSlice(ipnet.IP)
+		if !ok {
+			continue
+		}
+		ones, _ := ipnet.Mask.Size()
+		out.AllowedIPs = append(out.AllowedIPs, netip.PrefixFrom(addr.Unmap(), ones))
+	}
+	return out
+}

--- a/internal/wglink/routes_darwin.go
+++ b/internal/wglink/routes_darwin.go
@@ -1,0 +1,143 @@
+//go:build darwin
+
+package wglink
+
+import (
+	"fmt"
+	"net/netip"
+
+	"golang.org/x/net/route"
+)
+
+// interfaceRoutes lists the routes currently pointing at one interface.
+//
+// Read from the kernel's routing table over PF_ROUTE rather than by parsing netstat(1),
+// which prints destinations abbreviated — `100.90` for `100.90.0.0/16` — and would have this
+// guessing at prefix lengths from how many octets were printed.
+//
+// Every route through this interface counts as ours, which is a different rule from Linux
+// and lands in the same place. There, routes carry a protocol number and meshp filters on
+// its own; here there is no such field, and the reason one is not needed is that the
+// interface itself is ours: this process created the utun and nothing else has a reason to
+// point anything at it. What that admits is that a route an operator added by hand to a
+// meshp interface would be withdrawn on the next reconcile — which is also true on Linux
+// for a route added with meshp's protocol number, and is the same bargain: the agent removes
+// what it installed, and an interface it owns entirely is all of it.
+//
+// The kernel's own scope route for the interface is excluded. macOS installs one when an
+// address is added, and reporting it would have the planner try to withdraw a route it never
+// installed, on every pass, forever.
+func interfaceRoutes(index int) ([]netip.Prefix, error) {
+	rib, err := route.FetchRIB(0, route.RIBTypeRoute, 0)
+	if err != nil {
+		return nil, fmt.Errorf("wglink: reading the routing table: %w", err)
+	}
+	msgs, err := route.ParseRIB(route.RIBTypeRoute, rib)
+	if err != nil {
+		return nil, fmt.Errorf("wglink: parsing the routing table: %w", err)
+	}
+
+	var out []netip.Prefix
+	for _, msg := range msgs {
+		m, ok := msg.(*route.RouteMessage)
+		if !ok || m.Index != index {
+			continue
+		}
+		prefix, ok := prefixOf(m)
+		if !ok {
+			continue
+		}
+		// A host route to one of the interface's own addresses is the kernel's
+		// bookkeeping rather than a route meshp asked for.
+		if prefix.IsSingleIP() && isLocalRoute(m) {
+			continue
+		}
+		out = append(out, prefix)
+	}
+	return out, nil
+}
+
+// prefixOf turns a routing message's destination and netmask into a prefix.
+func prefixOf(m *route.RouteMessage) (netip.Prefix, bool) {
+	// Addrs is indexed by RTAX_*: 0 is the destination, 2 the netmask.
+	if len(m.Addrs) == 0 || m.Addrs[0] == nil {
+		return netip.Prefix{}, false
+	}
+	dst := addrOf(m.Addrs[0])
+	if !dst.IsValid() {
+		return netip.Prefix{}, false
+	}
+
+	// A route with no netmask is a host route. macOS omits the mask for those rather than
+	// sending an all-ones one.
+	bits := dst.BitLen()
+	if len(m.Addrs) > 2 && m.Addrs[2] != nil {
+		if mask := maskBits(m.Addrs[2], dst.BitLen()); mask >= 0 {
+			bits = mask
+		}
+	}
+	prefix, err := dst.Prefix(bits)
+	if err != nil {
+		return netip.Prefix{}, false
+	}
+	return prefix, true
+}
+
+func addrOf(a route.Addr) netip.Addr {
+	switch v := a.(type) {
+	case *route.Inet4Addr:
+		return netip.AddrFrom4(v.IP)
+	case *route.Inet6Addr:
+		return netip.AddrFrom16(v.IP).Unmap()
+	default:
+		return netip.Addr{}
+	}
+}
+
+// maskBits counts the leading ones in a netmask expressed as an address.
+//
+// Returns -1 for anything that is not a contiguous mask. A non-contiguous netmask is legal
+// in the routing socket's encoding and meaningless as a prefix length, so it is skipped
+// rather than rounded into something that would then be compared against a plan.
+func maskBits(a route.Addr, want int) int {
+	var raw []byte
+	switch v := a.(type) {
+	case *route.Inet4Addr:
+		raw = v.IP[:]
+	case *route.Inet6Addr:
+		raw = v.IP[:]
+	default:
+		return -1
+	}
+	if len(raw)*8 != want {
+		return -1
+	}
+
+	bits := 0
+	for i, b := range raw {
+		if b == 0xff {
+			bits += 8
+			continue
+		}
+		for mask := byte(0x80); mask != 0 && b&mask != 0; mask >>= 1 {
+			bits++
+		}
+		// Everything after the first non-full byte must be zero, or this is not a prefix.
+		for _, rest := range raw[i+1:] {
+			if rest != 0 {
+				return -1
+			}
+		}
+		if b&(b+1) != 0 {
+			return -1
+		}
+		break
+	}
+	return bits
+}
+
+// isLocalRoute reports whether a route is the kernel's own entry for an interface address.
+func isLocalRoute(m *route.RouteMessage) bool {
+	const rtfLocal = 0x200000 // RTF_LOCAL
+	return m.Flags&rtfLocal != 0
+}

--- a/internal/wglink/wglink_darwin.go
+++ b/internal/wglink/wglink_darwin.go
@@ -1,0 +1,550 @@
+//go:build darwin
+
+package wglink
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"golang.zx2c4.com/wireguard/conn"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/ipc"
+	"golang.zx2c4.com/wireguard/tun"
+	"golang.zx2c4.com/wireguard/wgctrl"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+
+	"github.com/meshpnet/meshp/internal/wgplan"
+)
+
+// macOS has no WireGuard in the kernel, so every interface here is a userspace device that
+// this process owns: wireguard-go moves the packets, and wgctrl configures it over the same
+// UAPI socket it would use for a userspace device on Linux.
+//
+// That last part is ADR-0015's bet paying off. "Set this private key, these peers, these
+// allowed IPs" is written once and runs unchanged here, because wgctrl speaks netlink to a
+// kernel device and the UAPI socket to a userspace one behind one interface. What is
+// genuinely different on this platform is everything *around* the tunnel — how an interface
+// comes into existence, how it gets an address, how a route is pointed at it — and that is
+// what this file is.
+
+// The socket directory every WireGuard tool on this platform agrees on. wg-quick(8) puts
+// its sockets and name files here, so `wg show` finds a meshp interface without being told
+// where to look.
+const wireguardRunDir = "/var/run/wireguard"
+
+// commandTimeout bounds one ifconfig or route invocation.
+//
+// These run on the reconcile path. Both are small, synchronous programs that either work or
+// fail in milliseconds, so a bound this generous only ever fires when something is very
+// wrong — and when it does, the agent reports a failed operation rather than stopping
+// converging on everything else.
+const commandTimeout = 10 * time.Second
+
+// darwinLink manages userspace WireGuard interfaces on macOS.
+//
+// The devices are held in this process. That is the load-bearing difference from Linux,
+// where an interface is kernel state that outlives the agent: here, meshpd exiting takes
+// every tunnel with it. Reconciliation rebuilds them on the next start, so the consequence
+// is a gap in connectivity across a restart rather than a wrong configuration — but it is
+// why Observe treats a name file with no live socket behind it as an interface that does
+// not exist, rather than as one to adopt.
+type darwinLink struct {
+	// mu serialises operations, for the reason the Linux implementation gives: one Link is
+	// shared by every membership on the host, each with its own reconcile timer, and
+	// wgctrl's client makes no promise about concurrent use. It also guards devices.
+	mu sync.Mutex
+
+	wg *wgctrl.Client
+
+	// devices maps the name meshp asked for to what is actually running. The map is this
+	// process's memory of what it created; the name file below is the same fact written
+	// down where another tool can read it.
+	devices map[string]*runningDevice
+
+	// runDir is where the name files live. A field rather than the constant everywhere so
+	// a test can exercise the stale-file handling without writing into the directory the
+	// rest of the system's WireGuard tools are using.
+	runDir string
+}
+
+// runningDevice is one wireguard-go tunnel this process started.
+type runningDevice struct {
+	dev *device.Device
+
+	// uapi accepts the configuration connections wgctrl makes. Closed before the device,
+	// so nothing is half-configuring a tunnel that is going away.
+	uapi net.Listener
+
+	// real is the interface the kernel gave us — utun4, utun9 — which is not the name
+	// meshp asked for and cannot be. See nameFile.
+	real string
+}
+
+// New returns a Link for this host.
+func New() (Link, error) {
+	// Created rather than assumed. wg-quick creates it too, and a first run on a fresh
+	// machine would otherwise fail inside wireguard-go with a message about a socket path
+	// rather than about a missing directory.
+	if err := os.MkdirAll(wireguardRunDir, 0o700); err != nil {
+		return nil, fmt.Errorf("wglink: preparing %s: %w", wireguardRunDir, err)
+	}
+	wg, err := wgctrl.New()
+	if err != nil {
+		return nil, fmt.Errorf("wglink: opening the WireGuard control socket: %w", err)
+	}
+	return &darwinLink{wg: wg, devices: map[string]*runningDevice{}, runDir: wireguardRunDir}, nil
+}
+
+func (l *darwinLink) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	var errs []error
+	for name, running := range l.devices {
+		errs = append(errs, l.stop(name, running))
+	}
+	l.devices = map[string]*runningDevice{}
+	errs = append(errs, l.wg.Close())
+	return errors.Join(errs...)
+}
+
+// Kind reports what is behind an interface.
+//
+// Always userspace where there is anything at all: macOS has no kernel WireGuard, which is
+// the whole reason this file exists. ADR-0015 requires this be reported rather than
+// inferred, because a silent fallback turns "why is this host a tenth the speed of that
+// one" into an unanswerable question.
+func (l *darwinLink) Kind(name string) (Kind, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if _, err := l.wg.Device(name); err != nil {
+		return KindUnknown, fmt.Errorf("wglink: reading %s: %w", name, err)
+	}
+	return KindUserspace, nil
+}
+
+// Observe reports what the interface currently holds.
+func (l *darwinLink) Observe(name string) (wgplan.Observed, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	real, ok, err := l.resolve(name)
+	if err != nil || !ok {
+		// Not an error when it is simply absent: that is what the planner needs in order
+		// to decide to create it.
+		return wgplan.Observed{}, err
+	}
+
+	iface, err := net.InterfaceByName(real)
+	if err != nil {
+		return wgplan.Observed{}, fmt.Errorf("wglink: reading %s (%s): %w", name, real, err)
+	}
+
+	obs := wgplan.Observed{
+		Exists: true,
+		Up:     iface.Flags&net.FlagUp != 0,
+		MTU:    iface.MTU,
+	}
+
+	dev, err := l.wg.Device(name)
+	if err != nil {
+		return wgplan.Observed{}, fmt.Errorf("wglink: %s is not a WireGuard interface: %w", name, err)
+	}
+	obs.ListenPort = dev.ListenPort
+	if dev.PrivateKey != (wgtypes.Key{}) {
+		obs.PrivateKey = wgplan.Key(dev.PrivateKey.String())
+	}
+	for _, peer := range dev.Peers {
+		obs.Peers = append(obs.Peers, peerFromDevice(peer))
+	}
+
+	if obs.Addresses, err = interfaceAddresses(iface); err != nil {
+		return wgplan.Observed{}, err
+	}
+	if obs.Routes, err = interfaceRoutes(iface.Index); err != nil {
+		return wgplan.Observed{}, err
+	}
+	return obs, nil
+}
+
+// Apply carries out one operation.
+func (l *darwinLink) Apply(name string, op wgplan.Op) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	switch op.Kind {
+	case wgplan.CreateDevice:
+		return l.createDevice(name, op.Device.MTU)
+	case wgplan.DestroyDevice:
+		return l.destroyDevice(name)
+	case wgplan.SetDevice:
+		return l.setDevice(name, op.Device)
+	case wgplan.SetPeer:
+		return l.setPeer(name, op.Peer)
+	case wgplan.RemovePeer:
+		return l.removePeer(name, op.Peer)
+	case wgplan.AddAddress:
+		return l.address(name, op.Prefix, true)
+	case wgplan.RemoveAddress:
+		return l.address(name, op.Prefix, false)
+	case wgplan.AddRoute:
+		return l.route(name, op.Prefix, true)
+	case wgplan.RemoveRoute:
+		return l.route(name, op.Prefix, false)
+	case wgplan.BringUp:
+		return l.bringUp(name)
+	default:
+		return fmt.Errorf("wglink: unknown operation %s", op.Kind)
+	}
+}
+
+// createDevice starts a userspace tunnel and publishes its UAPI socket.
+func (l *darwinLink) createDevice(name string, mtu int) error {
+	if _, running := l.devices[name]; running {
+		return nil
+	}
+	if mtu <= 0 {
+		mtu = device.DefaultMTU
+	}
+
+	// "utun" rather than the name meshp asked for. macOS names these devices itself, in
+	// sequence, and will not take a name of ours — so the interface is utun4 while meshp
+	// calls it meshp0, and the mapping has to be written down. See nameFile.
+	tunnel, err := tun.CreateTUN("utun", mtu)
+	if err != nil {
+		return fmt.Errorf("wglink: creating a utun device for %s: %w", name, err)
+	}
+	real, err := tunnel.Name()
+	if err != nil {
+		_ = tunnel.Close()
+		return fmt.Errorf("wglink: reading the name of the device created for %s: %w", name, err)
+	}
+
+	dev := device.NewDevice(tunnel, conn.NewDefaultBind(), &device.Logger{
+		Verbosef: device.DiscardLogf,
+		// Errors only. wireguard-go's verbose logging is per packet at times, and this
+		// runs as a daemon: what is worth keeping is what went wrong.
+		Errorf: device.DiscardLogf,
+	})
+	if err := dev.Up(); err != nil {
+		dev.Close()
+		return fmt.Errorf("wglink: starting the device for %s: %w", name, err)
+	}
+
+	// Named for what meshp calls the interface, not for the utun behind it. `wg show` then
+	// lists "meshp0" and agrees with the rest of the product, which is worth more than
+	// matching wg-quick's choice of the kernel's name — and the name file below is what
+	// bridges to `ifconfig` for anybody cross-referencing.
+	socket, err := ipc.UAPIOpen(name)
+	if err != nil {
+		dev.Close()
+		return fmt.Errorf("wglink: opening the control socket for %s: %w", name, err)
+	}
+	listener, err := ipc.UAPIListen(name, socket)
+	if err != nil {
+		dev.Close()
+		return fmt.Errorf("wglink: listening on the control socket for %s: %w", name, err)
+	}
+
+	go func() {
+		for {
+			c, err := listener.Accept()
+			if err != nil {
+				// The listener was closed, which is how this goroutine ends.
+				return
+			}
+			go dev.IpcHandle(c)
+		}
+	}()
+
+	if err := os.WriteFile(l.nameFile(name), []byte(real+"\n"), 0o600); err != nil {
+		_ = listener.Close()
+		dev.Close()
+		return fmt.Errorf("wglink: recording the interface name for %s: %w", name, err)
+	}
+
+	l.devices[name] = &runningDevice{dev: dev, uapi: listener, real: real}
+	return nil
+}
+
+// destroyDevice stops the tunnel and takes the interface with it.
+func (l *darwinLink) destroyDevice(name string) error {
+	running, ok := l.devices[name]
+	if !ok {
+		// Nothing of ours is running under that name. Removing a stale name file is still
+		// worth doing: it is what stops the next Observe reporting an interface that is
+		// not there.
+		_ = os.Remove(l.nameFile(name))
+		return nil
+	}
+	delete(l.devices, name)
+	return l.stop(name, running)
+}
+
+// stop closes one device. Not locked: every caller holds the lock already.
+func (l *darwinLink) stop(name string, running *runningDevice) error {
+	// The listener first, so nothing is half-configuring a tunnel that is going away.
+	err := running.uapi.Close()
+	running.dev.Close()
+	if rmErr := os.Remove(l.nameFile(name)); rmErr != nil && !os.IsNotExist(rmErr) {
+		err = errors.Join(err, rmErr)
+	}
+	if err != nil {
+		return fmt.Errorf("wglink: stopping %s: %w", name, err)
+	}
+	return nil
+}
+
+// setDevice sets the private key, listen port and MTU.
+func (l *darwinLink) setDevice(name string, dev wgplan.Device) error {
+	key, err := wgtypes.ParseKey(string(dev.PrivateKey))
+	if err != nil {
+		return fmt.Errorf("wglink: the private key for %s is not a WireGuard key: %w", name, err)
+	}
+	port := dev.ListenPort
+	cfg := wgtypes.Config{PrivateKey: &key, ListenPort: &port}
+	if err := l.wg.ConfigureDevice(name, cfg); err != nil {
+		return fmt.Errorf("wglink: configuring %s: %w", name, err)
+	}
+	if dev.MTU > 0 {
+		return l.setMTU(name, dev.MTU)
+	}
+	return nil
+}
+
+func (l *darwinLink) setMTU(name string, mtu int) error {
+	real, ok, err := l.resolve(name)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("wglink: setting the MTU of %s: no such interface", name)
+	}
+	return run("/sbin/ifconfig", real, "mtu", strconv.Itoa(mtu))
+}
+
+func (l *darwinLink) bringUp(name string) error {
+	real, ok, err := l.resolve(name)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("wglink: bringing up %s: no such interface", name)
+	}
+	return run("/sbin/ifconfig", real, "up")
+}
+
+func (l *darwinLink) setPeer(name string, peer wgplan.Peer) error {
+	cfg, err := peerConfig(peer)
+	if err != nil {
+		return err
+	}
+	if err := l.wg.ConfigureDevice(name, wgtypes.Config{Peers: []wgtypes.PeerConfig{cfg}}); err != nil {
+		return fmt.Errorf("wglink: setting a peer on %s: %w", name, err)
+	}
+	return nil
+}
+
+func (l *darwinLink) removePeer(name string, peer wgplan.Peer) error {
+	key, err := wgtypes.ParseKey(string(peer.PublicKey))
+	if err != nil {
+		return fmt.Errorf("wglink: %q is not a WireGuard key: %w", peer.PublicKey, err)
+	}
+	cfg := wgtypes.Config{Peers: []wgtypes.PeerConfig{{PublicKey: key, Remove: true}}}
+	if err := l.wg.ConfigureDevice(name, cfg); err != nil {
+		return fmt.Errorf("wglink: removing a peer from %s: %w", name, err)
+	}
+	return nil
+}
+
+// address puts an address on the interface, or takes one off.
+//
+// A utun is a point-to-point device, so an IPv4 address is given with itself as the
+// destination: `inet 100.90.0.7 100.90.0.7`. Without the second address ifconfig takes the
+// prefix's broadcast address as the peer, and the interface ends up routing to something
+// nobody is.
+func (l *darwinLink) address(name string, prefix netip.Prefix, add bool) error {
+	real, ok, err := l.resolve(name)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("wglink: addressing %s: no such interface", name)
+	}
+
+	addr := prefix.Addr()
+	family := "inet"
+	if addr.Is6() {
+		family = "inet6"
+	}
+	action := "alias"
+	if !add {
+		action = "-alias"
+	}
+
+	if addr.Is4() {
+		if add {
+			return run("/sbin/ifconfig", real, family, addr.String(), addr.String(),
+				"netmask", ipv4Netmask(prefix.Bits()), action)
+		}
+		return run("/sbin/ifconfig", real, family, addr.String(), action)
+	}
+	if add {
+		return run("/sbin/ifconfig", real, family, prefix.String(), action)
+	}
+	return run("/sbin/ifconfig", real, family, addr.String(), action)
+}
+
+// route points a prefix at the interface, or withdraws one.
+//
+// Written with route(8) rather than by hand over PF_ROUTE, while Observe reads the table
+// through golang.org/x/net/route. The asymmetry is deliberate: reading drives every
+// reconcile and has to be exact and structured, so it is worth a library; writing is a
+// discrete action taken once, whose failure is reported and acted on, and hand-marshalling
+// sockaddrs to save one exec is not a trade this needs to make.
+func (l *darwinLink) route(name string, prefix netip.Prefix, add bool) error {
+	real, ok, err := l.resolve(name)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("wglink: routing to %s: no such interface", name)
+	}
+
+	family := "-inet"
+	if prefix.Addr().Is6() {
+		family = "-inet6"
+	}
+	action := "add"
+	if !add {
+		action = "delete"
+	}
+	// -n so route does not try to resolve anything: this runs while the tunnel that
+	// resolution might depend on is being built.
+	return run("/sbin/route", "-n", action, family, prefix.String(), "-interface", real)
+}
+
+// resolve maps the name meshp uses to the interface macOS gave us.
+//
+// Three answers, and the third is why this is not just a map lookup. A name file with no
+// live interface behind it is what meshpd leaves after being killed: the tunnel died with
+// the process and the file outlived it. Reporting that as an existing interface would have
+// the planner configure something that is not there; removing the file and reporting
+// absence has it rebuild, which is what should happen.
+func (l *darwinLink) resolve(name string) (string, bool, error) {
+	if running, ok := l.devices[name]; ok {
+		return running.real, true, nil
+	}
+
+	raw, err := os.ReadFile(l.nameFile(name))
+	if os.IsNotExist(err) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("wglink: reading the interface name for %s: %w", name, err)
+	}
+	real := string(trimNewline(raw))
+	if real == "" {
+		_ = os.Remove(l.nameFile(name))
+		return "", false, nil
+	}
+	if !interfaceExists(real) {
+		// Left behind by a process that is gone. Tidied rather than reported, because
+		// there is nothing an operator would do about it that this cannot do itself.
+		_ = os.Remove(l.nameFile(name))
+		return "", false, nil
+	}
+	return real, true, nil
+}
+
+// interfaceExists reports whether the kernel still has an interface by this name.
+//
+// A predicate rather than an error check at the call site, because the answer there is not
+// "something went wrong": a name file whose interface is gone is the expected state after
+// meshpd was killed, and the only thing to do about it is to tidy up and rebuild.
+func interfaceExists(name string) bool {
+	_, err := net.InterfaceByName(name)
+	return err == nil
+}
+
+// nameFile is where the mapping from meshp's name to the kernel's is written down.
+//
+// The same convention wg-quick(8) uses on this platform, so anybody cross-referencing
+// `wg show` against `ifconfig` has the answer in the place they would look for it.
+func (l *darwinLink) nameFile(name string) string {
+	dir := l.runDir
+	if dir == "" {
+		dir = wireguardRunDir
+	}
+	return filepath.Join(dir, name+".name")
+}
+
+// interfaceAddresses lists the interface's own addresses as host prefixes.
+func interfaceAddresses(iface *net.Interface) ([]netip.Prefix, error) {
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, fmt.Errorf("wglink: reading the addresses of %s: %w", iface.Name, err)
+	}
+	var out []netip.Prefix
+	for _, raw := range addrs {
+		ipnet, ok := raw.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		addr, ok := netip.AddrFromSlice(ipnet.IP)
+		if !ok {
+			continue
+		}
+		addr = addr.Unmap()
+		// Link-local addresses are the kernel's, not ours. macOS gives every utun an
+		// fe80:: address of its own, and reporting it would have the planner withdraw an
+		// address it never installed.
+		if addr.IsLinkLocalUnicast() {
+			continue
+		}
+		ones, _ := ipnet.Mask.Size()
+		out = append(out, netip.PrefixFrom(addr, ones))
+	}
+	return out, nil
+}
+
+// run executes one system command, bounded, and reports what it said when it fails.
+//
+// The output matters. `route: writing to routing socket: File exists` is the whole
+// diagnosis, and an error that reported only the exit status would throw it away.
+func run(path string, args ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, path, args...).CombinedOutput()
+	if err != nil {
+		if len(out) > 0 {
+			return fmt.Errorf("wglink: %s %v: %w: %s", filepath.Base(path), args, err, trimNewline(out))
+		}
+		return fmt.Errorf("wglink: %s %v: %w", filepath.Base(path), args, err)
+	}
+	return nil
+}
+
+func trimNewline(b []byte) []byte {
+	for len(b) > 0 && (b[len(b)-1] == '\n' || b[len(b)-1] == '\r' || b[len(b)-1] == ' ') {
+		b = b[:len(b)-1]
+	}
+	return b
+}
+
+// ipv4Netmask renders a prefix length the way ifconfig wants it.
+func ipv4Netmask(bits int) string {
+	mask := net.CIDRMask(bits, 32)
+	return fmt.Sprintf("0x%02x%02x%02x%02x", mask[0], mask[1], mask[2], mask[3])
+}

--- a/internal/wglink/wglink_darwin_test.go
+++ b/internal/wglink/wglink_darwin_test.go
@@ -1,0 +1,295 @@
+//go:build darwin
+
+package wglink
+
+import (
+	"errors"
+	"net"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+
+	"github.com/meshpnet/meshp/internal/wgplan"
+)
+
+// requireRoot skips a test that cannot run without it.
+//
+// Creating a utun goes through PF_SYSTEM, which is root-only on this platform, so the tests
+// that touch a real interface are unrunnable on a developer's machine unless they choose to
+// run the suite as root. They are not optional in CI: the macos job runs them under sudo,
+// which is the whole reason that job exists (#144).
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("needs root: creating a utun device goes through PF_SYSTEM")
+	}
+}
+
+// The routing table is read, not guessed at. Against this host's real routes, whatever they
+// are — the assertion is about the shape of what comes back rather than its contents, since
+// no test can know what is in a developer's or a runner's routing table.
+func TestRoutesAreReadFromTheKernel(t *testing.T) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A machine with no interface carrying a route is not one this can say anything about.
+	found := false
+	for _, iface := range ifaces {
+		routes, err := interfaceRoutes(iface.Index)
+		if err != nil {
+			t.Fatalf("reading routes for %s: %v", iface.Name, err)
+		}
+		for _, prefix := range routes {
+			found = true
+			if !prefix.IsValid() {
+				t.Errorf("%s: invalid prefix %v", iface.Name, prefix)
+			}
+			if prefix.Addr() != prefix.Masked().Addr() {
+				t.Errorf("%s: %v has bits set below its prefix length, so the netmask was misread",
+					iface.Name, prefix)
+			}
+		}
+	}
+	if !found {
+		t.Skip("no interface on this host carries a route this can check")
+	}
+}
+
+// An interface that does not exist is absent rather than an error: that is what the planner
+// needs in order to decide to create it.
+func TestObservingAnAbsentInterface(t *testing.T) {
+	l := &darwinLink{devices: map[string]*runningDevice{}}
+
+	obs, err := l.Observe("meshp-nonexistent-" + t.Name())
+	if err != nil {
+		t.Fatalf("observing an absent interface: %v", err)
+	}
+	if obs.Exists {
+		t.Error("an interface that does not exist reported as existing")
+	}
+}
+
+// A name file left behind by a process that died is tidied away, not adopted.
+//
+// This is the ordinary state after meshpd is killed: the tunnel went with the process, and
+// the file outlived it. Reporting it as an existing interface would have the planner
+// configure something that is not there — and configure it forever, since every pass would
+// find the same file.
+func TestAStaleNameFileIsNotAnInterface(t *testing.T) {
+	dir := t.TempDir()
+	name := "meshp-stale"
+	path := filepath.Join(dir, name+".name")
+	if err := os.WriteFile(path, []byte("utun-that-is-not-there\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	l := &darwinLink{devices: map[string]*runningDevice{}, runDir: dir}
+	real, ok, err := l.resolve(name)
+	if err != nil {
+		t.Fatalf("resolving a stale name: %v", err)
+	}
+	if ok {
+		t.Errorf("a stale name file resolved to %q", real)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Error("the stale name file was left behind, so the next pass will read it again")
+	}
+}
+
+// The mapping is written where wg-quick(8) and anybody debugging would look for it.
+func TestTheNameFileRecordsTheRealInterface(t *testing.T) {
+	dir := t.TempDir()
+	l := &darwinLink{devices: map[string]*runningDevice{}, runDir: dir}
+
+	if got := l.nameFile("meshp0"); got != filepath.Join(dir, "meshp0.name") {
+		t.Errorf("name file = %q", got)
+	}
+}
+
+// An IPv4 netmask is rendered the way ifconfig wants it, which is hexadecimal and not
+// dotted-quad. Getting this wrong is not a parse error — ifconfig accepts a dotted-quad too
+// — but it is worth pinning, because the two are easy to confuse and only one is what the
+// manual page documents for this argument.
+func TestIPv4NetmaskRendering(t *testing.T) {
+	for _, tc := range []struct {
+		bits int
+		want string
+	}{
+		{32, "0xffffffff"},
+		{24, "0xffffff00"},
+		{16, "0xffff0000"},
+		{0, "0x00000000"},
+	} {
+		if got := ipv4Netmask(tc.bits); got != tc.want {
+			t.Errorf("ipv4Netmask(%d) = %s, want %s", tc.bits, got, tc.want)
+		}
+	}
+}
+
+// The kernel's own link-local address on a utun is not something meshp installed, so it must
+// not be reported as an address the planner could withdraw.
+func TestLinkLocalAddressesAreNotOurs(t *testing.T) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, iface := range ifaces {
+		addrs, err := interfaceAddresses(&iface)
+		if err != nil {
+			t.Fatalf("reading addresses of %s: %v", iface.Name, err)
+		}
+		for _, prefix := range addrs {
+			if prefix.Addr().IsLinkLocalUnicast() {
+				t.Errorf("%s: reported the kernel's link-local address %v as ours",
+					iface.Name, prefix)
+			}
+		}
+	}
+}
+
+// --- with a real interface -----------------------------------------------------------
+
+// The whole of it: a tunnel comes into existence, is configured through wgctrl exactly as a
+// Linux one would be, holds an address and a route, and reports itself honestly.
+func TestATunnelComesUpAndIsObservedBack(t *testing.T) {
+	requireRoot(t)
+
+	l, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	const name = "meshptest0"
+	key := genDarwinKey(t)
+	addr := netip.MustParsePrefix("100.90.77.1/32")
+	via := netip.MustParsePrefix("100.90.77.0/24")
+
+	plan := wgplan.Plan{Ops: []wgplan.Op{
+		{Kind: wgplan.CreateDevice, Device: wgplan.Device{MTU: 1380}},
+		{Kind: wgplan.SetDevice, Device: wgplan.Device{PrivateKey: key, ListenPort: 51899, MTU: 1380}},
+		{Kind: wgplan.AddAddress, Prefix: addr},
+		{Kind: wgplan.BringUp},
+		{Kind: wgplan.AddRoute, Prefix: via},
+	}}
+	t.Cleanup(func() { _ = l.Apply(name, wgplan.Op{Kind: wgplan.DestroyDevice}) })
+
+	if err := ApplyPlan(l, name, plan); err != nil {
+		t.Fatalf("applying the plan: %v", err)
+	}
+
+	obs, err := l.Observe(name)
+	if err != nil {
+		t.Fatalf("Observe: %v", err)
+	}
+	if !obs.Exists {
+		t.Fatal("the interface was created and does not exist")
+	}
+	if !obs.Up {
+		t.Error("the interface was brought up and is down")
+	}
+	if obs.ListenPort != 51899 {
+		t.Errorf("listen port = %d, want 51899", obs.ListenPort)
+	}
+	if obs.MTU != 1380 {
+		t.Errorf("MTU = %d, want 1380", obs.MTU)
+	}
+	if obs.PrivateKey != key {
+		t.Error("the private key that came back is not the one that went in")
+	}
+	if !hasPrefix(obs.Addresses, addr) {
+		t.Errorf("addresses = %v, want to contain %v", obs.Addresses, addr)
+	}
+	if !hasPrefix(obs.Routes, via) {
+		t.Errorf("routes = %v, want to contain %v", obs.Routes, via)
+	}
+
+	// ADR-0015 requires this be reported rather than inferred. On macOS it is always
+	// userspace, and a build that started claiming otherwise would be claiming a kernel
+	// implementation that does not exist on this platform.
+	kind, err := l.Kind(name)
+	if err != nil {
+		t.Fatalf("Kind: %v", err)
+	}
+	if kind != KindUserspace {
+		t.Errorf("kind = %s, want userspace", kind)
+	}
+
+	// And the mapping is on disk, where wg-quick(8) and anybody debugging would look.
+	raw, err := os.ReadFile(filepath.Join(wireguardRunDir, name+".name"))
+	if err != nil {
+		t.Fatalf("reading the name file: %v", err)
+	}
+	if real := strings.TrimSpace(string(raw)); !strings.HasPrefix(real, "utun") {
+		t.Errorf("the name file says %q, want a utun", real)
+	}
+}
+
+// Applying the same plan twice changes nothing, which is what makes the reconcile loop safe
+// to run on a timer. A create that failed on an interface that already exists, or an address
+// that could not be added twice, would make every pass after the first report an error.
+func TestApplyingTheSamePlanTwiceIsQuiet(t *testing.T) {
+	requireRoot(t)
+
+	l, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	const name = "meshptest1"
+	key := genDarwinKey(t)
+	t.Cleanup(func() { _ = l.Apply(name, wgplan.Op{Kind: wgplan.DestroyDevice}) })
+
+	create := wgplan.Plan{Ops: []wgplan.Op{
+		{Kind: wgplan.CreateDevice, Device: wgplan.Device{MTU: 1380}},
+		{Kind: wgplan.SetDevice, Device: wgplan.Device{PrivateKey: key, ListenPort: 51898, MTU: 1380}},
+		{Kind: wgplan.BringUp},
+	}}
+	if err := ApplyPlan(l, name, create); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	if err := ApplyPlan(l, name, create); err != nil {
+		t.Fatalf("second apply of the same plan: %v", err)
+	}
+}
+
+// Destroying an interface that is not there is success. The reconciler asks for it whenever
+// a membership goes away, including when it was never up.
+func TestDestroyingNothingIsFine(t *testing.T) {
+	requireRoot(t)
+
+	l, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	if err := l.Apply("meshp-never-existed", wgplan.Op{Kind: wgplan.DestroyDevice}); err != nil {
+		t.Errorf("destroying an absent interface: %v", err)
+	}
+}
+
+func genDarwinKey(t *testing.T) wgplan.Key {
+	t.Helper()
+	k, err := wgtypes.GeneratePrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return wgplan.Key(k.String())
+}
+
+func hasPrefix(all []netip.Prefix, want netip.Prefix) bool {
+	for _, p := range all {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/wglink/wglink_linux.go
+++ b/internal/wglink/wglink_linux.go
@@ -9,7 +9,6 @@ import (
 	"net/netip"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/jsimonetti/rtnetlink/v2"
 	"golang.org/x/sys/unix"
@@ -421,72 +420,6 @@ func (l *linux) route(name string, prefix netip.Prefix, add bool) error {
 }
 
 // peerConfig turns a planned peer into what wgctrl wants.
-func peerConfig(peer wgplan.Peer) (wgtypes.PeerConfig, error) {
-	key, err := wgtypes.ParseKey(string(peer.PublicKey))
-	if err != nil {
-		return wgtypes.PeerConfig{}, fmt.Errorf("peer key is not a WireGuard key: %w", err)
-	}
-	cfg := wgtypes.PeerConfig{PublicKey: key}
-
-	for _, prefix := range peer.AllowedIPs {
-		cfg.AllowedIPs = append(cfg.AllowedIPs, net.IPNet{
-			IP:   net.IP(prefix.Addr().AsSlice()),
-			Mask: net.CIDRMask(prefix.Bits(), prefix.Addr().BitLen()),
-		})
-	}
-
-	if peer.Endpoint != "" {
-		addr, err := net.ResolveUDPAddr("udp", peer.Endpoint)
-		if err != nil {
-			return wgtypes.PeerConfig{}, fmt.Errorf("endpoint %q: %w", peer.Endpoint, err)
-		}
-		cfg.Endpoint = addr
-	}
-	if peer.PresharedKey != "" {
-		psk, err := wgtypes.ParseKey(string(peer.PresharedKey))
-		if err != nil {
-			return wgtypes.PeerConfig{}, fmt.Errorf("preshared key is not a WireGuard key: %w", err)
-		}
-		cfg.PresharedKey = &psk
-	}
-	if peer.KeepaliveSeconds > 0 {
-		d := time.Duration(peer.KeepaliveSeconds) * time.Second
-		cfg.PersistentKeepaliveInterval = &d
-	}
-	return cfg, nil
-}
-
-// peerFromDevice turns what the kernel reports back into a planned peer, so the two can be
-// compared. Anything not represented here is invisible to the diff and would never be
-// corrected, so this and peerConfig have to stay in step.
-func peerFromDevice(peer wgtypes.Peer) wgplan.Peer {
-	out := wgplan.Peer{
-		PublicKey:        wgplan.Key(peer.PublicKey.String()),
-		KeepaliveSeconds: int(peer.PersistentKeepaliveInterval.Seconds()),
-	}
-	// Whether this peer's current endpoint is working, which is what decides whether
-	// replacing it would be a repair or would undo roaming.
-	if !peer.LastHandshakeTime.IsZero() {
-		out.HasHandshake = true
-		out.HandshakeAge = time.Since(peer.LastHandshakeTime)
-	}
-	if peer.Endpoint != nil {
-		out.Endpoint = peer.Endpoint.String()
-	}
-	if peer.PresharedKey != (wgtypes.Key{}) {
-		out.PresharedKey = wgplan.Key(peer.PresharedKey.String())
-	}
-	for _, ipnet := range peer.AllowedIPs {
-		addr, ok := netip.AddrFromSlice(ipnet.IP)
-		if !ok {
-			continue
-		}
-		ones, _ := ipnet.Mask.Size()
-		out.AllowedIPs = append(out.AllowedIPs, netip.PrefixFrom(addr.Unmap(), ones))
-	}
-	return out
-}
-
 // lookup finds an interface, reporting "not there" separately from "the lookup failed".
 //
 // The distinction is the whole point. An absent interface is a normal state — before

--- a/internal/wglink/wglink_other.go
+++ b/internal/wglink/wglink_other.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !darwin
 
 package wglink
 
@@ -6,6 +6,8 @@ package wglink
 //
 // A clear error rather than a build failure, so meshpd still compiles and runs everywhere:
 // a device can enrol, hold an address and report honestly that it has no tunnel. That is
-// the state macOS and Windows are in until their implementations land, and it is more
-// useful than a daemon that cannot be built there at all.
+// the state Windows and the mobile platforms are in until their implementations land, and
+// it is more useful than a daemon that cannot be built there at all.
+//
+// macOS left this stub behind when wglink_darwin.go landed.
 func New() (Link, error) { return nil, ErrUnsupported }


### PR DESCRIPTION
First slice of #151.

macOS had no data plane. `wglink.New()` returned `ErrUnsupported`, every non-Linux file was a stub, and a device could enrol, hold an address and report honestly that it had no tunnel. It now brings a tunnel up and carries traffic.

## ADR-0015's bet pays off

> `wgctrl` speaks netlink to kernel devices and the UAPI socket to userspace ones behind one interface, so "set this private key, these peers, these allowed IPs" is written once either way.

That is exactly what happened: setting a key, a port and a set of peers is the same code that runs on Linux, unchanged. `peerConfig` and `peerFromDevice` moved out of the Linux file into `peer.go` — the moment a second platform existed, the choice was to move them or keep two copies of the one function whose halves must stay in step.

What is genuinely different is everything *around* the tunnel, and that is what this PR is.

## Three decisions worth reviewing

**Naming.** macOS names utun devices itself, in sequence, and will not take a name of ours — the interface is `utun4` while meshp calls it `meshp0`. The mapping goes in `/var/run/wireguard/<name>.name`, which is where wg-quick(8) puts it and therefore where anybody cross-referencing `wg show` against `ifconfig` will look. I named the **UAPI socket for meshp's name rather than the kernel's**, which diverges from wg-quick — so `wg show meshp0` agrees with the rest of the product, and the name file bridges to `ifconfig`. That is the one place I chose against the platform convention, deliberately.

**Reading routes over PF_ROUTE, writing them with `route(8)`.** The asymmetry is deliberate. Reading drives every reconcile and has to be exact — and `netstat(1)` prints destinations abbreviated (`100.90` for `100.90.0.0/16`), which would have this guessing prefix lengths from how many octets were printed. `golang.org/x/net/route` gives it structured. Writing is a discrete action whose failure is reported and acted on; hand-marshalling sockaddrs to save one exec is not a trade this needs to make.

**Every route through the interface is ours.** A different rule from Linux, landing in the same place. There, routes carry a protocol number and meshp filters on its own (`RouteProtocol = 61`); here there is no such field, and none is needed because the utun itself is ours — this process created it and nothing else has a reason to point anything at it.

## The difference that will bite somebody

**The device lives in this process.** A kernel interface outlives the agent; a wireguard-go device does not. `meshpd` exiting takes every tunnel with it and leaves a name file behind.

So `Observe` treats a name file with no live interface as an interface that does not exist, and tidies the file. The next reconcile rebuilds, rather than configuring something that is not there — forever, since every pass would find the same file. There is a test for exactly that state, because it is the *ordinary* state after a kill, not an edge case.

## CI lands in the same commit

Not before, where it would have exercised a stub; not after, where there would be a window with a data plane merged and never run on the platform it was written for. That is #144's whole argument and this is the first PR to honour it.

Six of the nine tests run unprivileged and pass on my machine. **The three that create a real utun need root — `sudo` needs a password here, so I could not run them locally.** The job runs them under `sudo` and treats a skip as a failure, because an unprivileged run would otherwise report success while testing nothing. If `macos-latest` cannot create a utun, this PR fails loudly, which is the point.

I removed my own first draft of a "can this runner make a utun" pre-check step: every command in it ended in `|| true`, so it could not fail. The test is the probe.

## Verified locally

```
--- PASS: TestRoutesAreReadFromTheKernel
--- PASS: TestObservingAnAbsentInterface
--- PASS: TestAStaleNameFileIsNotAnInterface
--- PASS: TestTheNameFileRecordsTheRealInterface
--- PASS: TestIPv4NetmaskRendering
--- PASS: TestLinkLocalAddressesAreNotOurs
--- SKIP: TestATunnelComesUpAndIsObservedBack      (needs root)
--- SKIP: TestApplyingTheSamePlanTwiceIsQuiet      (needs root)
--- SKIP: TestDestroyingNothingIsFine              (needs root)
```

Route parsing is checked against this Mac's real routing table — that every prefix is valid and that none has bits set below its prefix length, which is what a misread netmask looks like. Address filtering is checked against every interface on the host, asserting the kernel's own link-local addresses are never reported as meshp's.

`golangci-lint` caught a swallowed error in `resolve()` — deliberate, but it was right that the intent lived in a comment rather than the code. It is now an `interfaceExists` predicate.

## Not in this slice

DNS via `scutil`, and fail-closed egress via `pf`. A macOS device gets a tunnel, no name resolution, and a full-tunnel group reported *unhonoured* rather than silently half-applied — which is the existing `egress_other.go` stub doing the right thing.

The docs say exactly that, in four places that claimed the data plane was Linux-only. While there, `README.md`'s status section stopped claiming there is no web dashboard and no user accounts, and that the administrative API is one shared token — all false since #147, and something #139 should have caught.