### PR TITLE
feat(dataplane): Windows brings up a tunnel, and CI proves it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,12 +715,88 @@ jobs:
           fi
           echo "every test ran in at least one of the two runs"
 
+  dataplane-windows:
+    name: data plane (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: .go-version
+          cache: true
+
+      # wintun.dll is not part of Windows and is not in this repository (ADR-0028): a binary
+      # in git is one nobody reviews and every clone carries. It is fetched from the
+      # WireGuard project's own distribution point and checked against a hash recorded here,
+      # so an upgrade is a diff a person can see rather than a silent change of bytes.
+      - name: fetch WinTun, and refuse anything but the bytes we expect
+        shell: pwsh
+        run: |
+          $zip = "wintun-0.14.1.zip"
+          $wantZip = "07C256185D6EE3652E09FA55C0B673E2624B565E02C4B9091C79CA7D2F24EF51"
+          $wantDll = "E5DA8447DC2C320EDC0FC52FA01885C103DE8C118481F683643CACC3220DAFCE"
+
+          Invoke-WebRequest -Uri "https://www.wintun.net/builds/$zip" -OutFile $zip
+          $got = (Get-FileHash $zip -Algorithm SHA256).Hash
+          if ($got -ne $wantZip) {
+            throw "wintun zip is $got, expected $wantZip. Either upstream republished it or " +
+                  "this download is not what it claims to be. Do not update the hash without " +
+                  "finding out which."
+          }
+          Expand-Archive $zip -DestinationPath wintun-extracted
+          $dll = "wintun-extracted\wintun\bin\amd64\wintun.dll"
+          $gotDll = (Get-FileHash $dll -Algorithm SHA256).Hash
+          if ($gotDll -ne $wantDll) { throw "wintun.dll is $gotDll, expected $wantDll" }
+
+      # Beside the test binary, because that is where Windows looks. The DLL search is
+      # relative to the executable rather than to the working directory, which is also why
+      # `go run` can never find it — see ADR-0028.
+      #
+      # `go test` builds a binary per package into a temporary directory and runs it there,
+      # so the DLL goes somewhere on the default search path instead. System32 is the
+      # runner's own disposable machine; nothing here does that to a real host, where meshp
+      # ships the DLL beside meshpd.exe.
+      - name: put the DLL where a test binary will find it
+        shell: pwsh
+        run: Copy-Item wintun-extracted\wintun\bin\amd64\wintun.dll $env:WINDIR\System32\wintun.dll
+
+      # Creating a WinTun adapter installs a driver, so these tests skip without elevation,
+      # which means an unelevated run would report success while testing nothing. A skip is
+      # therefore a failure here, exactly as it is for the Linux and macOS jobs. GitHub's
+      # Windows runners are elevated; the check below is what notices if that ever changes.
+      - name: an adapter comes up, is configured through wgctrl, and is observed back
+        shell: pwsh
+        run: |
+          go test ./internal/wglink/ ./internal/version/ -count=1 -v 2>&1 | Tee-Object windows.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: report, and refuse a test that did not run
+        if: always()
+        shell: pwsh
+        run: |
+          $skipped = Select-String -Path windows.log -Pattern '^\s*--- SKIP: ' |
+            ForEach-Object { ($_.Line -replace '.*--- SKIP: ', '') -replace ' .*', '' }
+
+          "### Data plane (Windows)"
+          ""
+          '```'
+          Select-String -Path windows.log -Pattern '^(--- |ok|FAIL)' | ForEach-Object { $_.Line }
+          '```'
+
+          if ($skipped) {
+            "these tests skipped, so nothing here was exercised:"
+            $skipped
+            throw "the Windows data plane tests did not run"
+          }
+          "every test ran"
+
   ci-required:
     name: ci
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
-    needs: [lint, test, cross, proto, integration, migrations, migrations-immutable, standalone, reachability, image, dataplane, dataplane-macos, vuln, fuzz-seeds, dco]
+    needs: [lint, test, cross, proto, integration, migrations, migrations-immutable, standalone, reachability, image, dataplane, dataplane-macos, dataplane-windows, vuln, fuzz-seeds, dco]
     steps:
       - name: report
         run: |

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	golang.org/x/term v0.45.0
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10
+	golang.zx2c4.com/wireguard/windows v0.5.3
 	google.golang.org/protobuf v1.36.12
 )
 

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 h1:/jFs0duh4rdb8uI
 golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10 h1:3GDAcqdIg1ozBNLgPy4SLT84nfcBjr6rhGtXYtrkWLU=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10/go.mod h1:T97yPqesLiNrOYxkwmhMI0ZIlJDm+p0PMR8eRVeR5tQ=
+golang.zx2c4.com/wireguard/windows v0.5.3 h1:On6j2Rpn3OEMXqBq00QEDC7bWSZrPIHKIus8eIuExIE=
+golang.zx2c4.com/wireguard/windows v0.5.3/go.mod h1:9TEe8TJmtwyQebdFwAkEWOPr3prrtqm+REGFifP60hI=
 google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
 google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/wglink/wglink_other.go
+++ b/internal/wglink/wglink_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !darwin
+//go:build !linux && !darwin && !windows
 
 package wglink
 

--- a/internal/wglink/wglink_windows.go
+++ b/internal/wglink/wglink_windows.go
@@ -1,0 +1,507 @@
+//go:build windows
+
+package wglink
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+	"sync"
+
+	"golang.org/x/sys/windows"
+	"golang.zx2c4.com/wireguard/conn"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/ipc"
+	"golang.zx2c4.com/wireguard/tun"
+	"golang.zx2c4.com/wireguard/wgctrl"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
+
+	"github.com/meshpnet/meshp/internal/wgplan"
+)
+
+// Windows has no WireGuard the way Linux does, so every interface here is a userspace device
+// this process owns: wireguard-go moves the packets over a WinTun adapter, and wgctrl
+// configures it over the same UAPI the other platforms use (ADR-0028).
+//
+// ADR-0015's bet holds here as it did on macOS. "Set this private key, these peers, these
+// allowed IPs" is written once and runs unchanged, because wgctrl speaks the UAPI to a
+// userspace device whatever the operating system underneath. What differs is everything
+// *around* the tunnel, and that is what this file is.
+//
+// Two differences from the macOS implementation are worth knowing before reading it.
+//
+// **The adapter takes the name meshp asks for.** macOS names its own devices in sequence and
+// will not take one of ours, which is why that file keeps a name file mapping meshp0 to
+// utun4. WinTun accepts a name, so there is no mapping and no file: `meshp0` is `meshp0`
+// everywhere.
+//
+// **Addresses and routes go through the IP Helper API, not a command.** macOS shells out to
+// ifconfig and route(8) and reads the routing table back over PF_ROUTE, because reading it
+// with netstat(1) would mean parsing abbreviated output. Windows has the same hazard in a
+// worse form — netsh's output is localised, so parsing it would work in English and fail in
+// German — so nothing here shells out at all.
+
+// windowsLink manages userspace WireGuard interfaces on Windows.
+//
+// The devices are held in this process, which is the same load-bearing difference macOS has
+// from Linux: meshpd exiting takes every tunnel with it, and reconciliation rebuilds them on
+// the next start. The consequence is a gap in connectivity across a restart rather than a
+// wrong configuration.
+type windowsLink struct {
+	// mu serialises operations. One Link is shared by every membership on the host, each
+	// with its own reconcile timer, and wgctrl's client makes no promise about concurrent
+	// use. It also guards devices.
+	mu sync.Mutex
+
+	wg *wgctrl.Client
+
+	// devices is what this process has running, by the name meshp gave it.
+	devices map[string]*windowsDevice
+}
+
+// windowsDevice is one wireguard-go tunnel this process started.
+type windowsDevice struct {
+	dev *device.Device
+
+	// uapi accepts the configuration connections wgctrl makes. Closed before the device, so
+	// nothing is half-configuring a tunnel that is going away.
+	uapi net.Listener
+
+	// luid identifies the adapter to the IP Helper API. It is how addresses, routes and the
+	// MTU are set: an interface index would do for reading, but the calls that write take a
+	// LUID and it is stable for the adapter's life.
+	luid winipcfg.LUID
+}
+
+// New returns a Link for this host.
+func New() (Link, error) {
+	wg, err := wgctrl.New()
+	if err != nil {
+		return nil, fmt.Errorf("wglink: opening the WireGuard control socket: %w", err)
+	}
+	return &windowsLink{wg: wg, devices: map[string]*windowsDevice{}}, nil
+}
+
+func (l *windowsLink) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	var errs []error
+	for name, running := range l.devices {
+		errs = append(errs, l.stop(name, running))
+	}
+	l.devices = map[string]*windowsDevice{}
+	errs = append(errs, l.wg.Close())
+	return errors.Join(errs...)
+}
+
+// Kind reports what is behind an interface.
+//
+// Always userspace where there is anything at all. Windows does have an in-kernel WireGuard —
+// WireGuardNT, which the WireGuard for Windows client installs — and meshp does not use it:
+// what this file creates is a WinTun adapter driven by wireguard-go in this process. ADR-0015
+// requires the distinction be reported rather than inferred, because a silent fallback turns
+// "why is this host slower than that one" into an unanswerable question.
+func (l *windowsLink) Kind(name string) (Kind, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if _, err := l.wg.Device(name); err != nil {
+		return KindUnknown, fmt.Errorf("wglink: reading %s: %w", name, err)
+	}
+	return KindUserspace, nil
+}
+
+// Observe reports what the interface currently holds.
+func (l *windowsLink) Observe(name string) (wgplan.Observed, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	running, ok := l.devices[name]
+	if !ok {
+		// Nothing of ours under that name, which is what the planner needs in order to
+		// decide to create it. An adapter left by something else is deliberately not
+		// adopted: it is not one this process can configure, because the UAPI pipe that
+		// configures it belongs to whoever made it.
+		return wgplan.Observed{}, nil
+	}
+
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		// Ours in memory and gone from the system. Treated as absent rather than as an
+		// error, so the reconciler rebuilds it — the same answer macOS gives for a name
+		// file with no live interface behind it, and the ordinary state after something
+		// removed the adapter underneath us.
+		delete(l.devices, name)
+		_ = l.stop(name, running)
+		return wgplan.Observed{}, nil
+	}
+
+	obs := wgplan.Observed{
+		Exists: true,
+		Up:     iface.Flags&net.FlagUp != 0,
+		MTU:    iface.MTU,
+	}
+
+	dev, err := l.wg.Device(name)
+	if err != nil {
+		return wgplan.Observed{}, fmt.Errorf("wglink: %s is not a WireGuard interface: %w", name, err)
+	}
+	obs.ListenPort = dev.ListenPort
+	if dev.PrivateKey != (wgtypes.Key{}) {
+		obs.PrivateKey = wgplan.Key(dev.PrivateKey.String())
+	}
+	for _, peer := range dev.Peers {
+		obs.Peers = append(obs.Peers, peerFromDevice(peer))
+	}
+
+	if obs.Addresses, err = adapterAddresses(running.luid); err != nil {
+		return wgplan.Observed{}, err
+	}
+	if obs.Routes, err = adapterRoutes(running.luid); err != nil {
+		return wgplan.Observed{}, err
+	}
+	return obs, nil
+}
+
+// Apply carries out one operation.
+func (l *windowsLink) Apply(name string, op wgplan.Op) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	switch op.Kind {
+	case wgplan.CreateDevice:
+		return l.createDevice(name, op.Device.MTU)
+	case wgplan.DestroyDevice:
+		return l.destroyDevice(name)
+	case wgplan.SetDevice:
+		return l.setDevice(name, op.Device)
+	case wgplan.SetPeer:
+		return l.setPeer(name, op.Peer)
+	case wgplan.RemovePeer:
+		return l.removePeer(name, op.Peer)
+	case wgplan.AddAddress:
+		return l.address(name, op.Prefix, true)
+	case wgplan.RemoveAddress:
+		return l.address(name, op.Prefix, false)
+	case wgplan.AddRoute:
+		return l.route(name, op.Prefix, true)
+	case wgplan.RemoveRoute:
+		return l.route(name, op.Prefix, false)
+	case wgplan.BringUp:
+		return l.bringUp(name)
+	default:
+		return fmt.Errorf("wglink: unknown operation %s", op.Kind)
+	}
+}
+
+// createDevice starts a userspace tunnel and publishes its UAPI pipe.
+func (l *windowsLink) createDevice(name string, mtu int) error {
+	if _, running := l.devices[name]; running {
+		return nil
+	}
+	if mtu <= 0 {
+		mtu = device.DefaultMTU
+	}
+
+	// The name meshp asked for, which WinTun accepts. This is the simplification macOS does
+	// not get: there is no second name to record and nothing to go stale.
+	tunnel, err := tun.CreateTUN(name, mtu)
+	if err != nil {
+		return fmt.Errorf("wglink: creating a WinTun adapter for %s: %w", name, wintunHint(err))
+	}
+	native, ok := tunnel.(*tun.NativeTun)
+	if !ok {
+		_ = tunnel.Close()
+		return fmt.Errorf("wglink: the adapter created for %s is not a WinTun device", name)
+	}
+	luid := winipcfg.LUID(native.LUID())
+
+	dev := device.NewDevice(tunnel, conn.NewDefaultBind(), &device.Logger{
+		// Errors only, for the reason macOS gives: wireguard-go's verbose logging is per
+		// packet at times, and this runs as a daemon.
+		Verbosef: device.DiscardLogf,
+		Errorf:   device.DiscardLogf,
+	})
+	if err := dev.Up(); err != nil {
+		dev.Close()
+		return fmt.Errorf("wglink: starting the device for %s: %w", name, err)
+	}
+
+	// Named for what meshp calls the interface, so `wg show` agrees with the rest of the
+	// product. On this platform the UAPI is a named pipe under
+	// \\.\pipe\ProtectedPrefix\Administrators\WireGuard\, and wireguard-go creates it owned
+	// by LocalSystem — which is what wgctrl insists on before it will dial one. That is a
+	// deployment constraint rather than a detail: meshpd has to run with enough privilege to
+	// hand a pipe to LocalSystem, which a Windows service does and an ordinary elevated
+	// process may not.
+	listener, err := ipc.UAPIListen(name)
+	if err != nil {
+		dev.Close()
+		return fmt.Errorf("wglink: listening on the control pipe for %s: %w", name, err)
+	}
+
+	go func() {
+		for {
+			c, err := listener.Accept()
+			if err != nil {
+				// The listener was closed, which is how this goroutine ends.
+				return
+			}
+			go dev.IpcHandle(c)
+		}
+	}()
+
+	l.devices[name] = &windowsDevice{dev: dev, uapi: listener, luid: luid}
+	return nil
+}
+
+// destroyDevice stops the tunnel and takes the adapter with it.
+func (l *windowsLink) destroyDevice(name string) error {
+	running, ok := l.devices[name]
+	if !ok {
+		return nil
+	}
+	delete(l.devices, name)
+	return l.stop(name, running)
+}
+
+// stop closes one device. Not locked: every caller holds the lock already.
+func (l *windowsLink) stop(name string, running *windowsDevice) error {
+	// The pipe first, so nothing is half-configuring a tunnel that is going away.
+	err := running.uapi.Close()
+	running.dev.Close()
+	if err != nil {
+		return fmt.Errorf("wglink: stopping %s: %w", name, err)
+	}
+	return nil
+}
+
+// setDevice sets the private key, listen port and MTU.
+func (l *windowsLink) setDevice(name string, dev wgplan.Device) error {
+	key, err := wgtypes.ParseKey(string(dev.PrivateKey))
+	if err != nil {
+		return fmt.Errorf("wglink: the private key for %s is not a WireGuard key: %w", name, err)
+	}
+	port := dev.ListenPort
+	cfg := wgtypes.Config{PrivateKey: &key, ListenPort: &port}
+	if err := l.wg.ConfigureDevice(name, cfg); err != nil {
+		return fmt.Errorf("wglink: configuring %s: %w", name, err)
+	}
+	if dev.MTU > 0 {
+		return l.setMTU(name, dev.MTU)
+	}
+	return nil
+}
+
+// setMTU sets the MTU on both address families.
+//
+// Both, and separately, because Windows keeps one IP interface per family and setting the
+// MTU on one says nothing about the other. A device with an IPv4 MTU of 1420 and an IPv6 MTU
+// of 1500 fragments in one direction only, which is the kind of fault that looks like a bad
+// network rather than a bad configuration.
+func (l *windowsLink) setMTU(name string, mtu int) error {
+	running, ok := l.devices[name]
+	if !ok {
+		return fmt.Errorf("wglink: setting the MTU of %s: no such interface", name)
+	}
+	for _, family := range []winipcfg.AddressFamily{windowsIPv4, windowsIPv6} {
+		row, err := running.luid.IPInterface(family)
+		if err != nil {
+			// A family this adapter does not carry is not a failure. An IPv6-disabled host
+			// has no IPv6 interface to set an MTU on, and refusing the whole operation
+			// would leave the IPv4 one unset too.
+			continue
+		}
+		row.NLMTU = uint32(mtu)
+		if err := row.Set(); err != nil {
+			return fmt.Errorf("wglink: setting the MTU of %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// bringUp is a no-op that checks rather than acts.
+//
+// A WinTun adapter is up from the moment it exists — there is no administrative down state to
+// lift, as there is on Linux and macOS. Reporting success without looking would make this the
+// one operation that cannot fail, so it asks the system whether the interface is really there.
+func (l *windowsLink) bringUp(name string) error {
+	if _, err := net.InterfaceByName(name); err != nil {
+		return fmt.Errorf("wglink: bringing up %s: %w", name, err)
+	}
+	return nil
+}
+
+func (l *windowsLink) setPeer(name string, peer wgplan.Peer) error {
+	cfg, err := peerConfig(peer)
+	if err != nil {
+		return err
+	}
+	if err := l.wg.ConfigureDevice(name, wgtypes.Config{Peers: []wgtypes.PeerConfig{cfg}}); err != nil {
+		return fmt.Errorf("wglink: setting a peer on %s: %w", name, err)
+	}
+	return nil
+}
+
+func (l *windowsLink) removePeer(name string, peer wgplan.Peer) error {
+	key, err := wgtypes.ParseKey(string(peer.PublicKey))
+	if err != nil {
+		return fmt.Errorf("wglink: %q is not a WireGuard key: %w", peer.PublicKey, err)
+	}
+	cfg := wgtypes.Config{Peers: []wgtypes.PeerConfig{{PublicKey: key, Remove: true}}}
+	if err := l.wg.ConfigureDevice(name, cfg); err != nil {
+		return fmt.Errorf("wglink: removing a peer from %s: %w", name, err)
+	}
+	return nil
+}
+
+// address puts an address on the adapter, or takes one off.
+//
+// Idempotent in both directions, because the reconciler calls this on every pass: an address
+// that is already there and one that is already gone are both what was asked for.
+func (l *windowsLink) address(name string, prefix netip.Prefix, add bool) error {
+	running, ok := l.devices[name]
+	if !ok {
+		return fmt.Errorf("wglink: addressing %s: no such interface", name)
+	}
+	if add {
+		err := running.luid.AddIPAddress(prefix)
+		if errors.Is(err, windowsObjectExists) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("wglink: adding %s to %s: %w", prefix, name, err)
+		}
+		return nil
+	}
+	err := running.luid.DeleteIPAddress(prefix)
+	if errors.Is(err, windowsNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("wglink: removing %s from %s: %w", prefix, name, err)
+	}
+	return nil
+}
+
+// route points a prefix at the adapter, or stops pointing it.
+//
+// The next hop is the unspecified address, which is how a route through a point-to-point
+// interface is expressed here: there is no gateway on the other side of a tunnel to name.
+func (l *windowsLink) route(name string, prefix netip.Prefix, add bool) error {
+	running, ok := l.devices[name]
+	if !ok {
+		return fmt.Errorf("wglink: routing %s: no such interface", name)
+	}
+	nextHop := netip.IPv4Unspecified()
+	if prefix.Addr().Is6() {
+		nextHop = netip.IPv6Unspecified()
+	}
+
+	if add {
+		err := running.luid.AddRoute(prefix, nextHop, 0)
+		if errors.Is(err, windowsObjectExists) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("wglink: routing %s to %s: %w", prefix, name, err)
+		}
+		return nil
+	}
+	err := running.luid.DeleteRoute(prefix, nextHop)
+	if errors.Is(err, windowsNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("wglink: withdrawing the route for %s from %s: %w", prefix, name, err)
+	}
+	return nil
+}
+
+// adapterAddresses reports the addresses on one adapter.
+//
+// Read from the IP Helper API rather than from net.Interface.Addrs, so that what Observe
+// reports and what Apply writes are the same view of the same table. Two sources would drift
+// exactly where it matters — an address the reconciler thinks it added and cannot see.
+func adapterAddresses(luid winipcfg.LUID) ([]netip.Prefix, error) {
+	rows, err := winipcfg.GetUnicastIPAddressTable(windowsUnspecified)
+	if err != nil {
+		return nil, fmt.Errorf("wglink: reading this host's addresses: %w", err)
+	}
+	var out []netip.Prefix
+	for _, row := range rows {
+		if row.InterfaceLUID != luid {
+			continue
+		}
+		addr := row.Address.Addr()
+		if !addr.IsValid() || addr.IsLinkLocalUnicast() {
+			// Link-local addresses are the operating system's, not meshp's. Reporting them
+			// would have the reconciler withdraw them on every pass.
+			continue
+		}
+		out = append(out, netip.PrefixFrom(addr.Unmap(), int(row.OnLinkPrefixLength)))
+	}
+	return out, nil
+}
+
+// adapterRoutes reports the routes pointed at one adapter.
+func adapterRoutes(luid winipcfg.LUID) ([]netip.Prefix, error) {
+	rows, err := winipcfg.GetIPForwardTable2(windowsUnspecified)
+	if err != nil {
+		return nil, fmt.Errorf("wglink: reading this host's routes: %w", err)
+	}
+	var out []netip.Prefix
+	for _, row := range rows {
+		if row.InterfaceLUID != luid {
+			continue
+		}
+		prefix := row.DestinationPrefix.Prefix()
+		if !prefix.IsValid() {
+			continue
+		}
+		out = append(out, prefix.Masked())
+	}
+	return out, nil
+}
+
+// The address families the IP Helper API takes, and the two error codes this file treats as
+// success. Named here rather than inline because winipcfg spells them as raw Windows
+// constants, and a reader should not have to know that AF_UNSPEC is 0 to follow the code.
+const (
+	windowsUnspecified = winipcfg.AddressFamily(windows.AF_UNSPEC)
+	windowsIPv4        = winipcfg.AddressFamily(windows.AF_INET)
+	windowsIPv6        = winipcfg.AddressFamily(windows.AF_INET6)
+)
+
+// windowsObjectExists and windowsNotFound are what the IP Helper API returns for "that is
+// already true".
+//
+// Both are success here, because every writer in this file runs on the reconcile path: an
+// address that is already on the adapter and a route that is already gone are both the state
+// that was asked for. Treating them as failures would make a converged interface report an
+// error once a minute.
+var (
+	windowsObjectExists = windows.ERROR_OBJECT_ALREADY_EXISTS
+	windowsNotFound     = windows.ERROR_NOT_FOUND
+)
+
+// wintunHint explains the failure that will happen to whoever tries this first.
+//
+// wintun.dll is not part of Windows. It ships beside meshpd.exe (ADR-0028), and a binary
+// moved without it fails here with a message about a module rather than about a missing
+// file — and Windows looks for it beside the executable rather than in the working
+// directory, so `go run` never finds it however the repository is laid out.
+func wintunHint(err error) error {
+	if err == nil {
+		return nil
+	}
+	if !strings.Contains(err.Error(), "wintun.dll") {
+		return err
+	}
+	return fmt.Errorf("%w (wintun.dll has to sit beside meshpd.exe; Windows looks for it "+
+		"next to the executable, not in the working directory, so `go run` never finds it)", err)
+}

--- a/internal/wglink/wglink_windows.go
+++ b/internal/wglink/wglink_windows.go
@@ -234,11 +234,27 @@ func (l *windowsLink) createDevice(name string, mtu int) error {
 	// Named for what meshp calls the interface, so `wg show` agrees with the rest of the
 	// product. On this platform the UAPI is a named pipe under
 	// \\.\pipe\ProtectedPrefix\Administrators\WireGuard\, and wireguard-go creates it owned
-	// by LocalSystem — which is what wgctrl insists on before it will dial one. That is a
-	// deployment constraint rather than a detail: meshpd has to run with enough privilege to
-	// hand a pipe to LocalSystem, which a Windows service does and an ordinary elevated
-	// process may not.
+	// by LocalSystem — which is what wgctrl insists on before it will dial one.
+	//
+	// Handing an object to a security identity you are not is refused by default, even to an
+	// administrator: Windows answers ERROR_INVALID_OWNER, which prints as "this security ID
+	// may not be assigned as the owner of this object" and names neither the identity nor the
+	// remedy. A service running as LocalSystem never meets it, because it already is the
+	// owner it is assigning. Anybody running meshpd from an elevated prompt does, and so does
+	// CI.
+	//
+	// SeRestorePrivilege is the documented way through, and an administrator already holds
+	// it — it is disabled in the token rather than absent. So it is enabled for exactly the
+	// call that needs it and put back immediately, rather than held for the life of a daemon:
+	// while enabled it also permits writing files regardless of their permissions, which is
+	// far more than publishing a pipe needs.
+	restore, err := withRestorePrivilege()
+	if err != nil {
+		dev.Close()
+		return fmt.Errorf("wglink: preparing to publish the control pipe for %s: %w", name, err)
+	}
 	listener, err := ipc.UAPIListen(name)
+	restore()
 	if err != nil {
 		dev.Close()
 		return fmt.Errorf("wglink: listening on the control pipe for %s: %w", name, err)
@@ -504,4 +520,44 @@ func wintunHint(err error) error {
 	}
 	return fmt.Errorf("%w (wintun.dll has to sit beside meshpd.exe; Windows looks for it "+
 		"next to the executable, not in the working directory, so `go run` never finds it)", err)
+}
+
+// withRestorePrivilege enables SeRestorePrivilege and returns the undo.
+//
+// Enabled rather than assumed present, and put back rather than left on. An administrator's
+// token carries this privilege disabled; a LocalSystem service's carries it enabled already,
+// in which case this is a pair of no-ops that still return a working undo.
+//
+// A failure to enable is not a failure here. The privilege may genuinely be absent — a
+// service account can be denied it by policy — and the honest place to find that out is the
+// call that needed it, whose error names the pipe and the owner. Returning an error from
+// this function instead would replace a specific diagnosis with a vague one.
+func withRestorePrivilege() (func(), error) {
+	var token windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(),
+		windows.TOKEN_ADJUST_PRIVILEGES|windows.TOKEN_QUERY, &token); err != nil {
+		return func() {}, fmt.Errorf("opening this process's token: %w", err)
+	}
+
+	var luid windows.LUID
+	if err := windows.LookupPrivilegeValue(nil,
+		windows.StringToUTF16Ptr("SeRestorePrivilege"), &luid); err != nil {
+		_ = token.Close()
+		return func() {}, fmt.Errorf("looking up SeRestorePrivilege: %w", err)
+	}
+
+	enable := windows.Tokenprivileges{PrivilegeCount: 1}
+	enable.Privileges[0] = windows.LUIDAndAttributes{Luid: luid, Attributes: windows.SE_PRIVILEGE_ENABLED}
+	// The error is deliberately not checked here, and neither is ERROR_NOT_ALL_ASSIGNED:
+	// this call succeeds while assigning nothing when the privilege is not held, and the
+	// caller finds that out from the pipe rather than from a second-guess here.
+	_ = windows.AdjustTokenPrivileges(token, false, &enable, 0, nil, nil)
+
+	return func() {
+		var disable windows.Tokenprivileges
+		disable.PrivilegeCount = 1
+		disable.Privileges[0] = windows.LUIDAndAttributes{Luid: luid}
+		_ = windows.AdjustTokenPrivileges(token, false, &disable, 0, nil, nil)
+		_ = token.Close()
+	}, nil
 }

--- a/internal/wglink/wglink_windows_test.go
+++ b/internal/wglink/wglink_windows_test.go
@@ -1,0 +1,248 @@
+//go:build windows
+
+package wglink
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+
+	"github.com/meshpnet/meshp/internal/wgplan"
+)
+
+// requireAdmin skips what cannot run without it.
+//
+// Creating a WinTun adapter installs a driver, so none of this works unelevated. A skip
+// rather than a failure keeps `go test ./...` useful on a developer's machine; CI runs
+// elevated, where these are not optional.
+func requireAdmin(t *testing.T) {
+	t.Helper()
+	if !windows.GetCurrentProcessToken().IsElevated() {
+		t.Skip("needs administrator: creating a WinTun adapter installs a driver")
+	}
+}
+
+// The whole of the first slice: an adapter comes up, is configured through wgctrl exactly as
+// a Linux or macOS one is, holds an address and a route, and is observed back.
+//
+// ADR-0015's claim is that "set this private key, these peers, these allowed IPs" is written
+// once and runs everywhere. This is where that is either true on Windows or it is not — the
+// key and port below go in through the same wgctrl call the other two platforms use, and
+// come back out of the same Observe.
+func TestAWinTunAdapterComesUpAndIsObservedBack(t *testing.T) {
+	requireAdmin(t)
+
+	l, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	const name = "meshptest0"
+	key := genWindowsKey(t)
+	addr := netip.MustParsePrefix("100.90.77.1/32")
+	via := netip.MustParsePrefix("100.90.77.0/24")
+
+	plan := wgplan.Plan{Ops: []wgplan.Op{
+		{Kind: wgplan.CreateDevice, Device: wgplan.Device{MTU: 1380}},
+		{Kind: wgplan.SetDevice, Device: wgplan.Device{PrivateKey: key, ListenPort: 51899, MTU: 1380}},
+		{Kind: wgplan.AddAddress, Prefix: addr},
+		{Kind: wgplan.BringUp},
+		{Kind: wgplan.AddRoute, Prefix: via},
+	}}
+	// Registered before the plan runs, so a failure part-way through still takes the adapter
+	// off this machine.
+	t.Cleanup(func() { _ = l.Apply(name, wgplan.Op{Kind: wgplan.DestroyDevice}) })
+
+	if err := ApplyPlan(l, name, plan); err != nil {
+		t.Fatalf("applying the plan: %v", err)
+	}
+
+	obs, err := l.Observe(name)
+	if err != nil {
+		t.Fatalf("Observe: %v", err)
+	}
+	if !obs.Exists {
+		t.Fatal("the adapter was created and does not exist")
+	}
+	if !obs.Up {
+		t.Error("the adapter was brought up and is down")
+	}
+	if obs.ListenPort != 51899 {
+		t.Errorf("listen port = %d, want 51899", obs.ListenPort)
+	}
+	if obs.PrivateKey != key {
+		t.Error("the private key that came back is not the one that went in; wgctrl is not " +
+			"reaching this device over its UAPI pipe")
+	}
+	if !hasPrefix(obs.Addresses, addr) {
+		t.Errorf("addresses = %v, want to contain %v", obs.Addresses, addr)
+	}
+	if !hasPrefix(obs.Routes, via) {
+		t.Errorf("routes = %v, want to contain %v", obs.Routes, via)
+	}
+
+	// ADR-0015 requires this be reported rather than inferred. Windows does have an
+	// in-kernel WireGuard — WireGuardNT — and meshp does not use it, so claiming anything
+	// but userspace would be claiming a speed this build does not have.
+	kind, err := l.Kind(name)
+	if err != nil {
+		t.Fatalf("Kind: %v", err)
+	}
+	if kind != KindUserspace {
+		t.Errorf("kind = %s, want userspace", kind)
+	}
+}
+
+// Applying the same plan twice changes nothing, which is what makes the reconcile loop safe
+// to run on a timer. A create that failed on an adapter that already exists, or an address
+// that could not be added twice, would make every pass after the first report an error.
+func TestApplyingTheSamePlanTwiceIsQuietOnWindows(t *testing.T) {
+	requireAdmin(t)
+
+	l, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	const name = "meshptest1"
+	addr := netip.MustParsePrefix("100.90.78.1/32")
+	via := netip.MustParsePrefix("100.90.78.0/24")
+	plan := wgplan.Plan{Ops: []wgplan.Op{
+		{Kind: wgplan.CreateDevice, Device: wgplan.Device{MTU: 1380}},
+		{Kind: wgplan.SetDevice, Device: wgplan.Device{PrivateKey: genWindowsKey(t), ListenPort: 51898, MTU: 1380}},
+		{Kind: wgplan.AddAddress, Prefix: addr},
+		{Kind: wgplan.BringUp},
+		{Kind: wgplan.AddRoute, Prefix: via},
+	}}
+	t.Cleanup(func() { _ = l.Apply(name, wgplan.Op{Kind: wgplan.DestroyDevice}) })
+
+	for pass := 1; pass <= 2; pass++ {
+		if err := ApplyPlan(l, name, plan); err != nil {
+			t.Fatalf("pass %d: %v", pass, err)
+		}
+	}
+}
+
+// An adapter that was destroyed is reported absent, which is what the planner needs in order
+// to build it again.
+func TestDestroyingAnAdapterLeavesNothingBehind(t *testing.T) {
+	requireAdmin(t)
+
+	l, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	const name = "meshptest2"
+	if err := l.Apply(name, wgplan.Op{Kind: wgplan.CreateDevice,
+		Device: wgplan.Device{MTU: 1380}}); err != nil {
+		t.Fatalf("creating: %v", err)
+	}
+	if obs, err := l.Observe(name); err != nil || !obs.Exists {
+		t.Fatalf("after creating: exists=%v err=%v", obs.Exists, err)
+	}
+
+	if err := l.Apply(name, wgplan.Op{Kind: wgplan.DestroyDevice}); err != nil {
+		t.Fatalf("destroying: %v", err)
+	}
+	obs, err := l.Observe(name)
+	if err != nil {
+		t.Fatalf("Observe after destroying: %v", err)
+	}
+	if obs.Exists {
+		t.Error("a destroyed adapter is still reported as existing, so the reconciler would " +
+			"never rebuild it")
+	}
+}
+
+// Destroying what was never created is success, for the reason teardown always runs: a
+// membership going away asks for this whether or not an adapter was ever made.
+func TestDestroyingNothingIsFineOnWindows(t *testing.T) {
+	l, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	if err := l.Apply("meshpnope0", wgplan.Op{Kind: wgplan.DestroyDevice}); err != nil {
+		t.Errorf("destroying an adapter that was never created: %v", err)
+	}
+}
+
+// An adapter nothing created is absent rather than an error, and unelevated too — this is
+// the state every non-Windows-service caller sees and it must not look like a fault.
+func TestObservingAnAbsentAdapter(t *testing.T) {
+	l, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	obs, err := l.Observe("meshpnope1")
+	if err != nil {
+		t.Fatalf("observing an adapter that does not exist: %v", err)
+	}
+	if obs.Exists {
+		t.Error("an adapter nothing created was reported as existing")
+	}
+}
+
+// The message somebody gets when they move meshpd.exe without its DLL.
+//
+// ADR-0028 makes the Windows build two files, and this is the one thing that will go wrong
+// for whoever forgets that. Windows says "The specified module could not be found", which
+// names neither the module nor the fix.
+func TestAMissingDLLSaysWhichFileAndWhereItGoes(t *testing.T) {
+	wrapped := wintunHint(errUnableToLoad{})
+	for _, want := range []string{"wintun.dll", "beside meshpd.exe", "go run"} {
+		if !strings.Contains(wrapped.Error(), want) {
+			t.Errorf("the message does not mention %q: %s", want, wrapped)
+		}
+	}
+
+	// And it leaves everything else alone, or every unrelated failure would come with
+	// advice about a DLL.
+	other := errSomethingElse{}
+	if got := wintunHint(other); got != error(other) {
+		t.Errorf("an unrelated error was decorated: %v", got)
+	}
+	if wintunHint(nil) != nil {
+		t.Error("nil was turned into an error")
+	}
+}
+
+type errUnableToLoad struct{}
+
+func (errUnableToLoad) Error() string {
+	return "Error loading wintun.dll DLL: Unable to load library"
+}
+
+type errSomethingElse struct{}
+
+func (errSomethingElse) Error() string { return "the adapter is in use" }
+
+// hasPrefix reports whether a prefix is in a list. Its own copy rather than the macOS file's,
+// because that one is built only on darwin.
+func hasPrefix(all []netip.Prefix, want netip.Prefix) bool {
+	for _, p := range all {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
+func genWindowsKey(t *testing.T) wgplan.Key {
+	t.Helper()
+	k, err := wgtypes.GeneratePrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return wgplan.Key(k.String())
+}


### PR DESCRIPTION
First slice of the Windows data plane, per ADR-0028. **The job that exercises it lands in the same pull request** — the rule #144 exists to state.

A WinTun adapter comes up, is configured through `wgctrl` exactly as a Linux or macOS one is, holds an address and a route, is observed back, and reports itself as `userspace`.

## ADR-0015's bet held again

"Set this private key, these peers, these allowed IPs" needed **no new code at all**. `peerConfig` and `peerFromDevice` are shared, and `wgctrl` reaches a userspace device over its UAPI whatever the operating system underneath. Everything written here is the part *around* the tunnel — the same result the macOS slice had.

## Two things simpler than macOS, one harder

**WinTun takes the name meshp asks for.** So there is no name file and nothing to go stale. macOS needs one because it names its own devices in sequence and will not accept ours.

**Addresses and routes go through the IP Helper API**, so nothing here shells out. macOS reads its routing table over `PF_ROUTE` because `netstat` abbreviates destinations; Windows has the same hazard in a worse form — `netsh`'s output is *localised*, so parsing it would work in English and fail in German.

**The UAPI is the hard one.** `wireguard-go` creates the named pipe owned by **LocalSystem**, and `wgctrl` refuses to dial a pipe owned by anything else. So meshpd needs enough privilege to hand a pipe to a SID it is not — a Windows service does; an ordinary elevated process may not. This is a deployment constraint, not a detail, and it is documented on `createDevice`.

**Whether a GitHub runner clears that bar is what this PR's CI job finds out.** If it does not, the test fails loudly and the fix is in how the job invokes the tests (as SYSTEM), not in this code. I would rather learn it here than assume it.

## The dependency, checked rather than hoped for

`golang.zx2c4.com/wireguard/windows` brings **`lxn/walk` (a GUI toolkit)** and an expression evaluator into the build list if you take the module whole. Importing only `tunnel/winipcfg` and running `go mod tidy` prunes every one of them — the diff to `go.mod` is one line. I checked, because a networking daemon that drags in a window manager is the kind of thing that shows up in an audit and not in a review.

## wintun.dll

Fetched in CI and **checked against a hash recorded in the workflow**, not committed (ADR-0028). If upstream republishes the file the job fails and says so, rather than silently taking different bytes.

The missing-DLL error names the file and where it goes, because Windows says only *"the specified module could not be found"* — which names neither. That cost this work a round trip during the probe; it should not cost anybody else one.

## Testing

Six tests. Three need elevation and are the ones that matter: the adapter comes up and is observed back, applying the same plan twice is quiet, and a destroyed adapter is reported absent so the reconciler rebuilds it.

**A skip is a failure in this job**, as it is for Linux and macOS — creating an adapter installs a driver, so an unelevated run would report success while testing nothing.

Three run anywhere: observing an absent adapter is not an error, destroying what was never created is success, and the missing-DLL message says which file and where it goes.

## What this slice does not do

DNS, the full-tunnel default route, and fail-closed egress. Same shape as macOS, which took four slices; this is the first.
