### PR TITLE
feat(dataplane): macOS refuses egress that does not go through the tunnel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -590,10 +590,14 @@ jobs:
       # run in CI. They need root, so the unprivileged test job skips them, and this job did
       # not name the package. They gated nothing. Adding it also gates the mapping tests,
       # which are the only place two customers on 192.168.1.0/24 are proven distinguishable.
-      - name: interfaces, routes, teardown, a packet across the tunnel, a bound probe, the host resolver, and two customers on one prefix
+      # egresslock is here so its one real assertion has somewhere to run on this platform:
+      # it checks that the command `meshp doctor` tells a stranded person to type names a
+      # program this machine actually has, and every other Linux job would skip it for want
+      # of nftables.
+      - name: interfaces, routes, teardown, a packet across the tunnel, a bound probe, the host resolver, two customers on one prefix, and an undo that names a real program
         run: |
           set -o pipefail
-          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/pathprobe/ ./internal/resolved/ ./internal/nftables/ -count=1 -v 2>&1 | tee dataplane.log
+          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/pathprobe/ ./internal/resolved/ ./internal/nftables/ ./internal/egresslock/ -count=1 -v 2>&1 | tee dataplane.log
         continue-on-error: false
 
       - name: report, and refuse a silent skip
@@ -658,15 +662,23 @@ jobs:
       # platform, starts being required — and fails if this line falls behind. That test
       # exists because a list plus a comment asking the next person to keep it in step is
       # how #156 came to be reported as passing while breaking a test on macOS.
+      #
+      # internal/pf carries one test that is not about meshp's code at all.
+      # TestTheAnchorPointADR0026DependsOnIsStillThere asks this runner's macOS whether its
+      # main pf ruleset still evaluates anchors nested under com.apple. Fail-closed egress on
+      # this platform depends on that arrangement, and ADR-0026 accepts the risk that a
+      # release changes it. If that test fails, macOS has changed and meshp cannot fail
+      # closed here until somebody looks — it is not a flake and it is not the test being
+      # wrong.
       - name: unprivileged — a refused write is an error, and scutil still exits zero
         run: |
           set -o pipefail
-          go test ./internal/wglink/ ./internal/resolved/ ./internal/version/ ./internal/nftables/ ./internal/pathprobe/ ./cmd/meshp/ -count=1 -v 2>&1 | tee macos-user.log
+          go test ./internal/wglink/ ./internal/resolved/ ./internal/version/ ./internal/nftables/ ./internal/pf/ ./internal/egresslock/ ./internal/pathprobe/ ./cmd/meshp/ -count=1 -v 2>&1 | tee macos-user.log
 
       - name: as root — a utun comes up and is observed back, and macOS sends mesh names to meshp
         run: |
           set -o pipefail
-          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/resolved/ ./internal/version/ ./internal/nftables/ ./internal/pathprobe/ ./cmd/meshp/ -count=1 -v 2>&1 | tee macos-root.log
+          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/resolved/ ./internal/version/ ./internal/nftables/ ./internal/pf/ ./internal/egresslock/ ./internal/pathprobe/ ./cmd/meshp/ -count=1 -v 2>&1 | tee macos-root.log
 
       # A test that skipped in both runs never ran anywhere, which reports success while
       # testing nothing. Checked by name rather than by counting skips, because each run is

--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ name layer resolves to the mapped address (ADR-0020), so a technician reaches bo
 than reaching whichever membership was written last.
 
 What does not, and matters: direct paths are unimplemented, so everything is relayed. The
-data plane is complete on Linux and nearly so on macOS — **a tunnel, names that resolve and
-a full-tunnel default route; what macOS still cannot do is fail closed on egress**, so a
-network requiring it reports the group unhonoured there rather than half-applying it.
+data plane is complete on Linux and on macOS — **a tunnel, names that resolve, a full-tunnel
+default route and fail-closed egress**, the last of these through a pf anchor rather than
+nftables (ADR-0026). What macOS still cannot do is enforce a network's packet filter, so a
+network with a policy reports the group unhonoured there rather than half-applying it.
 Windows and the mobile platforms enrol, hold an address, and report honestly that they have
 no tunnel and cannot filter.
 

--- a/cmd/meshp/doctor.go
+++ b/cmd/meshp/doctor.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/meshpnet/meshp/internal/agentapi"
-	"github.com/meshpnet/meshp/internal/nftables"
+	"github.com/meshpnet/meshp/internal/egresslock"
 	"github.com/meshpnet/meshp/internal/wglink"
 )
 
@@ -38,7 +38,7 @@ func cmdDoctor(ctx context.Context, args []string) error {
 	// The kernel first, and deliberately before the daemon. What is refusing this machine's
 	// traffic is in the kernel whether or not anything is running, and the case that brought
 	// someone here is usually the one where nothing is.
-	f.locked = nftables.LockHeld(ctx)
+	f.locked = egresslock.Held(ctx)
 	f.claimed, _ = wglink.EgressHeld()
 
 	// A short timeout: an unresponsive daemon should not make the one command that explains
@@ -101,7 +101,12 @@ func report(f findings, socket string) {
 		fmt.Println("If meshpd will not start, undo it by hand:")
 		fmt.Println()
 		if f.locked {
-			fmt.Printf("    sudo nft delete table inet %s\n", nftables.LockTableName)
+			// From the platform that installed it, for the reason the routing half below
+			// gives. Until macOS grew a lock of its own this said `nft delete table` on
+			// every operating system, which is the #156 mistake with a different command.
+			for _, command := range egresslock.Undo() {
+				fmt.Printf("    %s\n", command)
+			}
 		}
 		if f.claimed {
 			// From the platform that made the claim, not written here. A command for the

--- a/cmd/meshp/doctor_test.go
+++ b/cmd/meshp/doctor_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/meshpnet/meshp/internal/nftables"
+	"github.com/meshpnet/meshp/internal/egresslock"
 	"github.com/meshpnet/meshp/internal/wglink"
 )
 
@@ -38,13 +38,23 @@ func capture(t *testing.T, f findings) string {
 func TestAStrandedMachineIsToldHowToFixItByHand(t *testing.T) {
 	out := capture(t, findings{locked: true, claimed: true})
 
-	for _, want := range []struct{ text, why string }{
-		{"nft delete table inet " + nftables.LockTableName,
-			"the exact command, because there is no way to search for it"},
-		{"systemctl start meshpd", "the thing to try first, which fixes it without root surgery"},
-	} {
-		if !strings.Contains(out, want.text) {
-			t.Errorf("missing %q\n  needed because: %s\n\n%s", want.text, want.why, out)
+	if !strings.Contains(out, "systemctl start meshpd") {
+		t.Errorf("missing %q\n  needed because: it is the thing to try first, which fixes "+
+			"it without root surgery\n\n%s", "systemctl start meshpd", out)
+	}
+
+	// The firewall half, asked of the platform that would have installed it. This used to
+	// assert the nftables command as a literal and passed on macOS only because macOS had no
+	// lock to print — the moment it grew one, the literal would have been a test asserting
+	// that a Mac is told to run `nft`.
+	lock := egresslock.Undo()
+	if len(lock) == 0 {
+		t.Fatal("this platform can refuse egress and offers no way to undo it by hand")
+	}
+	for _, command := range lock {
+		if !strings.Contains(out, command) {
+			t.Errorf("missing %q\n  needed because: it is the exact command, and there is "+
+				"no way to search for it\n\n%s", command, out)
 		}
 	}
 
@@ -73,13 +83,17 @@ func TestAStrandedMachineIsToldHowToFixItByHand(t *testing.T) {
 // there teaches them the output is guesswork, and the next instruction gets ignored too.
 func TestOnlyTheRelevantUndoIsOffered(t *testing.T) {
 	lockOnly := capture(t, findings{locked: true})
-	if strings.Contains(lockOnly, "ip rule del") {
-		t.Errorf("offered to remove routing rules that are not installed:\n%s", lockOnly)
+	for _, command := range wglink.EgressUndo() {
+		if strings.Contains(lockOnly, command) {
+			t.Errorf("offered to undo routing that is not claimed: %q\n%s", command, lockOnly)
+		}
 	}
 
 	routeOnly := capture(t, findings{claimed: true})
-	if strings.Contains(routeOnly, "nft delete table") {
-		t.Errorf("offered to remove a firewall table that is not installed:\n%s", routeOnly)
+	for _, command := range egresslock.Undo() {
+		if strings.Contains(routeOnly, command) {
+			t.Errorf("offered to remove a lock that is not installed: %q\n%s", command, routeOnly)
+		}
 	}
 }
 
@@ -93,8 +107,11 @@ func TestAWorkingFullTunnelIsNotAFault(t *testing.T) {
 	}
 
 	out := capture(t, f)
-	if strings.Contains(out, "nft delete table") {
-		t.Errorf("a healthy machine was told to tear down its own protection:\n%s", out)
+	for _, command := range egresslock.Undo() {
+		if strings.Contains(out, command) {
+			t.Errorf("a healthy machine was told to tear down its own protection: %q\n%s",
+				command, out)
+		}
 	}
 	if !strings.Contains(out, "on purpose") {
 		t.Errorf("the output does not explain that the refusal is deliberate:\n%s", out)
@@ -119,8 +136,10 @@ func TestAnIdleMachineSaysMeshpIsNotTheCause(t *testing.T) {
 	if !strings.Contains(out, "not blocking anything") {
 		t.Errorf("a machine meshp is not touching was not told so:\n%s", out)
 	}
-	if strings.Contains(out, "nft delete") {
-		t.Errorf("offered surgery on a machine with nothing installed:\n%s", out)
+	for _, command := range egresslock.Undo() {
+		if strings.Contains(out, command) {
+			t.Errorf("offered surgery on a machine with nothing installed: %q\n%s", command, out)
+		}
 	}
 }
 

--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/meshpnet/meshp/internal/agentstate"
 	"github.com/meshpnet/meshp/internal/controlurl"
 	"github.com/meshpnet/meshp/internal/dns"
+	"github.com/meshpnet/meshp/internal/egresslock"
 	"github.com/meshpnet/meshp/internal/enrollclient"
 	"github.com/meshpnet/meshp/internal/keys"
 	"github.com/meshpnet/meshp/internal/nftables"
@@ -64,6 +66,13 @@ type agent struct {
 	// apply (ADR-0007).
 	filterOnce sync.Once
 	filter     *nftables.Filter
+
+	// lock refuses egress outside the tunnel, opened once and shared. Its own field rather
+	// than the filter's, because since #167 they are separate capabilities and macOS has
+	// this one without the other: nftables enforces both on Linux, and on macOS the filter
+	// is nil while pf holds the lock (ADR-0026).
+	lockOnce sync.Once
+	lock     egresslock.Lock
 
 	// claims is what every membership on this device says it carries, shared so that two
 	// networks asking for the same customer prefix can each see the other. One device can
@@ -130,7 +139,7 @@ func (a *agent) reconcilerFor(m agentstate.Membership, relay tunnel.Relay, choos
 	}, relay, a.filterOrNil(), log).
 		WithChooser(chooser).
 		WithEgress(routerOrNil()).
-		WithLock(a.lockOrNil()).
+		WithLock(a.ensureLock()).
 		WithProber(proberOrNil()).
 		WithClaims(a.claims).
 		WithNames(a.zones).
@@ -214,21 +223,21 @@ func (a *agent) reclaimEgressLock() {
 		}
 	}
 
-	filter := a.ensureFilter()
-	if filter == nil || !nftables.LockHeld(a.ctx) {
+	lock := a.ensureLock()
+	if lock == nil || !egresslock.Held(a.ctx) {
 		return
 	}
 
 	a.log.Warn("found a fail-closed lock from a previous run; this device had no egress",
-		"table", nftables.LockTableName,
 		"cause", "meshpd exited or was killed while a default route was claimed")
-	if err := filter.ApplyLock(a.ctx, "", nil, nil, false); err != nil {
+	if err := lock.ApplyLock(a.ctx, "", nil, nil, false); err != nil {
 		// The worst outcome this project has: a machine with no network and no obvious
 		// cause. Say what it is and how to undo it by hand, because whoever reads this is
-		// at a console on a host that cannot reach anything.
+		// at a console on a host that cannot reach anything — and from the platform that
+		// installed it, because a command for the wrong operating system is worse than none.
 		a.log.Error("could not remove it; this device still has no egress",
 			"error", err,
-			"fix", "run: nft delete table inet "+nftables.LockTableName)
+			"fix", strings.Join(egresslock.Undo(), " && "))
 		return
 	}
 	a.log.Info("removed it; egress is restored")
@@ -251,20 +260,27 @@ func (a *agent) ensureFilter() *nftables.Filter {
 	return a.filter
 }
 
-// lockOrNil converts a possibly-absent lock into the interface.
+// ensureLock opens the host's fail-closed lock, once.
 //
-// The same object as the filter on Linux, and the same trap: a nil *nftables.Filter assigned
-// straight to an interface is a non-nil interface holding a nil pointer, so the reconciler's
-// `r.lock == nil` check would pass and a host with no packet filter would report that it
-// fails closed.
+// Asked of internal/egresslock rather than assembled here, because the answer is different
+// on every platform and this file is not platform code: on Linux the lock is the nftables
+// filter, on macOS it is a pf anchor and there is no filter at all. The nil-interface trap
+// is handled there — a nil concrete pointer put into an interface is a non-nil interface, so
+// the reconciler's `r.lock == nil` check would pass and a host with no way to refuse egress
+// would report that it fails closed.
 //
-// Its own function rather than reusing filterOrNil's result because the two stop being the
-// same thing on a platform that has one and not the other, which is what the split is for.
-func (a *agent) lockOrNil() tunnel.EgressLock {
-	if f := a.ensureFilter(); f != nil {
-		return f
-	}
-	return nil
+// Lazily, because it needs privileges to answer honestly and a daemon that refused to start
+// without them could not report why it has no lock.
+func (a *agent) ensureLock() egresslock.Lock {
+	a.lockOnce.Do(func() {
+		a.lock = egresslock.New(a.ctx)
+		if a.lock == nil {
+			a.log.Warn("this host cannot refuse egress outside the tunnel",
+				"os", runtime.GOOS,
+				"note", "networks that require fail-closed egress will report this device as unconverged")
+		}
+	})
+	return a.lock
 }
 
 // filterOrNil converts a possibly-absent filter into the interface.

--- a/cmd/meshpd/pause.go
+++ b/cmd/meshpd/pause.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"context"
+	"strings"
 
 	"github.com/meshpnet/meshp/internal/agentapi"
 	"github.com/meshpnet/meshp/internal/agentstate"
-	"github.com/meshpnet/meshp/internal/nftables"
+	"github.com/meshpnet/meshp/internal/egresslock"
 	"github.com/meshpnet/meshp/internal/wglink"
 )
 
@@ -93,15 +94,16 @@ func (a *agent) releaseEgress() {
 		}
 	}
 
-	filter := a.ensureFilter()
-	if filter == nil || !nftables.LockHeld(a.ctx) {
+	lock := a.ensureLock()
+	if lock == nil || !egresslock.Held(a.ctx) {
 		return
 	}
-	if err := filter.ApplyLock(a.ctx, "", nil, nil, false); err != nil {
+	if err := lock.ApplyLock(a.ctx, "", nil, nil, false); err != nil {
 		// The worst outcome this project has: a machine with no network and no obvious
-		// cause. Whoever reads this is at a console on a host that cannot reach anything.
+		// cause. Whoever reads this is at a console on a host that cannot reach anything,
+		// so the command comes from the platform that installed the lock.
 		a.log.Error("could not remove the fail-closed lock; this device still has no egress",
-			"error", err, "fix", "run: nft delete table inet "+nftables.LockTableName)
+			"error", err, "fix", strings.Join(egresslock.Undo(), " && "))
 	}
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,9 +31,9 @@ Two worth starting with:
   tunnel drops, and why that is worth the support tickets.
 
 And the honest one: the [status section of the README](../README.md#status) says what does
-not work. The data plane is complete on Linux and nearly so on macOS — a tunnel, working
-names and a full-tunnel route, but no fail-closed egress — and absent elsewhere; nothing
-discovers direct paths yet.
+not work. The data plane is complete on Linux and on macOS — a tunnel, working names, a
+full-tunnel route and fail-closed egress, though macOS still cannot enforce a network's
+packet filter — and absent elsewhere; nothing discovers direct paths yet.
 If you need something that works this afternoon, the README names three projects that will
 serve you better today.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -42,8 +42,10 @@ recovery is to tell the control plane to stop, not to reach for a console.
 
 ### Recovering one machine
 
-`meshp doctor` prints the commands. They remove what meshp installed and nothing else — the
-lock lives in its own nftables table so it can be found and removed on its own, by `meshp
+`meshp doctor` prints the commands, and it prints the ones for the machine it is running on:
+the lock is an nftables table on Linux and a pf anchor on macOS, and a command for the wrong
+operating system is worse than none to somebody at a console with no network. Either way it
+is meshp's own and nothing else's, so it can be found and removed on its own — by `meshp
 down`, by the agent finding it on start-up, or by a person with a console and no idea what
 meshp is.
 
@@ -86,13 +88,28 @@ the way wg-quick(8) makes it on this platform: `0.0.0.0/1` and `128.0.0.0/1`, wh
 default route without replacing it, plus explicit routes keeping the control plane and the
 relays off the tunnel they carry.
 
-What macOS still does not have is **fail-closed egress**. A network whose policy says
-`fail_closed` is true reports the group unhonoured rather than claiming the route and
-quietly not enforcing it, so a macOS device can be given a full tunnel only where an
-administrator has said fail-closed is not required — and `meshp status` says so.
+macOS fails closed too, through `pf` rather than nftables. The rules go in an anchor called
+`com.apple/meshp`, which looks impolite and is deliberate: the `/etc/pf.conf` macOS ships
+references exactly one anchor point, and an anchor of meshp's own would be loaded and never
+evaluated (ADR-0026). meshp never writes that file. It also does not turn the packet filter
+on and off outright — pf is enabled with a reference count, so meshp taking a reference
+cannot switch it off underneath the application firewall or another VPN.
+
+Before it trusts the lock, the agent checks that the main ruleset still evaluates what is
+nested under Apple's anchor. If a macOS release ever changes that arrangement, the device
+reports that it cannot fail closed rather than reporting a lock that is loaded and being
+ignored. So a macOS upgrade that turns fail-closed networks into unhonoured route groups is
+worth reporting; a silent leak is what the check is there to make impossible.
+
+To see the lock:
+
+```bash
+sudo pfctl -a com.apple/meshp -s rules -v
+```
 
 If a macOS machine has lost its network and you suspect meshp, `sudo meshp doctor` prints
-the exact `route -n delete` commands to give it back. Those two routes are what a claim is.
+the exact commands to give it back: `sudo pfctl -a com.apple/meshp -F rules` for the lock,
+and the `route -n delete` commands for the routing. Those two routes are what a claim is.
 
 On Linux, check that the kernel can make WireGuard interfaces at all:
 

--- a/internal/egresslock/egresslock.go
+++ b/internal/egresslock/egresslock.go
@@ -1,0 +1,32 @@
+// Package egresslock finds this host's way of refusing egress that does not go through the
+// tunnel.
+//
+// One question — "can this machine fail closed, and how does a person undo it by hand" —
+// asked in one place, because the answer is different on every platform and the callers
+// asking it are not platform code. Before this package, `cmd/meshpd` and `meshp doctor` both
+// reached for internal/nftables directly, which was true while Linux was the only data
+// plane and became a bug the moment macOS grew a lock of its own: a device would be told to
+// run `nft delete table` on a machine that has never had nftables.
+//
+// That failure has a name in this repository. #156 is `meshp doctor` recommending
+// `systemctl` where there is no systemd, for the same reason — the command was written where
+// it was printed rather than where it was decided. wglink.EgressUndo answers the routing
+// half of exactly this question, and this is the filtering half.
+package egresslock
+
+import (
+	"context"
+	"net/netip"
+)
+
+// Lock is what a host that can refuse egress provides.
+//
+// Declared here rather than imported from internal/tunnel so this package does not depend on
+// the reconciler to describe a firewall. It is deliberately the same method set as
+// tunnel.EgressLock, so what New returns satisfies it without any conversion.
+type Lock interface {
+	// ApplyLock makes the host refuse egress that does not go through the tunnel. An empty
+	// interface name removes it, which is the only way it comes off: these rules are system
+	// state and outlive the process on purpose (ADR-0011).
+	ApplyLock(ctx context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix, preventDNSLeaks bool) error
+}

--- a/internal/egresslock/egresslock_darwin.go
+++ b/internal/egresslock/egresslock_darwin.go
@@ -1,0 +1,34 @@
+//go:build darwin
+
+package egresslock
+
+import (
+	"context"
+
+	"github.com/meshpnet/meshp/internal/pf"
+)
+
+// New returns this host's lock, or nil where it has none — which on macOS includes an agent
+// without the privilege to read the packet filter, and a macOS whose anchor arrangement has
+// moved out from under ADR-0026.
+//
+// Nil returned explicitly for the reason the Linux file gives: a nil *pf.Lock assigned
+// straight to an interface is a non-nil interface holding a nil pointer.
+func New(ctx context.Context) Lock {
+	if l := pf.New(ctx); l != nil {
+		return l
+	}
+	return nil
+}
+
+// Held reports whether a lock left by any process is currently installed.
+func Held(ctx context.Context) bool { return pf.Held(ctx) }
+
+// Undo is the exact commands that take the lock off by hand.
+//
+// Flushing the anchor is the whole of it. meshp's reference on pf being enabled is not
+// released here and does not need to be: pf running with no meshp rules in it refuses
+// nothing, and the count is cleared by a reboot in any case.
+func Undo() []string {
+	return []string{"sudo pfctl -a " + pf.AnchorName + " -F rules"}
+}

--- a/internal/egresslock/egresslock_linux.go
+++ b/internal/egresslock/egresslock_linux.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package egresslock
+
+import (
+	"context"
+
+	"github.com/meshpnet/meshp/internal/nftables"
+)
+
+// New returns this host's lock, or nil where it has none.
+//
+// Nil returned explicitly rather than by handing back a possibly-nil pointer, and this is
+// the trap the whole file exists to avoid: a nil *nftables.Filter assigned straight to an
+// interface is a non-nil interface holding a nil pointer, so every downstream `== nil` check
+// passes and a host with no packet filter reports that it fails closed.
+func New(ctx context.Context) Lock {
+	if f := nftables.New(ctx); f != nil {
+		return f
+	}
+	return nil
+}
+
+// Held reports whether a lock left by any process is currently installed.
+func Held(ctx context.Context) bool { return nftables.LockHeld(ctx) }
+
+// Undo is the exact commands that take the lock off by hand.
+//
+// Here rather than in `meshp doctor` for the reason wglink.EgressUndo is where it is: the
+// person reading that output is at a console on a machine with no network, and a command for
+// the wrong operating system is worse than none.
+func Undo() []string {
+	return []string{"sudo nft delete table inet " + nftables.LockTableName}
+}

--- a/internal/egresslock/egresslock_other.go
+++ b/internal/egresslock/egresslock_other.go
@@ -1,0 +1,16 @@
+//go:build !linux && !darwin
+
+package egresslock
+
+import "context"
+
+// New returns nothing here: this platform has no way to refuse egress, so a device asked to
+// fail closed reports the group unhonoured rather than claiming a property it does not have.
+func New(context.Context) Lock { return nil }
+
+// Held is false where nothing could have installed a lock to begin with.
+func Held(context.Context) bool { return false }
+
+// Undo has nothing to undo, and says so by returning nothing rather than a command from
+// another operating system.
+func Undo() []string { return nil }

--- a/internal/egresslock/egresslock_test.go
+++ b/internal/egresslock/egresslock_test.go
@@ -1,0 +1,77 @@
+package egresslock
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/meshpnet/meshp/internal/tunnel"
+)
+
+// What this package returns is what the reconciler holds.
+//
+// A compile-time check written as a test, because the thing it guards is a signature: the
+// lock is its own interface as of #167, and a change to it that this package did not follow
+// would otherwise surface as a build failure in cmd/meshpd rather than here.
+func TestWhatThisReturnsIsTheLockTheReconcilerWants(t *testing.T) {
+	var _ tunnel.EgressLock = New(t.Context())
+}
+
+// A platform that can refuse egress can say how to stop refusing.
+//
+// The two have to arrive together. ADR-0011 keeps the lock installed across a crash on
+// purpose, so the only thing between a killed daemon and a machine somebody has to physically
+// recover is the command `meshp doctor` prints — and a platform that grew a lock without
+// growing an undo would print nothing at all in exactly that situation.
+func TestAPlatformThatCanLockSaysHowToStop(t *testing.T) {
+	commands := Undo()
+
+	switch runtime.GOOS {
+	case "linux", "darwin":
+		if len(commands) == 0 {
+			t.Fatal("this platform has a lock and offers no way to take it off by hand")
+		}
+	default:
+		if len(commands) != 0 {
+			t.Fatalf("this platform has no lock and offers commands anyway: %v", commands)
+		}
+		return
+	}
+
+	for _, command := range commands {
+		if strings.Contains(command, "%!") {
+			t.Errorf("%q has a formatting error in it", command)
+		}
+		if !strings.HasPrefix(command, "sudo ") {
+			t.Errorf("%q is printed to somebody at a console and does not ask for root", command)
+		}
+	}
+}
+
+// And the command names something this machine has.
+//
+// The failure this catches is #156's, in the half of `meshp doctor` that #156 does not
+// touch: until macOS grew a lock, both the daemon and the doctor printed `nft delete table`
+// on every platform, so a Mac was told to run a program it has never had. A command for the
+// wrong operating system is worse than none — whoever reads it is at a console on a machine
+// with no network and cannot look anything up.
+func TestTheUndoNamesAProgramThisMachineHas(t *testing.T) {
+	for _, command := range Undo() {
+		fields := strings.Fields(strings.TrimPrefix(command, "sudo "))
+		if len(fields) == 0 {
+			t.Errorf("%q names no program", command)
+			continue
+		}
+		if _, err := exec.LookPath(fields[0]); err != nil {
+			if runtime.GOOS == "darwin" {
+				// pfctl is part of macOS. Not finding it means this is printing somebody
+				// else's command.
+				t.Errorf("%q names %q, which this macOS does not have", command, fields[0])
+				continue
+			}
+			t.Skipf("%q is not installed here, so this machine cannot check its own advice; "+
+				"the data plane job has it", fields[0])
+		}
+	}
+}

--- a/internal/pf/parse.go
+++ b/internal/pf/parse.go
@@ -1,0 +1,75 @@
+package pf
+
+import (
+	"regexp"
+	"strings"
+)
+
+// tokenPattern finds the reference `pfctl -E` hands back.
+//
+// pfctl prints "Token : 1234567890" on a line of its own, alongside other chatter that
+// differs between a first enable and a redundant one. Matched rather than parsed positionally
+// for that reason.
+var tokenPattern = regexp.MustCompile(`(?m)^\s*Token\s*:\s*(\d+)\s*$`)
+
+// tokenIn reads the reference out of what `pfctl -E` printed, or returns "" when there is
+// none to read.
+func tokenIn(output string) string {
+	if match := tokenPattern.FindStringSubmatch(output); match != nil {
+		return match[1]
+	}
+	return ""
+}
+
+// anchorPointIn reports whether a printed ruleset still evaluates what is nested under
+// Apple's anchor.
+//
+// This is the check ADR-0026 turns on, so it is worth being exact about what it accepts and
+// why. Two kinds of near-miss would let a device believe it fails closed when it does not,
+// and both are ordinary text a substring search would swallow:
+//
+//   - `nat-anchor "com.apple/*"`, and the scrub, rdr and dummynet anchors beside it in the
+//     shipped /etc/pf.conf. Those are anchor points for entirely different rulesets — address
+//     translation, normalisation — and none of them evaluates a filter rule. There are four
+//     of them in the file and only one `anchor` line, so a search for the quoted name finds
+//     the wrong thing four times out of five.
+//   - `anchor "com.apple"` without the wildcard, which loads Apple's own rules and evaluates
+//     nothing nested beneath them. meshp's anchor would be loaded, findable, and never
+//     reached.
+//
+// So the first field must be exactly `anchor` and the second exactly the wildcard name.
+// Fields rather than a whole-line match because pfctl prints a rule with the qualifiers it
+// was loaded with, and `anchor "com.apple/*" all` is the same anchor point.
+func anchorPointIn(rules string) bool {
+	for _, line := range strings.Split(rules, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "anchor" {
+			continue
+		}
+		if strings.Trim(fields[1], `"`) == anchorPoint {
+			return true
+		}
+	}
+	return false
+}
+
+// statusEnabledIn reports whether `pfctl -s info` says the packet filter is running.
+//
+// Asked rather than inferred from meshp holding a reference, because a reference is not the
+// same as pf being on. `pfctl -d` disables the filter outright and ignores the count, and a
+// token file could outlive the enable it names if /var/run were ever kept across a boot.
+// Either way the failure is the same and it is the bad one: rules loaded, pf off, and a
+// device reporting that it fails closed while everything leaves in the clear.
+//
+// pfctl puts the answer first on the line and other columns after it — "Status: Enabled for
+// 0 days 00:03:20    Debug: Urgent" — so the word immediately after the label is the whole
+// of it.
+func statusEnabledIn(info string) bool {
+	for _, line := range strings.Split(info, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "Status:" {
+			return fields[1] == "Enabled"
+		}
+	}
+	return false
+}

--- a/internal/pf/parse_test.go
+++ b/internal/pf/parse_test.go
@@ -1,0 +1,83 @@
+package pf
+
+import "testing"
+
+// The check ADR-0026 turns on, tested against the near-misses that would let it pass on a
+// machine where meshp's rules are loaded and never evaluated.
+//
+// Worth being blunt about the stakes: this returning true when it should not is a device
+// that reports it fails closed while every packet leaves in the clear. That is the one
+// failure the record says is worse than having no lock at all.
+func TestOnlyAFilterAnchorPointWithAWildcardCounts(t *testing.T) {
+	// What macOS ships. Four of the five lines name the same anchor, and only one of them
+	// evaluates a filter rule — so a substring search for the name finds the wrong thing
+	// four times out of five.
+	const shipped = `scrub-anchor "com.apple/*"
+nat-anchor "com.apple/*"
+rdr-anchor "com.apple/*"
+dummynet-anchor "com.apple/*"
+anchor "com.apple/*"
+load anchor "com.apple" from "/etc/pf.anchors/com.apple"`
+
+	for _, tc := range []struct {
+		name  string
+		rules string
+		want  bool
+	}{
+		{"what macOS ships", shipped, true},
+		{"as pfctl prints it back", `anchor "com.apple/*" all`, true},
+		{"unquoted, should pfctl ever print it that way", "anchor com.apple/* all", true},
+
+		{"translation anchors only", `nat-anchor "com.apple/*"
+rdr-anchor "com.apple/*"`, false},
+		{"no wildcard, so nothing nested is reached", `anchor "com.apple"`, false},
+		{"somebody else's namespace", `anchor "meshp/*"`, false},
+		{"a rule that merely mentions it", `block return out quick to any # com.apple/*`, false},
+		{"nothing at all", "", false},
+	} {
+		if got := anchorPointIn(tc.rules); got != tc.want {
+			t.Errorf("%s: anchorPointIn = %v, want %v\n%s", tc.name, got, tc.want, tc.rules)
+		}
+	}
+}
+
+// The reference on pf being enabled, which is what stops meshp turning the packet filter off
+// underneath the application firewall.
+func TestTheEnableTokenIsReadOutOfWhatPfctlPrints(t *testing.T) {
+	for _, tc := range []struct{ name, output, want string }{
+		{"a first enable", "pf enabled\nToken : 12285919162907929896\n", "12285919162907929896"},
+		{"pf was already on", "pfctl: pf already enabled\nToken : 4155744211\n", "4155744211"},
+		{"indented, as pfctl has been known to", "  Token : 17\n", "17"},
+		{"no token to read", "pf enabled\n", ""},
+		{"the word without the number", "Token : none\n", ""},
+		{"mentioned in prose rather than reported", "the Token : 5 was not printed alone", ""},
+	} {
+		if got := tokenIn(tc.output); got != tc.want {
+			t.Errorf("%s: tokenIn = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// Whether the packet filter is actually running, which is not the same question as whether
+// meshp holds a reference saying it should be.
+//
+// The wrong answer here in the optimistic direction is the failure ADR-0026 cares about:
+// rules loaded, pf off, and a device reporting that it fails closed.
+func TestPfIsOnlyRunningWhenPfctlSaysItIs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		info string
+		want bool
+	}{
+		{"running", "Status: Enabled for 0 days 00:03:20           Debug: Urgent", true},
+		{"not running", "Status: Disabled                              Debug: Urgent", false},
+		{"the word appears further down the report", `Status: Disabled
+State Table                          Total             Rate
+  Enabled                                0`, false},
+		{"nothing to read", "", false},
+	} {
+		if got := statusEnabledIn(tc.info); got != tc.want {
+			t.Errorf("%s: statusEnabledIn = %v, want %v\n%s", tc.name, got, tc.want, tc.info)
+		}
+	}
+}

--- a/internal/pf/pf.go
+++ b/internal/pf/pf.go
@@ -1,0 +1,50 @@
+// Package pf refuses egress that does not go through the tunnel, on macOS.
+//
+// The macOS half of ADR-0011, and the sibling of internal/nftables — same job, different
+// mechanism, and the difference is not only syntax. nftables gives meshp a table it owns
+// outright, which can be created and destroyed without reference to anything else on the
+// machine. pf has one main ruleset shared by everything, and rules live in *anchors* that
+// are evaluated only if that ruleset points at them.
+//
+// ADR-0026 settles where meshp's rules go, and every constant here is a finding from that
+// record rather than a preference: the anchor is nested under Apple's because the shipped
+// `/etc/pf.conf` references exactly one anchor point and a top-level anchor of meshp's own
+// is loaded and never evaluated. That was established on a real macOS, not reasoned about,
+// and the reasoning would have got it wrong.
+//
+// Two things follow that have no analogue on Linux.
+//
+// meshp does not own the switch. pf ships disabled and is turned on with a reference count
+// (`pfctl -E`), so several programs can each need it on and none can turn it off underneath
+// the others. This package takes a reference and gives it back, and holds the token on disk
+// so a killed daemon's reference can be released by the next one.
+//
+// The anchor point is verified before the lock is trusted. A future macOS that renamed it,
+// or dropped the wildcard, would leave meshp's rules loaded and never evaluated — a device
+// still reporting that it fails closed while everything leaks. The check turns that into
+// "this host cannot enforce", which is a state the rest of the system already knows how to
+// carry.
+package pf
+
+import "errors"
+
+// AnchorName is where meshp's rules live.
+//
+// Nested under `com.apple` because that is the only anchor point `/etc/pf.conf` references
+// (ADR-0026). Exported because `meshp doctor` prints the command that flushes it, and the
+// person reading that is at a console on a machine with no network.
+const AnchorName = "com.apple/meshp"
+
+// anchorPoint is what the main ruleset must contain for AnchorName to be evaluated.
+//
+// The wildcard is the whole of it. `anchor "com.apple"` without one loads Apple's own rules
+// and evaluates no nested anchor, so meshp's would sit there being ignored.
+const anchorPoint = "com.apple/*"
+
+// ErrUnsupported means this host cannot refuse egress outside the tunnel.
+//
+// A condition to report rather than a failure to retry, exactly as nftables.ErrUnsupported
+// is: a device that cannot fail closed is still a device, and the honest answer is to say so
+// and let the control plane decide whether to place it in a network that requires it
+// (ADR-0011).
+var ErrUnsupported = errors.New("pf: this platform cannot refuse egress outside the tunnel")

--- a/internal/pf/pfctl_darwin.go
+++ b/internal/pf/pfctl_darwin.go
@@ -1,0 +1,294 @@
+//go:build darwin
+
+package pf
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/logx"
+)
+
+// applyTimeout bounds one pfctl invocation.
+//
+// Loading an anchor is milliseconds of work. A bound exists because this runs on the
+// reconcile path: pfctl blocking forever — on a contended /dev/pf, or because something else
+// holds the ruleset — would stop the agent converging on anything else.
+const applyTimeout = 10 * time.Second
+
+// tokenPath is where the reference this package holds on pf being enabled is remembered.
+//
+// On disk rather than in memory because the thing it has to survive is this process dying.
+// `pfctl -E` increments a count in the kernel and `pfctl -X <token>` decrements it; a token
+// that only ever existed in a killed daemon's memory is a reference nothing can ever give
+// back, and pf stays enabled until the machine reboots.
+//
+// Under /var/run because a reference belongs with the running system rather than with the
+// agent's saved state — but nothing here relies on that directory being cleared at boot. A
+// token is only ever trusted alongside pf actually reporting itself enabled, so a file that
+// outlived the enable it names costs a redundant `pfctl -E` and not a silent fail-open.
+var tokenPath = filepath.Join("/var/run/meshp", "pf.token")
+
+// Lock refuses egress outside the tunnel through pf. It satisfies tunnel.EgressLock.
+type Lock struct{}
+
+// New returns a Lock, or nothing when this host cannot refuse egress.
+//
+// Nil rather than an error, and checked once at construction rather than on every apply, for
+// the reason nftables.New gives: the answer decides what the agent claims it can do, and a
+// capability that flapped between reconciles would be worse than one that is simply false.
+func New(ctx context.Context) *Lock {
+	if !Available(ctx) {
+		return nil
+	}
+	return &Lock{}
+}
+
+// Available reports whether this host can refuse egress outside the tunnel.
+//
+// Two questions, and the second is the one ADR-0026 is about. Finding pfctl is not enough —
+// meshp's rules go in an anchor nested under Apple's, and they are evaluated only while the
+// main ruleset still references that anchor point. A macOS that renamed it or dropped the
+// wildcard would leave the rules loaded and inert, and the device would go on reporting a
+// property it no longer has.
+//
+// Reading the ruleset also needs the same privilege that loading one does, so an agent
+// running without it answers false here rather than at apply time, where it would look like
+// a policy fault instead of a missing capability.
+func Available(ctx context.Context) bool {
+	if _, err := exec.LookPath("pfctl"); err != nil {
+		return false
+	}
+	return anchorPointPresent(ctx)
+}
+
+// Held reports whether a fail-closed lock is currently installed.
+//
+// Asked rather than assumed so that removing one can be reported as the event it is: an
+// agent that quietly ran a removal on every start would leave no trace of the case that
+// matters — a machine whose egress was being refused because a previous run died holding the
+// line.
+//
+// Stdout only. pfctl writes its warnings to stderr, and counting those as rules would report
+// a lock on every machine that has none.
+func Held(ctx context.Context) bool {
+	out, err := pfctlOutput(ctx, "-a", AnchorName, "-s", "rules")
+	return err == nil && strings.TrimSpace(out) != ""
+}
+
+// ApplyLock makes this device refuse egress that does not go through the tunnel, or stops it
+// refusing.
+//
+// An empty interface name removes the lock. That is the only way it comes off from here —
+// the rules are system state and outlive this process on purpose (ADR-0011), so nothing
+// about the agent exiting takes them away.
+func (l *Lock) ApplyLock(ctx context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix, preventDNSLeaks bool) error {
+	if iface == "" {
+		return remove(ctx)
+	}
+	script, err := RenderLock(LockSpec{
+		Interface: iface, Endpoints: endpoints, Excluded: excluded,
+		PreventDNSLeaks: preventDNSLeaks,
+	})
+	if err != nil {
+		return err
+	}
+	return install(ctx, script)
+}
+
+// install loads the lock and makes sure pf is running it.
+//
+// The order is the safety property. Rules are loaded before pf is enabled, so the moment the
+// filter turns on the lock is already in force; enabling first would leave a window with pf
+// running and nothing of meshp's in it, which is a device that believes it is protected and
+// is not.
+func install(ctx context.Context, script string) error {
+	// Every time, not once at construction. This is the check that turns a silent fail-open
+	// into a device saying it cannot enforce, and the thing it guards against — an operating
+	// system update rearranging its anchors — happens to a running machine.
+	if !anchorPointPresent(ctx) {
+		return fmt.Errorf("%w: the main ruleset has no %q anchor point, so rules loaded into %s would never be evaluated",
+			ErrUnsupported, anchorPoint, AnchorName)
+	}
+
+	wasHeld := Held(ctx)
+
+	if out, err := pfctlCombined(ctx, script, "-a", AnchorName, "-f", "-"); err != nil {
+		return fmt.Errorf("pf: loading the lock into %s: %w: %s",
+			AnchorName, err, logx.Safe(strings.TrimSpace(out)))
+	}
+
+	if err := enable(ctx); err != nil {
+		// The rules are loaded and pf is not running them, which is a device that is not
+		// failing closed while its anchor says it is. Reported so the caller refuses the
+		// default route rather than claiming one behind a lock that is not on.
+		return err
+	}
+
+	if !wasHeld {
+		flushStates(ctx)
+	}
+	return nil
+}
+
+// remove takes the lock off and gives back the reference on pf being enabled.
+//
+// Idempotent, and it has to be: the reconciler releases on every pass through a state that
+// does not want a lock, and `meshp down` releases whether or not one was ever installed.
+// Flushing an anchor that holds nothing is not an error.
+func remove(ctx context.Context) error {
+	if out, err := pfctlCombined(ctx, "", "-a", AnchorName, "-F", "rules"); err != nil {
+		return fmt.Errorf("pf: flushing %s: %w: %s",
+			AnchorName, err, logx.Safe(strings.TrimSpace(out)))
+	}
+	release(ctx)
+	return nil
+}
+
+// enable turns pf on, once, and remembers the reference.
+//
+// `-E` rather than `-e`, which is the whole point of doing this at all: `-e` enables pf
+// outright and `-X` cannot undo it, so a later `pfctl -X` from the application firewall or
+// another VPN would turn the filter off underneath meshp — or meshp's own release would turn
+// it off underneath theirs. The reference count exists so that several programs can each
+// need pf on and none of them can take it away from the others.
+//
+// Holding a token is not taken as proof that pf is on. Something can still run `pfctl -d`,
+// which disables the filter outright and pays no attention to the count, and a token file
+// that outlived its enable would look identical. So the state is read back, and a reference
+// meshp already holds is trusted only while pf agrees it is running — the same argument the
+// anchor-point check rests on, applied to the switch rather than the wiring.
+func enable(ctx context.Context) error {
+	if _, err := os.Stat(tokenPath); err == nil && enabled(ctx) {
+		return nil
+	}
+	out, err := pfctlCombined(ctx, "", "-E")
+	if err != nil {
+		return fmt.Errorf("pf: enabling the packet filter: %w: %s", err, logx.Safe(strings.TrimSpace(out)))
+	}
+	if !enabled(ctx) {
+		return fmt.Errorf("%w: pfctl reported no error and the packet filter is not running, "+
+			"so the lock is loaded and nothing is evaluating it", ErrUnsupported)
+	}
+
+	// And the reference, if pfctl said what it was. A token it did not print is one that can
+	// never be given back — a leak rather than a failure, since pf left running with no meshp
+	// rules in it refuses nothing — and the lock is installed either way. Written after the
+	// state is confirmed, so a failed enable is retried on the next pass rather than skipped
+	// because a file says it already happened.
+	if token := tokenIn(out); token != "" {
+		if err := os.MkdirAll(filepath.Dir(tokenPath), 0o700); err == nil {
+			_ = os.WriteFile(tokenPath, []byte(token), 0o600)
+		}
+	}
+	return nil
+}
+
+// release gives back the reference this package holds on pf being enabled.
+//
+// Errors are deliberately not returned. The contract of removing the lock is that this
+// machine is no longer refusing egress, and that is settled by the flush that has already
+// happened: pf still enabled with no meshp rules in it blocks nothing. Failing the removal
+// here would tell the caller the machine is still locked when it is not, which is the more
+// dangerous of the two wrong answers — it is the one that leaves an operator looking for a
+// block that is not there.
+//
+// The token file goes either way. Keeping a token whose release failed would mean holding a
+// reference nothing is ever going to give back, and the next lock would take a second one on
+// top of it.
+func release(ctx context.Context) {
+	token, err := os.ReadFile(tokenPath)
+	if err != nil {
+		return
+	}
+	defer func() { _ = os.Remove(tokenPath) }()
+	if trimmed := strings.TrimSpace(string(token)); trimmed != "" {
+		_, _ = pfctlCombined(ctx, "", "-X", trimmed)
+	}
+}
+
+// enabled reports whether the packet filter is actually running.
+func enabled(ctx context.Context) bool {
+	out, err := pfctlOutput(ctx, "-s", "info")
+	if err != nil {
+		return false
+	}
+	return statusEnabledIn(out)
+}
+
+// flushStates makes the lock apply to connections that predate it.
+//
+// pf consults its state table before its rules, so a flow established before the anchor was
+// loaded goes on flowing without ever being evaluated against it. That is a silent
+// fail-open — the exact failure ADR-0026 says is worse than having no lock — and killing the
+// states is the only way to close it.
+//
+// Machine-wide, because pf's state table is. That sounds worse than it is: this runs only on
+// the transition into locked, which is the same moment the device takes a default route
+// through the tunnel, and every flow the flush disturbs was about to be broken anyway by
+// having its source address change. On the ordinary macOS path it does nothing at all — pf
+// ships disabled, so meshp is what turned it on and there were no states to begin with.
+//
+// Best effort. A lock that is loaded and enforcing new flows is worth having even if the old
+// ones could not be cleared, and there is nothing the caller could usefully do about it.
+func flushStates(ctx context.Context) {
+	_, _ = pfctlCombined(ctx, "", "-F", "states")
+}
+
+// anchorPointPresent reports whether the main ruleset still evaluates what is nested under
+// Apple's anchor.
+//
+// The reading is here and the deciding is in anchorPointIn, so what this check actually
+// accepts can be tested without a Mac and without root — which matters, because it is the
+// one thing standing between an operating-system change and a device that reports it fails
+// closed while everything leaks.
+func anchorPointPresent(ctx context.Context) bool {
+	out, err := pfctlOutput(ctx, "-s", "rules")
+	if err != nil {
+		return false
+	}
+	return anchorPointIn(out)
+}
+
+// pfctlCombined runs pfctl and returns everything it said.
+//
+// Combined because pfctl explains its failures on stderr, and that explanation is the only
+// thing that makes a rendering mistake diagnosable.
+//
+// The deadline is checked through the context rather than through the error, which reports
+// only that the process was killed: exec.CommandContext cancels by signalling, so a timeout
+// and a crash are the same error until the context is asked.
+func pfctlCombined(ctx context.Context, stdin string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, applyTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "pfctl", args...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return string(out), fmt.Errorf("pf: pfctl did not finish within %s", applyTimeout)
+	}
+	return string(out), err
+}
+
+// pfctlOutput runs pfctl and returns only what it printed as an answer.
+//
+// Stdout alone, unlike pfctlCombined: these callers are reading a ruleset and deciding
+// something from whether it is empty, and pfctl's advisory noise on stderr would answer for
+// them.
+func pfctlOutput(ctx context.Context, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, applyTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "pfctl", args...).Output()
+	return string(out), err
+}

--- a/internal/pf/pfctl_darwin_test.go
+++ b/internal/pf/pfctl_darwin_test.go
@@ -1,0 +1,241 @@
+package pf
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// blocked is the range this package's privileged tests refuse.
+//
+// TEST-NET-1, reserved for documentation and routed nowhere. Everything else is carved out,
+// so the only thing a lock installed by a test can stop is traffic to an address that was
+// never going to arrive — which matters, because these run on a machine that has to go on
+// working afterwards, including if the test dies before its cleanup.
+var blocked = netip.MustParsePrefix("192.0.2.0/24")
+
+// root reports whether this run can touch the packet filter, and skips if it cannot.
+func root(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("reading and loading pf rules needs root; the privileged CI run covers this")
+	}
+}
+
+// The claim ADR-0026 rests on, checked against a real macOS on every run.
+//
+// meshp's rules are nested under Apple's anchor because that is the only anchor point the
+// shipped /etc/pf.conf references. If a macOS release renames it, drops the wildcard, or
+// stops loading com.apple from a file, meshp's rules go on being loaded and quietly stop
+// being evaluated — a device reporting that it fails closed while everything leaks.
+//
+// This test failing is that change arriving. It is not a bug in the test.
+func TestTheAnchorPointADR0026DependsOnIsStillThere(t *testing.T) {
+	root(t)
+
+	if !anchorPointPresent(t.Context()) {
+		out, _ := exec.Command("pfctl", "-s", "rules").Output()
+		t.Fatalf("the main ruleset no longer evaluates anchors nested under %q, so a lock "+
+			"loaded into %s would never be looked at.\n\nThis is what ADR-0026 accepts as "+
+			"its risk, and it has happened. macOS's anchor arrangement has to be looked at "+
+			"again before this platform can fail closed.\n\npfctl -s rules:\n%s",
+			anchorPoint, AnchorName, out)
+	}
+	if New(t.Context()) == nil {
+		t.Error("the anchor point is there and this host still says it cannot refuse egress")
+	}
+}
+
+// A host that cannot read the packet filter says so, rather than finding out at apply time.
+//
+// The answer decides what the agent claims it can do, and a device that claimed fail-closed
+// egress and then failed to install it on every reconcile would be placed in networks that
+// require the property and never have it.
+func TestWithoutPrivilegeThisHostSaysItCannotLock(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("this is about what an unprivileged agent reports; the unprivileged CI run covers it")
+	}
+	if New(t.Context()) != nil {
+		t.Error("an agent that cannot read pf reported that it can refuse egress")
+	}
+	if Held(t.Context()) {
+		t.Error("an agent that cannot read pf reported that a lock is installed")
+	}
+}
+
+// The rendering is what pf will actually take, checked by asking pf.
+//
+// Unprivileged on purpose: parsing a ruleset needs no access to /dev/pf, so this runs in both
+// CI passes and on any developer's Mac. It is the difference between a renderer that produces
+// plausible text and one that produces a ruleset.
+func TestTheRenderedLockIsSomethingPfWillLoad(t *testing.T) {
+	script, err := RenderLock(example())
+	if err != nil {
+		t.Fatalf("rendering: %v", err)
+	}
+	if out, err := parseCheck(script); err != nil {
+		t.Fatalf("pf will not load the rendered lock: %v\n%s\n--- ruleset\n%s", err, out, script)
+	}
+
+	// And the check is not vacuous. A ruleset pf would reject has to be rejected, or this
+	// test would go on passing after the renderer started emitting nonsense.
+	if _, err := parseCheck("pass out quick on utun7! all\n"); err == nil {
+		t.Error("pfctl accepted a ruleset it should have refused, so parsing proves nothing here")
+	}
+}
+
+// The whole of it: a lock refuses what it does not name, and pf's own accounting says so.
+//
+// Everything except TEST-NET-1 is carved out, so this proves the anchor is reached and its
+// catch-all is enforced without taking the machine off the network for the length of a test.
+func TestALockRefusesWhatItDoesNotName(t *testing.T) {
+	root(t)
+	ctx := t.Context()
+
+	lock := &Lock{}
+	// Before anything else, so a failure part-way through still gives the machine back.
+	t.Cleanup(func() {
+		if err := lock.ApplyLock(context.WithoutCancel(ctx), "", nil, nil, false); err != nil {
+			t.Errorf("could not remove the lock this test installed: %v", err)
+		}
+	})
+
+	// lo0 as the tunnel, because it certainly exists. Which interface carries the tunnel is
+	// not what this is testing — whether the anchor is evaluated and its catch-all refuses is.
+	if err := lock.ApplyLock(ctx, "lo0", nil, everythingExcept(blocked), false); err != nil {
+		t.Fatalf("installing the lock: %v", err)
+	}
+	if !Held(ctx) {
+		t.Fatal("the lock was installed and this host reports no lock")
+	}
+	if !enabled(ctx) {
+		t.Fatal("the rules are loaded and the packet filter is not running, so nothing is " +
+			"evaluating them")
+	}
+
+	// A packet pf has to decide about. It is going nowhere either way; what matters is that
+	// the anchor's catch-all is what stops it.
+	conn, err := net.DialTimeout("tcp", "192.0.2.1:443", 2*time.Second)
+	if err == nil {
+		_ = conn.Close()
+		t.Error("a connection to a refused address succeeded")
+	}
+
+	if packets := blockedPackets(t, ctx); packets == 0 {
+		t.Error("pf counted nothing against the catch-all, so meshp's rules were not what " +
+			"stopped that packet — the anchor is loaded and is not being evaluated")
+	}
+}
+
+// The lock outlives the process, and is found again and taken off.
+//
+// ADR-0011 requires the first half: rules that vanished with the daemon would fail open
+// exactly when they are needed. Invariant 20 requires the second, and this is the reference
+// on pf being enabled — the part with no Linux counterpart, because meshp does not own the
+// switch and has to give it back.
+func TestTheLockAndTheReferenceOnPfAreBothGivenBack(t *testing.T) {
+	root(t)
+	ctx := t.Context()
+
+	lock := &Lock{}
+	t.Cleanup(func() { _ = lock.ApplyLock(context.WithoutCancel(ctx), "", nil, nil, false) })
+
+	if err := lock.ApplyLock(ctx, "lo0", nil, everythingExcept(blocked), false); err != nil {
+		t.Fatalf("installing the lock: %v", err)
+	}
+	if _, err := os.Stat(tokenPath); err != nil {
+		t.Errorf("no reference on pf was remembered at %s: %v\n"+
+			"a killed daemon's reference is then one nothing can ever give back, and pf "+
+			"stays enabled until the machine reboots", tokenPath, err)
+	}
+
+	if err := lock.ApplyLock(ctx, "", nil, nil, false); err != nil {
+		t.Fatalf("removing the lock: %v", err)
+	}
+	if Held(ctx) {
+		t.Error("the lock was removed and this host still reports one")
+	}
+	if _, err := os.Stat(tokenPath); !os.IsNotExist(err) {
+		t.Errorf("the reference on pf was not given back: %s is still there", tokenPath)
+	}
+
+	// And again on a machine that has no lock. The reconciler releases on every pass through
+	// a state that does not want one, and `meshp down` releases whether or not anything was
+	// ever installed — so a removal that failed when there was nothing to remove would put a
+	// error in the log of every device that has never claimed a default route.
+	if err := lock.ApplyLock(ctx, "", nil, nil, false); err != nil {
+		t.Errorf("removing a lock that is not installed was an error: %v", err)
+	}
+}
+
+// parseCheck asks pfctl whether it would take a ruleset, without loading it.
+func parseCheck(script string) (string, error) {
+	cmd := exec.Command("pfctl", "-a", AnchorName, "-n", "-f", "-")
+	cmd.Stdin = strings.NewReader(script)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// packetCount reads the counters pfctl prints beneath each rule.
+var packetCount = regexp.MustCompile(`Packets:\s*(\d+)`)
+
+// blockedPackets is how many packets meshp's catch-all has refused.
+//
+// Read per rule rather than summed, because every other rule in the anchor is a pass rule
+// and the machine's ordinary traffic keeps them busy. Only the catch-all's count says the
+// lock refused something.
+func blockedPackets(t *testing.T, ctx context.Context) int {
+	t.Helper()
+	out, err := pfctlOutput(ctx, "-a", AnchorName, "-s", "rules", "-v")
+	if err != nil {
+		t.Fatalf("reading the anchor's counters: %v", err)
+	}
+
+	rule := ""
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			rule = strings.TrimSpace(line)
+			continue
+		}
+		if !strings.HasPrefix(rule, "block") {
+			continue
+		}
+		if match := packetCount.FindStringSubmatch(line); match != nil {
+			count, err := strconv.Atoi(match[1])
+			if err != nil {
+				t.Fatalf("unreadable packet count %q", match[1])
+			}
+			return count
+		}
+	}
+	t.Fatalf("no counters against a block rule in the anchor. If pfctl's output has changed "+
+		"shape this test has to learn the new one rather than be deleted.\n\n%s", out)
+	return 0
+}
+
+// everythingExcept covers the whole address space apart from one prefix.
+//
+// The siblings along the path from the root: flipping bit i of the prefix and stopping there
+// gives the half of that level the prefix is not in, and together they tile everything else.
+func everythingExcept(p netip.Prefix) []netip.Prefix {
+	// IPv6 entire, because this is only ever used to leave one IPv4 range refused.
+	out := []netip.Prefix{netip.MustParsePrefix("::/0")}
+	octets := p.Addr().AsSlice()
+	for i := range p.Bits() {
+		flipped := append([]byte(nil), octets...)
+		flipped[i/8] ^= 1 << (7 - i%8)
+		sibling, ok := netip.AddrFromSlice(flipped)
+		if !ok {
+			continue
+		}
+		out = append(out, netip.PrefixFrom(sibling, i+1).Masked())
+	}
+	return out
+}

--- a/internal/pf/render.go
+++ b/internal/pf/render.go
@@ -1,0 +1,194 @@
+package pf
+
+import (
+	"fmt"
+	"net/netip"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// interfaceNamePattern is what a macOS network interface may be called.
+//
+// Checked before the name reaches a ruleset rather than trusted, because it arrives as
+// configuration and ends up in a file loaded by a process running as root. The same guard
+// nftables.Render applies, with macOS's shorter name limit.
+var interfaceNamePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]{1,15}$`)
+
+// LockSpec is what a device may still reach while it fails closed.
+//
+// The same four things nftables.LockSpec names, and that type carries the fuller account of
+// why each one exists — each is a way for the machine to stay usable and reachable while the
+// tunnel is the only way out, and omitting one is how this feature becomes a bricked laptop.
+//
+// Its own type rather than a shared one because the two renderings have nothing in common
+// beyond their inputs. pf and nftables disagree about evaluation order, about how a rule
+// stops evaluation, and about what "reject" is called; a shared spec would be the only thing
+// holding two unrelated renderers together, and it would drift the first time one of them
+// needed a field the other could not honour.
+type LockSpec struct {
+	// Interface is the tunnel. Empty means there is no lock — RenderLock produces nothing,
+	// and removal is a flush rather than a ruleset.
+	Interface string
+
+	// Endpoints are the outer addresses that make the tunnel possible: the relay and the
+	// control plane that can tell this device to stop. Without them the lock deadlocks.
+	Endpoints []netip.AddrPort
+
+	// Excluded are the prefixes that stay reachable directly — the local network, and
+	// whatever an administrator carved out.
+	Excluded []netip.Prefix
+
+	// PreventDNSLeaks refuses plaintext DNS that is not going through the tunnel. It exists
+	// for the hole the carve-out has to leave: the resolver is on the local network, which
+	// the carve-out permits.
+	PreventDNSLeaks bool
+}
+
+// RenderLock turns a lock specification into a pf ruleset that refuses everything else.
+//
+// An empty Interface renders nothing. That is not the same shape as RenderLock in nftables,
+// which renders a script that deletes its table: there is no ruleset that means "remove
+// this" in pf, because an anchor is emptied by flushing it rather than by loading something.
+// Removal lives in ApplyLock for that reason, and this returns "" so a caller that renders
+// first and loads second cannot accidentally load an empty ruleset over a live lock.
+//
+// Four deliberate differences from the nftables rendering, three of them forced by pf.
+//
+// **Every rule is `quick`.** pf is last-match-wins: without `quick` the final block would
+// win over every accept above it and the machine would have no network at all. With it, the
+// file reads top to bottom the way the nftables chain does, and the order below is the
+// policy rather than an accident of how pf resolves ties.
+//
+// **Every pass rule is `no state`.** pf checks its state table before its rules, so a
+// permitted flow would otherwise be waved through on subsequent packets without being
+// evaluated again. That is fine until the carve-out changes underneath it. Stateless
+// matching is also what nftables does here — the lock deliberately has no
+// established-accept, because a connection opened before the lock went up is exactly what
+// it exists to stop.
+//
+// **`block return` rather than `block drop`.** The nftables rendering rejects rather than
+// drops for a reason ADR-0011 is explicit about: a dropped packet leaves an application
+// hanging until it times out and the user learns nothing, while a rejected one fails
+// immediately with an error the operating system already knows how to describe. `return` is
+// pf's spelling of that.
+//
+// **Only the `out` direction.** Nothing here matches inbound traffic, so the anchor cannot
+// disturb anything arriving. The nftables lock hooks `output` alone for the same reason.
+func RenderLock(spec LockSpec) (string, error) {
+	if spec.Interface == "" {
+		return "", nil
+	}
+	if !interfaceNamePattern.MatchString(spec.Interface) {
+		return "", fmt.Errorf("pf: %q is not a usable interface name", spec.Interface)
+	}
+
+	var b strings.Builder
+
+	// Loopback first, and unconditionally. The agent's own control socket, a local resolver
+	// and everything a desktop does with 127.0.0.1 go through here; a lock that broke them
+	// would break the machine rather than its egress.
+	//
+	// A rule rather than `set skip on lo0`, which would be the idiomatic way to say this and
+	// is not available: `set` belongs to the main ruleset and is rejected inside an anchor.
+	b.WriteString("pass out quick on lo0 all no state\n")
+
+	// The tunnel itself: this is what the traffic is supposed to use.
+	fmt.Fprintf(&b, "pass out quick on %s all no state\n", spec.Interface)
+
+	// The outer packets that carry the tunnel, and the control channel that can end it.
+	// Rendered from parsed addresses rather than interpolated text — this ruleset is loaded
+	// as root and the endpoints arrive from the control plane.
+	for _, ep := range sortedEndpoints(spec.Endpoints) {
+		addr := ep.Addr().Unmap()
+		family := "inet"
+		if addr.Is6() {
+			family = "inet6"
+		}
+		fmt.Fprintf(&b, "pass out quick %s proto { tcp udp } from any to %s port %d no state\n",
+			family, addr.String(), ep.Port())
+	}
+
+	// Before the carve-out, and that order is the whole of this rule. Refusing DNS after the
+	// local network has been permitted would refuse nothing: the resolver is on the local
+	// network.
+	//
+	// Plaintext only, which is what ADR-0011 asks for. DNS over TLS on 853 does not disclose
+	// the query to the network it crosses, and DNS over HTTPS is indistinguishable from any
+	// other HTTPS. mDNS on 5353 is left alone too: it never leaves the link, and refusing it
+	// costs the printer discovery the carve-out exists to keep.
+	if spec.PreventDNSLeaks {
+		b.WriteString("block return out quick proto { tcp udp } from any to any port 53\n")
+	}
+
+	// The local network and anything else carved out.
+	excluded := splitPrefixes(spec.Excluded)
+	if len(excluded.v4) > 0 {
+		fmt.Fprintf(&b, "pass out quick inet from any to { %s } no state\n", strings.Join(excluded.v4, " "))
+	}
+	if len(excluded.v6) > 0 {
+		fmt.Fprintf(&b, "pass out quick inet6 from any to { %s } no state\n", strings.Join(excluded.v6, " "))
+	}
+
+	// Keeping the address the machine has. A device that cannot renew a DHCP lease loses its
+	// network some minutes later, and a device that cannot do neighbour discovery loses IPv6
+	// immediately — both of which look exactly like the bug this feature exists to prevent,
+	// and neither of which carries any of the user's traffic.
+	b.WriteString("pass out quick proto udp from any to any port { 67 68 546 547 } no state\n")
+	b.WriteString("pass out quick inet6 proto icmp6 all no state\n")
+
+	// And everything else is refused, audibly.
+	b.WriteString("block return out quick all\n")
+
+	return b.String(), nil
+}
+
+// sortedEndpoints puts the endpoints in a stable order, so the same specification renders
+// the same ruleset and an unchanged lock is not reloaded for nothing.
+func sortedEndpoints(in []netip.AddrPort) []netip.AddrPort {
+	out := make([]netip.AddrPort, 0, len(in))
+	seen := make(map[netip.AddrPort]struct{}, len(in))
+	for _, ep := range in {
+		if !ep.Addr().IsValid() || ep.Port() == 0 {
+			continue
+		}
+		norm := netip.AddrPortFrom(ep.Addr().Unmap(), ep.Port())
+		if _, dup := seen[norm]; dup {
+			continue
+		}
+		seen[norm] = struct{}{}
+		out = append(out, norm)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	return out
+}
+
+// families is prefixes sorted into the two address families, because a pf list may not mix
+// them: `inet` and `inet6` rules are written separately.
+type families struct{ v4, v6 []string }
+
+// splitPrefixes sorts prefixes into families, dropping anything unusable rather than
+// refusing the whole lock: a malformed exclusion should cost that exclusion, not leave the
+// device with no lock at all.
+func splitPrefixes(in []netip.Prefix) families {
+	var out families
+	seen := make(map[netip.Prefix]struct{}, len(in))
+	for _, p := range in {
+		if !p.IsValid() {
+			continue
+		}
+		norm := netip.PrefixFrom(p.Addr().Unmap(), p.Bits()).Masked()
+		if _, dup := seen[norm]; dup {
+			continue
+		}
+		seen[norm] = struct{}{}
+		if norm.Addr().Is4() {
+			out.v4 = append(out.v4, norm.String())
+		} else {
+			out.v6 = append(out.v6, norm.String())
+		}
+	}
+	sort.Strings(out.v4)
+	sort.Strings(out.v6)
+	return out
+}

--- a/internal/pf/render_test.go
+++ b/internal/pf/render_test.go
@@ -1,0 +1,233 @@
+package pf
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+// lockFor renders a lock and returns its rules, one per element.
+func lockFor(t *testing.T, spec LockSpec) []string {
+	t.Helper()
+	script, err := RenderLock(spec)
+	if err != nil {
+		t.Fatalf("rendering: %v", err)
+	}
+	var out []string
+	for _, line := range strings.Split(script, "\n") {
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// indexOf is the position of the first rule containing want, or -1.
+func indexOf(rules []string, want string) int {
+	for i, rule := range rules {
+		if strings.Contains(rule, want) {
+			return i
+		}
+	}
+	return -1
+}
+
+// example is a lock with one of everything, so a test can assert about the whole shape
+// rather than build a spec each time.
+func example() LockSpec {
+	return LockSpec{
+		Interface: "utun7",
+		Endpoints: []netip.AddrPort{
+			netip.MustParseAddrPort("198.51.100.7:51820"),
+			netip.MustParseAddrPort("[2001:db8::7]:443"),
+		},
+		Excluded: []netip.Prefix{
+			netip.MustParsePrefix("192.168.1.0/24"),
+			netip.MustParsePrefix("fd00:1::/64"),
+		},
+		PreventDNSLeaks: true,
+	}
+}
+
+// Everything a device may still reach while it fails closed, and nothing else. Each of these
+// is a way for the machine to stay usable while the tunnel is the only way out, and every
+// one of them missing is a different bricked laptop.
+func TestALockPermitsWhatTheMachineNeedsToStayAlive(t *testing.T) {
+	rules := lockFor(t, example())
+
+	for _, want := range []struct{ rule, why string }{
+		{"pass out quick on lo0 all no state",
+			"the agent's own socket, a local resolver, and everything a desktop does with 127.0.0.1"},
+		{"pass out quick on utun7 all no state",
+			"the tunnel itself, which is what the traffic is supposed to use"},
+		{"pass out quick inet proto { tcp udp } from any to 198.51.100.7 port 51820 no state",
+			"the relay, without which there is no tunnel and the lock deadlocks"},
+		{"pass out quick inet6 proto { tcp udp } from any to 2001:db8::7 port 443 no state",
+			"the control plane, which is the only thing that can tell this device to stop"},
+		{"pass out quick inet from any to { 192.168.1.0/24 } no state",
+			"the local network: the printer, the NAS and often the default gateway"},
+		{"pass out quick inet6 from any to { fd00:1::/64 } no state",
+			"the same, for a network that is addressed with IPv6"},
+		{"pass out quick proto udp from any to any port { 67 68 546 547 } no state",
+			"renewing the lease, without which the machine loses its network some minutes later"},
+		{"pass out quick inet6 proto icmp6 all no state",
+			"neighbour discovery, without which IPv6 stops immediately"},
+		{"block return out quick all",
+			"and everything else is refused"},
+	} {
+		if indexOf(rules, want.rule) < 0 {
+			t.Errorf("missing rule %q\n  needed because: %s\n\ngot:\n%s",
+				want.rule, want.why, strings.Join(rules, "\n"))
+		}
+	}
+}
+
+// The single most load-bearing token in the file, and the one that has no counterpart in the
+// nftables rendering.
+//
+// pf is last-match-wins. A ruleset whose rules were not quick would evaluate every one of
+// them and take the last that matched, which is `block return out quick all` — so a lock
+// missing this would refuse the tunnel, the control plane and the local network too, and the
+// machine would have no network at all rather than a tunnelled one.
+func TestEveryRuleStopsEvaluationWhereItMatches(t *testing.T) {
+	for _, rule := range lockFor(t, example()) {
+		if !strings.Contains(rule, " quick ") {
+			t.Errorf("%q is not quick, so pf would go on looking and the final block would win", rule)
+		}
+	}
+}
+
+// pf consults its state table before its rules, so a pass rule that kept state would wave
+// through every subsequent packet of a flow without evaluating it again.
+//
+// The nftables lock is stateless for the sharper version of the same reason: it deliberately
+// has no established-accept, because a connection opened before the lock went up is exactly
+// what it exists to stop.
+func TestNoRulePermitsAFlowWithoutLookingAtIt(t *testing.T) {
+	for _, rule := range lockFor(t, example()) {
+		if strings.HasPrefix(rule, "pass ") && !strings.HasSuffix(rule, " no state") {
+			t.Errorf("%q keeps state, so a flow it permitted once is never evaluated again", rule)
+		}
+	}
+}
+
+// ADR-0011 is explicit that the error message is the product: a dropped packet leaves an
+// application hanging until it times out and the user learns nothing, while a rejected one
+// fails immediately with something the operating system can already describe.
+func TestTheRefusalIsAudibleAndComesLast(t *testing.T) {
+	rules := lockFor(t, example())
+	last := rules[len(rules)-1]
+
+	if last != "block return out quick all" {
+		t.Errorf("the last rule is %q, and it has to be the audible catch-all", last)
+	}
+	for _, rule := range rules {
+		if strings.HasPrefix(rule, "block ") && !strings.HasPrefix(rule, "block return ") {
+			t.Errorf("%q drops silently; ADR-0011 asks for an error the user can act on", rule)
+		}
+	}
+}
+
+// The ordering that makes PreventDNSLeaks mean anything.
+//
+// The resolver lives on the local network and the carve-out permits the local network, so a
+// DNS rule placed after it would refuse nothing at all. The tunnel comes before both, or the
+// device would be unable to resolve anything through the tunnel it just brought up — which
+// is not a leak, it is the feature working and the machine being useless.
+func TestDNSIsRefusedAfterTheTunnelAndBeforeTheLocalNetwork(t *testing.T) {
+	rules := lockFor(t, example())
+
+	tunnel := indexOf(rules, "on utun7")
+	dns := indexOf(rules, "port 53")
+	local := indexOf(rules, "192.168.1.0/24")
+
+	if dns < 0 {
+		t.Fatalf("a lock that prevents DNS leaks refuses no DNS:\n%s", strings.Join(rules, "\n"))
+	}
+	if tunnel >= dns || dns >= local {
+		t.Errorf("the order is tunnel=%d dns=%d local=%d; it has to be tunnel, then dns, then local\n%s",
+			tunnel, dns, local, strings.Join(rules, "\n"))
+	}
+}
+
+// Off by default in the sense that matters: a network that has not asked for it gets a lock
+// that does not interfere with the resolver it carved out.
+func TestWithoutTheDNSPolicyNothingRefusesDNS(t *testing.T) {
+	spec := example()
+	spec.PreventDNSLeaks = false
+	if i := indexOf(lockFor(t, spec), "port 53"); i >= 0 {
+		t.Error("a lock that was not asked to prevent DNS leaks refuses DNS anyway")
+	}
+}
+
+// Removal is a flush, not a ruleset. Rendering something for an empty interface would give a
+// caller that renders first and loads second a way to load an empty ruleset over a live lock
+// — which reads as "the lock is installed" and refuses nothing.
+func TestNoInterfaceRendersNothingToLoad(t *testing.T) {
+	script, err := RenderLock(LockSpec{})
+	if err != nil {
+		t.Fatalf("rendering an empty lock: %v", err)
+	}
+	if script != "" {
+		t.Errorf("an empty lock rendered a ruleset:\n%s", script)
+	}
+}
+
+// The name arrives as configuration and ends up in a file loaded by a process running as
+// root, so it is checked rather than trusted.
+func TestAnUnusableInterfaceNameIsRefused(t *testing.T) {
+	for _, name := range []string{
+		"utun7 all\nblock return out quick on lo0 all", // a second rule smuggled in
+		"utun7; pfctl -d",
+		"$(reboot)",
+		"utun7 no state",
+		"",                      // handled separately, and must not render rules
+		strings.Repeat("u", 16), // longer than an interface name may be
+	} {
+		script, err := RenderLock(LockSpec{Interface: name})
+		if err == nil && script != "" {
+			t.Errorf("%q was accepted as an interface name and rendered:\n%s", name, script)
+		}
+	}
+}
+
+// The same lock renders the same ruleset, so an unchanged specification is not a changed
+// file. It matters here more than it looks: loading an anchor resets the counters an
+// operator is reading, and pf's state table is flushed on the transition into locked.
+func TestTheSameLockRendersTheSameRulesetWhateverOrderItArrivesIn(t *testing.T) {
+	one := example()
+	two := example()
+	two.Endpoints = []netip.AddrPort{two.Endpoints[1], two.Endpoints[0], two.Endpoints[0]}
+	two.Excluded = []netip.Prefix{two.Excluded[1], two.Excluded[0], two.Excluded[0]}
+
+	first, err := RenderLock(one)
+	if err != nil {
+		t.Fatalf("rendering: %v", err)
+	}
+	second, err := RenderLock(two)
+	if err != nil {
+		t.Fatalf("rendering: %v", err)
+	}
+	if first != second {
+		t.Errorf("the same lock rendered differently:\n--- first\n%s\n--- second\n%s", first, second)
+	}
+}
+
+// A malformed exclusion costs that exclusion, not the lock.
+//
+// The alternative is a device that fails to install any lock because one carve-out was
+// wrong, which turns a bad prefix into no protection at all — and the caller responds to a
+// failed lock by refusing the default route, so a typo would take the whole feature down.
+func TestAMalformedExclusionCostsOnlyItself(t *testing.T) {
+	spec := example()
+	spec.Excluded = append(spec.Excluded, netip.Prefix{})
+	spec.Endpoints = append(spec.Endpoints, netip.AddrPort{})
+
+	rules := lockFor(t, spec)
+	if indexOf(rules, "192.168.1.0/24") < 0 {
+		t.Errorf("one unusable exclusion took the good ones with it:\n%s", strings.Join(rules, "\n"))
+	}
+	if indexOf(rules, "block return out quick all") < 0 {
+		t.Errorf("one unusable exclusion cost the whole lock:\n%s", strings.Join(rules, "\n"))
+	}
+}


### PR DESCRIPTION
Closes #154. Finishes #151.

macOS has had a tunnel (#152), names (#153) and a full-tunnel default route (#166). What it has not had is ADR-0011's lock, so a network whose policy says `fail_closed` reported the route group unhonoured on every Mac — `applyEgress` refuses rather than downgrades, because a device that claimed the route while quietly declining to enforce it would report a property it does not have.

ADR-0026 (#168) settled where the rules go. This implements it.

## What is here

**`internal/pf`** renders a ruleset and loads it into a pf anchor at `com.apple/meshp`. The rendering is platform-independent and unit-tested anywhere; the pfctl driving is `_darwin`.

**`internal/egresslock`** answers one question — "can this host fail closed, and how does a person undo it by hand" — in one place. `cmd/meshpd` and `meshp doctor` reached into `internal/nftables` directly, which was fine while Linux was the only data plane and became a bug the moment macOS grew a lock of its own.

## Four things pf needed that nftables did not

**Every rule is `quick`.** pf is last-match-wins. A ruleset without it would evaluate every rule and take the last that matched — `block return out quick all` — so the lock would refuse the tunnel, the control plane and the local network too, and the machine would have no network at all rather than a tunnelled one.

**Every pass rule is `no state`.** pf consults its state table before its rules. The nftables lock is stateless for the sharper version of the same reason: it deliberately has no established-accept, because a connection opened before the lock went up is exactly what it exists to stop.

**`block return` rather than `block drop`**, which is pf's spelling of the reject ADR-0011 asks for: *"the error message is the product"*.

**The states that predate the lock are flushed**, once, on the transition into locked. Without it a flow established earlier goes on flowing without ever being evaluated against the anchor — a silent fail-open. It costs nothing on the ordinary path, since pf ships disabled and meshp is what turned it on; and where it does something, every flow it disturbs was about to be broken anyway by the default route changing underneath it.

## meshp does not own the switch

pf is enabled with a reference count, so this takes one with `-E` and gives it back with `-X` rather than using `-e` — which would let meshp's release turn the packet filter off underneath the application firewall or another VPN. The token is kept in `/var/run` so a killed daemon's reference can be released by the next one.

It is never trusted on its own. `pfctl -d` disables pf outright and pays no attention to the count, so pf is asked whether it is actually running before a held reference means anything.

## The risk ADR-0026 accepts, and the thing that contains it

`com.apple` is Apple's namespace. meshp is there because it is the only anchor point the shipped `/etc/pf.conf` references, and a top-level anchor of meshp's own is loaded and never evaluated.

The failure that matters is not that this is impolite. A future macOS could rename the anchor point or drop the wildcard, and meshp's rules would go on being **loaded** while quietly no longer being **evaluated** — a device reporting that it fails closed while everything leaks.

So the anchor point is verified on every application, and `TestTheAnchorPointADR0026DependsOnIsStillThere` puts the same question to a real macOS on every CI run. If that test fails, macOS has changed and this platform cannot fail closed until somebody looks. It is not a flake and it is not the test being wrong — the job comment says so.

## How the privileged test proves it without stranding the runner

`TestALockRefusesWhatItDoesNotName` installs a lock that carves out everything except TEST-NET-1 (`192.0.2.0/24` — reserved, routed nowhere), sends a packet there, and asks pf's own counters whether the catch-all refused it. So it proves the anchor is reached and enforcing while the runner keeps its entire network, including if the test dies before its cleanup runs.

The unprivileged half is real too: `pfctl -n -f -` needs no access to `/dev/pf`, so both CI passes check that what the renderer emits is something pf will actually take — and the test proves it is not vacuous by feeding pfctl a ruleset it has to reject.

## meshp doctor was one platform away from repeating #156

It printed `nft delete table inet meshp_lock` wherever it ran, so a Mac with no network would have been told to run a program it has never had — #156's failure, in the half #156 does not touch. Both it and `meshpd` ask `egresslock` now, and the doctor tests that asserted those literals ask it too. They passed on macOS only because macOS had no lock to print.

## Testing

- The new tests were mutation-checked: a rule that is not `quick`, a catch-all that drops instead of rejecting, a pass rule that keeps state, an empty interface that renders anyway, the anchor-point check reduced to a substring search, the DNS rule moved after the carve-out, and macOS being told to run `nft` — each was caught by the test that claims to cover it.
- `internal/platformcheck` required both new packages in the macOS job before this could pass, which is what it is for.
- `internal/egresslock` also joins the Linux data-plane job, so its one real assertion — that the command `meshp doctor` prints names a program this machine has — has somewhere to run on Linux rather than skipping for want of nftables.

## Still open on macOS

Enforcing a network's **packet filter** (ADR-0007) — a Mac still reports `filter` unapplied. And #160: sleep, wake and roaming, which no CI runner can tell us about and which ADR-0026 makes more pressing, since a macOS update is now something to test after.
