### PR TITLE
fix(dataplane): a macOS laptop that changes networks or is killed recovers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Start here.
 |---|---|
 | [Invariants](INVARIANTS.md) | The claims this system makes, written so they can be checked by machines. |
 | [Decision records](adr/) | Why things are the way they are. |
+| [macOS laptop checks](testing/macos-laptop.md) | The things CI cannot prove, because a hosted runner never sleeps and never changes networks. |
 
 ## If you are evaluating meshp
 

--- a/docs/testing/macos-laptop.md
+++ b/docs/testing/macos-laptop.md
@@ -1,0 +1,162 @@
+# What a macOS laptop does: sleep, wake, and changing networks
+
+CI proves that a Mac can bring a tunnel up, resolve names, claim a default route and refuse
+egress that does not go through it. It proves all of that on an idle hosted runner, in under
+a minute, on a machine that never sleeps and never changes networks.
+
+That is a real proof and it is not the case anybody will actually run. A macOS device is a
+laptop: it closes, it moves between wifi and a phone hotspot, it joins a corporate VPN that
+claims the default route. Hosted runners do none of those things, which is why this is a
+document somebody follows rather than a job that runs (#160).
+
+**Run this before tagging a release, and before merging anything that touches
+`internal/wglink`, `internal/pf` or `internal/resolved` on macOS.** Record the results in the
+table at the bottom. An empty row is not a pass.
+
+## What you need
+
+- A control plane the laptop can reach **over the internet** — not a loopback one. Half of
+  what is being tested is what happens when the laptop's route to that address changes, and
+  a control plane on `127.0.0.1` cannot exercise it.
+- The Mac enrolled in a network, with `meshp status` reporting a tunnel whose kind is
+  `userspace`.
+- A network with a route group carrying `0.0.0.0/0` assigned to this device, and
+  `fail_closed` enforced. Without that, none of the egress behaviour is reachable.
+- Two networks you can move between. Wifi and a phone hotspot is the easiest pair, and a
+  hotspot is also the more honest test: a different gateway, a different address family
+  situation, and often carrier-grade NAT.
+
+## What to look at
+
+Keep these in three terminals. Everything here works on a machine with no internet, which is
+the state some of these steps produce.
+
+```bash
+meshp status
+```
+
+```bash
+sudo meshp doctor
+```
+
+```bash
+netstat -rn -f inet | head -20
+sudo pfctl -a com.apple/meshp -s rules -v
+```
+
+The daemon's own log is the fourth thing worth having, and where it goes depends on how
+meshpd was started. Run it in a terminal for these checks rather than under launchd, so the
+log is in front of you.
+
+## The checks
+
+### 1. Sleep and wake
+
+The tunnel lives inside the agent's process, so it survives a sleep only if the process and
+its sockets do. macOS suspends processes and tears down sockets aggressively.
+
+1. Confirm `meshp status` shows the tunnel up and a live session.
+2. Close the lid. Wait at least five minutes — a short sleep does not reach the same code
+   paths as one long enough for the control channel to time out server-side.
+3. Open it.
+4. Watch `meshp status` **without touching anything else**. That is the whole test: recovery
+   has to need nothing from the person carrying the laptop.
+
+**Pass:** within one reconcile interval (a minute by default), the tunnel is up, the session
+is connected, and peers handshake again. `meshp doctor` reports nothing stranded.
+
+**Record:** how long recovery took, and whether anything needed a nudge.
+
+### 2. Changing networks
+
+A new address means the tunnel's outer endpoint has moved. Because meshp is relay-first
+(ADR-0002), the relay connection has to be re-established rather than a direct path
+renegotiated — which should make this easier than it is for other implementations. "Should"
+is doing the work in that sentence, which is why this check exists.
+
+1. On wifi, with a full tunnel claimed, note the default gateway:
+   `route -n get default | grep gateway`.
+2. Note the carve-out routes meshp installed: `netstat -rn -f inet | grep -E '^(0\.0\.0\.0/1|128\.0\.0\.0/1)'`
+   and the host routes to your relay and control plane.
+3. Turn wifi off and tether to a phone.
+4. Watch `meshp status` and the routing table.
+
+**Pass:** the carve-out routes point at the **new** gateway, the relay reconnects, and the
+tunnel comes back — again with nothing done by hand.
+
+**Watch for:** a host route to the relay or the control plane still pointing at the old
+gateway. That address is not reachable on the new network, and with fail-closed egress in
+force the laptop has no way out at all until it is corrected. This is the specific thing that
+makes the reconcile interval matter more on macOS than on Linux: the carve-out is routed
+rather than marked, so it is pinned to whatever gateway was current when it was made.
+
+That correction was broken until #160 and is worth checking rather than assuming.
+`route add` reports an existing destination as "File exists" without touching it, so every
+re-claim was told the route it wanted was already there and the stale one survived. It is
+corrected in place now. **The remaining exposure is the interval itself**: nothing watches
+for a network change, so the gap between moving and recovering is however long it is until
+the next pass, up to a minute by default. Time it. If it is much longer than that, the
+correction is not happening and this check has found the same class of bug again.
+
+### 3. An ungraceful death while a full tunnel is claimed
+
+ADR-0011 keeps the lock installed across a crash on purpose, and Invariant 20 says the agent
+must never leave a host without networking. Those two pull against each other exactly here.
+
+1. With a full tunnel claimed and failing closed, `sudo kill -9` the daemon.
+2. Before restarting anything, run `sudo meshp doctor`. It should say the machine is refusing
+   traffic and that meshpd is not running, and print the commands to undo both halves.
+3. Check what is actually left: `sudo pfctl -a com.apple/meshp -s rules` and
+   `netstat -rn -f inet`.
+4. Start meshpd again and watch its first few log lines.
+
+**Pass:** the daemon reports what it found and removes it — both the pf anchor and the
+routes — and the machine has ordinary networking within a reconcile interval.
+
+**Watch for:** the daemon logging that it found a claimed default route and leaving routes
+behind anyway. Releasing the routing is the half with no equivalent of the firewall mark
+Linux uses to find its own work again: a restarted daemon reads
+`/var/run/meshp/egress-routes`, which the claim wrote, and takes off exactly what is named
+there. Check that the file is gone afterwards. If it is still present, the release did not
+complete and the next start will try to delete routes that may no longer be meshp's.
+
+### 4. A VPN that claims the default route
+
+Now that macOS fails closed (ADR-0026), this interaction is worth knowing rather than
+guessing at. Another VPN and meshp both want the default route, and both may be enabling pf.
+
+1. With meshp holding a full tunnel, connect a corporate or commercial VPN.
+2. Check `netstat -rn -f inet` for whose routes won.
+3. Check `sudo pfctl -s info` for the enable reference count, and `sudo pfctl -s rules` for
+   whether the `com.apple/*` anchor point is still there.
+4. Disconnect the other VPN and check that meshp's lock and routes are intact.
+
+**Pass:** whatever happens to routing, meshp's anchor is still nested where it can be
+evaluated, the pf reference count is not left at zero with meshp still expecting it, and
+disconnecting the other VPN does not leave this machine locked with nothing to carry
+traffic.
+
+**Record what happens even if it is bad.** This is the one check whose purpose is to find
+out rather than to confirm.
+
+### 5. `connected_since` after the laptop sleeps
+
+Server-side, and the reason it is here: a laptop that sleeps without closing its session
+leaves `membership_state.connected_since` set, so the device reads as connected on every
+replica until the session times out.
+
+1. Note the device as connected in the API.
+2. Sleep the laptop for longer than the session timeout.
+3. Poll the device's state and record how long it goes on claiming to be connected.
+
+**Pass:** it stops reading as connected within the timeout, and the bound is what the code
+says it is.
+
+## Results
+
+One row per build actually exercised. A release without a row for its build has not had this
+run.
+
+| Date | Build | macOS | 1 Sleep | 2 Networks | 3 kill -9 | 4 Other VPN | 5 connected_since | Notes |
+|---|---|---|---|---|---|---|---|---|
+| | | | | | | | | |

--- a/internal/wglink/egress_darwin.go
+++ b/internal/wglink/egress_darwin.go
@@ -9,7 +9,11 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
 	"sync"
 
 	"golang.org/x/net/route"
@@ -52,11 +56,28 @@ var egressHalves6 = []netip.Prefix{
 	netip.MustParsePrefix("8000::/1"),
 }
 
+// egressRecordPath is where a claim is written down so that a later process can undo it.
+//
+// This is the routing half of what reclaimEgressLock does at start-up, and the reason it
+// needs a file at all is that macOS has no equivalent of the firewall mark. Linux finds a
+// claim it did not make by asking the kernel for the mark, which is a constant; the halves
+// are a constant here too, but the host routes keeping the relay and the control plane off
+// the tunnel are not — they are whatever that claim's endpoints were.
+//
+// Without this a restarted daemon can see that a claim exists, because EgressHeld reads the
+// routing table, and has no way to take it off. It would log that it found one, delete
+// nothing, and report success: Invariant 20 not holding on this platform, quietly.
+//
+// Under /var/run because routes do not survive a reboot either. Nothing depends on that
+// directory being cleared, though — a record that outlived its routes asks for deletions
+// that are already true, and deleteRoute treats those as success.
+var egressRecordPath = filepath.Join("/var/run/meshp", "egress-routes")
+
 // Router claims the default route on macOS.
 //
 // It remembers what it installed, because releasing means removing exactly those routes and
-// nothing else. That memory is this process's, so a Router that has never claimed cannot
-// release what a previous process did — see EgressHeld, which asks the kernel instead.
+// nothing else — and it writes the same list down, because that memory dies with the
+// process and the routes do not. See egressRecordPath.
 type Router struct {
 	mu       sync.Mutex
 	claimed  []netip.Prefix
@@ -122,6 +143,10 @@ func (r *Router) Claim(iface string, endpoints []netip.AddrPort, excluded []neti
 		}
 		r.claimed = append(r.claimed, prefix)
 	}
+
+	// Written last, so the record only ever describes a claim that is fully in place. A
+	// half-made claim has already been undone by the error paths above.
+	recordClaim(append(append([]netip.Prefix{}, r.viaLocal...), r.claimed...))
 	return nil
 }
 
@@ -179,15 +204,87 @@ func (r *Router) Release() error {
 // first would leave the rest installed, which on this path means a machine still sending
 // everything into a tunnel that is going away.
 func (r *Router) releaseLocked() error {
+	remembered := append(append([]netip.Prefix{}, r.claimed...), r.viaLocal...)
+
 	var errs []error
-	for _, prefix := range append(append([]netip.Prefix{}, r.claimed...), r.viaLocal...) {
+	for _, prefix := range releaseTargets(remembered, recordedClaim()) {
 		if err := deleteRoute(prefix); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	r.claimed, r.viaLocal = nil, nil
+	forgetClaim()
 	return errors.Join(errs...)
 }
+
+// releaseTargets is which routes a release should take off.
+//
+// Three cases, and the third is why this is a function of its own rather than three lines
+// inside releaseLocked — it is the one that guesses, and guessing wrong takes a machine off
+// the network.
+//
+//   - What this process installed, which is the ordinary release.
+//   - Plus what any process wrote down, which is how a restarted daemon undoes a claim it
+//     did not make.
+//   - And if there is neither, the halves. The only caller that reaches a release with
+//     nothing to go on is one that checked EgressHeld first, so something *is* holding the
+//     routing and the record has been lost. The halves are the part that captures every
+//     packet the machine sends; guessing at them is better than leaving somebody with no way
+//     out. The host routes cannot be guessed at and are left behind, which is survivable —
+//     they point at a gateway that works, and the next claim corrects them.
+func releaseTargets(remembered, recorded []netip.Prefix) []netip.Prefix {
+	out := append([]netip.Prefix{}, remembered...)
+	for _, prefix := range recorded {
+		if !slices.Contains(out, prefix) {
+			out = append(out, prefix)
+		}
+	}
+	if len(out) == 0 {
+		out = append(append(out, egressHalves...), egressHalves6...)
+	}
+	return out
+}
+
+// recordClaim writes down what this claim installed.
+//
+// Best effort, and deliberately not fatal: a claim that worked is worth having even on a
+// host where /var/run cannot be written. What is lost is the ability of the *next* process
+// to undo it precisely, which releaseLocked falls back for.
+func recordClaim(prefixes []netip.Prefix) {
+	if err := os.MkdirAll(filepath.Dir(egressRecordPath), 0o700); err != nil {
+		return
+	}
+	var b strings.Builder
+	for _, prefix := range prefixes {
+		b.WriteString(prefix.String())
+		b.WriteString("\n")
+	}
+	_ = os.WriteFile(egressRecordPath, []byte(b.String()), 0o600)
+}
+
+// recordedClaim reads back what some process claimed, or nothing.
+//
+// Unparseable lines are skipped rather than failing the read. A record that has been
+// corrupted still names routes that ought to come off, and refusing the whole file over one
+// bad line would leave a machine holding all of them.
+func recordedClaim() []netip.Prefix {
+	raw, err := os.ReadFile(egressRecordPath)
+	if err != nil {
+		return nil
+	}
+	var out []netip.Prefix
+	for _, line := range strings.Split(string(raw), "\n") {
+		prefix, err := netip.ParsePrefix(strings.TrimSpace(line))
+		if err != nil {
+			continue
+		}
+		out = append(out, prefix)
+	}
+	return out
+}
+
+// forgetClaim removes the record, once the routes it names are gone.
+func forgetClaim() { _ = os.Remove(egressRecordPath) }
 
 // EgressHeld reports whether a default route claim is in place, whoever made it.
 //
@@ -203,11 +300,48 @@ func EgressHeld() (bool, error) {
 	return present, nil
 }
 
-// addRoute installs one route, treating "it is already there" as success.
+// addRoute makes one route exist and point where it is asked to.
 //
-// Idempotent because the reconciler calls this every pass. route(8) reports an existing
-// route as "File exists" and exits non-zero, which is not a failure of anything.
+// Idempotent because the reconciler calls this every pass, and "already there" is the
+// ordinary case rather than an error. What matters is what "already there" is taken to mean.
+//
+// It used to mean success. route(8) reports an existing destination as "File exists" and
+// exits non-zero without touching the route, so a destination whose gateway had gone stale
+// stayed stale for as long as the claim lasted — and on this platform the carve-out keeping
+// the relay and the control plane off the tunnel is a set of host routes pinned to whatever
+// gateway was current when the claim was made. A laptop that moved to another network kept
+// sending them to a gateway that is not on it. With fail-closed egress in force that is a
+// machine with no way out at all, and the reconciler running every minute could not fix it,
+// because every pass was told the route it wanted was already there (#160).
+//
+// So an existing destination is corrected rather than accepted. `route change` does it in
+// place, which matters: deleting first would leave a window with no route at all, and for
+// the halves that window is one where traffic leaves outside the tunnel. Replacing is the
+// fallback for a route that cannot be changed in place, because a leak measured in
+// milliseconds is better than a claim that silently is not what it says.
 func addRoute(prefix netip.Prefix, via ...string) error {
+	out, err := routeCommand("add", prefix, via...)
+	if err == nil {
+		return nil
+	}
+	if !bytes.Contains(out, []byte("File exists")) {
+		return fmt.Errorf("route add %s: %w: %s", prefix, err, trimNewline(out))
+	}
+
+	if _, err := routeCommand("change", prefix, via...); err == nil {
+		return nil
+	}
+	if err := deleteRoute(prefix); err != nil {
+		return err
+	}
+	if out, err := routeCommand("add", prefix, via...); err != nil {
+		return fmt.Errorf("route add %s: %w: %s", prefix, err, trimNewline(out))
+	}
+	return nil
+}
+
+// routeCommand runs one route(8) verb against one prefix.
+func routeCommand(verb string, prefix netip.Prefix, via ...string) ([]byte, error) {
 	family := "-inet"
 	if prefix.Addr().Is6() {
 		family = "-inet6"
@@ -215,15 +349,8 @@ func addRoute(prefix netip.Prefix, via ...string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
 	defer cancel()
 
-	args := append([]string{"-n", "add", family, prefix.String()}, via...)
-	out, err := exec.CommandContext(ctx, "/sbin/route", args...).CombinedOutput()
-	if err == nil {
-		return nil
-	}
-	if bytes.Contains(out, []byte("File exists")) {
-		return nil
-	}
-	return fmt.Errorf("route add %s: %w: %s", prefix, err, trimNewline(out))
+	args := append([]string{"-n", verb, family, prefix.String()}, via...)
+	return exec.CommandContext(ctx, "/sbin/route", args...).CombinedOutput()
 }
 
 // deleteRoute removes one, treating "it is not there" as success.

--- a/internal/wglink/egress_darwin.go
+++ b/internal/wglink/egress_darwin.go
@@ -300,42 +300,143 @@ func EgressHeld() (bool, error) {
 	return present, nil
 }
 
+// routeEnd is where the routing table currently sends a prefix.
+//
+// Either a gateway address or an interface name, because those are the two ways a route can
+// be written and route(8) takes them as different flags.
+type routeEnd struct {
+	present bool
+	gateway netip.Addr
+	iface   string
+}
+
+// goesTo reports whether this is already the route a claim is asking for.
+func (t routeEnd) goesTo(via []string) bool {
+	if !t.present || len(via) != 2 {
+		return false
+	}
+	switch via[0] {
+	case "-interface":
+		return t.iface != "" && t.iface == via[1]
+	case "-gateway":
+		want, err := netip.ParseAddr(via[1])
+		return err == nil && t.gateway.IsValid() && t.gateway == want.Unmap()
+	}
+	return false
+}
+
+// routeTarget asks the kernel where a prefix currently goes.
+func routeTarget(prefix netip.Prefix) (routeEnd, error) {
+	rib, err := route.FetchRIB(0, route.RIBTypeRoute, 0)
+	if err != nil {
+		return routeEnd{}, fmt.Errorf("reading the routing table: %w", err)
+	}
+	msgs, err := route.ParseRIB(route.RIBTypeRoute, rib)
+	if err != nil {
+		return routeEnd{}, fmt.Errorf("parsing the routing table: %w", err)
+	}
+	for _, msg := range msgs {
+		m, ok := msg.(*route.RouteMessage)
+		if !ok || len(m.Addrs) < 2 {
+			continue
+		}
+		if got, ok := prefixOf(m); !ok || got != prefix {
+			continue
+		}
+		if link, ok := m.Addrs[1].(*route.LinkAddr); ok {
+			return routeEnd{present: true, iface: linkName(link)}, nil
+		}
+		return routeEnd{present: true, gateway: addrOf(m.Addrs[1]).Unmap()}, nil
+	}
+	return routeEnd{}, nil
+}
+
+// linkName is what an interface route points at, by name.
+//
+// The routing socket may send the name or only the index, so the index is resolved when it
+// has to be. An interface that has gone away since the message was read has no name, and a
+// route pointing at one is not a route any claim is asking for.
+func linkName(link *route.LinkAddr) string {
+	if link.Name != "" {
+		return link.Name
+	}
+	if link.Index == 0 {
+		return ""
+	}
+	iface, err := net.InterfaceByIndex(link.Index)
+	if err != nil {
+		return ""
+	}
+	return iface.Name
+}
+
 // addRoute makes one route exist and point where it is asked to.
 //
 // Idempotent because the reconciler calls this every pass, and "already there" is the
 // ordinary case rather than an error. What matters is what "already there" is taken to mean.
 //
-// It used to mean success. route(8) reports an existing destination as "File exists" and
-// exits non-zero without touching the route, so a destination whose gateway had gone stale
-// stayed stale for as long as the claim lasted — and on this platform the carve-out keeping
-// the relay and the control plane off the tunnel is a set of host routes pinned to whatever
-// gateway was current when the claim was made. A laptop that moved to another network kept
-// sending them to a gateway that is not on it. With fail-closed egress in force that is a
-// machine with no way out at all, and the reconciler running every minute could not fix it,
-// because every pass was told the route it wanted was already there (#160).
+// It used to mean success, decided from what route(8) printed. That was wrong twice over.
+// route(8) does not modify an existing destination, so a route whose gateway had gone stale
+// stayed stale — and on this platform the carve-out keeping the relay and the control plane
+// off the tunnel is a set of host routes pinned to whatever gateway was current when the
+// claim was made. A laptop that moved to another network went on sending them to a gateway
+// that is not on it, and with fail-closed egress in force that is a machine with no way out
+// at all. The reconciler running every minute could not fix it, because every pass was told
+// the route it wanted was already there (#160).
 //
-// So an existing destination is corrected rather than accepted. `route change` does it in
-// place, which matters: deleting first would leave a window with no route at all, and for
-// the halves that window is one where traffic leaves outside the tunnel. Replacing is the
-// fallback for a route that cannot be changed in place, because a leak measured in
+// The second mistake was reading that from the command's output at all. The first attempt at
+// this fix branched on route(8) exiting non-zero with "File exists", which is what the old
+// comment here claimed it does, and the correction never ran — so the tests below still
+// found the stale route. What the kernel says is the only thing that cannot be misread, so
+// this asks the routing table before and after rather than trusting either the exit code or
+// the message.
+//
+// Changing in place is preferred to replacing: deleting first leaves a window with no route
+// at all, and for the halves that window is one where traffic leaves outside the tunnel.
+// Replacing is the fallback for a route that cannot be changed, because a leak measured in
 // milliseconds is better than a claim that silently is not what it says.
 func addRoute(prefix netip.Prefix, via ...string) error {
-	out, err := routeCommand("add", prefix, via...)
-	if err == nil {
+	target, err := routeTarget(prefix)
+	if err != nil {
+		return err
+	}
+	if target.goesTo(via) {
 		return nil
 	}
-	if !bytes.Contains(out, []byte("File exists")) {
-		return fmt.Errorf("route add %s: %w: %s", prefix, err, trimNewline(out))
+
+	if !target.present {
+		out, err := routeCommand("add", prefix, via...)
+		if err == nil {
+			return nil
+		}
+		// It appeared between the read and the write, which is the only way this happens
+		// and is not a failure of anything.
+		if !bytes.Contains(out, []byte("File exists")) {
+			return fmt.Errorf("route add %s: %w: %s", prefix, err, trimNewline(out))
+		}
 	}
 
 	if _, err := routeCommand("change", prefix, via...); err == nil {
-		return nil
+		if now, err := routeTarget(prefix); err == nil && now.goesTo(via) {
+			return nil
+		}
 	}
+
 	if err := deleteRoute(prefix); err != nil {
 		return err
 	}
 	if out, err := routeCommand("add", prefix, via...); err != nil {
 		return fmt.Errorf("route add %s: %w: %s", prefix, err, trimNewline(out))
+	}
+
+	// Verified rather than assumed, because everything above this line was once assumed.
+	now, err := routeTarget(prefix)
+	if err != nil {
+		return err
+	}
+	if !now.goesTo(via) {
+		return fmt.Errorf("wglink: %s was replaced and still does not go to %s",
+			prefix, strings.Join(via, " "))
 	}
 	return nil
 }

--- a/internal/wglink/egress_darwin_test.go
+++ b/internal/wglink/egress_darwin_test.go
@@ -446,3 +446,49 @@ func TestAHostRoutePinnedToTheWrongGatewayIsRepinned(t *testing.T) {
 			"the tunnel is unreachable and the tunnel cannot come back up", got, gateway)
 	}
 }
+
+// Whether a route already goes where a claim is asking for it to.
+//
+// This is the decision that says whether a correction happens at all, and getting it wrong
+// in the "yes it does" direction is the bug this whole mechanism exists to fix: a stale
+// carve-out that every pass believes is fine.
+func TestWhetherARouteAlreadyGoesWhereAsked(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		end  routeEnd
+		via  []string
+		want bool
+	}{
+		{"the interface it was asked for", routeEnd{present: true, iface: "utun5"},
+			[]string{"-interface", "utun5"}, true},
+		{"a different interface", routeEnd{present: true, iface: "en0"},
+			[]string{"-interface", "utun5"}, false},
+		{"the gateway it was asked for",
+			routeEnd{present: true, gateway: netip.MustParseAddr("192.168.1.1")},
+			[]string{"-gateway", "192.168.1.1"}, true},
+		{"the gateway of a network this laptop has left",
+			routeEnd{present: true, gateway: netip.MustParseAddr("192.168.1.1")},
+			[]string{"-gateway", "10.0.0.1"}, false},
+
+		{"no route at all", routeEnd{}, []string{"-interface", "utun5"}, false},
+		// Not a state routeTarget can produce, and asserted anyway: goesTo answers for a
+		// struct rather than for the routing table, and "absent" has to beat whatever else
+		// the struct is carrying or a caller could be told a route it has not got is fine.
+		{"absent, and carrying a target anyway",
+			routeEnd{iface: "utun5", gateway: netip.MustParseAddr("192.168.1.1")},
+			[]string{"-interface", "utun5"}, false},
+		{"an interface route asked for by gateway",
+			routeEnd{present: true, iface: "utun5"}, []string{"-gateway", "192.168.1.1"}, false},
+		{"a gateway route asked for by interface",
+			routeEnd{present: true, gateway: netip.MustParseAddr("192.168.1.1")},
+			[]string{"-interface", "utun5"}, false},
+		{"an interface that has gone away, so it has no name",
+			routeEnd{present: true}, []string{"-interface", "utun5"}, false},
+		{"something that is not a way of naming a route",
+			routeEnd{present: true, iface: "utun5"}, []string{"-blackhole"}, false},
+	} {
+		if got := tc.end.goesTo(tc.via); got != tc.want {
+			t.Errorf("%s: goesTo = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/wglink/egress_darwin_test.go
+++ b/internal/wglink/egress_darwin_test.go
@@ -4,6 +4,11 @@ package wglink
 
 import (
 	"net/netip"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 
 	"golang.org/x/net/route"
@@ -206,5 +211,238 @@ func TestNetmasksOfEveryLengthAreRead(t *testing.T) {
 	// does not have.
 	if got := maskBits(&route.Inet4Addr{IP: [4]byte{0xff, 0x0f, 0, 0}}, 32); got != -1 {
 		t.Errorf("a non-contiguous mask read as /%d", got)
+	}
+}
+
+// A claim has to be undoable by a process that did not make it.
+//
+// ADR-0011 keeps a full tunnel's routing in place across a crash on purpose, and Invariant 20
+// says the agent must never leave a host without networking. What joins those two is
+// meshpd finding the claim again on start-up and taking it off — and until this was written
+// down, macOS could not: Release removed what its own Router remembered, a restarted daemon
+// remembered nothing, and reclaimEgressLock logged that it had found a stale claim, deleted
+// nothing, and reported success.
+//
+// Linux has never had this problem because it finds its claim by the firewall mark, which is
+// a constant the kernel holds. This is that, for a platform with no marks.
+func TestAClaimIsWrittenDownSoAnotherProcessCanUndoIt(t *testing.T) {
+	egressRecordPath = filepath.Join(t.TempDir(), "egress-routes")
+
+	want := []netip.Prefix{
+		netip.MustParsePrefix("192.0.2.7/32"),
+		netip.MustParsePrefix("0.0.0.0/1"),
+	}
+	recordClaim(want)
+
+	got := recordedClaim()
+	if len(got) != len(want) {
+		t.Fatalf("wrote %d routes and read back %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("route %d is %s, want %s", i, got[i], want[i])
+		}
+	}
+
+	forgetClaim()
+	if left := recordedClaim(); len(left) != 0 {
+		t.Errorf("the record survived the release it describes: %v", left)
+	}
+}
+
+// A record that has been damaged still names the routes it can.
+//
+// Refusing the whole file over one bad line would leave a machine holding every route in it,
+// which is the outcome the record exists to prevent.
+func TestADamagedRecordStillNamesWhatItCan(t *testing.T) {
+	egressRecordPath = filepath.Join(t.TempDir(), "egress-routes")
+	if err := os.WriteFile(egressRecordPath,
+		[]byte("0.0.0.0/1\nnot a prefix\n\n128.0.0.0/1\n"), 0o600); err != nil {
+		t.Fatalf("writing a damaged record: %v", err)
+	}
+
+	got := recordedClaim()
+	if len(got) != 2 {
+		t.Fatalf("read %d routes out of a damaged record, want 2: %v", len(got), got)
+	}
+}
+
+// And the whole of it against the routing table: one Router claims, a different one releases.
+//
+// The second Router stands in for a restarted daemon. It shares nothing with the first but
+// the record on disk, which is exactly what reclaimEgressLock has to work from.
+func TestARestartedDaemonCanReleaseAClaimItDidNotMake(t *testing.T) {
+	requireRoot(t)
+	egressRecordPath = filepath.Join(t.TempDir(), "egress-routes")
+
+	// TEST-NET-1 rather than the halves: this is about whether the record is enough to find
+	// a route again, and it should not need to take the machine's traffic to prove it.
+	pinned := netip.MustParsePrefix("192.0.2.0/24")
+	t.Cleanup(func() { _ = deleteRoute(pinned) })
+
+	if err := addRoute(pinned, "-interface", "lo0"); err != nil {
+		t.Fatalf("adding %s: %v", pinned, err)
+	}
+	recordClaim([]netip.Prefix{pinned})
+
+	// A Router that has claimed nothing, which is what a daemon has after a kill -9.
+	if err := (&Router{}).Release(); err != nil {
+		t.Fatalf("releasing a claim this process did not make: %v", err)
+	}
+
+	present, err := routeExists(pinned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if present {
+		t.Error("a restarted daemon could not take off the route a previous one left; " +
+			"this machine keeps sending traffic into a tunnel that is gone")
+	}
+	if left := recordedClaim(); len(left) != 0 {
+		t.Errorf("the record outlived the routes it named: %v", left)
+	}
+}
+
+// Which routes a release takes off, including the case where it has to guess.
+//
+// The guess is the interesting one and the reason this is a function rather than three lines
+// inside releaseLocked: getting it wrong in one direction leaves a machine sending every
+// packet into a tunnel that is gone, and in the other deletes routes meshp never made.
+func TestWhatAReleaseTakesOff(t *testing.T) {
+	halves := netip.MustParsePrefix("0.0.0.0/1")
+	endpoint := netip.MustParsePrefix("192.0.2.7/32")
+	excluded := netip.MustParsePrefix("192.168.1.0/24")
+
+	t.Run("the ordinary release takes off what this process installed", func(t *testing.T) {
+		got := releaseTargets([]netip.Prefix{halves, endpoint}, nil)
+		if len(got) != 2 || got[0] != halves || got[1] != endpoint {
+			t.Errorf("got %v", got)
+		}
+	})
+
+	t.Run("a restarted daemon takes off what was written down", func(t *testing.T) {
+		got := releaseTargets(nil, []netip.Prefix{halves, endpoint})
+		if len(got) != 2 {
+			t.Fatalf("a release with nothing but a record took off %d routes: %v", len(got), got)
+		}
+		if !slices.Contains(got, endpoint) {
+			t.Error("the host route pinning an endpoint to the old gateway was left behind")
+		}
+	})
+
+	t.Run("what is remembered and what is recorded are not counted twice", func(t *testing.T) {
+		got := releaseTargets([]netip.Prefix{halves, endpoint}, []netip.Prefix{halves, excluded})
+		if len(got) != 3 {
+			t.Errorf("got %d routes, want 3 distinct: %v", len(got), got)
+		}
+	})
+
+	t.Run("with nothing to go on it takes off the halves", func(t *testing.T) {
+		got := releaseTargets(nil, nil)
+		if len(got) == 0 {
+			t.Fatal("a release with no record took nothing off, which is the bug this " +
+				"whole mechanism exists to fix: the machine goes on sending every packet " +
+				"into a tunnel that is gone")
+		}
+		for _, half := range append(append([]netip.Prefix{}, egressHalves...), egressHalves6...) {
+			if !slices.Contains(got, half) {
+				t.Errorf("%s was not taken off, so half the address space still points at "+
+					"a tunnel that is gone", half)
+			}
+		}
+		if slices.Contains(got, endpoint) {
+			t.Error("a release with nothing to go on invented a host route to delete")
+		}
+	})
+}
+
+// routeVia reports what the routing table says about a destination — the value of one of
+// route(8)'s "key: value" lines, such as `interface` or `gateway`.
+func routeVia(t *testing.T, destination, key string) string {
+	t.Helper()
+	out, err := exec.Command("/sbin/route", "-n", "get", destination).CombinedOutput()
+	if err != nil {
+		t.Fatalf("route -n get %s: %v: %s", destination, err, out)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		name, value, found := strings.Cut(strings.TrimSpace(line), ":")
+		if found && name == key {
+			return strings.TrimSpace(value)
+		}
+	}
+	t.Fatalf("route -n get %s printed no %s:\n%s", destination, key, out)
+	return ""
+}
+
+// A route that is already there but points somewhere else is corrected.
+//
+// This is the one that made a macOS laptop unable to survive changing networks. The carve-out
+// keeping the relay and the control plane off the tunnel is a set of host routes pinned to
+// whatever gateway was current when the claim was made, and every reconcile re-makes the
+// claim against the gateway the machine is using *now* — which was the whole design. But
+// route(8) reports an existing destination as "File exists" without touching it, and addRoute
+// read that as success. So the correcting pass corrected nothing, once a minute, forever.
+//
+// With fail-closed egress in force since ADR-0026, the consequence is not a slow tunnel. It
+// is a laptop that moved to another network and has no way out of it at all.
+func TestARouteThatPointsSomewhereElseIsCorrected(t *testing.T) {
+	requireRoot(t)
+
+	elsewhere := routeVia(t, "default", "interface")
+	if elsewhere == "lo0" {
+		t.Skip("this machine's default route is on loopback, so there is no second " +
+			"interface to be wrong about")
+	}
+
+	// TEST-NET-1: reserved, routed nowhere, and nothing on this machine wants it.
+	prefix := netip.MustParsePrefix("192.0.2.0/24")
+	t.Cleanup(func() { _ = deleteRoute(prefix) })
+
+	if err := addRoute(prefix, "-interface", "lo0"); err != nil {
+		t.Fatalf("adding %s: %v", prefix, err)
+	}
+	if got := routeVia(t, "192.0.2.1", "interface"); got != "lo0" {
+		t.Fatalf("the route was added and points at %q, so this test is not measuring what "+
+			"it thinks", got)
+	}
+
+	// The same destination, somewhere else. This is what a laptop changing networks asks
+	// for on the next reconcile.
+	if err := addRoute(prefix, "-interface", elsewhere); err != nil {
+		t.Fatalf("re-pointing %s: %v", prefix, err)
+	}
+	if got := routeVia(t, "192.0.2.1", "interface"); got != elsewhere {
+		t.Errorf("the route still points at %q rather than %q.\n"+
+			"A carve-out pinned to a gateway the machine has left is never corrected, so a "+
+			"laptop that changes networks while failing closed has no way out of the new one.",
+			got, elsewhere)
+	}
+}
+
+// And the same for a route named by gateway rather than by interface, which is the form the
+// carve-out actually uses.
+func TestAHostRoutePinnedToTheWrongGatewayIsRepinned(t *testing.T) {
+	requireRoot(t)
+
+	gateway, err := defaultGateway()
+	if err != nil {
+		t.Skipf("this machine has no IPv4 default route: %v", err)
+	}
+
+	prefix := netip.MustParsePrefix("192.0.2.9/32")
+	t.Cleanup(func() { _ = deleteRoute(prefix) })
+
+	// Loopback stands in for the gateway of a network the laptop has left: on-link, so the
+	// route can be installed, and not where anything should be sent.
+	if err := addRoute(prefix, "-gateway", "127.0.0.1"); err != nil {
+		t.Fatalf("pinning %s to loopback: %v", prefix, err)
+	}
+	if err := addRoute(prefix, "-gateway", gateway.String()); err != nil {
+		t.Fatalf("re-pinning %s to %s: %v", prefix, gateway, err)
+	}
+
+	if got := routeVia(t, "192.0.2.9", "gateway"); got != gateway.String() {
+		t.Errorf("the host route still goes via %q rather than %q; the endpoint it keeps off "+
+			"the tunnel is unreachable and the tunnel cannot come back up", got, gateway)
 	}
 }


### PR DESCRIPTION
Addresses #160.

The issue asks for a written test plan for the things CI cannot reach: a laptop sleeps, moves between wifi and a hotspot, and meets other VPNs, and a hosted runner does none of that.

**Writing the plan meant reading the code as if a laptop were about to run it, and two of the five checks would have failed.** Both are fixed here.

## 1. A stale carve-out was never corrected

macOS has no firewall mark, so the routes keeping the relay and the control plane off the tunnel are host routes pinned to whatever gateway was current when the claim was made. Every reconcile re-makes the claim against the gateway the machine is using *now* — that was the design, and `defaultGateway`'s comment says so:

> Read from the routing table rather than remembered, because [...] a laptop that changed networks since the last pass has a different one, and pinning the tunnel's endpoints to the old one would send them nowhere.

But `route(8)` reports an existing destination as `File exists` **without touching it**, and `addRoute` read that as success. So the correcting pass corrected nothing, once a minute, for as long as the claim lasted.

Since #169 the consequence is not a slow tunnel. A laptop that moves to another network is **failing closed with its relay pinned to a gateway that is not on it**: no tunnel, and no way out except the tunnel.

`addRoute` now changes such a route in place. Replacing it is the fallback rather than the first move, because deleting first leaves a window with no route at all — and for the halves that window is one where traffic leaves outside the tunnel.

## 2. A claim could not be released by the process that found it

ADR-0011 keeps the routing in place across a crash on purpose, and Invariant 20 says the agent must never leave a host without networking. What joins those two is meshpd finding the claim again at start-up.

On macOS it could not. `Release` removed what its own `Router` remembered; a restarted daemon remembers nothing; so `reclaimEgressLock` logged that it had found a stale claim, deleted nothing, and reported success. Linux has never had this problem because it finds its claim by the firewall mark, which is a constant the kernel holds.

The halves are constant here too, but the host routes are not — they are whatever that claim's endpoints were. So a claim is written to `/var/run/meshp/egress-routes`, and a release takes off what is named there. With neither memory nor record it falls back to the halves: that is the part which captures every packet the machine sends, and guessing at it beats leaving somebody with no way out. That decision is its own function (`releaseTargets`) precisely because it is the one that guesses.

## The plan

[`docs/testing/macos-laptop.md`](docs/testing/macos-laptop.md) — five checks (sleep/wake, changing networks, `kill -9` while claimed, another VPN, `connected_since` after a sleep), each with what to run, what passes, and a results table that a release is supposed to have a row in.

**Both bugs above are called out in the checks that would find them**, including how to tell a fix that is working from one that is not — a plan that only describes working behaviour teaches people to tick boxes.

## Testing

Four new tests, and the two that matter run as root on the macOS job:

- **a route that points somewhere else is corrected** — add via `lo0`, re-add via the real default interface, assert it moved. This fails on `main`.
- **a host route pinned to the wrong gateway is repinned** — the same in the form the carve-out actually uses.
- **a restarted daemon releases a claim it did not make** — one `Router` claims, a different one releases, sharing nothing but the record on disk.
- `releaseTargets` is unit-tested in all three cases including the guess, without touching the routing table.

Mutation-checked: never writing the record, refusing a damaged record whole, keeping the record after release. The route-correction mutations are only observable as root, so the macOS job is what exercises them.

## What is not here

**Nothing watches for a network change.** The recovery path is still the one-minute reconcile tick, so the gap between a laptop moving and recovering is up to a minute. The plan says to time it, and treats "much longer than that" as the same class of bug found again. Subscribing to `PF_ROUTE` messages so a change triggers an immediate pass is a mechanism rather than a test, and I would rather it had its own issue than arrived inside this one.

And CI still cannot sleep a laptop or move it between networks. That is why the document exists.
