### PR TITLE
feat(api): a guessed-at account slows down, and is never locked out

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,9 +32,10 @@ Out of scope: anything you deploy meshp on top of, and the deployment examples u
 `deploy/`, which are illustrative and say so.
 
 **Read this before you spend time on it.** meshp is pre-alpha and the README says not to
-deploy it. The data plane is Linux-only. Reports are still welcome and will be handled as
-above — but a finding that a half-built feature is half-built is not one, and there are
-several of those in the open issues already.
+deploy it. The data plane exists on Linux and macOS and nowhere else, and macOS cannot
+enforce a network's packet filter. Reports are still welcome and will be handled as above —
+but a finding that a half-built feature is half-built is not one, and there are several of
+those in the open issues already.
 
 ## Accounts, credentials and what happens to them
 
@@ -82,12 +83,17 @@ authenticated by cookie must carry an `Origin` naming this host.
 
 Said plainly, because a security policy that only lists strengths is not one:
 
-- **There is no lockout after repeated failures, and no per-account rate limit.** Sign-in
-  is throttled, but by the same per-address limiter the enrolment endpoints use, which is
-  deliberately generous — so it bounds a flood from one host and does nothing about a slow
-  distributed attempt on one account. Argon2id at 64 MiB makes online guessing expensive
-  rather than impossible. ADR-0024 names this as work its own decision creates; it is
-  tracked in [#148](https://github.com/meshpnet/meshp/issues/148).
+- **An account can still be guessed at, more slowly.** Five consecutive failures for an
+  address cost nothing; after that each attempt waits, doubling to a ceiling of one minute
+  (ADR-0027). That takes an attacker from roughly a million guesses a day to about fourteen
+  hundred. It is a slowdown and not a lockout, deliberately — a lockout is a denial of
+  service aimed at the account holder, and anyone who knows an address could impose it. So
+  fourteen hundred guesses a day is the residual exposure, and a weak password is still a
+  weak password. The answer to that is the second factor below.
+- **An attacker can make an account inconvenient to reach.** One failed attempt a minute,
+  sustained, keeps an address waiting more often than not. That is inherent to any
+  per-account throttle; here the window is a minute, any successful sign-in clears it, and
+  ten consecutive failures are reported in the log.
 - **There is no second factor.** The `mfa_enrolled_at` column exists and nothing writes it.
   ADR-0024 §1 commits to TOTP in the open core rather than as a paid feature.
 - **There is no password reset flow yet.** An administrator sets a password directly. The

--- a/cmd/meshp-control/main.go
+++ b/cmd/meshp-control/main.go
@@ -369,6 +369,7 @@ func run(ctx context.Context, log *slog.Logger, cfg runConfig) error {
 		log.Info("api serving", "admin_enabled", cfg.adminToken != "")
 
 		go pruneDeltaLog(ctx, log, st, cfg.deltaRetention)
+		go sweepExpired(ctx, log, st)
 	}()
 
 	defer func() {
@@ -637,6 +638,48 @@ func pruneDeltaLog(ctx context.Context, log *slog.Logger, st *store.Store, reten
 		if res.Rows > 0 {
 			log.Info("pruned the state change log",
 				"networks", res.Networks, "rows", res.Rows, "retention", retention)
+		}
+	}
+}
+
+// sweepExpired removes rows that have run out.
+//
+// Two tables, one loop, because they are the same chore: expired sessions and runs of failed
+// sign-ins that have gone quiet both belong to nobody and are removed on everybody's behalf.
+//
+// The session sweep is not new. Store.SweepSessions has existed since sessions did and
+// nothing has ever called it, so a deployment's user_sessions table has been growing by one
+// row per sign-in and shrinking only when somebody signs out — a mechanism nothing reached
+// (ADR-0018), found while adding the second table that needs the same treatment (#148).
+//
+// Hourly, and failures are not fatal. Both tables grow until the next sweep succeeds, which
+// is a size problem rather than a correctness one: an expired session is already refused by
+// the query that reads it, and a stale run of failures already produces no delay.
+func sweepExpired(ctx context.Context, log *slog.Logger, st *store.Store) {
+	const sweepInterval = time.Hour
+	ticker := time.NewTicker(sweepInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		// Bounded on its own, so a sweep cannot outlive the interval and overlap the next.
+		sweepCtx, cancel := context.WithTimeout(ctx, sweepInterval/2)
+		sessions, sessionsErr := st.SweepSessions(sweepCtx)
+		failures, failuresErr := st.SweepSignInFailures(sweepCtx)
+		cancel()
+
+		if err := errors.Join(sessionsErr, failuresErr); err != nil {
+			log.Error("could not sweep expired rows", "error", err)
+			continue
+		}
+		if sessions > 0 || failures > 0 {
+			log.Info("swept expired rows",
+				"sessions", sessions, "sign_in_failures", failures)
 		}
 	}
 }

--- a/docs/adr/0027-sign-in-slows-down-it-does-not-lock-out.md
+++ b/docs/adr/0027-sign-in-slows-down-it-does-not-lock-out.md
@@ -1,0 +1,117 @@
+# ADR-0027: A guessed-at account slows down; it is never locked out
+
+- **Status:** accepted
+- **Date:** 2026-08-28
+
+## Context
+
+ADR-0024 introduced password authentication and named the work that decision creates:
+
+> Argon2id with sensible parameters, a constant-time comparison, rate limiting on sign-in,
+> and lockout after repeated failures. None of it is novel and all of it has to be right.
+
+Three of the four shipped with it. The fourth did not, and #148 is the record of what is
+missing: sign-in sits behind the same per-address limiter the enrolment endpoints use, which
+bounds a flood from one host and does nothing about a slow attempt spread across many, aimed
+at one account. Argon2id at 64 MiB and two passes makes each guess cost real work — call it
+a tenth of a second — which is expensive rather than prohibitive. One host can put something
+like a million guesses a day against one address, and nothing counts them.
+
+What makes this worth a record rather than an afternoon's work is that the obvious fix has a
+victim. **Lockout is a denial of service aimed at the account holder.** Anyone who knows an
+address can lock its owner out by getting the password wrong enough times, and the person who
+suffers is the one who did nothing. A mechanism that protects an account by making it
+unusable has handed an attacker a cheaper attack than the one it prevents.
+
+## Decision
+
+Consecutive failed sign-ins for an address make the next attempt wait. The wait doubles and
+is **capped at one minute**. Nothing is ever locked out.
+
+- The first five failures cost nothing. People mistype.
+- The sixth costs a second, and each after that doubles: 2, 4, 8, 16, 32, then 60 for as long
+  as the failures continue.
+- A successful sign-in clears the count. So does an hour without an attempt.
+- Refusal is a `429` with `Retry-After`, not a `401`. Somebody who has mistyped six times is
+  told to wait, because "that email address and password do not match" would be a lie that
+  makes them keep trying.
+
+The count is keyed on the **submitted address**, whether or not an account exists for it, and
+stored as a hash rather than as text. Both halves of that matter and neither is fastidiousness
+— see the consequences.
+
+It lives in Postgres rather than in memory, because the control plane is meant to run as more
+than one instance and a counter held in one process is one an attacker walks around by
+spreading attempts across replicas.
+
+## Why a cap, and why one minute
+
+The cap is what makes this defensible rather than a trade of one attack for another.
+
+At a minute, an attacker's rate falls from roughly a million guesses a day to about fourteen
+hundred — three orders of magnitude — while the worst thing that can happen to a real person
+is that they wait a minute. That is an inconvenience they can sit through, not a support call,
+and nobody has to be trusted to unlock anything.
+
+It also dissolves a problem the issue raises: **whatever this does must not lock out the last
+owner**, or the bootstrap secret becomes the only way back into a deployment. With a one
+minute ceiling there is no such thing as locked out, so there is no exemption to write — and
+an exemption would have been a permanent hole aimed at the highest-value account in the
+system.
+
+## What this does not fix, said plainly
+
+**An attacker can still make an account inconvenient to reach.** One failed attempt a minute,
+sustained, keeps an address in the penalty box more often than not. That is inherent to any
+per-account throttle and this one has the mildest version of it: the window is a minute, a
+successful sign-in during any gap resets it, and the attempt rate needed to sustain it is
+loud in the log and bounded by the per-address limiter.
+
+**Fourteen hundred guesses a day is still a lot against a bad password.** This buys time and
+makes the attempt visible; it does not make a weak password safe. The answer to that is the
+second factor ADR-0024 §1 commits to, and this is what protects an account until it has one.
+
+## Consequences
+
+**Failures are counted for addresses that have no account.** Not doing so would be an oracle:
+if a known address is throttled and an unknown one is not, response time answers "does this
+person have an account here" for anybody who cares to measure — the same question the single
+shared refusal message exists to avoid answering. So the counter does not know whether the
+address exists, and cannot leak it.
+
+**The address is stored as a SHA-256 hash.** It follows from counting unknown addresses: an
+attacker choosing what goes in this table would otherwise be choosing what text this
+deployment stores, and the table would fill with the addresses of people who have no account
+here. A hash is a fixed-size key that answers the only question this table is asked, and it
+means a dump of it discloses nobody.
+
+**An account under sustained attack is reported once rather than per attempt.** Crossing ten
+consecutive failures logs a distinct warning naming the address; the individual refusals go
+on being logged as they were. #148's third complaint was that nothing tells anybody this is
+happening, and a line per attempt is not telling anybody — it is the thing an operator has
+already muted.
+
+**There is a new table to sweep.** It joins `user_sessions`, whose sweep existed and was
+called by nothing until this change, so both are now swept on the same hourly loop that
+prunes the delta log.
+
+## Alternatives considered
+
+**Lockout after N failures, expiring after some minutes.** What most systems do. Rejected on
+the victim: fifteen minutes is long enough to be a support call, and an attacker who can
+impose it repeatedly has denied service to somebody who did nothing. Every argument for it
+is an argument for the cap being higher, and the cap being higher is the whole of the harm.
+
+**Per-address counting only, without the per-account limit.** What exists today. It is the
+right tool for a flood and the wrong one for a patient attacker on one account, which is the
+threat that matters once a deployment is on the internet.
+
+**Requiring a second factor after repeated failures instead of slowing down.** Better, and
+unavailable: `users.mfa_enrolled_at` exists and nothing writes it. An account with no second
+factor cannot be asked for one, and that is most of them until ADR-0024 §1 is built. Worth
+revisiting then — the natural shape is that this slows down an account with no second factor
+and challenges one that has it.
+
+**Counting in memory.** Simpler, and wrong for a deployment running more than one control
+plane instance: an attacker spreads attempts across replicas and each one sees a count of one.
+The redundancy this project requires is what rules it out.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,6 +35,7 @@ deliberate act with a written reason rather than a drift nobody noticed.
 | [0024](0024-users-and-the-admin-token.md) | Local user accounts, scoped API tokens, and what becomes of the admin token |
 | [0025](0025-the-bus-is-postgresql.md) | The bus is PostgreSQL LISTEN/NOTIFY, not Redis |
 | [0026](0026-fail-closed-on-macos.md) | Fail-closed egress on macOS lives in a pf anchor under `com.apple` |
+| [0027](0027-sign-in-slows-down-it-does-not-lock-out.md) | A guessed-at account slows down; it is never locked out |
 
 ## Format
 

--- a/internal/api/uisession_test.go
+++ b/internal/api/uisession_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -290,4 +291,92 @@ func TestADeploymentWithNoAccountsCannotSignIn(t *testing.T) {
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("signing in to a deployment with no accounts = %d, want 401", resp.StatusCode)
 	}
+}
+
+// Six wrong passwords for one address and the seventh is told to wait.
+//
+// A 429 rather than the shared refusal, which is not a leak: failures are counted for every
+// address whether or not an account exists, so being told to wait says nothing about whether
+// there is anybody here to sign in as (ADR-0027). Answering 401 would tell somebody who has
+// mistyped that their password is wrong, which is false and makes them keep trying.
+func TestAGuessedAtAccountIsToldToWait(t *testing.T) {
+	h := newHarness(t)
+	createUser(t, h, "target@example.com")
+
+	var status int
+	var body map[string]any
+	var headers http.Header
+	for i := 0; i < 8; i++ {
+		status, headers, body = postSignIn(t, h, "target@example.com", "not the password")
+		if status == http.StatusTooManyRequests {
+			break
+		}
+		if status != http.StatusUnauthorized {
+			t.Fatalf("attempt %d: got %d, want 401 or 429: %v", i+1, status, body)
+		}
+	}
+
+	if status != http.StatusTooManyRequests {
+		t.Fatal("eight wrong passwords for one address were all answered the same way; " +
+			"nothing is slowing this account down")
+	}
+
+	// From this endpoint rather than from the per-address limiter in front of it, which
+	// answers 429 too. Without this the test would pass on a build where the account
+	// throttle did nothing at all.
+	message, _ := body["message"].(string)
+	if !strings.Contains(message, "failed sign-ins for that address") {
+		t.Errorf("the refusal came from somewhere else: %q", message)
+	}
+
+	// Actionable, or a browser has nothing to do but retry immediately and make it worse.
+	retry := headers.Get("Retry-After")
+	if retry == "" {
+		t.Error("no Retry-After, so nothing knows how long to wait")
+	} else if seconds, err := strconv.Atoi(retry); err != nil || seconds <= 0 || seconds > 60 {
+		t.Errorf("Retry-After is %q; it should be a whole number of seconds up to the "+
+			"one-minute ceiling ADR-0027 sets", retry)
+	}
+
+	// And it is a wait, not a lockout: the message has to say so, because somebody reading
+	// it needs to know whether to sit and wait or to go and find an administrator.
+	if !strings.Contains(message, "Nothing is locked") {
+		t.Errorf("the refusal does not say the account is not locked: %q", message)
+	}
+}
+
+// A different address is unaffected, or one person mistyping would slow down everybody.
+func TestSlowingOneAddressDoesNotSlowAnother(t *testing.T) {
+	h := newHarness(t)
+	createUser(t, h, "target@example.com")
+	createUser(t, h, "bystander@example.com")
+
+	for i := 0; i < 8; i++ {
+		postSignIn(t, h, "target@example.com", "not the password")
+	}
+
+	if cookie := signIn(t, h, "bystander@example.com", testPassword); cookie == nil {
+		t.Error("an address nobody guessed at could not sign in")
+	}
+}
+
+// postSignIn attempts a sign-in and returns everything the server said about it.
+func postSignIn(t *testing.T, h *harness, email, plain string) (int, http.Header, map[string]any) {
+	t.Helper()
+	payload, _ := json.Marshal(map[string]any{"email": email, "password": plain})
+	req, err := http.NewRequest(http.MethodPost, h.server.URL+"/api/v1/ui/session",
+		bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	return resp.StatusCode, resp.Header, body
 }

--- a/internal/api/usersession.go
+++ b/internal/api/usersession.go
@@ -2,8 +2,11 @@ package api
 
 import (
 	"errors"
+	"fmt"
+	"math"
 	"net/http"
 	"net/netip"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -68,7 +71,23 @@ func (s *Server) signInWithPassword(w http.ResponseWriter, r *http.Request, emai
 		UserAgent:    r.UserAgent(),
 		SourceIP:     requestAddr(r),
 	})
+	var slow store.SignInThrottled
 	switch {
+	case errors.As(err, &slow):
+		// A 429 rather than the shared refusal, and it is not a leak: the count is kept for
+		// every address whether or not an account exists, so being told to wait says nothing
+		// about whether there is anybody here to sign in as (ADR-0027). Answering 401 would
+		// tell somebody who has mistyped six times that their password is wrong, which is
+		// false and makes them keep trying.
+		seconds := int(math.Ceil(slow.RetryAfter.Seconds()))
+		w.Header().Set("Retry-After", strconv.Itoa(seconds))
+		s.log.Warn("a sign-in was refused for arriving too fast",
+			"email", logx.Safe(email), "remote", logx.Safe(clientKey(r)), "retry_after_s", seconds)
+		httpx.Error(w, s.log, http.StatusTooManyRequests, "rate_limited",
+			fmt.Sprintf("too many failed sign-ins for that address; try again in %d second(s). "+
+				"Nothing is locked: the wait is at most a minute and a correct password clears it.",
+				seconds))
+		return
 	case errors.Is(err, store.ErrSignInAmbiguous):
 		// Named as its own failure because it is the one a person can act on, and the
 		// action is not "try a different password". ADR-0021 refuses an ambiguous name the

--- a/internal/store/gen/models.go
+++ b/internal/store/gen/models.go
@@ -298,6 +298,13 @@ type RouteGroupPrefix struct {
 	Prefix       netip.Prefix
 }
 
+type SignInFailure struct {
+	EmailHash     []byte
+	Failures      int32
+	FirstFailedAt time.Time
+	LastFailedAt  time.Time
+}
+
 type StateChange struct {
 	ID            int64
 	NetworkID     uuid.UUID

--- a/internal/store/gen/users.sql.go
+++ b/internal/store/gen/users.sql.go
@@ -11,7 +11,21 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
+
+const clearSignInFailures = `-- name: ClearSignInFailures :execrows
+DELETE FROM sign_in_failures WHERE email_hash = $1
+`
+
+// scope: global as above. A success clears the run, whoever it came from.
+func (q *Queries) ClearSignInFailures(ctx context.Context, emailHash []byte) (int64, error) {
+	result, err := q.db.Exec(ctx, clearSignInFailures, emailHash)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
 
 const countUsers = `-- name: CountUsers :one
 SELECT count(*)::bigint FROM users WHERE deleted_at IS NULL
@@ -188,6 +202,28 @@ func (q *Queries) FindUsersByEmail(ctx context.Context, email string) ([]FindUse
 	return items, nil
 }
 
+const getSignInFailures = `-- name: GetSignInFailures :one
+SELECT email_hash, failures, first_failed_at, last_failed_at
+FROM sign_in_failures
+WHERE email_hash = $1
+`
+
+// scope: global a failed sign-in is not a tenant's property. The address is all that has been
+// offered at this point and it has not been shown to belong to anybody — narrowing this by
+// organisation would mean knowing whose account it is, which is the thing the caller does not
+// yet know and must not be made to reveal (ADR-0027).
+func (q *Queries) GetSignInFailures(ctx context.Context, emailHash []byte) (SignInFailure, error) {
+	row := q.db.QueryRow(ctx, getSignInFailures, emailHash)
+	var i SignInFailure
+	err := row.Scan(
+		&i.EmailHash,
+		&i.Failures,
+		&i.FirstFailedAt,
+		&i.LastFailedAt,
+	)
+	return i, err
+}
+
 const getUserForOrganizationByEmail = `-- name: GetUserForOrganizationByEmail :one
 SELECT id, organization_id, email, name, password_hash, suspended_at, deleted_at
 FROM users
@@ -308,6 +344,42 @@ func (q *Queries) ListUsersForOrganization(ctx context.Context, organizationID u
 	return items, nil
 }
 
+const recordSignInFailure = `-- name: RecordSignInFailure :one
+INSERT INTO sign_in_failures (email_hash, failures, first_failed_at, last_failed_at)
+VALUES ($1, 1, now(), now())
+ON CONFLICT (email_hash) DO UPDATE
+SET failures = CASE
+        WHEN sign_in_failures.last_failed_at < now() - $2::interval THEN 1
+        ELSE sign_in_failures.failures + 1
+    END,
+    first_failed_at = CASE
+        WHEN sign_in_failures.last_failed_at < now() - $2::interval THEN now()
+        ELSE sign_in_failures.first_failed_at
+    END,
+    last_failed_at = now()
+RETURNING email_hash, failures, first_failed_at, last_failed_at
+`
+
+type RecordSignInFailureParams struct {
+	EmailHash  []byte
+	ResetAfter pgtype.Interval
+}
+
+// scope: global as above.
+// Consecutive, so a run that has gone quiet starts again rather than resuming: an address
+// that failed six times yesterday should not pay yesterday's penalty today.
+func (q *Queries) RecordSignInFailure(ctx context.Context, arg RecordSignInFailureParams) (SignInFailure, error) {
+	row := q.db.QueryRow(ctx, recordSignInFailure, arg.EmailHash, arg.ResetAfter)
+	var i SignInFailure
+	err := row.Scan(
+		&i.EmailHash,
+		&i.Failures,
+		&i.FirstFailedAt,
+		&i.LastFailedAt,
+	)
+	return i, err
+}
+
 const setUserPasswordHash = `-- name: SetUserPasswordHash :execrows
 UPDATE users SET password_hash = $2, updated_at = now()
 WHERE id = $1 AND deleted_at IS NULL
@@ -378,6 +450,20 @@ DELETE FROM user_sessions WHERE expires_at < now() OR idle_expires_at < now()
 // leave every other organisation's dead rows behind and make the sweep a per-tenant chore.
 func (q *Queries) SweepExpiredUserSessions(ctx context.Context) (int64, error) {
 	result, err := q.db.Exec(ctx, sweepExpiredUserSessions)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const sweepSignInFailures = `-- name: SweepSignInFailures :execrows
+DELETE FROM sign_in_failures WHERE last_failed_at < now() - $1::interval
+`
+
+// scope: global a run of failures that has gone quiet belongs to nobody and is removed on
+// everybody's behalf, exactly as an expired session is.
+func (q *Queries) SweepSignInFailures(ctx context.Context, olderThan pgtype.Interval) (int64, error) {
+	result, err := q.db.Exec(ctx, sweepSignInFailures, olderThan)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/store/signinthrottle.go
+++ b/internal/store/signinthrottle.go
@@ -1,0 +1,174 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/meshpnet/meshp/internal/logx"
+	dbgen "github.com/meshpnet/meshp/internal/store/gen"
+)
+
+// How a guessed-at account is slowed down (ADR-0027).
+//
+// Not locked out, and the difference is the whole decision. Lockout is a denial of service
+// aimed at the account holder: anyone who knows an address can make its owner unable to sign
+// in, and the person who suffers did nothing. So the wait grows and then stops growing, and
+// the ceiling is low enough that nobody has to be unlocked by anybody.
+const (
+	// signInFreeAttempts is how many failures cost nothing before the next attempt waits.
+	//
+	// Five, because people mistype and a mechanism that charged for the first typo would be
+	// felt by everybody who has ever signed in and by no attacker at all.
+	signInFreeAttempts = 5
+
+	// signInMaxDelay is the ceiling, and it is the load-bearing number here.
+	//
+	// At a minute an attacker's rate falls from roughly a million guesses a day to about
+	// fourteen hundred, while the worst thing that happens to a real person is that they
+	// wait a minute — an inconvenience they can sit through rather than a support call. It
+	// is also why there is no exemption for the last owner of a deployment: with no such
+	// thing as locked out there is nothing to exempt anybody from, and an exemption would
+	// have been a permanent hole aimed at the most valuable account in the system.
+	signInMaxDelay = time.Minute
+
+	// signInResetAfter is how long a run of failures survives without a new one.
+	//
+	// Consecutive means consecutive: an address that failed six times yesterday should not
+	// pay yesterday's penalty today.
+	signInResetAfter = time.Hour
+
+	// signInAlarmAt is when an operator is told, once, rather than per attempt.
+	//
+	// #148's third complaint was that nothing says this is happening. Individual refusals
+	// are already logged; a line per attempt is not telling anybody, it is the thing an
+	// operator has already muted.
+	signInAlarmAt = 10
+)
+
+// SignInThrottled means this address has failed too often too recently.
+//
+// Its own error rather than another ErrSignInRefused, because the answer is different in kind:
+// every other refusal means the credential is wrong and there is nothing to wait for, and this
+// one means wait. Telling somebody who has mistyped six times that their password does not
+// match would be a lie that makes them keep trying.
+type SignInThrottled struct{ RetryAfter time.Duration }
+
+func (e SignInThrottled) Error() string {
+	return fmt.Sprintf("store: too many failed sign-ins for that address; wait %s",
+		e.RetryAfter.Round(time.Second))
+}
+
+// signInDelay is how long an address waits after this many consecutive failures.
+//
+// Doubling, then flat. Written as a function of the count rather than stored, so the curve is
+// one thing in one place and a deployment that changes it does not have to migrate anything.
+func signInDelay(failures int32) time.Duration {
+	if failures < signInFreeAttempts {
+		return 0
+	}
+	// Counted in failures already recorded, so this is what the *next* attempt waits: five
+	// recorded failures means the sixth attempt is the first to pay. Written this way round
+	// because it is the only way round that can save any work — the delay has to be known
+	// before the password is looked at.
+	//
+	// The first paid attempt costs a second and each after that doubles. Shifted rather than
+	// multiplied, and bounded before shifting: a count large enough to overflow the shift is
+	// well past the ceiling anyway, and a shift that wrapped would hand an attacker a delay
+	// of zero at exactly the point they had earned the most.
+	steps := failures - signInFreeAttempts
+	if steps > 16 {
+		return signInMaxDelay
+	}
+	delay := time.Duration(1<<uint(steps)) * time.Second
+	if delay > signInMaxDelay {
+		return signInMaxDelay
+	}
+	return delay
+}
+
+// signInKey is what this address is counted under.
+//
+// Hashed, and that follows from counting failures for addresses with no account: an attacker
+// choosing what goes in the table would otherwise be choosing what text this deployment
+// stores, and it would fill with the addresses of people who have no account here. The hash
+// answers the only question the table is asked and a dump of it discloses nobody.
+func signInKey(email string) []byte {
+	sum := sha256.Sum256([]byte(email))
+	return sum[:]
+}
+
+// signInWait reports how long this address must wait before an attempt is looked at.
+//
+// Asked before the address is looked up and before any password work, which is the point:
+// the whole purpose is to not do the guess. It is also why it is keyed on what was submitted
+// rather than on a user id — at this moment nobody knows whether there is a user, and finding
+// out first would make the delay itself say whether the account exists.
+func (s *Store) signInWait(ctx context.Context, key []byte) (time.Duration, error) {
+	row, err := s.Queries().GetSignInFailures(ctx, key)
+	if IsNotFound(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("store: reading sign-in failures: %w", err)
+	}
+	remaining := time.Until(row.LastFailedAt.Add(signInDelay(row.Failures)))
+	if remaining <= 0 {
+		return 0, nil
+	}
+	return remaining, nil
+}
+
+// noteSignInFailure counts one, and says so once when a run gets long.
+//
+// Errors are logged rather than returned. The caller is on its way to refusing this sign-in
+// and a counter that could not be written must not turn a refusal into a 500 — that would let
+// anybody who can make this table unwritable tell a refusal from a server fault, which is the
+// oracle the single shared refusal message exists to close.
+func (s *Store) noteSignInFailure(ctx context.Context, key []byte, email string) {
+	row, err := s.Queries().RecordSignInFailure(ctx, dbgen.RecordSignInFailureParams{
+		EmailHash:  key,
+		ResetAfter: pgtype.Interval{Microseconds: signInResetAfter.Microseconds(), Valid: true},
+	})
+	if err != nil {
+		s.log.Error("could not count a failed sign-in",
+			"error", err,
+			"consequence", "this address is not being slowed down")
+		return
+	}
+	if row.Failures == signInAlarmAt {
+		// Once, on the crossing. The address came from whoever typed it, so it is bounded
+		// before it reaches a log.
+		s.log.Warn("an account is being guessed at",
+			"email", logx.Safe(email),
+			"consecutive_failures", row.Failures,
+			"since", row.FirstFailedAt.UTC(),
+			"what_happens_now", "attempts on this address wait up to a minute; it is not locked")
+	}
+}
+
+// clearSignInFailures ends a run, because somebody got it right.
+func (s *Store) clearSignInFailures(ctx context.Context, key []byte) {
+	if _, err := s.Queries().ClearSignInFailures(ctx, key); err != nil {
+		// Logged and not returned: they are signed in either way, and the row expires on its
+		// own. What it costs is one more slow attempt if they sign in again immediately.
+		s.log.Warn("could not clear a run of failed sign-ins", "error", err)
+	}
+}
+
+// SweepSignInFailures removes runs that have gone quiet.
+//
+// Swept rather than left, for the reason expired sessions are: a table nobody prunes is one
+// nobody notices until it is too big to prune, and this one can be written to by anybody who
+// can reach the sign-in endpoint.
+func (s *Store) SweepSignInFailures(ctx context.Context) (int64, error) {
+	rows, err := s.Queries().SweepSignInFailures(ctx,
+		pgtype.Interval{Microseconds: signInResetAfter.Microseconds(), Valid: true})
+	if err != nil {
+		return 0, fmt.Errorf("store: sweeping sign-in failures: %w", err)
+	}
+	return rows, nil
+}

--- a/internal/store/signinthrottle_test.go
+++ b/internal/store/signinthrottle_test.go
@@ -1,0 +1,283 @@
+package store
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// The curve, which is the whole of ADR-0027's decision expressed as arithmetic.
+//
+// Two properties matter more than the individual numbers: it never exceeds a minute, and it
+// never goes down. The first is what makes this a slowdown rather than a lockout — with no
+// such thing as locked out, there is no exemption to write for the last owner of a
+// deployment, and no support call to answer. The second is what stops a determined attacker
+// finding a count that costs them less than the one before.
+func TestHowLongAGuessedAtAddressWaits(t *testing.T) {
+	for _, tc := range []struct {
+		failures int32
+		want     time.Duration
+	}{
+		// Counted in failures already recorded, so this is what the next attempt waits.
+		{0, 0}, {1, 0}, {4, 0}, // people mistype
+
+		{5, 1 * time.Second}, // the sixth attempt is the first to pay
+		{6, 2 * time.Second},
+		{7, 4 * time.Second},
+		{8, 8 * time.Second},
+		{9, 16 * time.Second},
+		{10, 32 * time.Second},
+
+		{11, time.Minute}, // 64s, capped
+		{12, time.Minute},
+		{100, time.Minute},
+
+		// Far past anything reachable, and asserted because the shift is where this could
+		// wrap: a count that overflowed it would hand an attacker no delay at all at exactly
+		// the point they had earned the most.
+		{1 << 20, time.Minute},
+		{1<<31 - 1, time.Minute},
+	} {
+		if got := signInDelay(tc.failures); got != tc.want {
+			t.Errorf("signInDelay(%d) = %s, want %s", tc.failures, got, tc.want)
+		}
+	}
+
+	var previous time.Duration
+	for n := int32(0); n < 200; n++ {
+		got := signInDelay(n)
+		if got < previous {
+			t.Fatalf("signInDelay(%d) = %s, less than signInDelay(%d) = %s", n, got, n-1, previous)
+		}
+		if got > signInMaxDelay {
+			t.Fatalf("signInDelay(%d) = %s, past the ceiling of %s", n, got, signInMaxDelay)
+		}
+		previous = got
+	}
+}
+
+// Two addresses are counted apart, and the same address the same way every time.
+func TestAddressesAreCountedApart(t *testing.T) {
+	one := signInKey("alice@example.com")
+	if len(one) != 32 {
+		t.Fatalf("the key is %d bytes; it should be a SHA-256", len(one))
+	}
+	if string(signInKey("alice@example.com")) != string(one) {
+		t.Error("the same address hashed to two different keys, so no run of failures would build")
+	}
+	if string(signInKey("bob@example.com")) == string(one) {
+		t.Error("two addresses share a key, so guessing at one would slow the other down")
+	}
+	if string(one) == "alice@example.com" {
+		t.Error("the address is stored as itself; an attacker chooses what goes in this table")
+	}
+}
+
+// signInFixture is an organisation with one person in it.
+func signInFixture(t *testing.T) (*Store, string, string) {
+	t.Helper()
+	s := freshStore(t)
+	ctx := testContext(t)
+
+	org, err := s.CreateOrganization(ctx, "acme", "Acme")
+	if err != nil {
+		t.Fatalf("creating an organisation: %v", err)
+	}
+	const email, plain = "alice@example.com", "correct horse battery staple"
+	if _, _, err := s.CreateUser(ctx, CreateUserRequest{
+		Organization: org.ID, Email: email, Password: plain,
+		Actor: BootstrapActor(),
+	}); err != nil {
+		t.Fatalf("creating a person: %v", err)
+	}
+	return s, email, plain
+}
+
+// fail signs in wrongly, and says what came back.
+func fail(t *testing.T, s *Store, email string) error {
+	t.Helper()
+	_, err := s.SignIn(testContext(t), SignInRequest{Email: email, Password: "not the password"})
+	return err
+}
+
+// The free attempts are free, and then they are not.
+//
+// The count of five is a product decision rather than an arbitrary one: people mistype, and a
+// mechanism that charged for the first typo would be felt by everybody who has ever signed in
+// and by no attacker at all.
+func TestTheSixthWrongPasswordStartsCostingTime(t *testing.T) {
+	s, email, _ := signInFixture(t)
+
+	for i := 1; i <= signInFreeAttempts; i++ {
+		if err := fail(t, s, email); !errors.Is(err, ErrSignInRefused) {
+			t.Fatalf("attempt %d: got %v, want a plain refusal", i, err)
+		}
+	}
+
+	var slow SignInThrottled
+	if err := fail(t, s, email); !errors.As(err, &slow) {
+		t.Fatalf("the sixth wrong password was answered with %v; nothing is slowing this "+
+			"address down and an attacker keeps their full rate", err)
+	}
+	if slow.RetryAfter <= 0 || slow.RetryAfter > signInMaxDelay {
+		t.Errorf("wait of %s is outside 0..%s", slow.RetryAfter, signInMaxDelay)
+	}
+}
+
+// The right password during a penalty is refused, and that is the mechanism working.
+//
+// It is also the cost ADR-0027 accepts and says so plainly: an attacker can make an account
+// inconvenient to reach. What they cannot do is make it unreachable, which is why the ceiling
+// is a minute and why nothing here is called a lockout.
+func TestACorrectPasswordWaitsToo(t *testing.T) {
+	s, email, plain := signInFixture(t)
+
+	for i := 0; i < signInFreeAttempts; i++ {
+		_ = fail(t, s, email)
+	}
+
+	var slow SignInThrottled
+	_, err := s.SignIn(testContext(t), SignInRequest{Email: email, Password: plain})
+	if !errors.As(err, &slow) {
+		t.Fatalf("signing in correctly during a penalty gave %v; the delay is not being "+
+			"applied before the password is looked at, which is the only place it saves work", err)
+	}
+}
+
+// Getting it right ends the run, whoever got it right.
+//
+// This is what bounds the denial of service: an attacker sustaining a penalty against
+// somebody loses it the moment that person signs in during a gap.
+func TestASuccessClearsTheRun(t *testing.T) {
+	s, email, plain := signInFixture(t)
+	ctx := testContext(t)
+
+	// One short of the limit, so the success itself is still a free attempt.
+	for i := 0; i < signInFreeAttempts-1; i++ {
+		_ = fail(t, s, email)
+	}
+	if _, err := s.SignIn(ctx, SignInRequest{Email: email, Password: plain}); err != nil {
+		t.Fatalf("signing in inside the free window: %v", err)
+	}
+
+	// The next wrong password starts a new run rather than resuming the old one, so it is
+	// refused rather than delayed.
+	if err := fail(t, s, email); !errors.Is(err, ErrSignInRefused) {
+		t.Errorf("after a success the count carried on: got %v", err)
+	}
+}
+
+// An address with no account is counted exactly like one that has.
+//
+// Not doing so would be an oracle. If a known address is slowed and an unknown one is not,
+// how long the answer takes says whether somebody has an account here — the question the
+// single shared refusal message exists to avoid answering, defeated by a timer.
+func TestAnUnknownAddressIsSlowedDownJustTheSame(t *testing.T) {
+	s, _, _ := signInFixture(t)
+	const stranger = "nobody@example.com"
+
+	for i := 0; i < signInFreeAttempts; i++ {
+		if err := fail(t, s, stranger); !errors.Is(err, ErrSignInRefused) {
+			t.Fatalf("attempt %d on an unknown address: %v", i+1, err)
+		}
+	}
+
+	var slow SignInThrottled
+	if err := fail(t, s, stranger); !errors.As(err, &slow) {
+		t.Fatalf("an address with no account was not slowed down; how long a refusal takes "+
+			"now answers whether an account exists. got %v", err)
+	}
+}
+
+// Being told to name an organisation is not a guess, and is not counted as one.
+func TestAnAmbiguousAddressIsNotAFailedGuess(t *testing.T) {
+	s, email, plain := signInFixture(t)
+	ctx := testContext(t)
+
+	other, err := s.CreateOrganization(ctx, "globex", "Globex")
+	if err != nil {
+		t.Fatalf("creating a second organisation: %v", err)
+	}
+	if _, _, err := s.CreateUser(ctx, CreateUserRequest{
+		Organization: other.ID, Email: email, Password: plain, Actor: BootstrapActor(),
+	}); err != nil {
+		t.Fatalf("creating the same address in a second organisation: %v", err)
+	}
+
+	for i := 0; i < signInFreeAttempts*3; i++ {
+		if _, err := s.SignIn(ctx, SignInRequest{Email: email, Password: plain}); !errors.Is(err, ErrSignInAmbiguous) {
+			t.Fatalf("attempt %d: got %v, want the ambiguous answer", i+1, err)
+		}
+	}
+}
+
+// The sweep removes runs that have gone quiet, and leaves live ones alone.
+func TestQuietRunsAreSweptAway(t *testing.T) {
+	s, email, _ := signInFixture(t)
+	ctx := testContext(t)
+
+	_ = fail(t, s, email)
+
+	// Nothing to take yet: the run is current.
+	if removed, err := s.SweepSignInFailures(ctx); err != nil {
+		t.Fatalf("sweeping: %v", err)
+	} else if removed != 0 {
+		t.Errorf("the sweep removed %d live run(s)", removed)
+	}
+
+	// Aged past the window. Done in SQL rather than by waiting an hour.
+	if _, err := s.pool.Exec(ctx,
+		`UPDATE sign_in_failures SET last_failed_at = now() - interval '2 hours'`); err != nil {
+		t.Fatalf("ageing the row: %v", err)
+	}
+	if removed, err := s.SweepSignInFailures(ctx); err != nil {
+		t.Fatalf("sweeping: %v", err)
+	} else if removed != 1 {
+		t.Errorf("the sweep removed %d rows, want 1; this table only ever grows", removed)
+	}
+}
+
+// A run that has gone quiet starts again rather than resuming.
+//
+// An address that failed six times yesterday should not pay yesterday's penalty today, and
+// without this the first mistype after a long gap would cost a minute.
+func TestAQuietRunStartsAgain(t *testing.T) {
+	s, email, _ := signInFixture(t)
+	ctx := testContext(t)
+
+	for i := 0; i < signInFreeAttempts+3; i++ {
+		_ = fail(t, s, email)
+	}
+	if _, err := s.pool.Exec(ctx,
+		`UPDATE sign_in_failures SET last_failed_at = now() - interval '2 hours'`); err != nil {
+		t.Fatalf("ageing the row: %v", err)
+	}
+
+	if err := fail(t, s, email); !errors.Is(err, ErrSignInRefused) {
+		t.Fatalf("the first attempt after a quiet hour was charged for the old run: %v", err)
+	}
+
+	var row struct{ Failures int32 }
+	if err := s.pool.QueryRow(ctx,
+		`SELECT failures FROM sign_in_failures`).Scan(&row.Failures); err != nil {
+		t.Fatalf("reading the run back: %v", err)
+	}
+	if row.Failures != 1 {
+		t.Errorf("the run resumed at %d rather than starting again", row.Failures)
+	}
+}
+
+// Not part of the mechanism, and asserted because a fixture that quietly stopped creating a
+// usable account would make every test above pass for the wrong reason.
+func TestTheFixtureAccountCanActuallySignIn(t *testing.T) {
+	s, email, plain := signInFixture(t)
+	session, err := s.SignIn(testContext(t), SignInRequest{Email: email, Password: plain})
+	if err != nil {
+		t.Fatalf("signing in with the right password: %v", err)
+	}
+	if session.Token == "" || session.User.ID == uuid.Nil {
+		t.Error("a sign-in that returned no session was treated as success")
+	}
+}

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -295,6 +295,19 @@ func userFrom(id, org uuid.UUID, email, name string, created time.Time, suspende
 func (s *Store) SignIn(ctx context.Context, req SignInRequest) (Session, error) {
 	email := strings.ToLower(strings.TrimSpace(req.Email))
 
+	// Before the address is looked up and before any password work, which is the point of it:
+	// the purpose is not to do the guess (ADR-0027). Keyed on what was submitted rather than
+	// on a user id, because at this moment nobody knows whether there is a user — and finding
+	// out first would make the delay itself answer whether the account exists.
+	key := signInKey(email)
+	wait, err := s.signInWait(ctx, key)
+	if err != nil {
+		return Session{}, err
+	}
+	if wait > 0 {
+		return Session{}, SignInThrottled{RetryAfter: wait}
+	}
+
 	candidates, err := s.Queries().FindUsersByEmail(ctx, email)
 	if err != nil {
 		return Session{}, fmt.Errorf("store: looking up the address: %w", err)
@@ -314,21 +327,26 @@ func (s *Store) SignIn(ctx context.Context, req SignInRequest) (Session, error) 
 
 	switch {
 	case len(candidates) > 1:
+		// Not counted as a failure. Nothing was guessed at — the answer is "say which
+		// organisation", and the next attempt names one and is counted like any other.
 		return Session{}, ErrSignInAmbiguous
 	case len(candidates) == 0:
 		// The work is still done, against a hash of nothing, so that an unknown address
 		// takes about as long as a known one. Without it, response time answers "does this
 		// person have an account here" for anybody who cares to measure.
 		_ = password.Verify(decoyHash, req.Password)
+		s.noteSignInFailure(ctx, key, email)
 		return Session{}, ErrSignInRefused
 	}
 
 	user := candidates[0]
 	if user.PasswordHash == nil || user.SuspendedAt != nil || user.DeletedAt != nil {
 		_ = password.Verify(decoyHash, req.Password)
+		s.noteSignInFailure(ctx, key, email)
 		return Session{}, ErrSignInRefused
 	}
 	if err := password.Verify(*user.PasswordHash, req.Password); err != nil {
+		s.noteSignInFailure(ctx, key, email)
 		return Session{}, ErrSignInRefused
 	}
 
@@ -346,6 +364,10 @@ func (s *Store) SignIn(ctx context.Context, req SignInRequest) (Session, error) 
 			}
 		}
 	}
+
+	// Right answer: the run is over, whoever it came from. An attacker sustaining a penalty
+	// against somebody loses it the moment that person gets in.
+	s.clearSignInFailures(ctx, key)
 
 	token, hash, err := newSessionToken()
 	if err != nil {

--- a/migrations/0014_sign_in_failures.sql
+++ b/migrations/0014_sign_in_failures.sql
@@ -1,0 +1,41 @@
+-- +goose Up
+
+-- What ADR-0024 asked for and did not build (#148, ADR-0027).
+--
+-- Sign-in is throttled per address by the same limiter the enrolment endpoints use, which is
+-- deliberately generous and bounds a flood from one host. It does nothing about a patient
+-- attempt on one account spread across many hosts, and Argon2id at 64 MiB makes each guess
+-- cost a tenth of a second rather than making it impossible.
+--
+-- Here rather than in memory because the control plane is meant to run as more than one
+-- instance. A counter held in one process is one an attacker walks around by spreading
+-- attempts across replicas, and each would see a count of one.
+CREATE TABLE sign_in_failures (
+    -- SHA-256 of the lowercased address, not the address.
+    --
+    -- Failures are counted for addresses that have no account, because a known address that
+    -- is throttled and an unknown one that is not would answer "does this person have an
+    -- account here" to anybody who cares to measure — the question the single shared refusal
+    -- message exists to avoid answering.
+    --
+    -- Which means an attacker chooses what goes in this table. A hash is a fixed-size key
+    -- that answers the only question this table is asked, and it keeps the addresses of
+    -- people who have no account here from accumulating in a deployment's database.
+    email_hash      bytea PRIMARY KEY,
+
+    -- Consecutive failures. Reset by a success, and by an hour of quiet.
+    failures        integer NOT NULL DEFAULT 1,
+
+    -- When this run of failures started, so a log line can say how long an account has been
+    -- guessed at rather than only that it is being guessed at now.
+    first_failed_at timestamptz NOT NULL DEFAULT now(),
+    last_failed_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- The sweep's access path. Rows are read by primary key and deleted by age, and there is no
+-- third question anybody asks this table.
+CREATE INDEX sign_in_failures_last_failed_idx ON sign_in_failures (last_failed_at);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS sign_in_failures;

--- a/queries/users.sql
+++ b/queries/users.sql
@@ -103,3 +103,39 @@ DELETE FROM user_sessions WHERE expires_at < now() OR idle_expires_at < now();
 -- the bootstrap secret, that there is now an account they could be using instead — a
 -- question no organisation owns.
 SELECT count(*)::bigint FROM users WHERE deleted_at IS NULL;
+
+-- name: GetSignInFailures :one
+-- scope: global a failed sign-in is not a tenant's property. The address is all that has been
+-- offered at this point and it has not been shown to belong to anybody — narrowing this by
+-- organisation would mean knowing whose account it is, which is the thing the caller does not
+-- yet know and must not be made to reveal (ADR-0027).
+SELECT email_hash, failures, first_failed_at, last_failed_at
+FROM sign_in_failures
+WHERE email_hash = $1;
+
+-- name: RecordSignInFailure :one
+-- scope: global as above.
+-- Consecutive, so a run that has gone quiet starts again rather than resuming: an address
+-- that failed six times yesterday should not pay yesterday's penalty today.
+INSERT INTO sign_in_failures (email_hash, failures, first_failed_at, last_failed_at)
+VALUES ($1, 1, now(), now())
+ON CONFLICT (email_hash) DO UPDATE
+SET failures = CASE
+        WHEN sign_in_failures.last_failed_at < now() - sqlc.arg(reset_after)::interval THEN 1
+        ELSE sign_in_failures.failures + 1
+    END,
+    first_failed_at = CASE
+        WHEN sign_in_failures.last_failed_at < now() - sqlc.arg(reset_after)::interval THEN now()
+        ELSE sign_in_failures.first_failed_at
+    END,
+    last_failed_at = now()
+RETURNING email_hash, failures, first_failed_at, last_failed_at;
+
+-- name: ClearSignInFailures :execrows
+-- scope: global as above. A success clears the run, whoever it came from.
+DELETE FROM sign_in_failures WHERE email_hash = $1;
+
+-- name: SweepSignInFailures :execrows
+-- scope: global a run of failures that has gone quiet belongs to nobody and is removed on
+-- everybody's behalf, exactly as an expired session is.
+DELETE FROM sign_in_failures WHERE last_failed_at < now() - sqlc.arg(older_than)::interval;


### PR DESCRIPTION
Closes #148 — the fourth of the four things ADR-0024 said its own decision creates. Three shipped with it.

## The decision, and why it has a record

The obvious fix has a victim. **Lockout is a denial of service aimed at the account holder**: anyone who knows an address can make its owner unable to sign in, and the person who suffers did nothing. A mechanism that protects an account by making it unusable has handed an attacker a cheaper attack than the one it prevents.

So [ADR-0027](docs/adr/0027-sign-in-slows-down-it-does-not-lock-out.md): an address that keeps failing **slows down and stops there**.

- Five consecutive failures cost nothing. People mistype.
- The sixth attempt waits a second, and each after that doubles — 2, 4, 8, 16, 32 — to a **ceiling of one minute**.
- A success clears the run. So does an hour of quiet.

**The ceiling is the load-bearing number.** At a minute, an attacker goes from roughly a million guesses a day to about fourteen hundred, while the worst thing that happens to a real person is that they wait a minute. That is an inconvenience they can sit through, not a support call, and nobody has to be trusted to unlock anything.

It also answers the issue's hardest constraint without a special case:

> Whatever this does must not lock out the last owner, or the bootstrap secret becomes the only way back into a deployment.

With no such thing as locked out there is nothing to exempt anybody from — and an exemption would have been a permanent hole aimed at the most valuable account in the system.

## Two consequences that are not fastidiousness

**Failures are counted for addresses that have no account.** If a known address were slowed and an unknown one were not, how long a refusal takes would answer *"does this person have an account here"* — exactly the question the single shared refusal message exists to avoid answering, defeated by a timer.

**Which means an attacker chooses what goes in the table**, so the key is a SHA-256 of the address rather than the address. It answers the only question the table is asked, and a deployment does not accumulate the addresses of people who have no account in it.

## Other decisions worth naming

**In Postgres, not in memory.** The control plane is meant to run as more than one instance. A counter held in one process is one an attacker walks around by spreading attempts across replicas, each seeing a count of one.

**A 429 with `Retry-After`, not the shared 401.** Telling somebody who has mistyped six times that their password does not match is false and makes them keep trying. It leaks nothing, because unknown addresses are throttled identically.

**Ten consecutive failures log once**, naming the address. #148's third complaint was that nothing tells anybody this is happening — and a line per attempt is not telling anybody, it is the thing an operator has already muted.

**Being told to name an organisation is not counted.** Nothing was guessed at; the next attempt names one and is counted like any other.

## What this does not fix, and SECURITY.md says so

Fourteen hundred guesses a day is still a lot against a bad password. This buys time and makes the attempt visible; the answer to a weak password is the second factor ADR-0024 §1 commits to, and this is what protects an account until it has one.

And an attacker can still make an account *inconvenient* to reach — one failed attempt a minute, sustained. That is inherent to any per-account throttle, and this is the mildest version: a one-minute window, cleared by any success, loud in the log.

## Found on the way

**`Store.SweepSessions` has existed since sessions did and nothing has ever called it.** `user_sessions` has been growing by a row per sign-in and shrinking only when somebody signs out — a mechanism nothing reaches (ADR-0018), found while adding the second table that needs the same treatment. Both are now swept on an hourly loop.

**SECURITY.md still said the data plane was Linux-only**, which stopped being true this week.

## Testing

Twelve tests. The curve is pure and unit-tested including the overflow guard — a count large enough to wrap the shift would hand an attacker no delay at exactly the point they had earned the most.

The rest need Postgres: the sixth wrong password is throttled, a correct password waits too (the cost the ADR accepts, asserted rather than glossed), a success clears the run, **an unknown address is slowed identically**, an ambiguous address is not counted, quiet runs start again rather than resuming, and the sweep takes them.

At the API: eight wrong passwords produce a 429 with a usable `Retry-After`, and the assertion checks the message so it cannot pass on the per-address limiter in front — which also answers 429 and would otherwise make this test green on a build where the account throttle did nothing.

An off-by-one turned up here: the first implementation gave six free attempts, not five. The ADR was the correct spec and the code was wrong.

**Local Postgres was unavailable for part of this** — the machine ran out of disk and Docker took an I/O error — so the DB-backed tests ran against a throwaway container for most of the work and the last run of them is CI's.
