### PR TITLE
chore: ignore the four binaries when built at the repository root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,18 @@
 *.test
 *.out
 
+# The same four binaries, at the repository root.
+#
+# `make build` puts them in bin/, which the rule above covers. A bare
+# `go build ./cmd/meshp` does not — it drops the binary here, named after the
+# package, and a 12 MB Mach-O then sits in `git status` waiting for somebody's
+# `git add -A` to commit it. Anchored to the root so the cmd/ directories that
+# share these names are unaffected.
+/meshp
+/meshpd
+/meshp-control
+/meshp-relay
+
 # Generated code IS committed — see docs/adr/0013-commit-generated-code.md.
 # `go build ./...` and `go install` have to work on a fresh clone, and the
 # protocol package is meant to be imported by meshp-sdk and the mobile clients.


### PR DESCRIPTION
`make build` puts the binaries in `bin/`, which `.gitignore` already covers. A bare `go build ./cmd/meshp` does not — it drops a binary at the repository root, named after the package, where nothing was ignoring it.

One had been sitting in `git status` long enough that `git add -A` picked it up while I was staging #157, and I caught it at the diff stat: 12 MB of Mach-O in a repository whose largest file is otherwise a test fixture.

Anchored with a leading `/` so the `cmd/` directories that share these names are unaffected. Verified rather than assumed:

```
$ git check-ignore -v meshp
.gitignore:15:/meshp	meshp

$ git check-ignore -v cmd/meshp
(nothing — correct)
```

Nothing already tracked changes: `git ls-files --error-unmatch meshp` finds nothing, so this only affects what shows up as untracked from here on.