### PR TITLE
feat(dns): names resolve on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,27 +647,50 @@ jobs:
       # mDNSResponder collects a supplemental domain from a service key meshp invented, on a
       # non-standard port, is not something that can be reasoned about — it either does or
       # it does not, and only a real macOS can say.
-      - name: a utun comes up and is observed back, and macOS sends mesh names to meshp
+      #
+      # Twice, because there are genuinely two classes of test here and each skips the other.
+      # Creating a utun needs root; being refused a write to the dynamic store needs *not*
+      # having it, and that refusal is a real path — ADR-0021 turns on a host that cannot
+      # configure its resolver saying so rather than reporting success. One run cannot
+      # exercise both, so the check below is that nothing skipped in both runs.
+      - name: unprivileged — a refused write is an error, and scutil still exits zero
         run: |
           set -o pipefail
-          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/resolved/ -count=1 -v 2>&1 | tee dataplane-macos.log
+          go test ./internal/wglink/ ./internal/resolved/ -count=1 -v 2>&1 | tee macos-user.log
 
-      - name: report, and refuse a silent skip
+      - name: as root — a utun comes up and is observed back, and macOS sends mesh names to meshp
+        run: |
+          set -o pipefail
+          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/resolved/ -count=1 -v 2>&1 | tee macos-root.log
+
+      # A test that skipped in both runs never ran anywhere, which reports success while
+      # testing nothing. Checked by name rather than by counting skips, because each run is
+      # *expected* to skip what the other covers.
+      - name: report, and refuse a test that ran nowhere
         if: always()
         run: |
+          skipped() { grep -E '^\s*--- SKIP: ' "$1" | sed 's/.*--- SKIP: //; s/ .*//' | sort -u; }
+          skipped macos-user.log > user-skips.txt || true
+          skipped macos-root.log > root-skips.txt || true
+          never_ran=$(comm -12 user-skips.txt root-skips.txt)
+
           {
             echo "### Data plane (macOS)"
             echo
             echo '```'
-            grep -E '^(--- |ok|FAIL)' dataplane-macos.log || true
+            grep -E '^(--- |ok|FAIL)' macos-root.log || true
             echo '```'
+            echo
+            echo "skipped unprivileged, covered as root: $(tr '\n' ' ' < user-skips.txt)"
+            echo "skipped as root, covered unprivileged: $(tr '\n' ' ' < root-skips.txt)"
           } | tee -a "$GITHUB_STEP_SUMMARY"
-          if grep -q -- "--- SKIP" dataplane-macos.log; then
-            grep -- "--- SKIP" dataplane-macos.log
-            echo "macOS data-plane tests were skipped, which reports success without testing anything"
+
+          if [ -n "$never_ran" ]; then
+            echo "these tests skipped in both runs, so they ran nowhere:"
+            echo "$never_ran"
             exit 1
           fi
-          echo "no macOS data-plane test was skipped"
+          echo "every test ran in at least one of the two runs"
 
   ci-required:
     name: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,10 +643,14 @@ jobs:
       # it, which means an unprivileged run would report success while testing nothing.
       # A skip is therefore a failure here, exactly as it is for the Linux job. -E keeps the
       # Go environment across sudo.
-      - name: a utun comes up, is configured through wgctrl, and is observed back
+      # resolved joins wglink here because it has the same shape of unknown: whether
+      # mDNSResponder collects a supplemental domain from a service key meshp invented, on a
+      # non-standard port, is not something that can be reasoned about — it either does or
+      # it does not, and only a real macOS can say.
+      - name: a utun comes up and is observed back, and macOS sends mesh names to meshp
         run: |
           set -o pipefail
-          sudo -E env "PATH=$PATH" go test ./internal/wglink/ -count=1 -v 2>&1 | tee dataplane-macos.log
+          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/resolved/ -count=1 -v 2>&1 | tee dataplane-macos.log
 
       - name: report, and refuse a silent skip
         if: always()

--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ name layer resolves to the mapped address (ADR-0020), so a technician reaches bo
 than reaching whichever membership was written last.
 
 What does not, and matters: direct paths are unimplemented, so everything is relayed. The
-data plane is Linux on its own — **macOS brings a tunnel up and carries traffic, and does
-not configure DNS or fail closed on egress**; Windows and the mobile platforms enrol, hold
-an address, and report honestly that they have no tunnel and cannot filter.
+data plane is complete on Linux and nearly so on macOS — **a tunnel, and names that
+resolve; what macOS still cannot do is fail closed on egress**. Windows and the mobile
+platforms enrol, hold an address, and report honestly that they have no tunnel and cannot
+filter.
 
 It is public from the first commit because the design decisions are the
 interesting part and we would rather be argued with early.

--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -83,7 +83,7 @@ type agent struct {
 	// only to something querying the agent directly, which the status command says plainly
 	// rather than leaving somebody to wonder why `ssh fileserver` does not work.
 	systemResolverOnce sync.Once
-	systemResolver     *resolved.Resolvectl
+	systemResolver     *resolved.System
 
 	ctx context.Context
 }
@@ -151,7 +151,7 @@ func proberOrNil() tunnel.Prober {
 
 // systemResolverOrNil converts a possibly-absent resolver configurer into the interface.
 //
-// Explicit for the reason routerOrNil and proberOrNil are: a nil *resolved.Resolvectl
+// Explicit for the reason routerOrNil and proberOrNil are: a nil *resolved.System
 // assigned straight to an interface is a non-nil interface holding a nil pointer, so the
 // reconciler's own nil check would pass and every reconcile would call a method on nothing.
 //

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,9 +31,9 @@ Two worth starting with:
   tunnel drops, and why that is worth the support tickets.
 
 And the honest one: the [status section of the README](../README.md#status) says what does
-not work. The data plane is complete on Linux and partial on macOS — a tunnel, and neither
-DNS nor fail-closed egress — and absent elsewhere; nothing discovers direct paths yet. If
-you need something that works this afternoon, the README names three projects that will
+not work. The data plane is complete on Linux and nearly so on macOS — a tunnel and working
+names, but no fail-closed egress — and absent elsewhere; nothing discovers direct paths yet.
+If you need something that works this afternoon, the README names three projects that will
 serve you better today.
 
 ## A note on what these pages claim

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,9 +16,9 @@ bug and worth an issue.
 ## What you need
 
 - Linux, with root. This page is written for Linux because that is where the data plane is
-  complete. macOS brings a tunnel up and carries traffic, but does not configure DNS and
-  cannot fail closed on egress; Windows and the mobile platforms enrol, hold an address, and
-  report honestly that they have no tunnel.
+  complete. macOS brings a tunnel up, carries traffic and resolves mesh names; what it
+  cannot yet do is fail closed on egress. Windows and the mobile platforms enrol, hold an
+  address, and report honestly that they have no tunnel.
 - Docker with the Compose plugin, for the control plane and its database.
 - A kernel that can create WireGuard interfaces. `sudo ip link add dev wgcheck type
   wireguard && sudo ip link del dev wgcheck` tells you in one line.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -76,9 +76,13 @@ no tunnel rather than pretending.
 On macOS there **is** a tunnel, and `meshp status` reports its kind as `userspace` — macOS
 has no WireGuard in the kernel, so wireguard-go moves the packets. Expect lower throughput
 and higher CPU than the same host would manage on Linux; that is the platform, not a fault.
-What macOS still does not have is DNS configuration and fail-closed egress, so a name will
-not resolve and a full-tunnel group will be reported unhonoured rather than silently
-half-applied.
+Names resolve on macOS too: the agent writes a supplemental match domain into the
+SystemConfiguration store, so only this network's suffix comes to meshp and everything else
+keeps going wherever it was already going. `scutil --dns` shows it as a resolver with a
+`domain` and a high `order`, which is the thing to look at when a mesh name does not answer.
+
+What macOS still does not have is fail-closed egress, so a full-tunnel group is reported
+unhonoured rather than silently half-applied.
 
 On Linux, check that the kernel can make WireGuard interfaces at all:
 

--- a/internal/resolved/resolvectl_linux.go
+++ b/internal/resolved/resolvectl_linux.go
@@ -21,8 +21,8 @@ import (
 // important thing it does.
 const callTimeout = 10 * time.Second
 
-// Resolvectl configures systemd-resolved.
-type Resolvectl struct{ path string }
+// System configures systemd-resolved.
+type System struct{ path string }
 
 // New returns a configurer for this host, or nil where systemd-resolved is not the thing
 // answering names.
@@ -35,7 +35,7 @@ type Resolvectl struct{ path string }
 // can have resolvectl and no systemd-resolved to talk to, which fails later and looks like a
 // meshp fault. This asks resolved for its status, which needs the same bus access that
 // configuring a link does.
-func New(ctx context.Context) *Resolvectl {
+func New(ctx context.Context) *System {
 	path, err := exec.LookPath("resolvectl")
 	if err != nil {
 		return nil
@@ -45,7 +45,7 @@ func New(ctx context.Context) *Resolvectl {
 	if err := exec.CommandContext(ctx, path, "status").Run(); err != nil {
 		return nil
 	}
-	return &Resolvectl{path: path}
+	return &System{path: path}
 }
 
 // Configure points one interface's queries for these domains at the agent's resolver.
@@ -58,7 +58,7 @@ func New(ctx context.Context) *Resolvectl {
 //
 // Idempotent because the reconciler calls it on every pass. resolvectl replaces a link's
 // configuration rather than appending to it, so the second call is a no-op in effect.
-func (r *Resolvectl) Configure(ctx context.Context, iface string, server netip.AddrPort, domains []string) error {
+func (r *System) Configure(ctx context.Context, iface string, server netip.AddrPort, domains []string) error {
 	if len(domains) == 0 {
 		// Nothing to route here. Reverting rather than configuring an empty set: a link
 		// left pointing at this resolver with no domains would still be consulted for
@@ -92,7 +92,7 @@ func (r *Resolvectl) Configure(ctx context.Context, iface string, server netip.A
 // The reason this package exists rather than one that edits resolv.conf: there is a real
 // undo, so the agent can take its configuration off without holding a copy of somebody
 // else's and hoping it is still current (Invariant 20).
-func (r *Resolvectl) Revert(ctx context.Context, iface string) error {
+func (r *System) Revert(ctx context.Context, iface string) error {
 	ctx, cancel := context.WithTimeout(ctx, callTimeout)
 	defer cancel()
 	if out, err := r.run(ctx, "revert", iface); err != nil {
@@ -102,7 +102,7 @@ func (r *Resolvectl) Revert(ctx context.Context, iface string) error {
 }
 
 // run invokes resolvectl and returns its output, bounded, for the error message.
-func (r *Resolvectl) run(ctx context.Context, args ...string) (string, error) {
+func (r *System) run(ctx context.Context, args ...string) (string, error) {
 	out, err := exec.CommandContext(ctx, r.path, args...).CombinedOutput()
 	return logx.Safe(strings.TrimSpace(string(out))), err
 }

--- a/internal/resolved/resolved.go
+++ b/internal/resolved/resolved.go
@@ -6,19 +6,30 @@
 // joined, and would make meshp answerable for the user's entire name resolution — a much
 // larger promise than the one being made (ADR-0021).
 //
-// # Why only systemd-resolved
+// # What decides whether a platform gets an implementation
 //
-// Because it is the one mechanism with a real undo. `resolvectl revert` puts a link back
-// exactly as it was, so the agent can honour Invariant 20 — remove what we installed —
-// without keeping a copy of somebody else's configuration and hoping it is still current
-// when the time comes.
+// One question: is there a real undo? The agent has to honour Invariant 20 — remove what we
+// installed — without keeping a copy of somebody else's configuration and hoping it is still
+// current when the time comes. ADR-0021 is explicit that a host which cannot manage that
+// must say so and leave the system's DNS alone rather than write a file it does not know how
+// to put back.
 //
-// The alternatives are shared mutable files that other software also edits.
-// /etc/resolv.conf is rewritten by NetworkManager, dhclient, containers and the user;
-// putting a line in it means either clobbering theirs or parsing and rewriting a file whose
-// format has three dialects. ADR-0021 is explicit that a host which cannot configure its
-// resolver must say so and leave the system's DNS alone rather than write a file it does not
-// know how to put back, and that is what this package does everywhere but here.
+// Two platforms pass, for different reasons.
+//
+// **Linux, through systemd-resolved.** `resolvectl revert` puts a link back exactly as it
+// was. The alternatives on Linux do not qualify: /etc/resolv.conf is rewritten by
+// NetworkManager, dhclient, containers and the user, so putting a line in it means either
+// clobbering theirs or parsing and rewriting a file whose format has three dialects.
+//
+// **macOS, through the SystemConfiguration dynamic store.** A stronger answer than Linux's,
+// and worth stating as such: there is nothing to put back. The store is keyed per service,
+// so meshp creates a key that is entirely its own and removes it to undo. Nobody else's
+// entry is read, merged or rewritten at any point — where `resolvectl revert` restores
+// previous state, this never disturbs any.
+//
+// What is left unimplemented is Windows and the mobile platforms. The mechanism exists on
+// each; nobody has written it, and until somebody does those hosts report that names will
+// not resolve rather than pretending.
 package resolved
 
 import (

--- a/internal/resolved/scutil_darwin.go
+++ b/internal/resolved/scutil_darwin.go
@@ -1,0 +1,199 @@
+//go:build darwin
+
+package resolved
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/logx"
+)
+
+// ErrUnsupported means this platform has no resolver meshp knows how to configure safely.
+//
+// Declared here as well as in the unsupported build because macOS has an implementation and
+// still needs the sentinel: New returns nil when scutil cannot be reached, and a caller that
+// held one anyway should get a refusal rather than a silent success.
+var ErrUnsupported = errors.New("resolved: no supported resolver on this platform")
+
+// callTimeout bounds one scutil invocation, for the reason the Linux implementation gives:
+// this runs on the reconcile path, and names are the least important thing the agent does.
+const callTimeout = 10 * time.Second
+
+// matchOrder is where meshp's supplemental domains sit relative to anything else claiming
+// them.
+//
+// High, so a corporate resolver that also claims a suffix wins. That is the conservative
+// direction: meshp is the newcomer on a machine that was resolving names before it arrived,
+// and a tie broken in meshp's favour would silently redirect a name somebody's employer
+// owns. If a network's suffix genuinely collides with one the host already resolves, the
+// answer is to change the suffix, not to outbid it.
+const matchOrder = 200000
+
+// System points macOS's resolver at meshp for the names meshp owns.
+//
+// Through the SystemConfiguration dynamic store, which is what makes this safe to do at all.
+// See the package documentation: the store is keyed per service, so meshp writes an entry
+// that is entirely its own and removes it to undo. Nothing of anybody else's is read,
+// merged or written back.
+type System struct{ path string }
+
+// New returns a configurer for this host, or nil where scutil cannot be reached.
+//
+// mDNSResponder is not optional on macOS the way systemd-resolved is on Linux, so there is
+// no equivalent of asking whether the daemon is running — if scutil answers, the store is
+// there. What this does check is that it answers, because a sandbox or a stripped image
+// that lacks it should produce a nil here rather than a failure per reconcile.
+func New(ctx context.Context) *System {
+	path, err := exec.LookPath("scutil")
+	if err != nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Stdin = strings.NewReader("list State:/Network/Global/DNS\nquit\n")
+	if err := cmd.Run(); err != nil {
+		return nil
+	}
+	return &System{path: path}
+}
+
+// Configure sends queries for these domains, on this interface, to this address.
+//
+// Called on every reconcile and idempotent: setting a key that already holds these values
+// writes the same values again. Nothing is read back first, matching what the Linux
+// implementation does and for the same reason — the operation is declarative, so
+// re-asserting is both simpler and self-repairing.
+//
+// Self-repairing matters more here than it looks. The dynamic store is memory, not a file:
+// a reboot empties it, and so does anything that resets the network configuration. A
+// version of this that remembered what it had already set would leave names broken until
+// the agent restarted, while the interface and the routes healed on the same timer.
+func (s *System) Configure(ctx context.Context, iface string, server netip.AddrPort, domains []string) error {
+	if len(domains) == 0 {
+		return s.Revert(ctx, iface)
+	}
+	if !server.IsValid() {
+		return fmt.Errorf("resolved: %s: no resolver address to point at", iface)
+	}
+
+	var script strings.Builder
+	script.WriteString("d.init\n")
+	fmt.Fprintf(&script, "d.add ServerAddresses * %s\n", server.Addr())
+
+	// The agent listens on a loopback port of its own choosing rather than 53, which is
+	// already taken on most machines and needs root besides. macOS carries the port in the
+	// same dictionary, so split DNS to a high port is expressible here — which is not true
+	// of every platform's resolver and is worth noting before somebody assumes it is.
+	fmt.Fprintf(&script, "d.add ServerPort # %d\n", server.Port())
+
+	// The whole of split DNS, in one key. Only these suffixes come to meshp; everything
+	// else keeps going wherever it was already going, which ADR-0021 requires and which a
+	// resolver claiming the root domain would quietly break on the first laptop that
+	// joined a corporate network.
+	script.WriteString("d.add SupplementalMatchDomains *")
+	for _, domain := range domains {
+		if err := validDomain(domain); err != nil {
+			return err
+		}
+		script.WriteString(" " + domain)
+	}
+	script.WriteString("\n")
+
+	script.WriteString("d.add SupplementalMatchOrders * #")
+	for range domains {
+		fmt.Fprintf(&script, " %d", matchOrder)
+	}
+	script.WriteString("\n")
+
+	fmt.Fprintf(&script, "set %s\nquit\n", storeKey(iface))
+	return s.run(ctx, script.String(), iface)
+}
+
+// Revert puts the resolver back as it was.
+//
+// Which is a stronger claim on this platform than on Linux, and it is the reason macOS gets
+// an implementation at all: there is nothing to put back. meshp's entry is its own key,
+// created by meshp and read by nobody else, so removing it leaves the store exactly as it
+// would have been had meshp never run. Compare /etc/resolv.conf, where "putting it back"
+// means having kept a copy of somebody else's file and hoping it is still current.
+//
+// Removing a key that is not there is not an error: scutil says so and this ignores it, for
+// the same reason the Linux Revert is safe on a link that was never configured — teardown is
+// called whenever a membership goes away, including when it never came up.
+func (s *System) Revert(ctx context.Context, iface string) error {
+	script := fmt.Sprintf("remove %s\nquit\n", storeKey(iface))
+	err := s.run(ctx, script, iface)
+	if err != nil && strings.Contains(err.Error(), "No such key") {
+		return nil
+	}
+	return err
+}
+
+// storeKey is where this interface's resolver configuration lives.
+//
+// Named for meshp and for the interface, so two networks on one device get one key each and
+// do not fight over a single global setting. The identifier does not have to name a real
+// network service — macOS collects supplemental domains from every service key it finds —
+// and deliberately does not, because a real service is somebody else's to configure.
+func storeKey(iface string) string {
+	return "State:/Network/Service/meshp-" + iface + "/DNS"
+}
+
+// validDomain refuses anything that would end up as another scutil command.
+//
+// The domains come from a network's DNS suffix, which comes from the control plane, which
+// is not this process. scutil reads a script on standard input, so a suffix containing a
+// newline would be a line of somebody else's choosing running as root — and one containing
+// a space would silently add a domain nobody asked for. Refused rather than escaped: there
+// is no escaping syntax here to get right, and a suffix that needs one is not a suffix.
+func validDomain(domain string) error {
+	if domain == "" {
+		return errors.New("resolved: an empty domain cannot be matched")
+	}
+	if strings.ContainsAny(domain, " \t\r\n\"'\\") {
+		return fmt.Errorf("resolved: %q is not a domain name", logx.Safe(domain))
+	}
+	if strings.HasPrefix(domain, "-") || len(domain) > 253 {
+		return fmt.Errorf("resolved: %q is not a domain name", logx.Safe(domain))
+	}
+	return nil
+}
+
+// run feeds a script to scutil and reports what it said when it fails.
+func (s *System) run(ctx context.Context, script, iface string) error {
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, s.path)
+	cmd.Stdin = strings.NewReader(script)
+	out, err := cmd.CombinedOutput()
+
+	// The trap in driving scutil: it reports a failed `set` or `remove` on standard output
+	// and **still exits zero**. Checking only the exit status would take "Permission
+	// denied" for a successful configuration and report that names work — which is the one
+	// outcome ADR-0021 rules out, since a host that cannot configure its resolver has to
+	// say so rather than leave the agent believing it did.
+	//
+	// So the rule is that any output at all is a failure. scutil is silent when a script
+	// does what it was asked; everything it prints from `set` or `remove` is a complaint.
+	// Verified rather than assumed: unprivileged, both commands print "  Permission denied"
+	// and exit 0.
+	text := strings.TrimSpace(string(out))
+	switch {
+	case err != nil && text != "":
+		return fmt.Errorf("resolved: %s: scutil: %w: %s", iface, err, logx.Safe(text))
+	case err != nil:
+		return fmt.Errorf("resolved: %s: scutil: %w", iface, err)
+	case text != "":
+		return fmt.Errorf("resolved: %s: scutil: %s", iface, logx.Safe(text))
+	}
+	return nil
+}

--- a/internal/resolved/scutil_darwin_test.go
+++ b/internal/resolved/scutil_darwin_test.go
@@ -1,0 +1,204 @@
+//go:build darwin
+
+package resolved
+
+import (
+	"context"
+	"net/netip"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("needs root: writing to the SystemConfiguration dynamic store")
+	}
+}
+
+// scutil exits zero when it fails, which is the trap in driving it.
+//
+// This is not a test of meshp so much as a test of the assumption meshp is built on, pinned
+// here because everything else in this file depends on it: if a future macOS made scutil
+// report failures through its exit status instead, the check in run() would still be right,
+// but a version of it that trusted the exit status would silently start reporting success
+// for every failed configuration. Somebody should find that out here.
+func TestScutilReportsFailureWithoutFailing(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("this is about what an unprivileged write looks like")
+	}
+	cmd := exec.Command("scutil")
+	cmd.Stdin = strings.NewReader(
+		"d.init\nd.add ServerAddresses * 127.0.0.1\nset State:/Network/Service/meshp-test-denied/DNS\nquit\n")
+	out, err := cmd.CombinedOutput()
+
+	if err != nil {
+		t.Skip("scutil now reports this through its exit status, which run() also handles")
+	}
+	if strings.TrimSpace(string(out)) == "" {
+		t.Fatal("an unprivileged write neither failed nor said anything, so run() cannot tell " +
+			"a refused configuration from a successful one")
+	}
+}
+
+// A refused write is an error, not a silent success. The whole of ADR-0021's requirement
+// that a host which cannot configure its resolver says so.
+func TestARefusedConfigurationIsAnError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("needs to be unprivileged for the write to be refused")
+	}
+	s := New(context.Background())
+	if s == nil {
+		t.Fatal("scutil is not reachable on this machine")
+	}
+
+	err := s.Configure(context.Background(), "meshptest0",
+		netip.MustParseAddrPort("127.0.0.1:5353"), []string{"test-mesh.example"})
+	if err == nil {
+		t.Fatal("an unprivileged configuration reported success; the agent would believe names work")
+	}
+	if !strings.Contains(err.Error(), "scutil") {
+		t.Errorf("error = %q, want it to name what refused", err)
+	}
+}
+
+// A domain from the control plane must not be able to become another scutil command. The
+// script goes to a process running as root on standard input, so a newline in a suffix is
+// somebody else's line.
+func TestADomainCannotSmuggleInAScutilCommand(t *testing.T) {
+	for _, bad := range []string{
+		"",
+		"good.example\nremove State:/Network/Global/IPv4",
+		"good.example remove",
+		"good.example\ttab",
+		"-leading-hyphen.example",
+		strings.Repeat("a", 254),
+		`quote".example`,
+		`back\slash.example`,
+	} {
+		if err := validDomain(bad); err == nil {
+			t.Errorf("validDomain(%q) allowed it", bad)
+		}
+	}
+	for _, good := range []string{
+		"hq.acme.meshp.internal",
+		"a.example",
+		"xn--bcher-kva.example",
+	} {
+		if err := validDomain(good); err != nil {
+			t.Errorf("validDomain(%q) = %v, want it allowed", good, err)
+		}
+	}
+}
+
+// Two networks on one device get one key each rather than fighting over a global setting.
+func TestEachInterfaceGetsItsOwnKey(t *testing.T) {
+	a, b := storeKey("meshp0"), storeKey("meshp1")
+	if a == b {
+		t.Fatal("two interfaces share one key, so the second would overwrite the first")
+	}
+	for _, key := range []string{a, b} {
+		if !strings.HasPrefix(key, "State:/Network/Service/") {
+			t.Errorf("%q is not in the dynamic store's service namespace", key)
+		}
+		if !strings.HasSuffix(key, "/DNS") {
+			t.Errorf("%q does not name a DNS dictionary", key)
+		}
+		if !strings.Contains(key, "meshp-") {
+			t.Errorf("%q does not say it is meshp's, so nobody reading the store would know", key)
+		}
+	}
+}
+
+// --- with the real store -------------------------------------------------------------
+
+// The whole of it: macOS honours a supplemental match domain pointing at a loopback port,
+// and reverting removes it completely.
+//
+// This is the assumption the entire package rests on, and it is not one that can be reasoned
+// about — either mDNSResponder collects supplemental domains from a service key meshp
+// invented, on a non-standard port, or it does not. `scutil --dns` is asked because it
+// reports the resolver list mDNSResponder actually assembled, rather than what was written.
+func TestMacOSHonoursASupplementalDomain(t *testing.T) {
+	requireRoot(t)
+
+	s := New(context.Background())
+	if s == nil {
+		t.Fatal("scutil is not reachable")
+	}
+	const iface = "meshptest-dns"
+	const domain = "test-mesh.example"
+	t.Cleanup(func() { _ = s.Revert(context.Background(), iface) })
+
+	if err := s.Configure(context.Background(), iface,
+		netip.MustParseAddrPort("127.0.0.1:5353"), []string{domain}); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	resolvers := systemResolvers(t)
+	if !strings.Contains(resolvers, domain) {
+		t.Fatalf("mDNSResponder did not pick up %s as a supplemental domain.\n"+
+			"This is the assumption the package rests on — a service key meshp invented is "+
+			"collected like any other.\nscutil --dns said:\n%s", domain, resolvers)
+	}
+	// The port matters as much as the domain: the agent listens on a high loopback port,
+	// and a resolver that took the address and ignored the port would send every mesh
+	// query to whatever is on 53.
+	if !strings.Contains(resolvers, "5353") {
+		t.Errorf("the supplemental resolver did not carry the port.\nscutil --dns said:\n%s", resolvers)
+	}
+
+	// And reverting leaves the store as it was, which is the claim that makes configuring
+	// it defensible at all.
+	if err := s.Revert(context.Background(), iface); err != nil {
+		t.Fatalf("Revert: %v", err)
+	}
+	if after := systemResolvers(t); strings.Contains(after, domain) {
+		t.Errorf("%s is still resolved after reverting.\nscutil --dns said:\n%s", domain, after)
+	}
+}
+
+// Configuring twice is configuring once. The reconciler calls this every pass.
+func TestConfiguringTwiceIsQuiet(t *testing.T) {
+	requireRoot(t)
+
+	s := New(context.Background())
+	if s == nil {
+		t.Fatal("scutil is not reachable")
+	}
+	const iface = "meshptest-dns-twice"
+	t.Cleanup(func() { _ = s.Revert(context.Background(), iface) })
+
+	for range 2 {
+		if err := s.Configure(context.Background(), iface,
+			netip.MustParseAddrPort("127.0.0.1:5353"), []string{"twice.example"}); err != nil {
+			t.Fatalf("Configure: %v", err)
+		}
+	}
+}
+
+// Reverting an interface that was never configured is success. Teardown runs whenever a
+// membership goes away, including when it never came up.
+func TestRevertingSomethingNeverConfigured(t *testing.T) {
+	requireRoot(t)
+
+	s := New(context.Background())
+	if s == nil {
+		t.Fatal("scutil is not reachable")
+	}
+	if err := s.Revert(context.Background(), "meshptest-never-configured"); err != nil {
+		t.Errorf("reverting an unconfigured interface: %v", err)
+	}
+}
+
+// systemResolvers is what mDNSResponder assembled, not what was written to the store.
+func systemResolvers(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("scutil", "--dns").CombinedOutput()
+	if err != nil {
+		t.Fatalf("scutil --dns: %v", err)
+	}
+	return string(out)
+}

--- a/internal/resolved/unsupported.go
+++ b/internal/resolved/unsupported.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !darwin
 
 package resolved
 
@@ -11,29 +11,32 @@ import (
 // ErrUnsupported means this platform has no resolver meshp knows how to configure safely.
 var ErrUnsupported = errors.New("resolved: no supported resolver on this platform")
 
-// Resolvectl is declared so the wiring compiles everywhere, and is never constructed here.
-// Empty rather than mirroring the Linux type's fields: an unused field is dead weight the
-// linter is right to object to.
-type Resolvectl struct{}
+// System is declared so the wiring compiles everywhere, and is never constructed here.
+// Empty rather than mirroring a real implementation's fields: an unused field is dead
+// weight the linter is right to object to.
+type System struct{}
 
-// New returns nothing on a platform where systemd-resolved is not what answers names.
+// New returns nothing on a platform whose resolver meshp has no safe way to configure.
 //
 // Nil rather than a stub that reports success. ADR-0021 requires a host that cannot
 // configure its resolver to say so and leave the system's DNS alone; a stub reporting
 // success would leave the agent believing names work while every lookup went to whatever
 // the machine used before.
-func New(context.Context) *Resolvectl { return nil }
+//
+// Linux and macOS have implementations. What is left here is Windows and the mobile
+// platforms, where the mechanism exists and nothing has been written for it yet.
+func New(context.Context) *System { return nil }
 
 // Configure fails rather than silently doing nothing.
 //
 // Unreachable, because New returns nil here. It refuses rather than returning success for
 // the reason the pathprobe stub does: "nothing happened" and "it worked" must not look the
 // same to a caller, or a wiring mistake on a new platform reads as working software.
-func (r *Resolvectl) Configure(context.Context, string, netip.AddrPort, []string) error {
+func (r *System) Configure(context.Context, string, netip.AddrPort, []string) error {
 	return ErrUnsupported
 }
 
 // Revert is a no-op that succeeds: there is nothing this platform could have installed, and
 // a teardown path that errors would report a failure to remove something that was never
 // there.
-func (r *Resolvectl) Revert(context.Context, string) error { return nil }
+func (r *System) Revert(context.Context, string) error { return nil }


### PR DESCRIPTION
Second slice of #151, after the tunnel in #152. macOS had a tunnel and no names — `resolved.New` returned nil, and the agent said so.

## macOS answers the package's own question better than Linux does

`internal/resolved` asks one thing of a platform: **is there a real undo?** ADR-0021 requires that a host which cannot put the resolver back must leave it alone rather than write a file it does not know how to restore.

- Linux passes because `resolvectl revert` restores a link to what it was — which means having kept something to restore.
- macOS passes *more cleanly*: the SystemConfiguration dynamic store is keyed per service, so meshp creates a key that is entirely its own and removes it to undo. Nobody else's entry is read, merged or rewritten at any point. There is nothing to put back.

Split DNS is `SupplementalMatchDomains`, which is exactly the mechanism ADR-0021 describes — only this network's suffix comes to meshp, everything else keeps going wherever it was already going.

**The match order is deliberately high**, so a corporate resolver claiming the same suffix wins. meshp is the newcomer on a machine that was resolving names before it arrived, and a tie broken in meshp's favour would silently redirect a name somebody's employer owns. If a suffix genuinely collides, the answer is to change the suffix, not to outbid it.

## Two things found by testing, not reasoning

**`scutil` exits zero when it fails.** It prints `  Permission denied` and carries on. My first version of the failure check was *exactly backwards* — it treated the two leading spaces as a marker of success — so every refused configuration would have been reported as working. That is the one outcome ADR-0021 rules out: a host that cannot configure its resolver must say so, not leave the agent believing names work.

```
$ printf 'd.init\n...\nset State:/Network/Service/meshp-test/DNS\nquit\n' | scutil
  Permission denied
exit status: 0
```

The rule is now that **any output at all is a failure** — scutil is silent when a script does what it was asked. There is a test pinning that assumption on its own, so a future macOS that starts reporting through exit statuses is discovered here rather than in the field.

**A domain could have smuggled in a scutil command.** The suffixes come from the control plane and the script goes to a process running as root on standard input, so a suffix containing a newline is a line of somebody else's choosing. Refused rather than escaped: there is no escaping syntax here to get right, and a suffix that needs one is not a suffix.

## A rename

`resolved.Resolvectl` → `resolved.System`. The name was accurate while systemd-resolved was the only implementation and is a lie on a platform driving `scutil` — the same argument that moved `peerConfig` out of the Linux file in #152. `resolvectl_other.go` became `unsupported.go`, since it now covers Windows and mobile rather than "not Linux".

## Verified

Four tests pass unprivileged, including the one that proves a refused write is an error rather than a false success:

```
--- PASS: TestScutilReportsFailureWithoutFailing
--- PASS: TestARefusedConfigurationIsAnError
--- PASS: TestADomainCannotSmuggleInAScutilCommand
--- PASS: TestEachInterfaceGetsItsOwnKey
--- SKIP: TestMacOSHonoursASupplementalDomain      (needs root)
--- SKIP: TestConfiguringTwiceIsQuiet              (needs root)
--- SKIP: TestRevertingSomethingNeverConfigured    (needs root)
```

`sudo` needs a password here, so the three root-gated ones run in CI, where a skip is a failure. What they prove is the assumption the whole package rests on and which cannot be reasoned about: that **mDNSResponder collects a supplemental domain from a service key meshp invented, on a non-standard port**. The test asks `scutil --dns` — the resolver list mDNSResponder actually assembled — rather than reading back what was written, and it checks the port as well as the domain, because a resolver that took the address and ignored the port would send every mesh query to whatever is on 53.

## Still missing on macOS

Fail-closed egress via `pf`, which is the last thing between macOS and parity. Worth its own issue: it is eight files' worth on Linux, and a tunnel with working names that cannot fail closed is still useful.