### PR TITLE
test(meshpd): the daemon's wiring is tested, and its nil checks are reachable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,6 +663,12 @@ jobs:
       # exists because a list plus a comment asking the next person to keep it in step is
       # how #156 came to be reported as passing while breaking a test on macOS.
       #
+      # cmd/meshpd is here because it now has tests to run. internal/platformcheck logged it
+      # for weeks — "decides something from the operating system and has no tests at all" —
+      # and naming it before there was anything to run would have failed the job rather than
+      # testing anything. Its tests touch nothing on the host: no interface, no packet
+      # filter, no resolver, and nothing that could take this runner off the network.
+      #
       # internal/pf carries one test that is not about meshp's code at all.
       # TestTheAnchorPointADR0026DependsOnIsStillThere asks this runner's macOS whether its
       # main pf ruleset still evaluates anchors nested under com.apple. Fail-closed egress on
@@ -673,12 +679,12 @@ jobs:
       - name: unprivileged — a refused write is an error, and scutil still exits zero
         run: |
           set -o pipefail
-          go test ./internal/wglink/ ./internal/resolved/ ./internal/version/ ./internal/nftables/ ./internal/pf/ ./internal/egresslock/ ./internal/pathprobe/ ./cmd/meshp/ -count=1 -v 2>&1 | tee macos-user.log
+          go test ./internal/wglink/ ./internal/resolved/ ./internal/version/ ./internal/nftables/ ./internal/pf/ ./internal/egresslock/ ./internal/pathprobe/ ./cmd/meshp/ ./cmd/meshpd/ -count=1 -v 2>&1 | tee macos-user.log
 
       - name: as root — a utun comes up and is observed back, and macOS sends mesh names to meshp
         run: |
           set -o pipefail
-          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/resolved/ ./internal/version/ ./internal/nftables/ ./internal/pf/ ./internal/egresslock/ ./internal/pathprobe/ ./cmd/meshp/ -count=1 -v 2>&1 | tee macos-root.log
+          sudo -E env "PATH=$PATH" go test ./internal/wglink/ ./internal/resolved/ ./internal/version/ ./internal/nftables/ ./internal/pf/ ./internal/egresslock/ ./internal/pathprobe/ ./cmd/meshp/ ./cmd/meshpd/ -count=1 -v 2>&1 | tee macos-root.log
 
       # A test that skipped in both runs never ran anywhere, which reports success while
       # testing nothing. Checked by name rather than by counting skips, because each run is

--- a/cmd/meshpd/agent.go
+++ b/cmd/meshpd/agent.go
@@ -136,38 +136,21 @@ func (a *agent) reconcilerFor(m agentstate.Membership, relay tunnel.Relay, choos
 		AddressV6:     m.AddressV6,
 		ListenPort:    m.ListenPort,
 		ControlURL:    m.ControlURL,
-	}, relay, a.filterOrNil(), log).
+	}, relay, filterOrNil(a.ensureFilter()), log).
 		WithChooser(chooser).
-		WithEgress(routerOrNil()).
+		WithEgress(routerOrNil(wglink.NewRouter())).
 		WithLock(a.ensureLock()).
-		WithProber(proberOrNil()).
+		WithProber(proberOrNil(pathprobe.NewDialer())).
 		WithClaims(a.claims).
 		WithNames(a.zones).
-		WithSystemResolver(a.systemResolverOrNil(), a.resolver.Addr)
+		WithSystemResolver(resolverOrNil(a.ensureSystemResolver()), a.resolver.Addr)
 }
 
-// proberOrNil converts a possibly-absent dialer into the interface.
-//
-// Explicit for the reason routerOrNil is, and it has bitten this project already: a nil
-// *pathprobe.BoundDialer assigned straight to an interface is a non-nil interface holding a
-// nil pointer, so the reconciler's `r.prober == nil` check would pass and every probe would
-// panic on a platform that has no dialer.
-func proberOrNil() tunnel.Prober {
-	if d := pathprobe.NewDialer(); d != nil {
-		return d
-	}
-	return nil
-}
-
-// systemResolverOrNil converts a possibly-absent resolver configurer into the interface.
-//
-// Explicit for the reason routerOrNil and proberOrNil are: a nil *resolved.System
-// assigned straight to an interface is a non-nil interface holding a nil pointer, so the
-// reconciler's own nil check would pass and every reconcile would call a method on nothing.
+// ensureSystemResolver opens the host's resolver configurer, once.
 //
 // Once, and lazily: it asks systemd-resolved for its status, which is a process spawn, and
 // doing that per membership per reconcile would be a spawn a minute for nothing.
-func (a *agent) systemResolverOrNil() tunnel.SystemResolver {
+func (a *agent) ensureSystemResolver() *resolved.System {
 	a.systemResolverOnce.Do(func() {
 		a.systemResolver = resolved.New(a.ctx)
 		if a.systemResolver == nil {
@@ -176,22 +159,7 @@ func (a *agent) systemResolverOrNil() tunnel.SystemResolver {
 				"hint", "meshp status reports the resolver address; addresses always work")
 		}
 	})
-	if a.systemResolver == nil {
-		return nil
-	}
 	return a.systemResolver
-}
-
-// routerOrNil converts a possibly-absent router into the interface.
-//
-// Explicit for the same reason relayOrNil and filterOrNil are: a nil *wglink.Router assigned
-// straight to an interface is a non-nil interface holding a nil pointer, so every downstream
-// nil check would pass and the reconciler would believe this host can claim a default route.
-func routerOrNil() tunnel.Egress {
-	if r := wglink.NewRouter(); r != nil {
-		return r
-	}
-	return nil
 }
 
 // reclaimEgressLock removes a fail-closed lock left behind by a previous life.
@@ -283,18 +251,6 @@ func (a *agent) ensureLock() egresslock.Lock {
 	return a.lock
 }
 
-// filterOrNil converts a possibly-absent filter into the interface.
-//
-// Explicit for the same reason relayOrNil is: a nil *nftables.Filter assigned straight to
-// an interface is a non-nil interface holding a nil pointer, so every downstream nil check
-// would pass and the reconciler would believe it can enforce.
-func (a *agent) filterOrNil() tunnel.Filter {
-	if f := a.ensureFilter(); f != nil {
-		return f
-	}
-	return nil
-}
-
 // relayFor returns this membership's relay attachment, or nil when there is no data plane
 // to carry relayed packets into.
 //
@@ -330,37 +286,6 @@ type sessionHandle struct {
 	applier *deviceApplier
 	relay   *relaylink.Link
 	started time.Time
-}
-
-// relayOrNil and relayCredentials convert a possibly-absent link into interfaces.
-//
-// Explicitly, because a nil *relaylink.Link assigned straight to an interface produces a
-// non-nil interface holding a nil pointer: every `if relay != nil` downstream would be true
-// and the first call would panic. Platforms with no data plane take exactly that path.
-// pathsOrNil hands over the reconciler as a path reporter, or nothing.
-//
-// A typed nil would satisfy the interface and be called, so the nil check has to happen
-// here rather than at the call site — the same trap the control plane's presence hook
-// documents.
-func pathsOrNil(r *tunnel.Reconciler) sessionclient.PathReports {
-	if r == nil {
-		return nil
-	}
-	return r
-}
-
-func relayOrNil(l *relaylink.Link) tunnel.Relay {
-	if l == nil {
-		return nil
-	}
-	return l
-}
-
-func relayCredentials(l *relaylink.Link) sessionclient.RelayCredentials {
-	if l == nil {
-		return nil
-	}
-	return l
 }
 
 // relayStatus renders a link for the status socket, or nothing when there is no link.

--- a/cmd/meshpd/agent_test.go
+++ b/cmd/meshpd/agent_test.go
@@ -1,0 +1,351 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/meshpnet/meshp/internal/agentstate"
+)
+
+// quiet builds an agent on a fresh state directory. The log goes nowhere: these tests are
+// about what the agent does, and the daemon is deliberately talkative.
+func quiet(t *testing.T) *agent {
+	t.Helper()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return newAgent(t.Context(), log, t.TempDir(), 0)
+}
+
+// enrolled writes a state file with one membership and returns the directory and its id.
+func enrolled(t *testing.T) (dir string, membershipID uuid.UUID) {
+	t.Helper()
+	dir = t.TempDir()
+	membershipID = uuid.New()
+	state := &agentstate.State{
+		IdentityPublicKey:  "abcdefghijklmnopqrstuvwxyz0123456789ABCD",
+		IdentityPrivateKey: "0123456789ABCDEFabcdef",
+		Memberships: []agentstate.Membership{{
+			MembershipID: membershipID,
+			NetworkID:    uuid.New(),
+			DeviceID:     uuid.New(),
+			// Refused immediately rather than hung on, so a regression that started a
+			// session here fails fast instead of waiting for a dial to time out.
+			ControlURL:          "https://127.0.0.1:1",
+			InterfaceName:       "meshp0",
+			WireGuardPublicKey:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=",
+			WireGuardPrivateKey: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb=",
+			JoinedAt:            time.Now().UTC(),
+		}},
+	}
+	if err := agentstate.Save(dir, state); err != nil {
+		t.Fatalf("writing state: %v", err)
+	}
+	return dir, membershipID
+}
+
+// Being installed before anybody has a token is the ordinary case, not a failure.
+//
+// An earlier version of this exited here, which meant joining a network required restarting
+// a service. The socket has to come up on a device with no state at all or `meshp join` has
+// nothing to talk to.
+func TestADeviceWithNoStateStaysUpAndSaysSo(t *testing.T) {
+	a := quiet(t)
+
+	if err := a.load(); err != nil {
+		t.Fatalf("a device that has never been enrolled refused to start: %v", err)
+	}
+
+	status, err := a.Status(t.Context())
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.Enrolled {
+		t.Error("a device with no state reported itself enrolled")
+	}
+	if len(status.Memberships) != 0 {
+		t.Errorf("a device with no state reported %d memberships", len(status.Memberships))
+	}
+	if status.StartedAt.IsZero() {
+		t.Error("status carries no start time, so nothing can say how long this has been up")
+	}
+}
+
+// And the other half of that, which is the dangerous one.
+//
+// A state file that exists and cannot be read is not "start fresh". Treating it as one
+// abandons the device's identity and leaves a registered device that nobody can revoke by
+// name — the device's own record of who it is, gone because a write was truncated.
+func TestAStateFileThatCannotBeReadIsNotStartFresh(t *testing.T) {
+	a := quiet(t)
+	if err := os.WriteFile(agentstate.Path(a.stateDir), []byte("{ this is not"), 0o600); err != nil {
+		t.Fatalf("writing a broken state file: %v", err)
+	}
+
+	if err := a.load(); err == nil {
+		t.Fatal("an unreadable state file was accepted; this device has just forgotten who it is")
+	}
+
+	status, err := a.Status(t.Context())
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.Enrolled {
+		t.Error("a device whose state would not load reported itself enrolled")
+	}
+}
+
+// Taking a device off the mesh has to survive a reboot.
+//
+// A machine that came back up carrying traffic its owner had deliberately stopped would be
+// the opposite of what they asked for, and they would have no reason to check.
+func TestBeingTakenDownSurvivesARestart(t *testing.T) {
+	dir, _ := enrolled(t)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	first := newAgent(t.Context(), log, dir, 0)
+	if err := first.load(); err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+	first.setPaused(true)
+
+	// A different agent on the same directory, which is what a restart is.
+	second := newAgent(t.Context(), log, dir, 0)
+	if err := second.load(); err != nil {
+		t.Fatalf("loading after a restart: %v", err)
+	}
+	if !second.paused() {
+		t.Fatal("a device taken down deliberately came back up on the mesh")
+	}
+
+	status, err := second.Status(t.Context())
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !status.Paused {
+		t.Error("status does not say the device was taken down, so nobody can tell this from a fault")
+	}
+}
+
+// And a device that was taken down does not merely fail to connect — it does not look at its
+// memberships at all.
+//
+// The guard is in startAll rather than at its call sites, because the call sites are "the
+// daemon started" and "somebody ran meshp up", and only one of them knows about pausing.
+//
+// Read out of the log, which is the only place this decision is visible and is also where an
+// operator would look for it. The unpaused half is not a courtesy: without it this passes on
+// any agent that fails to start a session for any reason at all, which is what the first
+// version of this test did.
+func TestADeviceTakenDownDoesNotEvenLookAtItsMemberships(t *testing.T) {
+	downDir, _ := enrolled(t)
+	upDir, _ := enrolled(t)
+
+	var down, up bytes.Buffer
+
+	stopped := newAgent(t.Context(), slog.New(slog.NewTextHandler(&down, nil)), downDir, 0)
+	if err := stopped.load(); err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+	stopped.setPaused(true)
+	stopped.startAll()
+
+	started := newAgent(t.Context(), slog.New(slog.NewTextHandler(&up, nil)), upDir, 0)
+	if err := started.load(); err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+	started.startAll()
+
+	// The membership these tests write carries an identity that will not decode, so an
+	// agent that reaches it says so. That is the marker: reaching it at all is the failure.
+	const reached = "cannot start a session without a usable identity"
+
+	if !strings.Contains(up.String(), reached) {
+		t.Fatalf("the running device never reached its memberships, so this test would pass "+
+			"whatever the guard did:\n%s", up.String())
+	}
+	if strings.Contains(down.String(), reached) {
+		t.Errorf("a device taken down deliberately went on to consider its memberships:\n%s",
+			down.String())
+	}
+	if !strings.Contains(down.String(), "staying off the mesh") {
+		t.Errorf("nothing in the log says why this device is doing nothing:\n%s", down.String())
+	}
+}
+
+// Recording against state that is not there has to be an error rather than a silent no-op.
+//
+// These are called from the session as it applies what the server sent. Swallowing them
+// would leave a device reporting a state version it never converged on, and the control
+// plane sending deltas from a point the device never reached.
+func TestRecordingAgainstStateThatIsNotThereIsAnError(t *testing.T) {
+	a := quiet(t)
+	if err := a.load(); err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+
+	if err := a.setApplied(uuid.New(), 7); err == nil {
+		t.Error("a state version was recorded against a device with no local state")
+	}
+	if err := a.setListenPort(uuid.New(), 51820); err == nil {
+		t.Error("a listen port was recorded against a device with no local state")
+	}
+
+	// And with state, against a membership this device does not have.
+	dir, _ := enrolled(t)
+	b := newAgent(t.Context(), slog.New(slog.NewTextHandler(io.Discard, nil)), dir, 0)
+	if err := b.load(); err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+	if err := b.setApplied(uuid.New(), 7); err == nil {
+		t.Error("a state version was recorded against a membership this device does not have")
+	}
+	if err := b.setListenPort(uuid.New(), 51820); err == nil {
+		t.Error("a listen port was recorded against a membership this device does not have")
+	}
+}
+
+// An unchanged value is not written back.
+//
+// This runs on every reconcile, which is once a minute per membership on every device. A
+// device that rewrote its state file each time would be doing a disk write a minute to
+// record that nothing had changed — and the point of persisting the port at all is that the
+// next start asks for the same one, which an unchanged write does not help with.
+func TestAnUnchangedValueIsNotWrittenBack(t *testing.T) {
+	dir, membershipID := enrolled(t)
+	a := newAgent(t.Context(), slog.New(slog.NewTextHandler(io.Discard, nil)), dir, 0)
+	if err := a.load(); err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+
+	if err := a.setListenPort(membershipID, 51820); err != nil {
+		t.Fatalf("recording a port: %v", err)
+	}
+	if err := a.setApplied(membershipID, 12); err != nil {
+		t.Fatalf("recording a version: %v", err)
+	}
+
+	written, err := agentstate.Load(dir)
+	if err != nil {
+		t.Fatalf("reading back: %v", err)
+	}
+	before := written.UpdatedAt
+
+	// The same values again, which is what every reconcile after the first sends.
+	if err := a.setListenPort(membershipID, 51820); err != nil {
+		t.Fatalf("recording the same port: %v", err)
+	}
+	if err := a.setApplied(membershipID, 12); err != nil {
+		t.Fatalf("recording the same version: %v", err)
+	}
+
+	after, err := agentstate.Load(dir)
+	if err != nil {
+		t.Fatalf("reading back: %v", err)
+	}
+	if !after.UpdatedAt.Equal(before) {
+		t.Errorf("the state file was rewritten for values that had not changed (%s then %s)",
+			before, after.UpdatedAt)
+	}
+}
+
+// A port of zero is not a port. It is what a membership that has never come up says, and
+// recording it would overwrite the one this device settled on last time.
+func TestAPortOfZeroIsNotRecorded(t *testing.T) {
+	dir, membershipID := enrolled(t)
+	a := newAgent(t.Context(), slog.New(slog.NewTextHandler(io.Discard, nil)), dir, 0)
+	if err := a.load(); err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+	if err := a.setListenPort(membershipID, 51820); err != nil {
+		t.Fatalf("recording a port: %v", err)
+	}
+
+	if err := a.setListenPort(membershipID, 0); err != nil {
+		t.Fatalf("a port of zero was an error: %v", err)
+	}
+
+	written, err := agentstate.Load(dir)
+	if err != nil {
+		t.Fatalf("reading back: %v", err)
+	}
+	if got := written.Memberships[0].ListenPort; got != 51820 {
+		t.Errorf("the port this device settled on became %d; peers now hold a dead endpoint", got)
+	}
+}
+
+// A membership read from disk says nothing about whether an interface is up right now.
+//
+// This is the reason to ask the daemon rather than read the state file, and reporting a
+// tunnel that is not there would make `meshp status` agree with the device's hopes.
+func TestAMembershipFromDiskIsNotAReportOfALiveTunnel(t *testing.T) {
+	dir, _ := enrolled(t)
+	a := newAgent(t.Context(), slog.New(slog.NewTextHandler(io.Discard, nil)), dir, 0)
+	if err := a.load(); err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+
+	status, err := a.Status(t.Context())
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if len(status.Memberships) != 1 {
+		t.Fatalf("got %d memberships, want 1", len(status.Memberships))
+	}
+	m := status.Memberships[0]
+	if m.TunnelUp {
+		t.Error("a membership with no running session reported a tunnel that is up")
+	}
+	if m.Connected {
+		t.Error("a membership with no running session reported a live control channel")
+	}
+	if m.Relay != nil {
+		t.Error("a membership with no running session reported a relay attachment")
+	}
+}
+
+// A device with no data plane reports no tunnel, rather than an empty one.
+//
+// "" is not a kind. A status that said the tunnel was down and named a kind would read as a
+// broken interface rather than as a platform that has none.
+func TestNoDataPlaneReportsNoTunnelAndNoKind(t *testing.T) {
+	applier := &deviceApplier{}
+
+	up, kind := applier.tunnelStatus()
+	if up || kind != "" {
+		t.Errorf("a membership with no reconciler reported up=%v kind=%q", up, kind)
+	}
+	if got := applier.lastError(); got != "" {
+		t.Errorf("a membership with no reconciler reported the error %q", got)
+	}
+
+	// What the applier was told beats what the reconciler would say, and there is no
+	// reconciler here to say anything.
+	applier.setLastError("the control plane refused this device")
+	if got := applier.lastError(); got != "the control plane refused this device" {
+		t.Errorf("the recorded error was lost: %q", got)
+	}
+}
+
+// Keys are elided in logs, and a short one is left alone rather than being decorated with an
+// ellipsis that suggests there is more to it.
+func TestAKeyIsElidedOnlyWhenThereIsSomethingToElide(t *testing.T) {
+	const key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa="
+
+	long := truncateKey(key)
+	if len(long) >= len(key) {
+		t.Errorf("a full key reached the log: %q", long)
+	}
+	if !strings.HasSuffix(long, "…") {
+		t.Errorf("an elided key does not say it was elided: %q", long)
+	}
+
+	if got := truncateKey("short"); got != "short" {
+		t.Errorf("a short key was decorated: %q", got)
+	}
+}

--- a/cmd/meshpd/main.go
+++ b/cmd/meshpd/main.go
@@ -17,9 +17,16 @@
 //   - Everything it installs, it can remove. An agent crash or uninstall must never
 //     leave a host without networking (Invariant 20).
 //
-// Neither is exercised yet, because nothing here touches the network stack. What this
-// build does is hold sessions and record what it is told, which is what makes the
-// convergence machinery testable before there is anything to converge.
+// Both are exercised now, which they were not when this was written: meshpd creates
+// interfaces, configures the host's resolver, loads packet-filter rules and claims default
+// routes, and every one of those it can take back off — including after a kill, which is
+// what reclaimEgressLock is for.
+//
+// What is left in this package is the wiring between those things and the sessions that
+// drive them. That is why so much of it converts a possibly-absent implementation into an
+// interface: whether this host has a data plane, a dialer, a packet filter or a way to
+// configure names is a different answer on every platform, and saying "no" honestly is the
+// job (#165).
 package main
 
 import (

--- a/cmd/meshpd/main_test.go
+++ b/cmd/meshpd/main_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/agentapi"
+	"github.com/meshpnet/meshp/internal/agentstate"
+)
+
+// Where the daemon keeps its keys is a platform decision, and an operator's is final.
+//
+// Absolute is the part worth asserting rather than the exact string: meshpd is started by
+// systemd or launchd, whose working directory is not the one whoever wrote the unit had in
+// mind, and a relative state directory would put a device's identity somewhere nobody can
+// find it — and somewhere a second start might not find either.
+func TestTheStateDirectoryIsAbsoluteAndTheEnvironmentWins(t *testing.T) {
+	t.Setenv("MESHP_STATE_DIR", "")
+	if dir := defaultStateDir(); !filepath.IsAbs(dir) {
+		t.Errorf("the default state directory is %q, which is relative to wherever the "+
+			"service manager happened to start this process", dir)
+	}
+
+	chosen := filepath.Join(t.TempDir(), "elsewhere")
+	t.Setenv("MESHP_STATE_DIR", chosen)
+	if dir := defaultStateDir(); dir != chosen {
+		t.Errorf("the environment did not win: got %q, want %q", dir, chosen)
+	}
+}
+
+// The daemon and the CLI have to agree about where the socket is, or `meshp status` reports
+// nothing on a device that is working perfectly.
+//
+// Nothing joins these two: meshpd computes a default per platform and meshp takes
+// agentapi.DefaultSocketPath. They agree today everywhere meshp runs, and this is what says
+// so out loud.
+//
+// Windows is the exception and is deliberately not asserted. meshpd puts the socket under
+// C:\ProgramData\meshp and the CLI would still ask for the unix path, which is a real
+// disagreement — and not yet a bug, because Windows has no data plane at all (#144). Whoever
+// takes that issue has to teach cmd/meshp the same rule.
+func TestTheDaemonAndTheCLIAgreeOnWhereTheSocketIs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("meshp has no Windows data plane yet; see #144")
+	}
+	t.Setenv("MESHP_SOCKET", "")
+
+	if got := defaultSocketPath(); got != agentapi.DefaultSocketPath {
+		t.Errorf("meshpd listens on %q and meshp asks for %q; a working device would report "+
+			"nothing", got, agentapi.DefaultSocketPath)
+	}
+
+	t.Setenv("MESHP_SOCKET", "/tmp/somewhere.sock")
+	if got := defaultSocketPath(); got != "/tmp/somewhere.sock" {
+		t.Errorf("the environment did not win: got %q", got)
+	}
+}
+
+// A cosmetic mistake in a unit file must not keep a device offline.
+//
+// The interval only decides how often a converged interface is re-checked. Refusing to start
+// over an unparseable one would take a machine off the network to complain about a typo, so
+// it falls back and says so on stderr.
+func TestAMalformedIntervalDoesNotKeepADeviceOffline(t *testing.T) {
+	const fallback = 90 * time.Second
+
+	for _, tc := range []struct {
+		name, value string
+		want        time.Duration
+	}{
+		{"unset", "", fallback},
+		{"a duration", "15s", 15 * time.Second},
+		{"nonsense", "every so often", fallback},
+		{"a bare number, which Go does not accept", "60", fallback},
+		{"switched off deliberately", "0s", 0},
+	} {
+		t.Setenv("MESHP_TEST_INTERVAL", tc.value)
+		if got := envDuration("MESHP_TEST_INTERVAL", fallback); got != tc.want {
+			t.Errorf("%s: envDuration(%q) = %s, want %s", tc.name, tc.value, got, tc.want)
+		}
+	}
+}
+
+// The same argument for the log level: an unreadable one still logs.
+//
+// A daemon that exited over `MESHP_LOG_LEVEL=verbose` would be a device off the network
+// because somebody guessed a word.
+func TestAnUnreadableLogLevelStillLogs(t *testing.T) {
+	ctx := context.Background()
+
+	fallback := newLogger("verbose")
+	if !fallback.Enabled(ctx, slog.LevelInfo) {
+		t.Error("an unreadable log level left the daemon silent at info")
+	}
+	if fallback.Enabled(ctx, slog.LevelDebug) {
+		t.Error("an unreadable log level was taken as a request for debug logging")
+	}
+
+	// And a readable one is honoured, or the fallback above would be the only behaviour.
+	if !newLogger("debug").Enabled(ctx, slog.LevelDebug) {
+		t.Error("debug was asked for and not enabled")
+	}
+	if newLogger("error").Enabled(ctx, slog.LevelWarn) {
+		t.Error("error was asked for and warnings were logged anyway")
+	}
+}
+
+// "There is no state" and "the state cannot be read" have to stay different questions.
+//
+// The first is normal: the agent is installed before anyone has a token and must stay up so
+// that `meshp join` has something to talk to. The second must never be treated as start
+// fresh — that abandons the device's identity and leaves a registered device nobody can
+// revoke by name.
+func TestOnlyAnAbsentStateFileCountsAsNotEnrolled(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"never enrolled", agentstate.ErrNotEnrolled, true},
+		{"no file", fs.ErrNotExist, true},
+		{"wrapped on the way up", fmt.Errorf("loading: %w", agentstate.ErrNotEnrolled), true},
+
+		{"readable by more than its owner", agentstate.ErrPermissive, false},
+		{"there and unparseable", fmt.Errorf("state.json is not valid state: unexpected end of JSON input"), false},
+		{"the disk is failing", fs.ErrPermission, false},
+	} {
+		if got := isNotEnrolled(tc.err); got != tc.want {
+			t.Errorf("%s: isNotEnrolled(%v) = %v, want %v", tc.name, tc.err, got, tc.want)
+		}
+	}
+}

--- a/cmd/meshpd/ornil.go
+++ b/cmd/meshpd/ornil.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"github.com/meshpnet/meshp/internal/nftables"
+	"github.com/meshpnet/meshp/internal/pathprobe"
+	"github.com/meshpnet/meshp/internal/relaylink"
+	"github.com/meshpnet/meshp/internal/resolved"
+	"github.com/meshpnet/meshp/internal/sessionclient"
+	"github.com/meshpnet/meshp/internal/tunnel"
+	"github.com/meshpnet/meshp/internal/wglink"
+)
+
+// proberOrNil hands over a dialer as the interface, or nothing when this host has none.
+//
+// The canonical version of a conversion this file repeats seven times, and the reason it is
+// written out at all rather than assigned directly.
+//
+// A nil *T put into an interface is not a nil interface. It is a non-nil interface holding a
+// nil pointer, so every `x == nil` downstream passes and the first method call panics — on
+// the platform with no data plane, no dialer, no packet filter, which is precisely where the
+// absence was supposed to *be* the answer. It has bitten this project already.
+//
+// Each of these takes what a constructor returned rather than calling the constructor
+// itself, and that is not a style choice. Every one of these constructors returns something
+// on Linux and on macOS, so the case that matters cannot be reached by calling them; passing
+// the value in is what lets a test hand over a nil and see what comes back (#165).
+func proberOrNil(d *pathprobe.BoundDialer) tunnel.Prober {
+	if d == nil {
+		return nil
+	}
+	return d
+}
+
+// routerOrNil hands over a router as the interface, or nothing — so a device asked for a
+// full tunnel it cannot deliver reports the group unhonoured instead of pretending.
+func routerOrNil(r *wglink.Router) tunnel.Egress {
+	if r == nil {
+		return nil
+	}
+	return r
+}
+
+// filterOrNil hands over a packet filter as the interface, or nothing — so a host that
+// cannot enforce says so rather than accepting a policy it will not apply (ADR-0007).
+func filterOrNil(f *nftables.Filter) tunnel.Filter {
+	if f == nil {
+		return nil
+	}
+	return f
+}
+
+// resolverOrNil hands over the host's resolver configurer as the interface, or nothing —
+// so names answer to a direct query and `meshp status` says why (ADR-0021).
+func resolverOrNil(s *resolved.System) tunnel.SystemResolver {
+	if s == nil {
+		return nil
+	}
+	return s
+}
+
+// relayOrNil hands over a relay link as the interface, or nothing when this build has no
+// relay: relayed peers then get no endpoint, which is what they had before there was one.
+func relayOrNil(l *relaylink.Link) tunnel.Relay {
+	if l == nil {
+		return nil
+	}
+	return l
+}
+
+// relayCredentials hands over the same link as the thing that holds its capability.
+func relayCredentials(l *relaylink.Link) sessionclient.RelayCredentials {
+	if l == nil {
+		return nil
+	}
+	return l
+}
+
+// pathsOrNil hands over the reconciler as a path reporter, or nothing.
+//
+// The same trap the control plane's presence hook documents, reached from the other side: a
+// membership with no reconciler is a device with no data plane, and it would report paths
+// for an interface that does not exist.
+func pathsOrNil(r *tunnel.Reconciler) sessionclient.PathReports {
+	if r == nil {
+		return nil
+	}
+	return r
+}

--- a/cmd/meshpd/ornil_test.go
+++ b/cmd/meshpd/ornil_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/meshpnet/meshp/internal/nftables"
+	"github.com/meshpnet/meshp/internal/pathprobe"
+	"github.com/meshpnet/meshp/internal/relaylink"
+	"github.com/meshpnet/meshp/internal/resolved"
+	"github.com/meshpnet/meshp/internal/tunnel"
+	"github.com/meshpnet/meshp/internal/wglink"
+)
+
+// The trap these functions exist for, which this package could not reach until they took an
+// argument.
+//
+// A nil *T put into an interface is a non-nil interface holding a nil pointer. Every
+// `x == nil` downstream then passes and the first method call panics — on the platform with
+// no data plane, no dialer, no packet filter, which is exactly where the absence was
+// supposed to be the answer. Four separate comments in this package warned about it and
+// nothing checked.
+//
+// Each case names what actually goes wrong, because "returns nil" is not why any of this is
+// written the way it is.
+func TestAnAbsentImplementationBecomesANilInterface(t *testing.T) {
+	if got := proberOrNil(nil); got != nil {
+		t.Error("a host with no bound dialer got a prober; the first path probe would panic " +
+			"instead of the reconciler falling back to the handshake")
+	}
+	if got := routerOrNil(nil); got != nil {
+		t.Error("a host that cannot claim a default route got an Egress; it would report a " +
+			"full tunnel honoured and send nothing through it")
+	}
+	if got := filterOrNil(nil); got != nil {
+		t.Error("a host that cannot filter got a Filter; it would accept a network's policy " +
+			"and fail on every one (ADR-0007)")
+	}
+	if got := resolverOrNil(nil); got != nil {
+		t.Error("a host whose resolver meshp cannot configure got a SystemResolver; every " +
+			"reconcile would panic rather than names answering directly")
+	}
+	if got := relayOrNil(nil); got != nil {
+		t.Error("a build with no relay got a Relay; configuring a relayed peer would panic")
+	}
+	if got := relayCredentials(nil); got != nil {
+		t.Error("a build with no relay got RelayCredentials; the session would panic asking " +
+			"for a capability that cannot exist")
+	}
+	if got := pathsOrNil(nil); got != nil {
+		t.Error("a membership with no reconciler got a PathReports; it would report paths " +
+			"for an interface that does not exist")
+	}
+}
+
+// And the other half, or the check above would be satisfied by functions that return nil
+// always — which would take the data plane off every device on every platform.
+func TestSomethingPresentIsHandedOver(t *testing.T) {
+	if got := proberOrNil(&pathprobe.BoundDialer{}); got == nil {
+		t.Error("a host with a bound dialer was reported as having none")
+	}
+	if got := routerOrNil(&wglink.Router{}); got == nil {
+		t.Error("a host that can claim a default route was reported as unable to")
+	}
+	if got := filterOrNil(&nftables.Filter{}); got == nil {
+		t.Error("a host that can enforce a policy was reported as unable to")
+	}
+	if got := resolverOrNil(&resolved.System{}); got == nil {
+		t.Error("a host whose resolver meshp can configure was reported as unable to")
+	}
+	if got := relayOrNil(&relaylink.Link{}); got == nil {
+		t.Error("a live relay link was dropped, leaving every relayed peer unreachable")
+	}
+	if got := relayCredentials(&relaylink.Link{}); got == nil {
+		t.Error("a live relay link was not offered as the holder of its capability")
+	}
+	if got := pathsOrNil(&tunnel.Reconciler{}); got == nil {
+		t.Error("a live reconciler was not offered as a path reporter, so the control plane " +
+			"would never learn which paths work")
+	}
+}


### PR DESCRIPTION
Closes #165.

`internal/platformcheck` has been logging this package since #164 — *"cmd/meshpd decides something from the operating system and has no tests at all"* — and it logs rather than fails on purpose, because naming a package with no tests in the macOS job would fail the job rather than test anything.

## The question the issue asks

> Whether the answer is tests here or a smaller `cmd/meshpd`. A package that is hard to test because it is wiring is often a package whose wiring belongs somewhere with a seam.

**Tests here.** The seams a refactor would move this towards already exist: `internal/tunnel` takes interfaces, and `wglink`, `resolved`, `nftables` and `egresslock` each do their own platform dispatch. What is left in `cmd/meshpd` genuinely is wiring, and moving it would move it rather than make it testable. What the package lacked was tests for the decisions it *does* make.

## The nil-interface trap, which could not be reached

Six functions existed only to convert a possibly-absent implementation into an interface, four carrying a copy of the same warning. `proberOrNil` records that it has bitten the project already:

> a nil `*pathprobe.BoundDialer` assigned straight to an interface is a non-nil interface holding a nil pointer, so the reconciler's `r.prober == nil` check would pass and every probe would panic on a platform that has no dialer.

None of it was checkable. Three of the six called their constructor inline, and every one of those constructors returns something on Linux and on macOS — so the case the functions exist for could not be reached by calling them.

**They take an argument now.** That is the whole change: a test can hand over a nil and see what comes back. They also moved to `ornil.go` with one canonical explanation instead of four copies.

### Why not generics

One `orNil[I, P](p P) I` would replace six near-identical bodies, and I wrote it before throwing it away. Collapsing them needs a runtime type assertion (`any(p).(I)`), so an instantiation whose concrete type does not satisfy the named interface compiles fine and panics at daemon start. For a process whose stated job is to never leave a host without networking, that is the wrong side of the trade. Six boring functions keep the compiler checking.

## What is tested

Sixteen tests, on what this package decides rather than what it wires:

- the state directory is absolute — a relative one puts a device's identity wherever systemd or launchd happened to start the process
- **the daemon and the CLI agree on where the socket is** — nothing joined those two, and a drift means `meshp status` reports nothing on a device that is working perfectly
- a malformed `MESHP_RECONCILE_INTERVAL` or `MESHP_LOG_LEVEL` does not keep a device offline
- an absent state file is "not enrolled"; an unreadable one is **not** "start fresh" — that would abandon the device's identity and leave a registered device nobody can revoke by name
- being taken down survives a restart, and a device that was taken down does not even look at its memberships
- an unchanged value is not written back — this runs once a minute per membership on every device
- a port of zero does not overwrite the one a device settled on
- a membership read from disk is not a report of a live tunnel

**Nothing here touches the host** — no interface, no packet filter, no resolver, no socket. That is deliberate, because these now run as root on the macOS runner: a test that called `reclaimEgressLock` would remove a real fail-closed lock from whatever machine it ran on, including a developer's own.

## A test that was passing for the wrong reason

Fifteen mutations were checked. Two survived the first pass, and one of them mattered.

The pause test asserted that no sessions started on a device taken down deliberately — and it **passed with the guard removed**. The test membership carries an identity that will not decode, so `ensureSession` bailed before registering anything either way, and `len(a.running) == 0` was true for a reason that had nothing to do with pausing.

It reads the log now, and asserts that the *unpaused* device does reach its memberships. Without that half it would pass on any agent that fails to start a session for any reason at all.

(The other survivor was my own bad mutation: I changed the Linux branch of `defaultStateDir` while running on macOS. Mutating the darwin branch catches it — which is the argument for this package being in both jobs.)

## Also

`cmd/meshpd` joins the macOS job, so `platformcheck` stops logging it. And the package comment claimed *"nothing here touches the network stack"*, which stopped being true several data planes ago.
