### PR TITLE
docs: say what Windows can do, which is a tunnel and nothing above it

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,12 @@ data plane is complete on Linux and on macOS — **a tunnel, names that resolve,
 default route and fail-closed egress**, the last of these through a pf anchor rather than
 nftables (ADR-0026). What macOS still cannot do is enforce a network's packet filter, so a
 network with a policy reports the group unhonoured there rather than half-applying it.
-Windows and the mobile platforms enrol, hold an address, and report honestly that they have
-no tunnel and cannot filter.
+
+**Windows has a tunnel and nothing above it yet.** A WinTun adapter comes up, carries an
+address and a route, and is configured exactly as the other two are (ADR-0028) — but names
+do not resolve, a full tunnel cannot be claimed, and it cannot fail closed or filter. Each
+of those is reported unhonoured rather than half-applied. The mobile platforms enrol, hold
+an address, and report honestly that they have no tunnel at all.
 
 It is public from the first commit because the design decisions are the
 interesting part and we would rather be argued with early.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,8 +32,10 @@ Out of scope: anything you deploy meshp on top of, and the deployment examples u
 `deploy/`, which are illustrative and say so.
 
 **Read this before you spend time on it.** meshp is pre-alpha and the README says not to
-deploy it. The data plane exists on Linux and macOS and nowhere else, and macOS cannot
-enforce a network's packet filter. Reports are still welcome and will be handled as above —
+deploy it. The data plane exists on Linux, macOS and Windows and nowhere else; macOS cannot
+enforce a network's packet filter, and Windows has only a tunnel — no name resolution, no
+full-tunnel route, no fail-closed egress and no filtering. Reports are still welcome and
+will be handled as above —
 but a finding that a half-built feature is half-built is not one, and there are several of
 those in the open issues already.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,8 @@ Two worth starting with:
 And the honest one: the [status section of the README](../README.md#status) says what does
 not work. The data plane is complete on Linux and on macOS — a tunnel, working names, a
 full-tunnel route and fail-closed egress, though macOS still cannot enforce a network's
-packet filter — and absent elsewhere; nothing discovers direct paths yet.
+packet filter. Windows has a tunnel and nothing above it yet, and the mobile platforms have
+none. Nothing discovers direct paths anywhere.
 If you need something that works this afternoon, the README names three projects that will
 serve you better today.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,9 +16,11 @@ bug and worth an issue.
 ## What you need
 
 - Linux, with root. This page is written for Linux because that is where the data plane is
-  complete. macOS brings a tunnel up, carries traffic, resolves mesh names and can take a
-  full-tunnel default route; what it cannot yet do is fail closed on egress. Windows and the mobile platforms enrol, hold an
-  address, and report honestly that they have no tunnel.
+  complete. macOS is complete too — a tunnel, mesh names, a full-tunnel default route and
+  fail-closed egress — except that it cannot enforce a network's packet filter. Windows
+  brings a tunnel up and has nothing above it yet: no names, no full tunnel, no fail-closed
+  egress. The mobile platforms enrol, hold an address, and report honestly that they have no
+  tunnel.
 - Docker with the Compose plugin, for the control plane and its database.
 - A kernel that can create WireGuard interfaces. `sudo ip link add dev wgcheck type
   wireguard && sudo ip link del dev wgcheck` tells you in one line.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -71,9 +71,16 @@ reachable.
 sudo meshp status
 ```
 
-`interface meshp0 (not up)` on Windows or a mobile platform is correct for now: there is no
-data plane there yet, so a device enrols, holds an address, and reports honestly that it has
-no tunnel rather than pretending.
+`interface meshp0 (not up)` on a mobile platform is correct for now: there is no data plane
+there yet, so a device enrols, holds an address, and reports honestly that it has no tunnel
+rather than pretending.
+
+On Windows there **is** a tunnel as of ADR-0028, reported as `userspace`, and nothing above
+it: names do not resolve, a full tunnel cannot be claimed, and it can neither fail closed nor
+filter. Each of those is reported unhonoured rather than half-applied, so a Windows device
+can be given a network with no policy and no egress group and nothing else. It needs
+`wintun.dll` beside `meshpd.exe`; without it the tunnel fails with a message naming the file
+and where to put it.
 
 On macOS there **is** a tunnel, and `meshp status` reports its kind as `userspace` — macOS
 has no WireGuard in the kernel, so wireguard-go moves the packets. Expect lower throughput


### PR DESCRIPTION
#175 made five documents wrong, one of them `SECURITY.md`. Fixing them now rather than with the next slice: a false claim about what a pre-alpha data plane does is precisely the sentence somebody reads before deciding whether to trust it.

## The corrected claim

Everywhere, and narrow: **Windows brings up a tunnel, carries an address and a route, and has nothing above it** — no names, no full-tunnel route, no fail-closed egress, no filtering. Each is reported unhonoured rather than half-applied, so what a Windows device can be given today is a network with no policy and no egress group.

| file | was |
|---|---|
| `README.md` | Windows "has no tunnel and cannot filter" |
| `SECURITY.md` | "the data plane exists on Linux and macOS and nowhere else" |
| `docs/README.md` | data plane "absent elsewhere" |
| `docs/troubleshooting.md` | "there is no data plane there yet" |
| `docs/quickstart.md` | Windows has no tunnel — **and macOS cannot fail closed** |

## One of these had been wrong for longer, and that is the interesting part

`docs/quickstart.md` still said macOS cannot fail closed on egress. That stopped being true when #169 merged — I updated the README, the docs index and the troubleshooting guide for that change and **missed this one**.

It is the same failure `internal/platformcheck` exists to prevent for code: a list kept in step by hand. There is no equivalent guard for prose, and this is the second time a status claim has outlived the thing it describes (`SECURITY.md` said "Linux-only" until last week).

Worth a guard eventually — something that fails when a `_windows.go` or `_darwin.go` file exists for a capability the docs say is absent. Not built here, because it would be guessing at what the right check is on one example. Two is a pattern; three would be a design.

## Also

`troubleshooting.md` gains the thing a Windows user will actually hit: `wintun.dll` has to sit beside `meshpd.exe`, and without it the tunnel fails with a message about a module rather than about a file.