### PR TITLE
fix: meshp doctor start hint is platform-aware

### DIFF
--- a/cmd/meshp/doctor.go
+++ b/cmd/meshp/doctor.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"runtime"
 	"flag"
 	"fmt"
 	"time"
@@ -84,6 +85,23 @@ type findings struct {
 // and the thing that would undo it is not running.
 func (f findings) strandedEgress() bool { return (f.locked || f.claimed) && !f.daemonUp }
 
+
+
+
+func startMeshpdCommand() string {
+	if runtime.GOOS == "linux" {
+		return "sudo systemctl start meshpd"
+	}
+	return "start meshpd however this system starts services"
+}
+
+func startMeshpdHint() string {
+	if runtime.GOOS == "linux" {
+		return "Start it with 'sudo systemctl start meshpd'."
+	}
+	return "Start meshpd however this system starts services."
+}
+
 func report(f findings, socket string) {
 	switch {
 	case f.strandedEgress():
@@ -96,7 +114,7 @@ func report(f findings, socket string) {
 		fmt.Println()
 		fmt.Println("Starting meshpd again removes it:")
 		fmt.Println()
-		fmt.Println("    sudo systemctl start meshpd")
+		fmt.Println("    " + startMeshpdCommand())
 		fmt.Println()
 		fmt.Println("If meshpd will not start, undo it by hand:")
 		fmt.Println()
@@ -144,7 +162,7 @@ func report(f findings, socket string) {
 		fmt.Printf("  socket   %s\n", socket)
 		fmt.Println()
 		fmt.Println("Whatever is wrong with this machine's network, meshp is not the")
-		fmt.Println("cause. Start it with 'sudo systemctl start meshpd'.")
+		fmt.Println("cause. " + startMeshpdHint())
 
 	case !f.enrolled:
 		fmt.Println("meshpd is running and this device has not joined a network.")

--- a/cmd/meshp/doctor.go
+++ b/cmd/meshp/doctor.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"context"
-	"runtime"
 	"flag"
 	"fmt"
+	"runtime"
 	"time"
 
 	"github.com/meshpnet/meshp/internal/agentapi"
@@ -85,21 +85,31 @@ type findings struct {
 // and the thing that would undo it is not running.
 func (f findings) strandedEgress() bool { return (f.locked || f.claimed) && !f.daemonUp }
 
-
-
-
+// startMeshpdCommand is how meshpd is started on this machine, as something typeable.
+//
+// The whole of #66. `doctor` told everybody to run `systemctl start meshpd`, which is a
+// command two of the three platforms with a data plane do not have — and this is the one
+// screen ADR-0011 says has to carry commands that work, because whoever is reading it has no
+// network and cannot look anything up.
+//
+// Linux gets the unit under deploy/systemd. Nothing else gets a service manager, because
+// meshp does not yet define one: there is no launchd plist and no Windows service in this
+// repository, so naming a label for either would put a command on the screen that fails.
+// Running the binary is what is true on those platforms today, and it is what somebody
+// debugging is doing anyway.
+//
+// When deploy/ grows a plist or a service definition, this is where the command for it goes.
 func startMeshpdCommand() string {
 	if runtime.GOOS == "linux" {
 		return "sudo systemctl start meshpd"
 	}
-	return "start meshpd however this system starts services"
+	return "sudo meshpd"
 }
 
+// startMeshpdHint is the same command in a sentence, for the branch that is prose rather
+// than a block somebody types.
 func startMeshpdHint() string {
-	if runtime.GOOS == "linux" {
-		return "Start it with 'sudo systemctl start meshpd'."
-	}
-	return "Start meshpd however this system starts services."
+	return "Start it with '" + startMeshpdCommand() + "'."
 }
 
 func report(f findings, socket string) {

--- a/cmd/meshp/doctor_test.go
+++ b/cmd/meshp/doctor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
@@ -38,9 +39,9 @@ func capture(t *testing.T, f findings) string {
 func TestAStrandedMachineIsToldHowToFixItByHand(t *testing.T) {
 	out := capture(t, findings{locked: true, claimed: true})
 
-	if !strings.Contains(out, "systemctl start meshpd") {
+	if !strings.Contains(out, startMeshpdCommand()) {
 		t.Errorf("missing %q\n  needed because: it is the thing to try first, which fixes "+
-			"it without root surgery\n\n%s", "systemctl start meshpd", out)
+			"it without root surgery\n\n%s", startMeshpdCommand(), out)
 	}
 
 	// The firewall half, asked of the platform that would have installed it. This used to
@@ -193,5 +194,67 @@ func TestTheUndoCommandsAreTypeableAsPrinted(t *testing.T) {
 	// And the two agree, since one number is used for both by design.
 	if wglink.EgressMark != wglink.EgressTable {
 		t.Error("the mark and the table have drifted apart")
+	}
+}
+
+// The command to start meshpd is this machine's, not Linux's.
+//
+// #66: `doctor` told every platform to run `systemctl start meshpd`, and two of the three
+// with a data plane have no systemd. This is the one screen ADR-0011 says must carry
+// commands that work — whoever is reading it has no network and cannot look anything up — so
+// a command for the wrong operating system is worse than none.
+//
+// Asserted through startMeshpdCommand rather than against literals, for the reason the undo
+// commands are: a test that spelled out the Linux string would pass on the Linux jobs and
+// say nothing about anywhere else. Both the macOS and Windows jobs run this package.
+func TestTheStartCommandIsForThisMachine(t *testing.T) {
+	command := startMeshpdCommand()
+
+	if command == "" {
+		t.Fatal("this platform is told nothing about how to start meshpd")
+	}
+	if strings.Contains(command, "%!") {
+		t.Errorf("%q has a formatting error in it", command)
+	}
+
+	// Typeable as it stands. The failure this guards against is a sentence where a command
+	// should be — "start meshpd however this system starts services" passes a platform check
+	// and loses the point #66 is about.
+	fields := strings.Fields(strings.TrimPrefix(command, "sudo "))
+	if len(fields) == 0 {
+		t.Fatalf("%q names no program", command)
+	}
+	if _, err := exec.LookPath(fields[0]); err != nil && runtime.GOOS != "windows" {
+		// meshpd itself will not be on PATH in a test run, which is the honest case here:
+		// what matters is that a program is named at all.
+		if fields[0] != "meshpd" {
+			t.Errorf("%q names %q, which this machine does not have", command, fields[0])
+		}
+	}
+
+	// And it reaches both screens: the stranded one, and the one a machine with no meshp
+	// state shows. Those were separate literals before #66 and only one of them was fixed.
+	for _, f := range []findings{{locked: true, claimed: true}, {}} {
+		if out := capture(t, f); !strings.Contains(out, command) {
+			t.Errorf("the start command is not on this screen:\n%s", out)
+		}
+	}
+}
+
+// Linux keeps its unit, because deploy/systemd is real. Nothing else names a service
+// manager, because meshp does not define one — there is no launchd plist and no Windows
+// service in this repository, so a label for either would be a command that fails.
+func TestOnlyLinuxIsToldToUseSystemd(t *testing.T) {
+	command := startMeshpdCommand()
+	switch runtime.GOOS {
+	case "linux":
+		if !strings.Contains(command, "systemctl") {
+			t.Errorf("Linux is not told to use its unit: %q", command)
+		}
+	default:
+		if strings.Contains(command, "systemctl") {
+			t.Errorf("%s is told to run systemctl, which it does not have: %q",
+				runtime.GOOS, command)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Only suggest systemctl start on Linux in meshp doctor

## Changes

- startMeshpdCommand/Hint use systemctl on Linux and a generic service message elsewhere

Fixes #66
