### PR TITLE
feat(dataplane): macOS can take a full-tunnel default route

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -661,12 +661,12 @@ jobs:
       - name: unprivileged — a refused write is an error, and scutil still exits zero
         run: |
           set -o pipefail
-          go test ./internal/wglink/ ./internal/resolved/ ./internal/version/ ./internal/nftables/ ./internal/pathprobe/ -count=1 -v 2>&1 | tee macos-user.log
+          go test ./internal/wglink/ ./internal/resolved/ ./internal/version/ ./internal/nftables/ ./internal/pathprobe/ ./cmd/meshp/ -count=1 -v 2>&1 | tee macos-user.log
 
       - name: as root — a utun comes up and is observed back, and macOS sends mesh names to meshp
         run: |
           set -o pipefail
-          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/resolved/ ./internal/version/ ./internal/nftables/ ./internal/pathprobe/ -count=1 -v 2>&1 | tee macos-root.log
+          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/resolved/ ./internal/version/ ./internal/nftables/ ./internal/pathprobe/ ./cmd/meshp/ -count=1 -v 2>&1 | tee macos-root.log
 
       # A test that skipped in both runs never ran anywhere, which reports success while
       # testing nothing. Checked by name rather than by counting skips, because each run is

--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ name layer resolves to the mapped address (ADR-0020), so a technician reaches bo
 than reaching whichever membership was written last.
 
 What does not, and matters: direct paths are unimplemented, so everything is relayed. The
-data plane is complete on Linux and nearly so on macOS — **a tunnel, and names that
-resolve; what macOS still cannot do is fail closed on egress**. Windows and the mobile
-platforms enrol, hold an address, and report honestly that they have no tunnel and cannot
-filter.
+data plane is complete on Linux and nearly so on macOS — **a tunnel, names that resolve and
+a full-tunnel default route; what macOS still cannot do is fail closed on egress**, so a
+network requiring it reports the group unhonoured there rather than half-applying it.
+Windows and the mobile platforms enrol, hold an address, and report honestly that they have
+no tunnel and cannot filter.
 
 It is public from the first commit because the design decisions are the
 interesting part and we would rather be argued with early.

--- a/cmd/meshp/doctor.go
+++ b/cmd/meshp/doctor.go
@@ -104,8 +104,12 @@ func report(f findings, socket string) {
 			fmt.Printf("    sudo nft delete table inet %s\n", nftables.LockTableName)
 		}
 		if f.claimed {
-			fmt.Printf("    sudo ip rule del fwmark %#x\n", wglink.EgressMark)
-			fmt.Printf("    sudo ip route flush table %d\n", wglink.EgressTable)
+			// From the platform that made the claim, not written here. A command for the
+			// wrong operating system is worse than none, and whoever is reading this is at
+			// a console on a machine with no network.
+			for _, command := range wglink.EgressUndo() {
+				fmt.Printf("    %s\n", command)
+			}
 		}
 		fmt.Println()
 		fmt.Println("Starting meshpd and undoing it by hand both restore this machine's")

--- a/cmd/meshp/doctor_test.go
+++ b/cmd/meshp/doctor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -40,11 +41,25 @@ func TestAStrandedMachineIsToldHowToFixItByHand(t *testing.T) {
 	for _, want := range []struct{ text, why string }{
 		{"nft delete table inet " + nftables.LockTableName,
 			"the exact command, because there is no way to search for it"},
-		{"ip rule del fwmark", "the routing half, which the firewall command does not undo"},
 		{"systemctl start meshpd", "the thing to try first, which fixes it without root surgery"},
 	} {
 		if !strings.Contains(out, want.text) {
 			t.Errorf("missing %q\n  needed because: %s\n\n%s", want.text, want.why, out)
+		}
+	}
+
+	// The routing half, which the firewall command does not undo — asked of the platform
+	// that would have installed it rather than written out here. This used to assert the
+	// Linux commands and passed only because CI ran it on Linux; a second implementation of
+	// the claim made that a test whose result depended on where it ran.
+	undo := wglink.EgressUndo()
+	if len(undo) == 0 {
+		t.Fatal("this platform can claim a default route and offers no way to undo one by hand")
+	}
+	for _, command := range undo {
+		if !strings.Contains(out, command) {
+			t.Errorf("missing %q\n  needed because: it is how the routing half comes off\n\n%s",
+				command, out)
 		}
 	}
 
@@ -128,16 +143,33 @@ func TestOnlyAStrandedMachineIsAFault(t *testing.T) {
 	}
 }
 
-// The mark has to be printed the way `ip` expects it, or the command on the screen does not
-// work when typed — which is the only thing this command is for.
-func TestTheMarkIsPrintedAsIpExpectsIt(t *testing.T) {
+// Whatever this platform prints has to be typeable as it stands, because the only thing this
+// command is for is being read off a screen by somebody who cannot look anything up.
+//
+// On Linux that means the mark in the hex form `ip rule` takes and the table in the decimal
+// form `ip route` takes — the numbers are one value used two ways and each tool wants it
+// differently. Asserted through EgressUndo rather than against literals so that a platform
+// whose claim is made of routes rather than rules is checked as strictly.
+func TestTheUndoCommandsAreTypeableAsPrinted(t *testing.T) {
 	out := capture(t, findings{claimed: true})
 
-	if !strings.Contains(out, "fwmark 0x6d657368") {
-		t.Errorf("the mark is not in the hex form `ip rule` takes:\n%s", out)
+	for _, command := range wglink.EgressUndo() {
+		if !strings.Contains(out, command) {
+			t.Errorf("%q is not on the screen as it would be typed:\n%s", command, out)
+		}
+		if strings.Contains(command, "%!") {
+			t.Errorf("%q has a formatting error in it", command)
+		}
 	}
-	if !strings.Contains(out, "flush table 1835365224") {
-		t.Errorf("the table is not in the decimal form `ip route` takes:\n%s", out)
+	if runtime.GOOS == "linux" {
+		// The two forms one number takes, which is the part a change to either constant
+		// would silently get wrong.
+		if !strings.Contains(out, "fwmark 0x6d657368") {
+			t.Errorf("the mark is not in the hex form `ip rule` takes:\n%s", out)
+		}
+		if !strings.Contains(out, "flush table 1835365224") {
+			t.Errorf("the table is not in the decimal form `ip route` takes:\n%s", out)
+		}
 	}
 	// And the two agree, since one number is used for both by design.
 	if wglink.EgressMark != wglink.EgressTable {

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,8 +31,9 @@ Two worth starting with:
   tunnel drops, and why that is worth the support tickets.
 
 And the honest one: the [status section of the README](../README.md#status) says what does
-not work. The data plane is complete on Linux and nearly so on macOS — a tunnel and working
-names, but no fail-closed egress — and absent elsewhere; nothing discovers direct paths yet.
+not work. The data plane is complete on Linux and nearly so on macOS — a tunnel, working
+names and a full-tunnel route, but no fail-closed egress — and absent elsewhere; nothing
+discovers direct paths yet.
 If you need something that works this afternoon, the README names three projects that will
 serve you better today.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,8 +16,8 @@ bug and worth an issue.
 ## What you need
 
 - Linux, with root. This page is written for Linux because that is where the data plane is
-  complete. macOS brings a tunnel up, carries traffic and resolves mesh names; what it
-  cannot yet do is fail closed on egress. Windows and the mobile platforms enrol, hold an
+  complete. macOS brings a tunnel up, carries traffic, resolves mesh names and can take a
+  full-tunnel default route; what it cannot yet do is fail closed on egress. Windows and the mobile platforms enrol, hold an
   address, and report honestly that they have no tunnel.
 - Docker with the Compose plugin, for the control plane and its database.
 - A kernel that can create WireGuard interfaces. `sudo ip link add dev wgcheck type

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -81,8 +81,18 @@ SystemConfiguration store, so only this network's suffix comes to meshp and ever
 keeps going wherever it was already going. `scutil --dns` shows it as a resolver with a
 `domain` and a high `order`, which is the thing to look at when a mesh name does not answer.
 
-What macOS still does not have is fail-closed egress, so a full-tunnel group is reported
-unhonoured rather than silently half-applied.
+macOS can also be given a full tunnel now. It has no policy routing, so the claim is made
+the way wg-quick(8) makes it on this platform: `0.0.0.0/1` and `128.0.0.0/1`, which beat any
+default route without replacing it, plus explicit routes keeping the control plane and the
+relays off the tunnel they carry.
+
+What macOS still does not have is **fail-closed egress**. A network whose policy says
+`fail_closed` is true reports the group unhonoured rather than claiming the route and
+quietly not enforcing it, so a macOS device can be given a full tunnel only where an
+administrator has said fail-closed is not required — and `meshp status` says so.
+
+If a macOS machine has lost its network and you suspect meshp, `sudo meshp doctor` prints
+the exact `route -n delete` commands to give it back. Those two routes are what a claim is.
 
 On Linux, check that the kernel can make WireGuard interfaces at all:
 

--- a/internal/tunnel/egress.go
+++ b/internal/tunnel/egress.go
@@ -70,7 +70,7 @@ func (r *Reconciler) applyEgress(ctx context.Context, iface string, want bool, f
 			return []string{"egress"}
 		}
 	}
-	if err := r.egress.Claim(iface); err != nil {
+	if err := r.egress.Claim(iface, carve.Endpoints, carve.Prefixes); err != nil {
 		// The lock is on and the route is not, which is the safe half of a half-done claim:
 		// the device sends nothing rather than sending it the wrong way. Taking the lock off
 		// again would restore the leak it was installed to prevent, so it stays, the group is

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -223,10 +223,19 @@ type Filter interface {
 // which way is the right one. Nil where the platform cannot do it, in which case a device
 // asked for a default route reports the group unhonoured rather than half-claiming it.
 type Egress interface {
-	// Claim sends everything except the tunnel's own packets through the tunnel. Which
-	// packets are the tunnel's own, and how they are recognised, belongs to the
-	// implementation — this package has no business knowing about firewall marks.
-	Claim(iface string) error
+	// Claim sends everything except the tunnel's own packets through the tunnel.
+	//
+	// The carve-out is passed rather than left to the implementation, which it was until
+	// macOS needed it. Linux recognises the tunnel's own packets by a firewall mark and so
+	// needs nothing here; macOS has no equivalent, and keeps the tunnel reachable by
+	// routing its endpoints around the tunnel explicitly. Both are "how this platform knows
+	// which packets are its own", which is the implementation's business — but only one of
+	// them can work it out unaided.
+	//
+	// endpoints are the control plane and the relays; excluded is everything else that must
+	// stay off the tunnel. Losing either is how a device routes its own outer packets into
+	// its own tunnel and disappears.
+	Claim(iface string, endpoints []netip.AddrPort, excluded []netip.Prefix) error
 
 	// Release gives the routing back.
 	Release() error

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -904,7 +904,7 @@ type fakeEgress struct {
 	order    *[]string
 }
 
-func (e *fakeEgress) Claim(iface string) error {
+func (e *fakeEgress) Claim(iface string, _ []netip.AddrPort, _ []netip.Prefix) error {
 	if e.claimErr != nil {
 		return e.claimErr
 	}

--- a/internal/wglink/egress.go
+++ b/internal/wglink/egress.go
@@ -16,3 +16,16 @@ const (
 	EgressMark  uint32 = 0x6d657368 // "mesh"
 	EgressTable uint32 = 0x6d657368
 )
+
+// EgressUndo is the exact commands that remove a default-route claim by hand.
+//
+// Per platform, because the claim is: Linux installs a routing rule and a table, macOS
+// installs routes. Here rather than in `meshp doctor` for the reason the constants above are
+// here — the person reading that output is at a console on a machine with no network, and a
+// command for the wrong operating system is worse than none.
+//
+// That failure has a precedent in this repository: `meshp doctor` recommended `systemctl` on
+// every platform until #156, because the command was written where it was printed rather
+// than where it was decided. Adding a second implementation of the claim was the moment to
+// not repeat it.
+func EgressUndo() []string { return egressUndo() }

--- a/internal/wglink/egress_darwin.go
+++ b/internal/wglink/egress_darwin.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/netip"
 	"os/exec"
 	"sync"
@@ -109,7 +110,12 @@ func (r *Router) Claim(iface string, endpoints []netip.AddrPort, excluded []neti
 		r.viaLocal = append(r.viaLocal, prefix)
 	}
 
-	for _, prefix := range append(append([]netip.Prefix{}, egressHalves...), egressHalves6...) {
+	halves, err := halvesFor(iface)
+	if err != nil {
+		_ = r.releaseLocked()
+		return err
+	}
+	for _, prefix := range halves {
 		if err := addRoute(prefix, "-interface", iface); err != nil {
 			_ = r.releaseLocked()
 			return fmt.Errorf("wglink: claiming %s: %w", prefix, err)
@@ -117,6 +123,47 @@ func (r *Router) Claim(iface string, endpoints []netip.AddrPort, excluded []neti
 		r.claimed = append(r.claimed, prefix)
 	}
 	return nil
+}
+
+// halvesFor is the halves to claim, for the address families this tunnel actually carries.
+//
+// Not both unconditionally, which is what this did first. A network with no IPv6 address
+// pool gives its devices a tunnel with no IPv6 address, and routing ::/1 into an interface
+// that cannot carry it fails — so the whole claim failed, and a full tunnel never worked on
+// an IPv4-only network. Claiming a family the tunnel has no address for would be wrong even
+// if the kernel allowed it: it would take the machine's IPv6 traffic and drop it.
+func halvesFor(iface string) ([]netip.Prefix, error) {
+	device, err := net.InterfaceByName(iface)
+	if err != nil {
+		return nil, fmt.Errorf("wglink: reading %s: %w", iface, err)
+	}
+	addrs, err := interfaceAddresses(device)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []netip.Prefix
+	for _, addr := range addrs {
+		switch {
+		case addr.Addr().Is4() && !hasFamily(out, true):
+			out = append(out, egressHalves...)
+		case addr.Addr().Is6() && !hasFamily(out, false):
+			out = append(out, egressHalves6...)
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("wglink: %s has no addresses, so there is nothing to route into it", iface)
+	}
+	return out, nil
+}
+
+func hasFamily(prefixes []netip.Prefix, v4 bool) bool {
+	for _, prefix := range prefixes {
+		if prefix.Addr().Is4() == v4 {
+			return true
+		}
+	}
+	return false
 }
 
 // Release gives the routing back by removing exactly what was added.

--- a/internal/wglink/egress_darwin.go
+++ b/internal/wglink/egress_darwin.go
@@ -1,0 +1,273 @@
+//go:build darwin
+
+package wglink
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"os/exec"
+	"sync"
+
+	"golang.org/x/net/route"
+)
+
+// Claiming a default route on macOS, which has no policy routing.
+//
+// Linux exempts the tunnel's own outer packets with a firewall mark and puts a default route
+// in a table only unmarked traffic reaches. macOS has neither marks nor rules, so the claim
+// is made the way wg-quick(8) makes it on this platform: two routes more specific than any
+// default, and explicit routes around the tunnel for everything that must not go through it.
+//
+// # Why halves rather than a default
+//
+// 0.0.0.0/1 and 128.0.0.0/1 together cover every IPv4 address, and each is one bit longer
+// than 0.0.0.0/0 — so they win on longest-prefix match without the existing default route
+// being touched. That matters more here than it looks: the machine's real default is how the
+// outer WireGuard packets leave, and replacing it would mean putting it back exactly as it
+// was afterwards, from a copy taken while the network was in whatever state it was in. This
+// way there is nothing to put back. Releasing means deleting four routes that meshp added
+// and nothing else.
+//
+// # Why the carve-out is routed rather than marked
+//
+// Without a mark there is nothing to distinguish the tunnel's own packets from the traffic
+// it carries, so they have to be named. Each endpoint gets a host route through whatever the
+// default gateway was when the claim was made — which is also the reason this cannot survive
+// the machine changing networks without another pass, and why the reconciler making that
+// pass every minute matters more on this platform than on Linux (#160).
+
+// egressHalves are the two routes that beat a default without replacing it.
+var egressHalves = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/1"),
+	netip.MustParsePrefix("128.0.0.0/1"),
+}
+
+// egressHalves6 is the same trick for IPv6.
+var egressHalves6 = []netip.Prefix{
+	netip.MustParsePrefix("::/1"),
+	netip.MustParsePrefix("8000::/1"),
+}
+
+// Router claims the default route on macOS.
+//
+// It remembers what it installed, because releasing means removing exactly those routes and
+// nothing else. That memory is this process's, so a Router that has never claimed cannot
+// release what a previous process did — see EgressHeld, which asks the kernel instead.
+type Router struct {
+	mu       sync.Mutex
+	claimed  []netip.Prefix
+	viaLocal []netip.Prefix
+}
+
+// NewRouter returns something that can claim a default route.
+func NewRouter() *Router { return &Router{} }
+
+// Claim sends everything through the tunnel except what must not go through it.
+//
+// Order matters and is the opposite of Linux's. There the mark goes first, because a rule
+// exempting marked traffic exempts nothing until something is marking it. Here the carve-out
+// goes first, because the moment the halves are installed every packet with no more specific
+// route goes into the tunnel — including the outer packets carrying the tunnel itself.
+func (r *Router) Claim(iface string, endpoints []netip.AddrPort, excluded []netip.Prefix) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	gateway, err := defaultGateway()
+	if err != nil {
+		return fmt.Errorf("wglink: finding the current default gateway: %w", err)
+	}
+
+	// Everything that must stay off the tunnel, pinned to the gateway the machine is using
+	// now. Endpoints become host routes; excluded prefixes are already prefixes.
+	var direct []netip.Prefix
+	for _, endpoint := range endpoints {
+		addr := endpoint.Addr().Unmap()
+		if !addr.Is4() {
+			// IPv6 endpoints are skipped rather than mishandled: pinning one needs the
+			// IPv6 default gateway, which is a second lookup this does not do yet, and a
+			// route through the wrong gateway is worse than no route.
+			continue
+		}
+		direct = append(direct, netip.PrefixFrom(addr, addr.BitLen()))
+	}
+	for _, prefix := range excluded {
+		if prefix.Addr().Is4() {
+			direct = append(direct, prefix)
+		}
+	}
+
+	for _, prefix := range direct {
+		if err := addRoute(prefix, "-gateway", gateway.String()); err != nil {
+			// Undo what has gone in, so a half-made claim does not leave the machine
+			// routing some of its traffic somewhere nobody asked for.
+			_ = r.releaseLocked()
+			return fmt.Errorf("wglink: keeping %s off the tunnel: %w", prefix, err)
+		}
+		r.viaLocal = append(r.viaLocal, prefix)
+	}
+
+	for _, prefix := range append(append([]netip.Prefix{}, egressHalves...), egressHalves6...) {
+		if err := addRoute(prefix, "-interface", iface); err != nil {
+			_ = r.releaseLocked()
+			return fmt.Errorf("wglink: claiming %s: %w", prefix, err)
+		}
+		r.claimed = append(r.claimed, prefix)
+	}
+	return nil
+}
+
+// Release gives the routing back by removing exactly what was added.
+func (r *Router) Release() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.releaseLocked()
+}
+
+// releaseLocked removes what this Router installed. Not locked: every caller holds it.
+//
+// Every route is attempted even when one fails, and the errors are joined. Stopping at the
+// first would leave the rest installed, which on this path means a machine still sending
+// everything into a tunnel that is going away.
+func (r *Router) releaseLocked() error {
+	var errs []error
+	for _, prefix := range append(append([]netip.Prefix{}, r.claimed...), r.viaLocal...) {
+		if err := deleteRoute(prefix); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	r.claimed, r.viaLocal = nil, nil
+	return errors.Join(errs...)
+}
+
+// EgressHeld reports whether a default route claim is in place, whoever made it.
+//
+// Asked of the kernel rather than of this process's memory, which is the point: `meshp
+// doctor` runs in a different process from the daemon, usually after the daemon has died,
+// and the question it is answering is "is this machine refusing traffic because of something
+// meshp left behind".
+func EgressHeld() (bool, error) {
+	present, err := routeExists(egressHalves[0])
+	if err != nil {
+		return false, err
+	}
+	return present, nil
+}
+
+// addRoute installs one route, treating "it is already there" as success.
+//
+// Idempotent because the reconciler calls this every pass. route(8) reports an existing
+// route as "File exists" and exits non-zero, which is not a failure of anything.
+func addRoute(prefix netip.Prefix, via ...string) error {
+	family := "-inet"
+	if prefix.Addr().Is6() {
+		family = "-inet6"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+
+	args := append([]string{"-n", "add", family, prefix.String()}, via...)
+	out, err := exec.CommandContext(ctx, "/sbin/route", args...).CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	if bytes.Contains(out, []byte("File exists")) {
+		return nil
+	}
+	return fmt.Errorf("route add %s: %w: %s", prefix, err, trimNewline(out))
+}
+
+// deleteRoute removes one, treating "it is not there" as success.
+func deleteRoute(prefix netip.Prefix) error {
+	family := "-inet"
+	if prefix.Addr().Is6() {
+		family = "-inet6"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "/sbin/route",
+		"-n", "delete", family, prefix.String()).CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	if bytes.Contains(out, []byte("not in table")) {
+		return nil
+	}
+	return fmt.Errorf("route delete %s: %w: %s", prefix, err, trimNewline(out))
+}
+
+// defaultGateway is where the machine currently sends what it cannot route otherwise.
+//
+// Read from the routing table rather than remembered, because the claim is made against
+// whatever the machine is using at the moment it is made. A laptop that changed networks
+// since the last pass has a different one, and pinning the tunnel's endpoints to the old one
+// would send them nowhere.
+func defaultGateway() (netip.Addr, error) {
+	rib, err := route.FetchRIB(0, route.RIBTypeRoute, 0)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("reading the routing table: %w", err)
+	}
+	msgs, err := route.ParseRIB(route.RIBTypeRoute, rib)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("parsing the routing table: %w", err)
+	}
+
+	for _, msg := range msgs {
+		m, ok := msg.(*route.RouteMessage)
+		if !ok || len(m.Addrs) < 2 {
+			continue
+		}
+		dst, gw := addrOf(m.Addrs[0]), addrOf(m.Addrs[1])
+		// The default route: destination 0.0.0.0 with no netmask, or one of all zeroes.
+		if !dst.Is4() || dst != netip.AddrFrom4([4]byte{}) || !gw.IsValid() || !gw.Is4() {
+			continue
+		}
+		// Not one of ours. A machine that already has meshp's halves installed still has a
+		// real default underneath them, and that is the one to pin endpoints to.
+		return gw, nil
+	}
+	return netip.Addr{}, errors.New("this machine has no IPv4 default route to send the tunnel's own packets through")
+}
+
+// routeExists reports whether a prefix is in the table.
+func routeExists(want netip.Prefix) (bool, error) {
+	rib, err := route.FetchRIB(0, route.RIBTypeRoute, 0)
+	if err != nil {
+		return false, fmt.Errorf("reading the routing table: %w", err)
+	}
+	msgs, err := route.ParseRIB(route.RIBTypeRoute, rib)
+	if err != nil {
+		return false, fmt.Errorf("parsing the routing table: %w", err)
+	}
+	for _, msg := range msgs {
+		m, ok := msg.(*route.RouteMessage)
+		if !ok {
+			continue
+		}
+		if got, ok := prefixOf(m); ok && got == want {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// egressUndo removes the routes this platform's claim installs.
+//
+// The halves only. The endpoint routes meshp adds alongside them point at the machine's real
+// gateway, which is where those destinations would have gone anyway — they are redundant
+// rather than harmful once the halves are gone, and listing every one of them would bury the
+// two commands that actually give the machine its network back.
+func egressUndo() []string {
+	var out []string
+	for _, half := range append(append([]netip.Prefix{}, egressHalves...), egressHalves6...) {
+		family := "-inet"
+		if half.Addr().Is6() {
+			family = "-inet6"
+		}
+		out = append(out, fmt.Sprintf("sudo route -n delete %s %s", family, half))
+	}
+	return out
+}

--- a/internal/wglink/egress_darwin_test.go
+++ b/internal/wglink/egress_darwin_test.go
@@ -6,6 +6,8 @@ import (
 	"net/netip"
 	"testing"
 
+	"golang.org/x/net/route"
+
 	"github.com/meshpnet/meshp/internal/wgplan"
 )
 
@@ -109,6 +111,15 @@ func TestClaimingAndReleasingTheDefaultRoute(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = l.Apply(iface, opDestroy()) })
 
+	// Addressed, because a real claim is only ever made on a tunnel that has one — and
+	// because Claim now decides which address families to take from what the interface
+	// actually carries. A bare utun was not a realistic fixture and hid that.
+	if err := l.Apply(iface, wgplan.Op{
+		Kind: wgplan.AddAddress, Prefix: netip.MustParsePrefix("100.90.77.1/32"),
+	}); err != nil {
+		t.Fatalf("addressing the interface: %v", err)
+	}
+
 	real, ok, err := l.(*darwinLink).resolve(iface)
 	if err != nil || !ok {
 		t.Fatalf("resolving the interface: %v", err)
@@ -160,5 +171,40 @@ func TestClaimingAndReleasingTheDefaultRoute(t *testing.T) {
 		} else if present {
 			t.Errorf("%s is still in the table after releasing", half)
 		}
+	}
+}
+
+// A netmask is read correctly whatever its length.
+//
+// Written after the round-trip test failed with "0.0.0.0/1 is not in the table after
+// claiming" — the routes were there and the reader could not see them. The contiguity check
+// rejected every mask whose length was not a multiple of eight, so a /24 was found and a /1
+// and a /12 were not.
+//
+// That is not only this file's problem: interfaceRoutes uses the same parsing for Observe,
+// so a route with a length like /12 was invisible to the reconciler and could never be
+// withdrawn. Pinned here because the failure looks like "the route was not added" and is
+// nothing of the sort.
+func TestNetmasksOfEveryLengthAreRead(t *testing.T) {
+	for _, tc := range []struct {
+		mask [4]byte
+		want int
+	}{
+		{[4]byte{0x00, 0, 0, 0}, 0},
+		{[4]byte{0x80, 0, 0, 0}, 1}, // the halves this file claims with
+		{[4]byte{0xff, 0xf0, 0, 0}, 12},
+		{[4]byte{0xff, 0xff, 0xff, 0}, 24},
+		{[4]byte{0xff, 0xff, 0xff, 0xff}, 32},
+	} {
+		addr := &route.Inet4Addr{IP: tc.mask}
+		if got := maskBits(addr, 32); got != tc.want {
+			t.Errorf("maskBits(%v) = %d, want %d", tc.mask, got, tc.want)
+		}
+	}
+
+	// And a mask that is not contiguous is refused rather than rounded into a length it
+	// does not have.
+	if got := maskBits(&route.Inet4Addr{IP: [4]byte{0xff, 0x0f, 0, 0}}, 32); got != -1 {
+		t.Errorf("a non-contiguous mask read as /%d", got)
 	}
 }

--- a/internal/wglink/egress_darwin_test.go
+++ b/internal/wglink/egress_darwin_test.go
@@ -1,0 +1,164 @@
+//go:build darwin
+
+package wglink
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/meshpnet/meshp/internal/wgplan"
+)
+
+func opCreate() wgplan.Op {
+	return wgplan.Op{Kind: wgplan.CreateDevice, Device: wgplan.Device{MTU: 1380}}
+}
+
+func opDestroy() wgplan.Op { return wgplan.Op{Kind: wgplan.DestroyDevice} }
+
+// The gateway is read from the kernel, not remembered.
+//
+// A laptop that changed networks since the last pass has a different one, and pinning the
+// tunnel's own endpoints to the old gateway would send them nowhere — which on this platform
+// means the tunnel stops carrying anything and the machine is inside it.
+func TestTheDefaultGatewayIsReadFromTheRoutingTable(t *testing.T) {
+	gateway, err := defaultGateway()
+	if err != nil {
+		t.Skipf("this machine has no IPv4 default route: %v", err)
+	}
+	if !gateway.IsValid() || !gateway.Is4() {
+		t.Errorf("gateway = %v, want a v4 address", gateway)
+	}
+	if gateway.IsUnspecified() {
+		t.Error("the gateway is 0.0.0.0, which is the destination rather than the gateway — " +
+			"the routing message's fields are being read in the wrong order")
+	}
+}
+
+// Nothing is claimed on a machine meshp is not running on.
+func TestEgressIsNotHeldWhenNothingClaimedIt(t *testing.T) {
+	held, err := EgressHeld()
+	if err != nil {
+		t.Fatalf("EgressHeld: %v", err)
+	}
+	if held {
+		t.Skip("something has already claimed a default route on this machine; " +
+			"this test cannot say whether it was meshp")
+	}
+}
+
+// Adding a route that is already there is success, because the reconciler adds them every
+// pass. route(8) reports it as "File exists" and exits non-zero, which is not a failure of
+// anything.
+func TestAddingARouteTwiceIsSuccess(t *testing.T) {
+	requireRoot(t)
+
+	// TEST-NET-1, which is reserved for documentation and reaches nothing. Chosen over any
+	// of the halves deliberately: this test is about the idempotence of one operation, and
+	// it should not need the machine's default route to prove it.
+	prefix := netip.MustParsePrefix("192.0.2.0/24")
+	t.Cleanup(func() { _ = deleteRoute(prefix) })
+
+	for range 2 {
+		if err := addRoute(prefix, "-interface", "lo0"); err != nil {
+			t.Fatalf("adding %s: %v", prefix, err)
+		}
+	}
+
+	present, err := routeExists(prefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !present {
+		t.Error("the route was added twice and is not in the table")
+	}
+}
+
+// Removing a route that is not there is success, for the reason teardown always runs: a
+// membership going away asks for a release whether or not a claim was ever made.
+func TestDeletingARouteThatIsNotThereIsSuccess(t *testing.T) {
+	requireRoot(t)
+
+	if err := deleteRoute(netip.MustParsePrefix("198.51.100.0/24")); err != nil {
+		t.Errorf("deleting a route that was never added: %v", err)
+	}
+}
+
+// The whole claim, and back again.
+//
+// This one deliberately takes the machine's traffic. Between Claim and Release every packet
+// with no more specific route goes into a utun with no peers, which is a blackhole — so the
+// window is as short as it can be made, nothing does network I/O inside it, and the release
+// is registered before the claim so that a failure between them still puts the routes back.
+//
+// The risk is real and bounded: on a CI runner the worst case is a job that fails loudly on
+// a machine that is thrown away afterwards, which is a better trade than never exercising
+// the one function this file exists for. Do not add anything to this test that talks to the
+// network.
+func TestClaimingAndReleasingTheDefaultRoute(t *testing.T) {
+	requireRoot(t)
+
+	l, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	const iface = "meshptest-egress"
+	if err := l.Apply(iface, opCreate()); err != nil {
+		t.Fatalf("creating the interface: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Apply(iface, opDestroy()) })
+
+	real, ok, err := l.(*darwinLink).resolve(iface)
+	if err != nil || !ok {
+		t.Fatalf("resolving the interface: %v", err)
+	}
+
+	router := NewRouter()
+	// Registered before the claim, so a failure inside it still gives the routing back.
+	t.Cleanup(func() { _ = router.Release() })
+
+	endpoint := netip.MustParseAddrPort("198.51.100.7:51820")
+	if err := router.Claim(real, []netip.AddrPort{endpoint}, nil); err != nil {
+		t.Fatalf("claiming: %v", err)
+	}
+
+	// Read from the kernel, not from the Router's own memory: what matters is what the
+	// machine will do with a packet, not what this process believes it asked for.
+	for _, half := range egressHalves {
+		present, err := routeExists(half)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !present {
+			t.Errorf("%s is not in the table after claiming", half)
+		}
+	}
+	pinned := netip.PrefixFrom(endpoint.Addr(), 32)
+	if present, err := routeExists(pinned); err != nil {
+		t.Fatal(err)
+	} else if !present {
+		t.Error("the tunnel's own endpoint was not routed around the tunnel, so the outer " +
+			"packets would go into the tunnel they carry")
+	}
+
+	held, err := EgressHeld()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !held {
+		t.Error("EgressHeld says nothing is claimed while a claim is in place; " +
+			"meshp doctor would tell somebody their machine is fine")
+	}
+
+	if err := router.Release(); err != nil {
+		t.Fatalf("releasing: %v", err)
+	}
+	for _, half := range append(append([]netip.Prefix{}, egressHalves...), pinned) {
+		if present, err := routeExists(half); err != nil {
+			t.Fatal(err)
+		} else if present {
+			t.Errorf("%s is still in the table after releasing", half)
+		}
+	}
+}

--- a/internal/wglink/egress_linux.go
+++ b/internal/wglink/egress_linux.go
@@ -2,6 +2,11 @@
 
 package wglink
 
+import (
+	"fmt"
+	"net/netip"
+)
+
 // Router claims and releases a full tunnel's routing. It satisfies tunnel.Egress.
 //
 // A type rather than the bare functions so the mark stays an implementation detail: the
@@ -18,7 +23,13 @@ func NewRouter() *Router { return &Router{} }
 //
 // The mark first. A rule that exempts marked traffic exempts nothing until something is
 // marking it, and in that gap the tunnel's own packets are routed into the tunnel.
-func (r *Router) Claim(iface string) error {
+//
+// The carve-out is ignored here, and that is the whole difference between this and the
+// macOS implementation. A mark exempts the tunnel's own packets whatever their destination,
+// so Linux does not need to be told which addresses those are — and enumerating them would
+// be worse than the mark, because an endpoint that roamed between passes would be routed
+// into the tunnel until the next one. The lock still needs them; the routing does not.
+func (r *Router) Claim(iface string, _ []netip.AddrPort, _ []netip.Prefix) error {
 	if err := SetEgressMark(iface, EgressMark); err != nil {
 		return err
 	}
@@ -30,3 +41,11 @@ func (r *Router) Release() error { return ReleaseDefaultRoute(EgressMark) }
 
 // EgressHeld reports whether a claim from a previous life is still in place.
 func EgressHeld() (bool, error) { return DefaultRouteClaimed(EgressMark) }
+
+// egressUndo removes the rule and the table this platform's claim installs.
+func egressUndo() []string {
+	return []string{
+		fmt.Sprintf("sudo ip rule del fwmark %#x", EgressMark),
+		fmt.Sprintf("sudo ip route flush table %d", EgressTable),
+	}
+}

--- a/internal/wglink/egress_other.go
+++ b/internal/wglink/egress_other.go
@@ -1,19 +1,25 @@
-//go:build !linux
+//go:build !linux && !darwin
 
 package wglink
 
-// Router is unavailable off Linux, where there is no policy routing to claim with.
+import "net/netip"
+
+// Router is unavailable here: no policy routing, and no way to claim a default route without
+// taking somebody else's.
 type Router struct{}
 
 // NewRouter returns nothing, so a device asked for a full tunnel reports the group
 // unhonoured rather than claiming one it cannot enforce.
 func NewRouter() *Router { return nil }
 
-// Claim is unsupported off Linux.
-func (r *Router) Claim(string) error { return ErrUnsupported }
+// Claim is unsupported here.
+func (r *Router) Claim(string, []netip.AddrPort, []netip.Prefix) error { return ErrUnsupported }
 
 // Release is unsupported off Linux.
 func (r *Router) Release() error { return ErrUnsupported }
 
 // EgressHeld is false everywhere but Linux, where nothing could have claimed one.
 func EgressHeld() (bool, error) { return false, nil }
+
+// egressUndo has nothing to undo: nothing here can claim a default route.
+func egressUndo() []string { return nil }

--- a/internal/wglink/routes_darwin.go
+++ b/internal/wglink/routes_darwin.go
@@ -4,6 +4,7 @@ package wglink
 
 import (
 	"fmt"
+	"net"
 	"net/netip"
 
 	"golang.org/x/net/route"
@@ -99,6 +100,13 @@ func addrOf(a route.Addr) netip.Addr {
 // Returns -1 for anything that is not a contiguous mask. A non-contiguous netmask is legal
 // in the routing socket's encoding and meaningless as a prefix length, so it is skipped
 // rather than rounded into something that would then be compared against a plan.
+//
+// net.IPMask.Size does both jobs and is used rather than counted by hand, which is how this
+// was written first and got wrong: the contiguity check rejected every mask whose length was
+// not a multiple of eight. A /24 passed and a /1 and a /12 did not, so Observe silently
+// dropped those routes and the reconciler could never withdraw one. Size returns a zero
+// length for a mask that is not contiguous, which is the same answer this needs and is
+// already correct.
 func maskBits(a route.Addr, want int) int {
 	var raw []byte
 	switch v := a.(type) {
@@ -113,27 +121,13 @@ func maskBits(a route.Addr, want int) int {
 		return -1
 	}
 
-	bits := 0
-	for i, b := range raw {
-		if b == 0xff {
-			bits += 8
-			continue
-		}
-		for mask := byte(0x80); mask != 0 && b&mask != 0; mask >>= 1 {
-			bits++
-		}
-		// Everything after the first non-full byte must be zero, or this is not a prefix.
-		for _, rest := range raw[i+1:] {
-			if rest != 0 {
-				return -1
-			}
-		}
-		if b&(b+1) != 0 {
-			return -1
-		}
-		break
+	ones, bits := net.IPMask(raw).Size()
+	if bits == 0 {
+		// Not contiguous. Size reports both as zero for those, and a zero length is
+		// otherwise a legitimate answer for a mask of all zeroes.
+		return -1
 	}
-	return bits
+	return ones
 }
 
 // isLocalRoute reports whether a route is the kernel's own entry for an interface address.


### PR DESCRIPTION
First half of #154. macOS had a tunnel and names and could not be given a full tunnel at all — `NewRouter()` returned nil, so `applyEgress` refused long before the question of failing closed came up.

## The fourth question, answered

#154 lists four things to answer first. This answers *"does the policy-routing half have an equivalent?"* — and the answer is that it does not need one.

Linux exempts the tunnel's own outer packets with a firewall mark and puts a default route in a table only unmarked traffic reaches. macOS has neither marks nor rules. So the claim is made the way wg-quick(8) makes it here: **`0.0.0.0/1` and `128.0.0.0/1`**, each one bit longer than a default and therefore winning on longest-prefix match *without the machine's real default being touched*.

That matters more than it looks. The real default is how the outer WireGuard packets leave; replacing it would mean putting it back afterwards from a copy taken while the network was in whatever state it was in. This way **there is nothing to put back** — releasing is deleting four routes meshp added and nothing else. Same "is there a real undo" test that decided macOS gets a DNS implementation in #153.

**`Egress.Claim` now takes the carve-out.** Without a mark there is nothing distinguishing the tunnel's own packets from the traffic it carries, so they have to be named. The reconciler already computed it and was passing it only to the lock. Linux ignores it, and says why: a mark exempts those packets wherever they go, and enumerating them would be *worse* — an endpoint that roamed between passes would be routed into the tunnel until the next one.

The gateway is read from the kernel on every claim rather than remembered, which is what lets this survive a laptop changing networks, and is why the minute reconcile matters more here than on Linux (#160).

## Two things this nearly broke

**`meshp doctor` would have printed Linux commands on a Mac.** It prints the exact commands to undo a claim by hand, hardcoded where they are printed. `EgressHeld()` starting to return true on macOS would have put `sudo ip rule del fwmark 0x6d657368` in front of somebody at a console on a Mac with no network — the precise failure #156 exists to fix, on a new platform, introduced by me. The commands now come from the platform that installed them, which is where the constants already lived and for the same stated reason.

**Two doctor tests asserted those literals**, so they passed only because CI ran them on Linux. They ask the platform now.

And that change made `cmd/meshp` name `runtime.GOOS` — which made `internal/platformcheck`, merged this morning, fail and demand `./cmd/meshp/` in the macOS job:

```
cmd/meshp decides something from the operating system and is not run by the macOS job
```

The guard caught its author, four hours old. Worth noting its detection is a **lower bound**: `cmd/meshp`'s tests were already platform-dependent *through* `wglink.EgressUndo()` before they named `GOOS` themselves, and nothing would have spotted that.

## Tests

Two run unprivileged and pass here — reading this Mac's real default gateway, and `EgressHeld` on a machine with no claim. Three need root and run in the macOS job.

The round-trip test **deliberately takes the machine's traffic**: between claim and release every packet with no more specific route goes into a utun with no peers. The window is as short as it can be made, nothing does network I/O inside it, and the release is registered before the claim so a failure between them still puts the routes back. On a CI runner the worst case is a job that fails loudly on a machine that is thrown away, which I think is a better trade than never exercising the one function the file exists for. There is a comment saying not to add anything to that test that talks to the network.

## Not in this half

Fail-closed egress via `pf` — questions one to three of #154, and the harder ones. A macOS device can be given a full tunnel where an administrator has said `fail_closed` is not required; a network that requires it still reports the group **unhonoured** rather than claiming the route and quietly not enforcing it, which is ADR-0011's rule and unchanged.