### PR TITLE
feat(replicas): a change on one control plane reaches agents on another

### DIFF
--- a/cmd/meshp-control/main.go
+++ b/cmd/meshp-control/main.go
@@ -22,12 +22,16 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/meshpnet/meshp/internal/api"
+	"github.com/meshpnet/meshp/internal/bus"
 	"github.com/meshpnet/meshp/internal/clock"
 	"github.com/meshpnet/meshp/internal/enroll"
 	"github.com/meshpnet/meshp/internal/httpx"
@@ -81,6 +85,12 @@ func main() {
 		// after an outage, a weekend, or a closed laptop.
 		deltaRetention = flag.Duration("delta-retention", envDuration("MESHP_DELTA_RETENTION", 72*time.Hour),
 			"how long to keep the state change log; agents behind it are sent a snapshot")
+
+		// How many meshp-control processes this deployment runs, which decides whether a
+		// change made here has to reach agents held elsewhere (ADR-0025). One is the
+		// default and needs no bus: with a single process there is nowhere else to tell.
+		replicas = flag.Int("replicas", envInt("MESHP_REPLICAS", 1),
+			"how many control-plane replicas this deployment runs; 2 or more connects the bus")
 	)
 	flag.Parse()
 
@@ -159,6 +169,7 @@ func main() {
 		adminToken:      *adminToken,
 		skipMigrate:     *skipMigrate,
 		deltaRetention:  *deltaRetention,
+		replicas:        *replicas,
 	}
 	if err := run(ctx, log, cfg); err != nil {
 		log.Error("meshp-control exited with error", "error", err)
@@ -177,6 +188,7 @@ type runConfig struct {
 	adminToken      string
 	skipMigrate     bool
 	deltaRetention  time.Duration
+	replicas        int
 }
 
 func run(ctx context.Context, log *slog.Logger, cfg runConfig) error {
@@ -306,8 +318,11 @@ func run(ctx context.Context, log *slog.Logger, cfg runConfig) error {
 			return
 		}
 
+		replicaBus := newBus(ctx, st, sessionServer, cfg, log)
+
 		apiServer := api.New(st, enroll.NewService(st, challenger, clock.System{}, log), sessionServer, api.Config{
 			AdminToken: cfg.adminToken,
+			Bus:        replicaBus,
 			Clock:      clock.System{},
 			Log:        log,
 		})
@@ -423,6 +438,43 @@ func open(ctx context.Context, log *slog.Logger, cfg runConfig) (*store.Store, e
 
 	log.Info("control plane ready")
 	return st, nil
+}
+
+// newBus connects this replica to the others, and starts listening.
+//
+// Configuration decides, not a build tag (ADR-0012), and the default is the single-replica
+// one: a deployment that has not said it runs several replicas gets a bus that does nothing,
+// which is exactly right — with one process the publisher and every subscriber are the same
+// process, and tellNetwork already nudges the local hub directly.
+//
+// Turning it on is MESHP_REPLICAS=2 or more. That is a statement about the deployment rather
+// than a count this process verifies: nothing here knows how many replicas exist, and a
+// deployment that sets it and runs one process pays a held connection for nothing rather
+// than breaking.
+func newBus(ctx context.Context, st *store.Store, sessions *session.Server, cfg runConfig, log *slog.Logger) bus.Bus {
+	if cfg.replicas < 2 {
+		return bus.Local{}
+	}
+
+	b := bus.NewPostgres(st.Pool(), log)
+	log.Info("running as one of several replicas",
+		"replicas", cfg.replicas,
+		"bus", "postgresql LISTEN/NOTIFY",
+		"note", "a change made on any replica wakes agents held by all of them")
+
+	go b.Subscribe(ctx, func(networkID uuid.UUID) {
+		// Everything this replica is holding for that network. The message says only that
+		// the network changed, so the state is read from PostgreSQL as it would be for any
+		// other nudge — nothing arriving over the bus is trusted as data (ADR-0025).
+		if sessions == nil {
+			return
+		}
+		if n := sessions.Hub().NotifyNetwork(networkID); n > 0 {
+			log.Debug("another replica reported a change",
+				"network_id", networkID, "sessions", n)
+		}
+	})
+	return b
 }
 
 // probeMux builds a mux carrying only the health endpoints.
@@ -588,6 +640,23 @@ func envDuration(key string, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return d
+}
+
+// envInt reads a whole number from the environment.
+//
+// A value that is not a number falls back rather than failing to start. The alternative is
+// a control plane that refuses to boot over a typo in a variable whose only effect is
+// whether it opens one extra connection.
+func envInt(key string, fallback int) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return fallback
+	}
+	return n
 }
 
 func envBool(key string) bool {

--- a/docs/adr/0012-presence-and-bus-interface.md
+++ b/docs/adr/0012-presence-and-bus-interface.md
@@ -1,7 +1,15 @@
 # ADR-0012: Presence and pub/sub sit behind an interface with in-memory and Redis implementations
 
-- **Status:** accepted
+- **Status:** accepted, amended for `Bus` by [ADR-0025](0025-the-bus-is-postgresql.md)
 - **Date:** 2026-08-10
+
+> **`Bus` is PostgreSQL, not Redis.** ADR-0025 changed that half when `Bus` turned out to be
+> the first of the two to be needed: the argument below for accepting Redis — that a
+> deployment large enough for replicas is large enough to run it — holds for `Presence`,
+> which is high-frequency by definition, and not for `Bus`, which publishes on
+> administrative change. Everything else here stands, `Presence` included: the interfaces,
+> the selection being configuration rather than a build tag, and the rule that nothing which
+> must survive a restart lives in either.
 
 ## Context
 

--- a/docs/adr/0025-the-bus-is-postgresql.md
+++ b/docs/adr/0025-the-bus-is-postgresql.md
@@ -1,0 +1,116 @@
+# ADR-0025: The bus is PostgreSQL LISTEN/NOTIFY, not Redis
+
+- **Status:** accepted
+- **Date:** 2026-08-25
+- **Amends:** [ADR-0012](0012-presence-and-bus-interface.md), for `Bus` only
+
+## Context
+
+ADR-0012 defined two interfaces — `Presence` and `Bus` — and named their
+implementations: "an in-memory version used when a single replica is configured, and a
+Redis version used otherwise."
+
+Two years of that record being unimplemented is not why it is being revisited. It is
+being revisited because the first thing to actually need it is `Bus`, on its own, and
+the reasoning that made Redis the obvious answer for *both* does not survive being
+applied to one.
+
+ADR-0012's own Context states the tension:
+
+> Self-hosting should be `docker compose up` with as few moving parts as possible.
+> Requiring Redis to run a ten-device network is a tax on exactly the users we most want.
+
+It accepted that tax on the grounds that a deployment large enough to need replicas is
+large enough to run Redis. That trade is real for `Presence`, which is high-frequency by
+definition. It is not real for `Bus`: a notification is published when an administrator
+changes something, which is a human-rate event, not a per-heartbeat one.
+
+## Decision
+
+`Bus` is PostgreSQL `LISTEN`/`NOTIFY`. Every deployment already has PostgreSQL, so
+redundancy costs no additional infrastructure.
+
+`Presence` is not settled here. It stays as ADR-0012 describes — in-memory today, and
+whatever it eventually needs is a separate decision, because the argument that moves `Bus`
+to PostgreSQL is precisely the argument that keeps `Presence` out of it. ADR-0012 is
+otherwise unchanged: the interfaces stay, the selection stays configuration rather than a
+build tag, and nothing that must survive a restart lives in either.
+
+### Why this is better than Redis here, not merely cheaper
+
+**A notification is delivered at `COMMIT`.** This is the part that would have been a bug
+with Redis rather than a cost. The publisher changes state in a transaction and then tells
+the world; with Redis those are two systems and there is a window between them, so a
+replica can be woken to read state that has not committed yet — and it reads the old state,
+concludes nothing changed, and goes back to sleep. The change then waits for the next
+heartbeat, which is exactly the outage `Bus` exists to avoid, appearing only under load.
+
+PostgreSQL has no such window. `NOTIFY` inside a transaction fires when that transaction
+commits, and **never fires at all if it rolls back**. Both were verified against a real
+server before this was written, not inferred from the manual.
+
+**One fewer thing to secure, back up and watch.** A Redis carrying wake-ups for every
+network on a control plane is a component with credentials, a network position and a
+failure mode, added to a product whose argument is that self-hosting should be ordinary.
+
+**It cannot silently become load-bearing.** ADR-0012 requires that a missed notification
+degrade to the agent's next heartbeat noticing a version gap. A queue that is best-effort
+by construction — no persistence, no delivery guarantee, dropped entirely if a listener is
+not connected — keeps that honest in a way a durable queue would quietly erode.
+
+### What this costs
+
+**A connection per replica, held open.** `LISTEN` needs a session of its own; it cannot
+share the pool, because a pooled connection is handed back between statements. With
+`MaxConns` at 16 this is affordable and it is a real charge against the pool.
+
+**`NOTIFY` has a global queue with a ceiling.** PostgreSQL keeps pending notifications in
+one server-wide 8 GB queue and raises an error when it fills, which happens when a listener
+stops consuming. meshp publishes on administrative change rather than on heartbeat, so the
+rate is orders of magnitude below the risk — but "we are far from the limit" is a fact
+about today's usage, and anything that starts publishing per-device-event should read this
+paragraph first.
+
+**Payloads are capped at 8000 bytes.** Irrelevant here: the payload is one network id, and
+deliberately nothing more — the message says *what changed*, never *how*, so a listener
+always reads the committed state rather than trusting a wire format.
+
+## Consequences
+
+**Redundancy stops requiring extra infrastructure.** Two `meshp-control` containers against
+one PostgreSQL is now a working configuration rather than a broken one. That matters
+disproportionately for this product: redundancy that required an operator to stand up and
+secure a second data store would be redundancy most self-hosters do not have.
+
+**Redis is not ruled out and is no longer implied.** If `Presence` eventually needs a shared
+store, that decision is made on its own terms. Having `Bus` on PostgreSQL does not
+prejudice it, and does not oblige a deployment that adds Redis for `Presence` to move `Bus`
+there too.
+
+**The in-memory implementation stays.** A single-replica deployment does not need a
+listening connection, and the selection is configuration. This also keeps the test path
+ADR-0012 asked for, where the same suite runs against both.
+
+**One notification may nudge a replica twice.** The publisher notifies its own hub directly
+*and* publishes, so it receives its own message back. Harmless — `Session.Notify` coalesces,
+and ten nudges produce one push — and deliberately not optimised away, because suppressing
+self-delivery means tracking a replica identity for no benefit, while the local notify must
+not depend on the bus round trip: if PostgreSQL is unreachable the agents attached to *this*
+replica should still be woken.
+
+## Alternatives considered
+
+**Redis, as ADR-0012 said.** The right answer if `Presence` and `Bus` had to share a
+mechanism, and the wrong one for `Bus` alone. Rejected on the infrastructure tax and on the
+commit-window bug above; the second is what changed this from a preference into a decision.
+
+**No bus; let the heartbeat find it.** Agents already carry `applied_state_version` and the
+server already compares it, so a change reaches every device within one heartbeat interval
+with no new machinery at all. Genuinely tempting, and rejected because that interval is the
+difference between revoking a device and *having* revoked it — an administrator who removes
+a laptop expects it gone, not gone within a minute.
+
+**A polled table.** A `state_changes` table replicas poll. No held connection and no queue
+ceiling, at the cost of a query per replica per interval forever, and of reintroducing the
+latency the bus exists to remove. It is what to fall back to if the queue ceiling ever
+becomes a real constraint rather than a paragraph.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -103,6 +103,38 @@ An owner can see and revoke everybody's at
 Tokens expire: ninety days by default, a year at most, and there is no unexpiring one. That
 is deliberate — a bearer secret that never expires outlives the reason it was made.
 
+### Running more than one control plane
+
+One `meshp-control` is a single point of failure. More than one works, and needs one setting:
+
+```
+MESHP_REPLICAS=2
+```
+
+That is a statement about the deployment rather than a count anything verifies — nothing in
+a replica knows how many others exist. What it decides is whether the replica connects to
+the bus that carries "network N changed" between them (ADR-0025), which is PostgreSQL's own
+`LISTEN`/`NOTIFY`. **There is no second data store to run**: redundancy costs you a second
+container and nothing else.
+
+Point every replica at the same PostgreSQL and put them behind whatever already balances
+your traffic. They share no state of their own; PostgreSQL is the source of truth and always
+was.
+
+Two things are worth knowing before you rely on it.
+
+**An agent holds a session with one replica at a time**, so a replica going away drops its
+agents and they reconnect — to whichever replica the balancer gives them, with no loss of
+configuration. What they lose is the seconds it takes to notice.
+
+**`meshp status` and the overview report what one replica can see.** Liveness is per-process
+today, so with several replicas the device list is the subset connected to whichever one
+answered. Addresses, routes and policy are unaffected — those come from PostgreSQL — and the
+gap is being closed separately.
+
+Leave it at 1, or unset, for a single-replica deployment. A replica that connects to the bus
+when there is nobody to talk to holds a database connection open for nothing.
+
 ### TLS
 
 Agents refuse a plaintext control URL to anything but loopback, so a control plane serving

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/meshpnet/meshp/internal/authz"
+	"github.com/meshpnet/meshp/internal/bus"
 	"github.com/meshpnet/meshp/internal/clock"
 	"github.com/meshpnet/meshp/internal/enroll"
 	"github.com/meshpnet/meshp/internal/httpx"
@@ -56,6 +57,10 @@ type Config struct {
 	EnrolRatePerSecond float64
 	EnrolBurst         float64
 
+	// Bus tells other control-plane replicas that a network changed (ADR-0025). Nil is a
+	// single-replica deployment, where the local hub is the only thing to nudge.
+	Bus bus.Bus
+
 	Clock clock.Clock
 	Log   *slog.Logger
 }
@@ -73,6 +78,11 @@ type Server struct {
 	// how the read endpoints stay usable in a test that does not stand one up: a device
 	// with no presence reads as disconnected, which is what it is.
 	presence Presence
+
+	// bus tells the other replicas that a network changed (ADR-0025). Nil in a test that
+	// stands no bus up, which reads as a single-replica deployment — the local hub is
+	// still nudged, so nothing a test asserts about one process changes.
+	bus bus.Bus
 
 	// bootstrapWarnedAt is when the administrative token was last complained about, so the
 	// complaint is occasional rather than per request. See warnBootstrapTokenUsed.
@@ -101,6 +111,7 @@ func New(st *store.Store, svc *enroll.Service, sess *session.Server, cfg Config)
 		cfg:     cfg,
 		log:     cfg.Log,
 		limit:   newLimiter(cfg.EnrolRatePerSecond, cfg.EnrolBurst, 10_000, cfg.Clock),
+		bus:     cfg.Bus,
 	}
 	// Taken through the interface rather than held as a *Hub, so the thing that replaces
 	// it for multi-replica deployments (ADR-0012) has one place to arrive. A typed nil

--- a/internal/api/enroll.go
+++ b/internal/api/enroll.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/base64"
 	"net/http"
 	"net/netip"
@@ -123,14 +124,45 @@ func (s *Server) handleRedeem(w http.ResponseWriter, r *http.Request) {
 //
 // Best effort by construction: an agent that is not connected has nothing to be told,
 // and will see the change in the state it is sent when it next connects.
+//
+// Two things happen, and the order is not an accident. The agents attached to *this*
+// replica are nudged directly, and then every other replica is told over the bus
+// (ADR-0025). Doing the local nudge first means a control plane that has lost PostgreSQL
+// still wakes the agents it is holding — the bus is where the change reaches replicas this
+// process cannot see, not the mechanism by which it reaches its own.
+//
+// This replica hears its own message back and nudges a second time. Harmless: Session.Notify
+// coalesces, so ten nudges produce one push. Suppressing it would mean carrying a replica
+// identity through the message for no benefit.
 func (s *Server) tellNetwork(networkID uuid.UUID) {
-	if s.session == nil {
+	if s.session != nil {
+		if n := s.session.Hub().NotifyNetwork(networkID); n > 0 {
+			s.log.Debug("nudged connected agents", "network_id", networkID, "sessions", n)
+		}
+	}
+	if s.bus == nil {
 		return
 	}
-	if n := s.session.Hub().NotifyNetwork(networkID); n > 0 {
-		s.log.Debug("nudged connected agents", "network_id", networkID, "sessions", n)
+	// Bounded, and its own context rather than the request's: the change has committed and
+	// the response is on its way, so a caller who has hung up must not take the other
+	// replicas' notification with them.
+	ctx, cancel := context.WithTimeout(context.Background(), busPublishTimeout)
+	defer cancel()
+	if err := s.bus.Publish(ctx, networkID); err != nil {
+		// Logged and not returned. The change is already durable, and ADR-0012 requires a
+		// missed notification to cost latency rather than correctness — so failing the
+		// request here would turn a working change into a reported failure.
+		s.log.Warn("other replicas were not told about a change",
+			"network_id", networkID, "error", err,
+			"consequence", "agents held by other replicas see this on their next heartbeat")
 	}
 }
+
+// busPublishTimeout bounds telling the other replicas.
+//
+// Short, because it happens after the work is done and while a client is waiting for the
+// response: a slow bus should not become a slow API.
+const busPublishTimeout = 2 * time.Second
 
 // sourceAddr extracts the caller's address for the audit trail. Nil when it cannot
 // be parsed, which is better than recording something invented.

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -1,0 +1,71 @@
+// Package bus carries "network N's state changed" between control-plane replicas.
+//
+// It exists so that an administrator's change reaches every agent, not only the agents
+// attached to the replica that took the request. One replica revokes a device; the agents
+// holding sessions on the other two have to be told.
+//
+// # Nothing here is load-bearing
+//
+// ADR-0012 is explicit that no correctness property may depend on delivery: a missed
+// notification must degrade to the agent's next heartbeat noticing a version gap, never to
+// a permanently stale agent. That is what makes a best-effort queue the right shape rather
+// than a compromise — and it is a property to preserve, not merely to rely on. Anything
+// that starts *needing* a message to arrive has moved a correctness property into a
+// channel built to drop them.
+//
+// So a publish that fails is logged and not retried, and a subscriber that misses a
+// reconnect window misses the messages sent during it. Both cost latency and neither costs
+// correctness.
+package bus
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// Bus publishes and receives "this network changed".
+//
+// The message carries a network id and deliberately nothing else. It says *what* changed
+// and never *how*, so a listener always reads the committed state from PostgreSQL rather
+// than trusting something that arrived over a wire — which means there is no format to
+// version, and a replica running older code cannot be confused by a newer one's message.
+type Bus interface {
+	// Publish says a network's state changed. Best effort: the error is worth logging and
+	// not worth failing a request over, because the change is already committed and the
+	// heartbeat will carry it.
+	Publish(ctx context.Context, networkID uuid.UUID) error
+
+	// Subscribe calls fn for every network id published, until ctx is done. It reconnects
+	// on its own; a caller that had to supervise it would be a caller that could get the
+	// supervision wrong.
+	Subscribe(ctx context.Context, fn func(networkID uuid.UUID))
+
+	// Close releases whatever the implementation holds.
+	Close() error
+}
+
+// Local is the bus for a deployment running one replica.
+//
+// It does nothing, and that is the whole implementation: with one replica the publisher and
+// every subscriber are the same process, and tellNetwork already nudges the local hub
+// directly. A Local that looped messages back would deliver every notification twice for no
+// benefit.
+//
+// Not nil, because a nil Bus would put a nil check at every call site, and one of them would
+// eventually be missing.
+type Local struct{}
+
+// Publish discards the message. See the type documentation.
+func (Local) Publish(context.Context, uuid.UUID) error { return nil }
+
+// Subscribe waits for the context and delivers nothing.
+//
+// It blocks rather than returning, so the caller's supervision loop behaves the same way
+// whichever implementation is configured — a Subscribe that returned immediately would have
+// a single-replica deployment spinning through a reconnect loop that has nothing to
+// reconnect to.
+func (Local) Subscribe(ctx context.Context, _ func(uuid.UUID)) { <-ctx.Done() }
+
+// Close releases nothing.
+func (Local) Close() error { return nil }

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -1,0 +1,272 @@
+package bus
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// These need a real PostgreSQL, because what is being tested is PostgreSQL's behaviour
+// rather than meshp's arithmetic. A fake would assert that the fake agrees with itself.
+func testPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	url := os.Getenv("MESHP_TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("set MESHP_TEST_DATABASE_URL to run the bus tests")
+	}
+	pool, err := pgxpool.New(context.Background(), url)
+	if err != nil {
+		t.Fatalf("connecting: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// collector gathers what a subscriber receives.
+type collector struct {
+	mu   sync.Mutex
+	got  []uuid.UUID
+	seen chan struct{}
+}
+
+func newCollector() *collector { return &collector{seen: make(chan struct{}, 64)} }
+
+func (c *collector) fn(id uuid.UUID) {
+	c.mu.Lock()
+	c.got = append(c.got, id)
+	c.mu.Unlock()
+	select {
+	case c.seen <- struct{}{}:
+	default:
+	}
+}
+
+func (c *collector) all() []uuid.UUID {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]uuid.UUID(nil), c.got...)
+}
+
+// has reports whether one particular id has arrived.
+func (c *collector) has(want uuid.UUID) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, id := range c.got {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+// waitForID blocks until one particular id arrives, or fails.
+//
+// By id rather than by count, which the first version of this got wrong: readiness is
+// established by publishing a throwaway id, so a wait for "one message" is satisfied by the
+// probe that proved the subscriber was listening, and the test then asserts against a
+// message that has not arrived yet.
+func (c *collector) waitForID(t *testing.T, want uuid.UUID) {
+	t.Helper()
+	deadline := time.After(10 * time.Second)
+	for {
+		if c.has(want) {
+			return
+		}
+		select {
+		case <-c.seen:
+		case <-time.After(50 * time.Millisecond):
+		case <-deadline:
+			t.Fatalf("waited for %s and got %v", want, c.all())
+		}
+	}
+}
+
+// The whole point: a change published by one replica reaches another.
+//
+// Two pools against one database, which is what two meshp-control processes are.
+func TestAChangeOnOneReplicaReachesAnother(t *testing.T) {
+	publisher := NewPostgres(testPool(t), nil)
+	subscriber := NewPostgres(testPool(t), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	got := newCollector()
+	go subscriber.Subscribe(ctx, got.fn)
+	waitUntilListening(t, ctx, publisher, got)
+
+	network := uuid.New()
+	if err := publisher.Publish(ctx, network); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	got.waitForID(t, network)
+}
+
+// Every replica hears it, not just the first. A bus that delivered to one subscriber would
+// leave the other replicas' agents waiting for a heartbeat.
+func TestEveryReplicaHearsIt(t *testing.T) {
+	publisher := NewPostgres(testPool(t), nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var collectors []*collector
+	for range 3 {
+		sub := NewPostgres(testPool(t), nil)
+		got := newCollector()
+		go sub.Subscribe(ctx, got.fn)
+		collectors = append(collectors, got)
+	}
+	for _, got := range collectors {
+		waitUntilListening(t, ctx, publisher, got)
+	}
+
+	network := uuid.New()
+	if err := publisher.Publish(ctx, network); err != nil {
+		t.Fatal(err)
+	}
+	for i, got := range collectors {
+		if !t.Run("replica "+string(rune('a'+i)), func(t *testing.T) {
+			got.waitForID(t, network)
+		}) {
+			t.Errorf("replica %d never heard about %s", i, network)
+		}
+	}
+}
+
+// A notification in a transaction that rolls back is never delivered.
+//
+// This is the property that makes PostgreSQL the right carrier rather than merely the
+// cheapest one (ADR-0025): a replica cannot be woken to read state that was never
+// committed. Asserted here because the ADR claims it, and a claim in a record that nothing
+// checks is a claim that quietly stops being true.
+func TestARolledBackChangeIsNeverAnnounced(t *testing.T) {
+	pool := testPool(t)
+	publisher := NewPostgres(pool, nil)
+	subscriber := NewPostgres(testPool(t), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	got := newCollector()
+	go subscriber.Subscribe(ctx, got.fn)
+	waitUntilListening(t, ctx, publisher, got)
+
+	rolledBack, committed := uuid.New(), uuid.New()
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(ctx, "SELECT pg_notify($1, $2)", channel, rolledBack.String()); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// A second, committed, so there is something to wait for: proving a message did not
+	// arrive needs a message that did, or the test passes by being too quick.
+	if err := publisher.Publish(ctx, committed); err != nil {
+		t.Fatal(err)
+	}
+	got.waitForID(t, committed)
+
+	if got.has(rolledBack) {
+		t.Error("a notification from a rolled-back transaction was delivered")
+	}
+}
+
+// A subscriber that is not connected misses what was sent, and carries on.
+//
+// Stated as a test because it is a design property rather than a defect: LISTEN has no
+// backlog, and ADR-0012 requires that a missed notification cost latency rather than
+// correctness. Somebody who later makes this durable should have to delete this test and
+// think about what they are changing.
+func TestMessagesSentWhileDisconnectedAreLost(t *testing.T) {
+	publisher := NewPostgres(testPool(t), nil)
+	subscriber := NewPostgres(testPool(t), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Nobody listening yet.
+	missed := uuid.New()
+	if err := publisher.Publish(ctx, missed); err != nil {
+		t.Fatal(err)
+	}
+
+	got := newCollector()
+	go subscriber.Subscribe(ctx, got.fn)
+	later := uuid.New()
+	waitUntilListeningWith(t, ctx, publisher, got, later)
+
+	if got.has(missed) {
+		t.Error("a message published before anybody listened was delivered, " +
+			"which means something is buffering and the failure mode has changed")
+	}
+}
+
+// The local bus does nothing, and blocks in Subscribe rather than returning.
+//
+// The second half matters: a Subscribe that returned immediately would have a
+// single-replica deployment spinning through a reconnect loop with nothing to reconnect to.
+func TestTheLocalBusDoesNothingAndWaits(t *testing.T) {
+	var b Bus = Local{}
+	if err := b.Publish(context.Background(), uuid.New()); err != nil {
+		t.Errorf("Publish: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		b.Subscribe(ctx, func(uuid.UUID) { t.Error("the local bus delivered a message") })
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("Subscribe returned before its context was cancelled")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe did not return after its context was cancelled")
+	}
+}
+
+// waitUntilListening publishes until the subscriber shows signs of life.
+//
+// LISTEN is asynchronous: Subscribe has to connect and issue it before anything sent will
+// arrive, and a test that published once immediately would be racing that. Sending a
+// throwaway id until one lands is how the test waits for readiness without reaching into
+// the implementation.
+func waitUntilListening(t *testing.T, ctx context.Context, publisher *Postgres, got *collector) {
+	t.Helper()
+	waitUntilListeningWith(t, ctx, publisher, got, uuid.New())
+}
+
+func waitUntilListeningWith(t *testing.T, ctx context.Context, publisher *Postgres, got *collector, probe uuid.UUID) {
+	t.Helper()
+	deadline := time.After(10 * time.Second)
+	for {
+		if err := publisher.Publish(ctx, probe); err != nil {
+			t.Fatalf("publishing a readiness probe: %v", err)
+		}
+		select {
+		case <-got.seen:
+			return
+		case <-time.After(100 * time.Millisecond):
+		case <-deadline:
+			t.Fatal("the subscriber never became ready")
+		}
+	}
+}

--- a/internal/bus/postgres.go
+++ b/internal/bus/postgres.go
@@ -1,0 +1,165 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// channel is the PostgreSQL notification channel every replica listens on.
+//
+// One channel for every network rather than one per network, because a replica cares about
+// whichever networks its agents happen to hold and that set changes as devices connect.
+// Issuing a LISTEN per network would mean tracking that set and un-listening as it shrank;
+// filtering a handful of ids in the subscriber is free by comparison.
+const channel = "meshp_network_changed"
+
+// reconnect bounds how fast a listener retries, and how slow it gets.
+//
+// A control plane that has lost PostgreSQL has bigger problems than a missed nudge, so this
+// backs off rather than hammering — and it caps low enough that recovery is quick, because
+// the window while it is disconnected is a window in which changes reach agents only on
+// their next heartbeat.
+const (
+	reconnectMin = 250 * time.Millisecond
+	reconnectMax = 5 * time.Second
+)
+
+// Postgres carries notifications over LISTEN/NOTIFY (ADR-0025).
+//
+// Publishing borrows a pooled connection like any other statement. Listening cannot: LISTEN
+// registers interest for the session, and a pooled connection is handed back between
+// statements, so the subscriber dials a connection of its own and keeps it.
+type Postgres struct {
+	pool *pgxpool.Pool
+	log  *slog.Logger
+
+	mu     sync.Mutex
+	closed bool
+}
+
+// NewPostgres returns a bus over an existing pool.
+func NewPostgres(pool *pgxpool.Pool, log *slog.Logger) *Postgres {
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	return &Postgres{pool: pool, log: log}
+}
+
+// Publish says a network's state changed.
+//
+// Called after the change has committed, so this is its own statement rather than part of
+// the caller's transaction. Being outside the transaction is what makes the ordering safe
+// in the direction that matters: the state is already durable when the message goes out, so
+// no listener can be woken to read something that is not there yet.
+//
+// A caller that ever wants the reverse — notify *with* the commit — should send this inside
+// the transaction instead, where PostgreSQL holds it until commit and discards it on
+// rollback. That property is why this is PostgreSQL and not Redis, and it is available here
+// the day something needs it.
+func (p *Postgres) Publish(ctx context.Context, networkID uuid.UUID) error {
+	if _, err := p.pool.Exec(ctx, "SELECT pg_notify($1, $2)", channel, networkID.String()); err != nil {
+		return fmt.Errorf("bus: publishing that %s changed: %w", networkID, err)
+	}
+	return nil
+}
+
+// Subscribe calls fn for every network id published, until ctx is done.
+//
+// Reconnects on its own, and deliberately does not report failures to the caller: there is
+// nothing a caller could do that this cannot, and a Subscribe that returned an error would
+// have every caller writing the same retry loop slightly differently.
+//
+// What a caller does need to know is that messages sent while this is disconnected are lost
+// — LISTEN has no backlog, and a notification with nobody listening is discarded by the
+// server. That is by design (see the package documentation): the agents on this replica
+// pick the change up on their next heartbeat.
+func (p *Postgres) Subscribe(ctx context.Context, fn func(uuid.UUID)) {
+	backoff := reconnectMin
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		err := p.listen(ctx, fn)
+		switch {
+		case ctx.Err() != nil:
+			return
+		case err != nil:
+			p.log.Warn("the replica bus is not connected",
+				"error", err, "retry_in", backoff,
+				"consequence", "changes made on other replicas reach this one's agents "+
+					"on their next heartbeat rather than immediately")
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff *= 2; backoff > reconnectMax {
+			backoff = reconnectMax
+		}
+	}
+}
+
+// listen holds one connection for as long as it works.
+func (p *Postgres) listen(ctx context.Context, fn func(uuid.UUID)) error {
+	// A connection of its own rather than one from the pool. Holding a pooled connection
+	// for the life of the process would take it out of circulation without the pool
+	// knowing why, and the pool would still count it against MaxConns.
+	conn, err := pgx.ConnectConfig(ctx, p.pool.Config().ConnConfig)
+	if err != nil {
+		return fmt.Errorf("bus: connecting to listen: %w", err)
+	}
+	defer func() {
+		// Its own context: the caller's is usually already cancelled by the time this
+		// runs, and a close that inherited it would not get the chance to say goodbye.
+		closeCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = conn.Close(closeCtx)
+	}()
+
+	if _, err := conn.Exec(ctx, "LISTEN "+channel); err != nil {
+		return fmt.Errorf("bus: listening on %s: %w", channel, err)
+	}
+	p.log.Info("the replica bus is connected", "channel", channel)
+
+	for {
+		notification, err := conn.WaitForNotification(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("bus: waiting for a notification: %w", err)
+		}
+		networkID, err := uuid.Parse(notification.Payload)
+		if err != nil {
+			// Somebody else on this channel, or a message from a version that carries
+			// something other than a network id. Ignored rather than fatal: this
+			// connection is still good, and refusing to carry on would turn one bad
+			// message into a replica that stops hearing anything.
+			p.log.Warn("a bus notification was not a network id", "channel", notification.Channel)
+			continue
+		}
+		fn(networkID)
+	}
+}
+
+// Close marks the bus closed. The listening connection belongs to Subscribe and ends with
+// the context it was given.
+func (p *Postgres) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return errors.New("bus: already closed")
+	}
+	p.closed = true
+	return nil
+}


### PR DESCRIPTION
First slice of #145.

Two `meshp-control` replicas each knew only their own agents. An administrator revoking a device on one left that device — connected to the other — waiting for its next heartbeat.

## ADR-0012 said Redis. This says PostgreSQL, and ADR-0012 is why

ADR-0012's own Context states the tension:

> Self-hosting should be `docker compose up` with as few moving parts as possible. Requiring Redis to run a ten-device network is a tax on exactly the users we most want.

It accepted that tax on the grounds that a deployment large enough to need replicas is large enough to run Redis. **That holds for `Presence`**, which is high-frequency by definition. **It does not hold for `Bus`**, which publishes when an administrator changes something — a human-rate event.

So [ADR-0025](docs/adr/0025-the-bus-is-postgresql.md) amends that half only. `Presence` stays exactly as ADR-0012 describes, because the argument that moves `Bus` into PostgreSQL is precisely the argument that keeps `Presence` out of it.

**Redundancy now costs a second container and nothing else.**

## It is better here, not merely cheaper

That is what turned a preference into a decision. **A notification is delivered at `COMMIT`, and never at all on rollback.**

With Redis, the state change and the message are two systems with a window between them: a replica can be woken to read state that has not committed yet, conclude nothing changed, and go back to sleep. The change then waits for the next heartbeat — the exact outage the bus exists to prevent, appearing only under load.

I verified both properties against a real server *before* writing the record, and both are now asserted by tests. A claim in an ADR that nothing checks is a claim that quietly stops being true:

```
--- PASS: TestARolledBackChangeIsNeverAnnounced
```

Mutated it by turning the `Rollback` into a `Commit`, and it fails as it should.

## Three decisions in the code

**`tellNetwork` nudges its own hub first, then publishes.** Not an accident: a control plane that has lost PostgreSQL should still wake the agents it is holding. The bus is how a change reaches replicas this process cannot see — not the mechanism by which it reaches its own.

**A replica hears its own message and nudges twice.** Harmless, since `Session.Notify` coalesces. Suppressing it would mean carrying a replica identity through the message for no benefit.

**Nothing arriving over the bus is trusted as data.** The payload is a network id and deliberately nothing else — it says *what* changed, never *how* — so a listener always reads committed state from PostgreSQL. There is no wire format to version, and an older replica cannot be confused by a newer one's message.

## Verified with two real binaries

```
--- replica A ---
running as one of several replicas  replicas=2  bus="postgresql LISTEN/NOTIFY"
the replica bus is connected        channel=meshp_network_changed
--- replica B ---
running as one of several replicas  replicas=2  bus="postgresql LISTEN/NOTIFY"
the replica bus is connected        channel=meshp_network_changed

listeners in pg_stat_activity: 2
a network created on A, read from B: ["hq"]
a single replica, started with no MESHP_REPLICAS: connects no bus  ✓
```

The unit tests prove delivery between processes (two pools against one database is what two replicas are); the binaries prove the wiring in `main.go` actually starts.

## The test that failed first was mine

Readiness has to be established by publishing a throwaway id and waiting for it — `LISTEN` is asynchronous, so a test that published once immediately would race the subscriber connecting. My first version then waited for "one message", which the readiness probe itself satisfied, so the assertion ran before the real message arrived. It waits for a *particular* id now. Ran `-count=3` and under `-race`; no flakes.

## Scope

`Presence` is untouched and still per-process, so the overview reports what one replica can see. Addresses, routes and policy are unaffected — those come from PostgreSQL — and `docs/self-hosting.md` says so plainly rather than leaving it to be discovered.

No CI change needed: `make integration` already runs `go test ./... -race`, so the bus tests are picked up by the existing job.