### PR TITLE
feat(replicas): the overview stops calling other replicas' devices disconnected

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -127,10 +127,16 @@ Two things are worth knowing before you rely on it.
 agents and they reconnect — to whichever replica the balancer gives them, with no loss of
 configuration. What they lose is the seconds it takes to notice.
 
-**`meshp status` and the overview report what one replica can see.** Liveness is per-process
-today, so with several replicas the device list is the subset connected to whichever one
-answered. Addresses, routes and policy are unaffected — those come from PostgreSQL — and the
-gap is being closed separately.
+**Whether a device is connected is shared; what it last reported is not.** Every replica
+knows which devices have a control session open, because that is recorded when a session
+opens and closes. What a device says on each heartbeat — the version it applied, what its
+tunnel is doing — stays in the replica that received it, which is deliberate: writing it
+where every replica could see it would mean a database write per heartbeat per device
+(ADR-0012).
+
+So the overview shows every connected device, and for the ones attached to another replica
+it says `reported to another replica` in place of tunnel detail rather than implying the
+device has gone quiet.
 
 Leave it at 1, or unset, for a single-replica deployment. A replica that connects to the bus
 when there is nobody to talk to holds a database connection open for nothing.

--- a/internal/api/faults.go
+++ b/internal/api/faults.go
@@ -56,7 +56,12 @@ const tunnelGrace = 2 * time.Minute
 // Only an active membership can be in trouble. A revoked or suspended one is doing exactly
 // what was asked of it, and reporting it as broken would put an operator's own decision in
 // front of them as a fault to investigate.
-func deviceFaults(d store.OverviewDevice, live *session.Connected, now time.Time) []Fault {
+// connectedElsewhere is whether some other replica is holding this device's session, which
+// only the database knows. It is passed separately from live because the two answer
+// different questions: live is "do we have its heartbeat data", connectedElsewhere is "is it
+// talking to anybody". Collapsing them is what made a device attached to the replica next
+// door look like one that had never been heard from.
+func deviceFaults(d store.OverviewDevice, live *session.Connected, connectedElsewhere bool, now time.Time) []Fault {
 	faults := make([]Fault, 0, 2)
 	if d.State != "active" {
 		return faults
@@ -73,9 +78,14 @@ func deviceFaults(d store.OverviewDevice, live *session.Connected, now time.Time
 		// account of the failure that came from the machine it happened on.
 		faults = append(faults, Fault{Code: faultLastError, Message: d.LastError})
 	}
-	if live == nil && d.LastAckAt == nil {
+	if live == nil && !connectedElsewhere && d.LastAckAt == nil {
 		// Enrolled and never heard from. Easy to miss in a list of names, and usually an
 		// installation that did not finish rather than a device that has gone away.
+		//
+		// connectedElsewhere is what stops this being raised against a device that is
+		// connected right now to another replica and has simply not acknowledged anything
+		// yet — a window of seconds after a join, during which this would have reported a
+		// fault about a device doing exactly what it should.
 		faults = append(faults, Fault{
 			Code:    faultNeverApplied,
 			Message: "has never applied any configuration",

--- a/internal/api/faults_test.go
+++ b/internal/api/faults_test.go
@@ -44,7 +44,11 @@ func TestWhatCountsAsABrokenDevice(t *testing.T) {
 		name   string
 		device store.OverviewDevice
 		live   *session.Connected
-		want   []string
+
+		// elsewhere is whether another replica holds this device's session, which is
+		// what the database knows and this process does not.
+		elsewhere bool
+		want      []string
 	}{
 		{
 			name:   "a device with nothing wrong",
@@ -115,7 +119,7 @@ func TestWhatCountsAsABrokenDevice(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := codes(deviceFaults(tc.device, tc.live, now))
+			got := codes(deviceFaults(tc.device, tc.live, tc.elsewhere, now))
 			if len(tc.want) == 0 && len(got) == 0 {
 				return
 			}
@@ -186,5 +190,32 @@ func TestADroppedControlSessionDoesNotBreakARouteGroup(t *testing.T) {
 	group := store.OverviewGroup{Advertisers: []store.OverviewAdvertiser{advertiser("enabled", "healthy")}}
 	if faults := groupFaults(group); len(faults) != 0 {
 		t.Errorf("faults = %v, want none: liveness is not part of this rule", codes(faults))
+	}
+}
+
+// A device connected to another replica is not a device that has never been heard from.
+//
+// The two look identical to a control plane that only knows its own sessions, which is what
+// made this wrong: `live == nil` meant "we have no heartbeat data", and it was being read as
+// "nobody does". On a two-replica deployment that turns roughly half the devices into
+// reported faults about installations that are working.
+func TestADeviceHeldByAnotherReplicaIsNotAFault(t *testing.T) {
+	now := time.Now().UTC()
+	device := store.OverviewDevice{State: "active"} // no LastAckAt: it has acknowledged nothing yet
+
+	// What this replica sees for a device attached to the one next door: no session of its
+	// own, and no acknowledgement in the database yet.
+	elsewhere := codes(deviceFaults(device, nil, true, now))
+	for _, code := range elsewhere {
+		if code == faultNeverApplied {
+			t.Error("a device connected to another replica was reported as never having " +
+				"applied any configuration")
+		}
+	}
+
+	// And the fault still fires for a device that genuinely is not talking to anybody,
+	// which is the case it exists for.
+	if got := codes(deviceFaults(device, nil, false, now)); !same(got, []string{faultNeverApplied}) {
+		t.Errorf("a device connected nowhere = %v, want %v", got, []string{faultNeverApplied})
 	}
 }

--- a/internal/api/overview.go
+++ b/internal/api/overview.go
@@ -97,8 +97,19 @@ func (s *Server) handleNetworkOverview(w http.ResponseWriter, r *http.Request) {
 			"applied_version":      d.AppliedVersion,
 			"connected":            false,
 		}
-		if c, live := connected[d.MembershipID]; live {
+
+		// Connected here, or connected to another replica. The database knows the second
+		// and only this process knows the first, so the answer is the union — before this,
+		// a control plane reported the devices attached to itself and called the rest
+		// disconnected, which on a two-replica deployment is roughly half of them.
+		c, live := connected[d.MembershipID]
+		if live || d.ConnectedSince != nil {
 			device["connected"] = true
+			device["connected_since"] = d.ConnectedSince
+		}
+
+		if live {
+			// This replica is holding the session, so it has what the device last said.
 			device["connected_since"] = c.ConnectedAt
 			// The agent's own number, beside the database's. They disagree while an
 			// acknowledgement is in flight, and a reader chasing a device that looks stuck
@@ -121,6 +132,17 @@ func (s *Server) handleNetworkOverview(w http.ResponseWriter, r *http.Request) {
 					"relayed":     c.Tunnel.Relayed,
 				}
 			}
+		} else if device["connected"] == true {
+			// Held by another replica. Said rather than left to be inferred from a missing
+			// tunnel field, which a reader would otherwise take for "this device has not
+			// reported yet" — a device that has been talking to the replica next door for
+			// an hour is not the same as one that has never said anything, and only one of
+			// them is worth investigating.
+			//
+			// ADR-0012 keeps the per-heartbeat detail in the process that received it, so
+			// there is genuinely nothing to show here. Reporting the absence honestly is
+			// the whole of what this control plane can do about that.
+			device["reported_by"] = "another_replica"
 		}
 		if d.AddressV4 != nil {
 			device["address_v4"] = d.AddressV4.String()
@@ -141,11 +163,11 @@ func (s *Server) handleNetworkOverview(w http.ResponseWriter, r *http.Request) {
 		// What is wrong with it, decided here rather than by whoever is rendering
 		// (ADR-0023). Always present and always a list, so a consumer never has to tell
 		// absent from empty before it can decide whether to raise an alarm.
-		var live *session.Connected
-		if c, ok := connected[d.MembershipID]; ok {
-			live = &c
+		var held *session.Connected
+		if live {
+			held = &c
 		}
-		faults := deviceFaults(d, live, now)
+		faults := deviceFaults(d, held, d.ConnectedSince != nil, now)
 		device["faults"] = faults
 		faultCount += len(faults)
 

--- a/internal/api/replica_presence_test.go
+++ b/internal/api/replica_presence_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+)
+
+// A device connected to one replica shows as connected on the other.
+//
+// The whole of the presence half of #145. Before this, a control plane reported the devices
+// attached to *itself* and called every other one disconnected — so on a two-replica
+// deployment roughly half the devices in the overview were wrong, and an MSP asking "is this
+// customer's device online" got a different answer depending on which replica answered.
+//
+// Simulated rather than orchestrated: standing a second httptest server up would give a
+// second hub but the same process, and what is being tested is precisely what happens when
+// the hub does *not* know about a session that the database does. So the database is put
+// into the state another replica would leave it in, and this replica — whose hub is empty —
+// is asked.
+func TestADeviceHeldByAnotherReplicaReadsAsConnected(t *testing.T) {
+	h := newHarness(t)
+	res := h.enrol("held-elsewhere")
+
+	// Before: no session anywhere, so it reads as disconnected. Establishes that the
+	// assertion below is about the change rather than about a default.
+	if connected := overviewConnected(t, h, res.MembershipID.String()); connected {
+		t.Fatal("a device with no session anywhere reads as connected")
+	}
+
+	// What the replica next door writes when a device opens a control channel with it.
+	// This process's hub knows nothing about it.
+	if _, err := h.store.Pool().Exec(h.ctx,
+		`UPDATE membership_state
+		 SET connected_since = now(), control_session_id = 'a-session-on-another-replica'
+		 WHERE membership_id = $1`, res.MembershipID); err != nil {
+		t.Fatal(err)
+	}
+
+	if connected := overviewConnected(t, h, res.MembershipID.String()); !connected {
+		t.Error("a device connected to another replica reads as disconnected")
+	}
+}
+
+// And it says the detail is somebody else's, rather than implying the device has gone quiet.
+//
+// A device attached to the replica next door for an hour and one that has never said
+// anything both have no tunnel data here. Rendering them the same way is how an operator is
+// sent to investigate a device that is working.
+func TestTheOverviewSaysWhenTheDetailIsAnotherReplicas(t *testing.T) {
+	h := newHarness(t)
+	res := h.enrol("held-elsewhere")
+
+	if _, err := h.store.Pool().Exec(h.ctx,
+		`UPDATE membership_state
+		 SET connected_since = now(), control_session_id = 'a-session-on-another-replica'
+		 WHERE membership_id = $1`, res.MembershipID); err != nil {
+		t.Fatal(err)
+	}
+
+	device := overviewDevice(t, h, res.MembershipID.String())
+	if device["reported_by"] != "another_replica" {
+		t.Errorf("reported_by = %v, want another_replica", device["reported_by"])
+	}
+	if _, hasTunnel := device["tunnel"]; hasTunnel {
+		t.Error("this replica reported tunnel detail for a session it is not holding")
+	}
+	// And no fault, which is the failure that would have reached somebody's dashboard.
+	if faults, _ := device["faults"].([]any); len(faults) != 0 {
+		t.Errorf("faults = %v, want none for a device that is connected and working", faults)
+	}
+}
+
+// overviewDevice reads one device out of the overview.
+func overviewDevice(t *testing.T, h *harness, membershipID string) map[string]any {
+	t.Helper()
+	status, _, body := doJSON(t, http.MethodGet,
+		h.server.URL+"/api/v1/networks/"+h.netID.String()+"/overview", nil, nil, true)
+	if status != http.StatusOK {
+		t.Fatalf("overview = %d: %v", status, body)
+	}
+	devices, _ := body["devices"].([]any)
+	for _, raw := range devices {
+		device, _ := raw.(map[string]any)
+		if device["membership_id"] == membershipID {
+			return device
+		}
+	}
+	t.Fatalf("membership %s is not in the overview", membershipID)
+	return nil
+}
+
+func overviewConnected(t *testing.T, h *harness, membershipID string) bool {
+	t.Helper()
+	return overviewDevice(t, h, membershipID)["connected"] == true
+}

--- a/internal/store/gen/overview.sql.go
+++ b/internal/store/gen/overview.sql.go
@@ -101,7 +101,19 @@ SELECT
     s.applied_version,
     s.last_ack_at,
     s.last_error,
-    s.unapplied_components
+    s.unapplied_components,
+    -- Whether a control session is open, as recorded by whichever replica is holding it.
+    --
+    -- The one piece of liveness that is not per-process. ADR-0012 keeps presence out of
+    -- PostgreSQL because it is high-frequency, and that is true of what a device *reports* —
+    -- an applied version and a path report on every heartbeat. It is not true of whether the
+    -- session exists at all, which changes when a device connects and when it goes away.
+    --
+    -- These two columns have been written on connect and disconnect since the first
+    -- migration and read by nothing, so a control plane could only ever report the devices
+    -- attached to itself. On one replica that is the same answer; on two it is half of one.
+    s.connected_since,
+    s.control_session_id
 FROM device_network_memberships m
 JOIN devices d ON d.id = m.device_id
 LEFT JOIN membership_state s ON s.membership_id = m.id
@@ -128,6 +140,8 @@ type ListNetworkOverviewDevicesRow struct {
 	LastAckAt           *time.Time
 	LastError           *string
 	UnappliedComponents []string
+	ConnectedSince      *time.Time
+	ControlSessionID    *string
 }
 
 // Every membership in a network, with whatever it last told the control plane.
@@ -164,6 +178,8 @@ func (q *Queries) ListNetworkOverviewDevices(ctx context.Context, arg ListNetwor
 			&i.LastAckAt,
 			&i.LastError,
 			&i.UnappliedComponents,
+			&i.ConnectedSince,
+			&i.ControlSessionID,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/overview.go
+++ b/internal/store/overview.go
@@ -45,6 +45,15 @@ type OverviewDevice struct {
 	// now, which is why a device that cannot filter, or cannot carry what it advertises,
 	// has been invisible to everyone but whoever was logged into it.
 	Unapplied []string
+
+	// ConnectedSince is when a control session was opened, by whichever replica is holding
+	// it. Nil when no session is open anywhere.
+	//
+	// The shared half of liveness. What a device *reports* — an applied version, a path
+	// report — arrives on every heartbeat and stays in the process that received it
+	// (ADR-0012); whether the session exists changes only when a device connects or goes
+	// away, which is cheap enough to keep where every replica can see it.
+	ConnectedSince *time.Time
 }
 
 // OverviewAdvertiser is one device offering to carry a route group's prefixes.
@@ -159,6 +168,10 @@ func (s *Store) NetworkOverview(ctx context.Context, networkID uuid.UUID, device
 				RevokedAt:    row.RevokedAt,
 				LastAckAt:    row.LastAckAt,
 				Unapplied:    row.UnappliedComponents,
+
+				// Set by whichever replica is holding the session, so this is true across
+				// all of them rather than only for the one being asked.
+				ConnectedSince: row.ConnectedSince,
 			}
 			// Nil where a membership has never opened a session and so has no state row.
 			// Zero is the right reading of that — it has applied nothing — and it is also

--- a/queries/overview.sql
+++ b/queries/overview.sql
@@ -81,7 +81,19 @@ SELECT
     s.applied_version,
     s.last_ack_at,
     s.last_error,
-    s.unapplied_components
+    s.unapplied_components,
+    -- Whether a control session is open, as recorded by whichever replica is holding it.
+    --
+    -- The one piece of liveness that is not per-process. ADR-0012 keeps presence out of
+    -- PostgreSQL because it is high-frequency, and that is true of what a device *reports* —
+    -- an applied version and a path report on every heartbeat. It is not true of whether the
+    -- session exists at all, which changes when a device connects and when it goes away.
+    --
+    -- These two columns have been written on connect and disconnect since the first
+    -- migration and read by nothing, so a control plane could only ever report the devices
+    -- attached to itself. On one replica that is the same answer; on two it is half of one.
+    s.connected_since,
+    s.control_session_id
 FROM device_network_memberships m
 JOIN devices d ON d.id = m.device_id
 LEFT JOIN membership_state s ON s.membership_id = m.id

--- a/web/app.js
+++ b/web/app.js
@@ -143,6 +143,11 @@ function show(...nodes) {
 
 /** How a device's data plane reads, in words. */
 function tunnelSummary(device) {
+  // Held by another control-plane replica, which has the device's report and this one does
+  // not. Said rather than shown as "not reported yet": a device that has been talking to the
+  // replica next door for an hour and one that has never said anything are different, and
+  // only the second is worth investigating.
+  if (device.reported_by === "another_replica") return "reported to another replica";
   // Absent because the device has not said, which is not the same as having nothing.
   if (!device.tunnel) return device.connected ? "not reported yet" : "—";
   const { peers, talking, relayed } = device.tunnel;


### PR DESCRIPTION
Second slice of #145, after the bus in #155.

A control plane reported the devices attached to **itself** and called every other one disconnected. On a two-replica deployment that is roughly half the overview wrong — and for MSP use, "is this customer's device online?" answered differently depending on which replica you hit is a support call.

## Presence is not one thing, and that is the whole slice

ADR-0012 keeps presence out of PostgreSQL because it is high-frequency. That is true of what a device *reports* — an applied version and a path report on **every heartbeat**. It is not true of whether the session exists at all, which changes when a device connects and when it goes away.

Split those and the expensive half never needs sharing.

**And the cheap half was already there.** `membership_state.connected_since` and `control_session_id` have been written on connect and disconnect since the first migration, by whichever replica holds the session — and read by nothing. The overview query simply did not select them.

A column that exists, a writer that exists, no reader. The same shape as five of the tables ADR-0024 graduated, and found the same way.

So there is no Redis here, no new table, and no write per heartbeat. Just a query that reads two columns it was ignoring.

## The bug that would have reached a dashboard

`deviceFaults` took `live *session.Connected` and used `live == nil` to mean two different things: *"we have no heartbeat data for this device"* and *"nobody is talking to this device"*. On one replica those coincide. On two they do not.

The consequence was a false `never_applied` fault — "has never applied any configuration" — raised against a device that had connected to the replica next door seconds earlier and not yet acknowledged anything. A fault, on somebody's dashboard, about a device doing exactly what it should.

It now takes the distinction as an argument. Mutating it back fails two tests.

## Honest about what it cannot know

Where the session belongs to another replica, the response carries `reported_by: "another_replica"` rather than quietly omitting tunnel detail. A device that has been talking to the replica next door for an hour and one that has never said anything both have no tunnel data *here*, and rendering them identically is how an operator gets sent to investigate a working device. The page says `reported to another replica` in that column.

## Tests

```
--- PASS: TestADeviceHeldByAnotherReplicaReadsAsConnected
--- PASS: TestTheOverviewSaysWhenTheDetailIsAnotherReplicas
--- PASS: TestADeviceHeldByAnotherReplicaIsNotAFault
```

Simulated rather than orchestrated: a second `httptest` server would give a second hub but the same process, and what is being tested is precisely what happens when the hub does **not** know about a session the database does. So the database is put into the state another replica would leave it in, and this replica — whose hub is empty — is asked.

Both mutations caught:

- connectedness back to local-hub-only → both overview tests fail
- the fault back to ignoring other replicas → the false `never_applied` returns

The existing `overview_test.go` suite still passes, which is what says a locally-held session did not lose its detail.

## Scope

`#145` can close after this. What remains per-process is exactly what ADR-0012 said should stay there.

One thing worth stating plainly: this makes the *overview* correct across replicas. It does not make agent session handling multi-replica-aware in any deeper sense — an agent still holds one session with one replica, and a replica going away still drops its agents to reconnect elsewhere. That was already true and is unchanged.