### PR TITLE
refactor(tunnel): the egress lock is its own collaborator

### DIFF
--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -130,6 +130,7 @@ func (a *agent) reconcilerFor(m agentstate.Membership, relay tunnel.Relay, choos
 	}, relay, a.filterOrNil(), log).
 		WithChooser(chooser).
 		WithEgress(routerOrNil()).
+		WithLock(a.lockOrNil()).
 		WithProber(proberOrNil()).
 		WithClaims(a.claims).
 		WithNames(a.zones).
@@ -248,6 +249,22 @@ func (a *agent) ensureFilter() *nftables.Filter {
 		}
 	})
 	return a.filter
+}
+
+// lockOrNil converts a possibly-absent lock into the interface.
+//
+// The same object as the filter on Linux, and the same trap: a nil *nftables.Filter assigned
+// straight to an interface is a non-nil interface holding a nil pointer, so the reconciler's
+// `r.lock == nil` check would pass and a host with no packet filter would report that it
+// fails closed.
+//
+// Its own function rather than reusing filterOrNil's result because the two stop being the
+// same thing on a platform that has one and not the other, which is what the split is for.
+func (a *agent) lockOrNil() tunnel.EgressLock {
+	if f := a.ensureFilter(); f != nil {
+		return f
+	}
+	return nil
 }
 
 // filterOrNil converts a possibly-absent filter into the interface.

--- a/internal/tunnel/egress.go
+++ b/internal/tunnel/egress.go
@@ -35,13 +35,13 @@ func (r *Reconciler) applyEgress(ctx context.Context, iface string, want bool, f
 			"hint", "a full tunnel needs policy routing, which this host does not have")
 		return []string{"egress"}
 	}
-	if failClosed && r.filter == nil {
+	if failClosed && r.lock == nil {
 		// Refused rather than downgraded. An administrator asking for fail-closed is asking
 		// for the property that traffic never leaves outside the tunnel, and a device that
 		// claimed the route while quietly declining to enforce it would report the property
 		// and not have it — which is the dishonesty ADR-0011 is written against.
 		r.log.Error("this network asks devices to fail closed and this host cannot",
-			"hint", "fail-closed egress needs a packet filter, and this host has none")
+			"hint", "fail-closed egress needs a way to refuse traffic, and this host has none")
 		return []string{"egress"}
 	}
 
@@ -64,7 +64,7 @@ func (r *Reconciler) applyEgress(ctx context.Context, iface string, want bool, f
 	}
 
 	if failClosed {
-		if err := r.filter.ApplyLock(ctx, iface, carve.Endpoints, carve.Prefixes, preventDNSLeaks); err != nil {
+		if err := r.lock.ApplyLock(ctx, iface, carve.Endpoints, carve.Prefixes, preventDNSLeaks); err != nil {
 			r.log.Error("cannot refuse egress outside the tunnel; not claiming a default route",
 				"error", logx.SafeError(err))
 			return []string{"egress"}
@@ -109,8 +109,8 @@ func (r *Reconciler) releaseEgress(ctx context.Context) {
 	// The lock comes off even when the routing did not, and its error is kept only if
 	// nothing else failed first. Leaving a lock behind because a route would not release is
 	// how a device ends up refusing everything with no explanation.
-	if r.filter != nil {
-		if err := r.filter.ApplyLock(ctx, "", nil, nil, false); err != nil && failed == nil {
+	if r.lock != nil {
+		if err := r.lock.ApplyLock(ctx, "", nil, nil, false); err != nil && failed == nil {
 			failed = err
 		}
 	}

--- a/internal/tunnel/egress_test.go
+++ b/internal/tunnel/egress_test.go
@@ -25,6 +25,10 @@ func withEgress(t *testing.T) (*Reconciler, *fakeFilter, *fakeEgress, *[]string)
 	m.ControlURL = "https://198.51.100.10:8443"
 	r := New(newFakeLink(), m, nil, filter, nil)
 	r.egress = router
+	// The same object as the filter, which is what a Linux host has. The split exists for
+	// the platform where they differ, and these tests are about the ordering between the
+	// lock and the route rather than about which object provides which.
+	r.lock = filter
 	return r, filter, router, order
 }
 
@@ -237,6 +241,7 @@ func TestPreventLeaksReachesTheLock(t *testing.T) {
 	m.ControlURL = "https://198.51.100.10:8443"
 	r := New(newFakeLink(), m, nil, filter, nil)
 	r.egress = router
+	r.lock = filter
 
 	state := peerset.New()
 	state.Apply(&meshpv1.StateDelta{
@@ -272,5 +277,66 @@ func TestLeakPreventionIsNotAssumed(t *testing.T) {
 	}
 	if filter.dnsLocked[0] {
 		t.Error("DNS was refused for a network that never asked for it")
+	}
+}
+
+// A host that can refuse traffic and cannot enforce a policy is a host that fails closed.
+//
+// The whole reason ApplyLock left Filter. macOS is about to be exactly this: it will have a
+// pf ruleset that can drop what does not go through the tunnel, and no implementation of
+// ACLs, forwarding or prefix mapping. Before the split it had to have both or neither, and
+// "neither" meant a laptop could not be given a full tunnel at all.
+//
+// What this asserts is that the two capabilities are now independent in the direction that
+// matters: the lock goes on, and nothing pretends a policy was enforced.
+func TestAHostWithALockAndNoFilterStillFailsClosed(t *testing.T) {
+	lock := &fakeFilter{}
+	router := &fakeEgress{}
+	m := membership()
+	m.ControlURL = "https://198.51.100.10:8443"
+
+	// No filter at all — the shape of a platform with no ACL implementation.
+	r := New(newFakeLink(), m, nil, nil, nil)
+	r.egress = router
+	r.lock = lock
+
+	if _, err := r.Apply(context.Background(), egressState(1)); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(lock.dnsLocked) == 0 {
+		t.Fatal("a host with a lock and no filter did not install one, so it cannot fail closed")
+	}
+	if len(router.events) == 0 {
+		t.Error("the route was never claimed, so the lock is refusing everything for nothing")
+	}
+}
+
+// And the converse: a host that can enforce a policy and cannot refuse traffic does not
+// claim the route when the network asks devices to fail closed.
+//
+// This held before the split too, through `r.filter == nil`. It is asserted here because the
+// split moved which field decides it, and getting that wrong would mean a device claiming a
+// default route while quietly declining to enforce the property it was claimed for — which
+// is the dishonesty ADR-0011 is written against.
+func TestAHostWithAFilterAndNoLockWillNotClaim(t *testing.T) {
+	filter := &fakeFilter{}
+	router := &fakeEgress{}
+	m := membership()
+	m.ControlURL = "https://198.51.100.10:8443"
+
+	r := New(newFakeLink(), m, nil, filter, nil)
+	r.egress = router
+	// No lock.
+
+	if _, err := r.Apply(context.Background(), egressState(1)); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(router.events) != 0 {
+		t.Errorf("a host that cannot fail closed claimed the default route anyway: %v", router.events)
+	}
+	if len(filter.dnsLocked) != 0 {
+		t.Error("something installed a lock through the filter, which is no longer its job")
 	}
 }

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -103,6 +103,10 @@ type Reconciler struct {
 	// about it (ADR-0007); what it must not do is accept a policy and ignore it.
 	filter Filter
 
+	// lock refuses egress outside the tunnel, or is nil where this host cannot. Separate
+	// from filter because a platform can have one and not the other — see EgressLock.
+	lock EgressLock
+
 	// lastFilter is what was last successfully loaded, kept so an unchanged policy is not
 	// reloaded on every reconcile. Reloading is atomic and cheap, but it resets the drop
 	// counters an operator is reading.
@@ -182,6 +186,25 @@ type Reconciler struct {
 	relayed map[string]bool
 }
 
+// EgressLock makes the host refuse traffic that does not go through the tunnel.
+//
+// Separate from Filter, which it was part of until macOS needed one without the other. They
+// are both "the packet filter" on Linux and one implementation satisfies both, but they
+// answer different questions and the reconciler has always treated them that way: a host
+// with no filter cannot enforce a *policy* and reports `filter` unapplied, while a host with
+// no lock cannot *fail closed* and reports `egress`. Those are separate capabilities with
+// separate consequences, and combining them meant a platform had to have both or neither.
+//
+// The alternative was a macOS implementation of Filter that did the lock and refused
+// everything else, which would have a device claim it can enforce a policy and then fail on
+// every one — the dishonesty ADR-0007 and ADR-0011 are written against.
+type EgressLock interface {
+	// ApplyLock makes the host refuse egress that does not go through the tunnel. An empty
+	// interface name removes it, which is the only way it comes off: these rules are system
+	// state and outlive the process on purpose (ADR-0011).
+	ApplyLock(ctx context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix, preventDNSLeaks bool) error
+}
+
 // Filter enforces a packet filter on this host.
 //
 // An interface so the reconciler can be tested without root, and so a platform with no
@@ -195,11 +218,6 @@ type Filter interface {
 	// list means stop: a device that has been withdrawn must not go on being a gateway
 	// nobody knows about.
 	ApplyForward(ctx context.Context, iface string, groups []*meshpv1.AdvertisedRoutes_Group) error
-
-	// ApplyLock makes the host refuse egress that does not go through the tunnel. An empty
-	// interface name removes it, which is the only way it comes off: these rules are system
-	// state and outlive the process on purpose (ADR-0011).
-	ApplyLock(ctx context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix, preventDNSLeaks bool) error
 
 	// ApplyMap makes this host reach colliding prefixes at the ranges allocated for them.
 	// An empty map means nothing collides and must remove whatever was installed before,
@@ -274,6 +292,16 @@ func (r *Reconciler) WithClaims(c *Claims) *Reconciler {
 //
 // Nil is meaningful and is the ordinary case: most devices are not full-tunnel, and a host
 // that cannot claim one reports the group unhonoured rather than half-claiming it.
+// WithLock lets this reconciler make the host refuse traffic that leaves outside the tunnel.
+//
+// Nil means it cannot, and a network asking devices to fail closed is reported unhonoured
+// rather than claimed and not enforced (ADR-0011). On Linux this is the same object as the
+// filter; on a platform that has one and not the other it is not.
+func (r *Reconciler) WithLock(l EgressLock) *Reconciler {
+	r.lock = l
+	return r
+}
+
 func (r *Reconciler) WithEgress(e Egress) *Reconciler {
 	r.egress = e
 	return r


### PR DESCRIPTION
Preparation for the second half of #154, and worth reviewing on its own because it is a decision rather than a translation. No `pf` code here.

## What the grouping was costing

`ApplyLock` was one of five methods on `tunnel.Filter`. The other four are ACLs, route-group forwarding, prefix mapping, and asking the host what else drops forwarded packets. On Linux one `nftables` implementation provides all five and the grouping cost nothing.

macOS is about to have a `pf` ruleset that can refuse what does not go through the tunnel, and no implementation of ACLs, forwarding or mapping. With one interface there were two ways to express that and both are bad:

- a `Filter` that implements `ApplyLock` and refuses the other four — a device that claims it can enforce a policy and then fails every one, which is what ADR-0007 and ADR-0011 are written against;
- no lock at all, which is where macOS is today: it cannot be given a full tunnel on any network that asks devices to fail closed.

## The reasoning was already split

The reconciler has always treated these as separate capabilities with separate consequences:

| missing | consequence | reported as |
| --- | --- | --- |
| filter | a policy cannot be enforced | `filter` |
| lock | the device cannot fail closed | `egress` |

Different nil checks, different messages, different unapplied components. The *interface* was combined; the reasoning never was. This makes the types agree with what the code already believed.

## The change

`Filter` loses `ApplyLock`; `EgressLock` gains it; `WithLock` joins `WithEgress` and the others. `cmd/meshpd` passes the same `*nftables.Filter` to both — through its own `lockOrNil` rather than reusing `filterOrNil`'s result, because the two stop being the same object on the platform this is for, and because a nil `*nftables.Filter` in a non-nil interface is a trap this file already has two comments about.

## Tests

Two new ones assert the halves are independent in both directions:

- a host with a lock and no filter **still fails closed** — the shape macOS is about to be;
- a host with a filter and no lock **does not claim the route**, which held before through `r.filter == nil` and is asserted now because the split moved which field decides it. Getting that wrong means a device claiming a default route while quietly declining to enforce the property it was claimed for.

Both mutations caught. The first is the satisfying one: reaching the lock through the filter is now a **compile error** rather than a test failure.

```
internal/tunnel/egress.go:67:22: r.filter.ApplyLock undefined (type Filter has no field or method ApplyLock)
```

## What this does not change

Nothing about behaviour on Linux, where one object satisfies both interfaces and is passed to both. No new capability on any platform — macOS still has no lock, and a network asking devices to fail closed still reports the group unhonoured there. That is the next PR.