### PR TITLE
feat(dataplane): names resolve on Windows, through NRPT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -765,10 +765,14 @@ jobs:
       # which means an unelevated run would report success while testing nothing. A skip is
       # therefore a failure here, exactly as it is for the Linux and macOS jobs. GitHub's
       # Windows runners are elevated; the check below is what notices if that ever changes.
-      - name: an adapter comes up, is configured through wgctrl, and is observed back
+      # internal/resolved joins for the same reason wglink is here: whether the DNS client
+      # reads the policy meshp writes cannot be reasoned about. ADR-0029 records that Windows
+      # accepts a rule it cannot use and reports success, so the test that matters resolves a
+      # name and waits for the query to arrive rather than checking that a registry key exists.
+      - name: an adapter comes up, is configured through wgctrl, and a configured name reaches meshp
         shell: pwsh
         run: |
-          go test ./internal/wglink/ ./internal/version/ -count=1 -v 2>&1 | Tee-Object windows.log
+          go test ./internal/wglink/ ./internal/resolved/ ./internal/version/ -count=1 -v 2>&1 | Tee-Object windows.log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: report, and refuse a test that did not run

--- a/cmd/meshpd/dnsport_other.go
+++ b/cmd/meshpd/dnsport_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+// dnsListenPort is whatever the kernel has spare.
+//
+// Zero asks for any, which is what keeps meshp out of a fight with whatever this machine was
+// already using for DNS. Both platforms that get here can be told which port afterwards.
+const dnsListenPort = 0

--- a/cmd/meshpd/dnsport_windows.go
+++ b/cmd/meshpd/dnsport_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package main
+
+// dnsListenPort is 53 on Windows, because nothing else is expressible.
+//
+// See dnsListenAddr. The cost is real and ADR-0029 accepts it: this is the one platform where
+// meshp competes for a well-known port, and a machine already running something on 53 — WSL
+// and Docker Desktop both can — gets no name resolution from meshp. It fails at start-up,
+// loudly, rather than resolving into a hole.
+const dnsListenPort = 53

--- a/cmd/meshpd/main.go
+++ b/cmd/meshpd/main.go
@@ -89,14 +89,22 @@ func main() {
 	log.Info("meshpd stopped cleanly")
 }
 
-// dnsListenAddr is where the resolver listens.
+// dnsListenAddr is where the resolver listens, which is not the same everywhere.
 //
-// Loopback, because the kill switch permits loopback unconditionally and a resolver anybody
-// on the café Wi-Fi could query would tell them what machines are in your customers'
-// networks. Port zero: the kernel picks, and what it picked is read back and reported,
-// because 53 is almost always already taken by whatever the machine was using before and
-// fighting it would break the host's existing DNS to install ours.
-var dnsListenAddr = netip.MustParseAddrPort("127.0.0.1:0")
+// Loopback on every platform, because the kill switch permits loopback unconditionally and a
+// resolver anybody on the café Wi-Fi could query would tell them what machines are in your
+// customers' networks.
+//
+// The port is where they part company, and it is a platform's answer rather than a
+// preference. Linux and macOS take zero — the kernel picks, and what it picked is read back
+// and reported — because 53 is almost always already taken and fighting it would break the
+// host's existing DNS to install ours. Both can be told about a port afterwards.
+//
+// Windows cannot. It names a DNS server by address alone; a rule naming a port is accepted,
+// stores nothing, and black-holes the domain while reporting success (ADR-0029). So there the
+// resolver competes for 53 like everybody else, and a host that cannot have it reports that
+// names will not resolve rather than configuring something that does not work.
+var dnsListenAddr = netip.AddrPortFrom(netip.AddrFrom4([4]byte{127, 0, 0, 1}), dnsListenPort)
 
 func run(ctx context.Context, log *slog.Logger, stateDir, socketPath, socketGroup string, reconcileEvery time.Duration) error {
 	agent := newAgent(ctx, log, stateDir, reconcileEvery)

--- a/cmd/meshpd/main_test.go
+++ b/cmd/meshpd/main_test.go
@@ -136,3 +136,31 @@ func TestOnlyAnAbsentStateFileCountsAsNotEnrolled(t *testing.T) {
 		}
 	}
 }
+
+// The resolver listens on loopback, wherever it is.
+//
+// Not a preference: the fail-closed lock permits loopback unconditionally, and a resolver
+// anybody on the café Wi-Fi could query would tell them what machines are in a customer's
+// network. The port differs by platform (ADR-0029) and the address must not.
+func TestTheResolverIsOnLoopbackEverywhere(t *testing.T) {
+	if !dnsListenAddr.Addr().IsLoopback() {
+		t.Errorf("the resolver listens on %s, which is reachable from off this machine",
+			dnsListenAddr)
+	}
+
+	// And the port is the platform's answer rather than a constant. Windows cannot be told
+	// about a port at all, so it takes 53; everywhere else asks the kernel for a spare one
+	// so meshp is not competing with whatever was already resolving names here.
+	switch runtime.GOOS {
+	case "windows":
+		if dnsListenAddr.Port() != 53 {
+			t.Errorf("Windows resolver port is %d; a rule naming any other port is accepted "+
+				"and black-holes the domain (ADR-0029)", dnsListenAddr.Port())
+		}
+	default:
+		if dnsListenAddr.Port() != 0 {
+			t.Errorf("port is %d; asking for a fixed one puts meshp in a fight with whatever "+
+				"this machine already runs on it", dnsListenAddr.Port())
+		}
+	}
+}

--- a/internal/resolved/nrpt_windows.go
+++ b/internal/resolved/nrpt_windows.go
@@ -1,0 +1,239 @@
+//go:build windows
+
+package resolved
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"golang.org/x/sys/windows/registry"
+)
+
+// ErrUnsupported means this platform has no resolver meshp knows how to configure safely.
+//
+// Declared here as well as in the unsupported build because Windows has an implementation
+// and does not build that file.
+var ErrUnsupported = errors.New("resolved: no supported resolver on this platform")
+
+// policyPath is where the Name Resolution Policy Table lives.
+//
+// The mechanism ADR-0029 chose, and the only one on this platform that routes by name rather
+// than by interface. Interface DNS — what winipcfg.SetDNS writes — makes Windows pick servers
+// by interface metric, so a nameserver on the tunnel adapter takes queries for names that
+// have nothing to do with meshp. That is the capture-everything behaviour ADR-0021 refuses.
+const policyPath = `SYSTEM\CurrentControlSet\Services\Dnscache\Parameters\DnsPolicyConfig`
+
+// meshpRules names the rules meshp owns.
+//
+// Each rule is a subkey named for a GUID, and meshp has to find its own again to remove them.
+// A marker value rather than a name pattern, because Dnscache is entitled to expect a GUID
+// there and a prefix of ours would not be one — and because reading a value is exact where
+// matching a name is a guess about somebody else's convention.
+const meshpRules = "MeshpInterface"
+
+// ruleNamespace makes a rule's key name a function of what it is for.
+//
+// A deterministic GUID, so configuring the same domain twice writes the same key rather than
+// accumulating one per reconcile. The namespace is arbitrary and fixed; what matters is that
+// it is meshp's and never changes, or a release would orphan every rule the last one made.
+var ruleNamespace = uuid.MustParse("6f1d1a2e-8f0f-4d5b-9a3c-2b0d7e5c4a11")
+
+// System points Windows' resolver at meshp for the names meshp owns.
+type System struct{}
+
+// New returns a configurer for this host, or nil where the policy table cannot be written.
+//
+// Opened for writing rather than assumed, because that is what decides the answer: the table
+// is under HKLM and an agent without administrative rights cannot touch it. ADR-0021 wants a
+// host that cannot configure its resolver to say so and leave the system's DNS alone, and
+// finding out here rather than per reconcile is what makes that a capability rather than a
+// recurring failure.
+func New(context.Context) *System {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, policyPath, registry.WRITE)
+	if err != nil {
+		// The parent exists on every Windows that has a DNS client, but the leaf is created
+		// by the first rule anybody adds, so its absence is ordinary rather than fatal.
+		created, _, createErr := registry.CreateKey(registry.LOCAL_MACHINE, policyPath, registry.WRITE)
+		if createErr != nil {
+			return nil
+		}
+		_ = created.Close()
+		return &System{}
+	}
+	_ = key.Close()
+	return &System{}
+}
+
+// Configure sends queries for these domains, on this interface, to this address.
+//
+// Called on every reconcile and idempotent: the key for a domain is a function of the domain,
+// so re-asserting writes the same values to the same place.
+//
+// The port is checked rather than carried, and refusing is the whole of why. Windows names a
+// DNS server by address alone; handed "127.0.0.1:15353" it accepts the rule, stores an empty
+// server list, and black-holes the namespace while reporting success (ADR-0029). A resolver
+// on any other port must therefore be refused here, or meshp would break the names it was
+// asked to resolve and report that it had configured them.
+func (s *System) Configure(ctx context.Context, iface string, server netip.AddrPort, domains []string) error {
+	if server.Port() != 53 {
+		return fmt.Errorf("%w: this platform names a DNS server by address alone, and meshp's "+
+			"resolver is on port %d — a rule naming a port is accepted and silently black-holes "+
+			"the domain (ADR-0029)", ErrUnsupported, server.Port())
+	}
+	wanted := cleanDomains(domains)
+	if len(wanted) == 0 {
+		return s.Revert(ctx, iface)
+	}
+
+	// Whatever this interface had before, so a domain that has gone away takes its rule with
+	// it rather than outliving the network that asked for it.
+	existing, err := s.rulesFor(iface)
+	if err != nil {
+		return err
+	}
+	keep := make(map[string]bool, len(wanted))
+
+	for _, domain := range wanted {
+		name := ruleKeyName(iface, domain)
+		keep[name] = true
+		if err := writeRule(name, iface, domain, server.Addr()); err != nil {
+			return err
+		}
+	}
+	for _, name := range existing {
+		if !keep[name] {
+			_ = registry.DeleteKey(registry.LOCAL_MACHINE, policyPath+`\`+name)
+		}
+	}
+	return nil
+}
+
+// Revert removes every rule meshp made for this interface.
+//
+// Safe for an interface that was never configured: finding nothing is the ordinary answer for
+// a device that never had names, and a teardown that failed on it would report an error for
+// removing something that was never there.
+func (s *System) Revert(_ context.Context, iface string) error {
+	names, err := s.rulesFor(iface)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, name := range names {
+		if err := registry.DeleteKey(registry.LOCAL_MACHINE, policyPath+`\`+name); err != nil {
+			errs = append(errs, fmt.Errorf("resolved: removing the rule for %s: %w", iface, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// rulesFor lists the rule keys meshp made for one interface.
+//
+// By reading the marker out of each rule rather than by recomputing the names meshp would
+// have chosen. Recomputing needs the domains, and Revert is called when they are already
+// gone — by a membership that has left, which is exactly when a rule left behind would
+// black-hole a name nobody is serving any more.
+func (s *System) rulesFor(iface string) ([]string, error) {
+	root, err := registry.OpenKey(registry.LOCAL_MACHINE, policyPath, registry.ENUMERATE_SUB_KEYS)
+	if err != nil {
+		if errors.Is(err, registry.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("resolved: reading the name resolution policy table: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	names, err := root.ReadSubKeyNames(-1)
+	if err != nil {
+		return nil, fmt.Errorf("resolved: listing name resolution policies: %w", err)
+	}
+
+	var mine []string
+	for _, name := range names {
+		rule, err := registry.OpenKey(registry.LOCAL_MACHINE, policyPath+`\`+name, registry.QUERY_VALUE)
+		if err != nil {
+			// Somebody else's rule that this process cannot read is somebody else's rule.
+			continue
+		}
+		owner, _, readErr := rule.GetStringValue(meshpRules)
+		_ = rule.Close()
+		if readErr == nil && owner == iface {
+			mine = append(mine, name)
+		}
+	}
+	sort.Strings(mine)
+	return mine, nil
+}
+
+// writeRule creates or replaces one policy.
+//
+// Read back before it is believed. ADR-0029 records why: Windows accepts a rule it cannot
+// use and reports success, so the only way to know a namespace is served rather than
+// black-holed is to ask what was stored. This is the third time on these platforms that a
+// call has succeeded having done nothing — route(8) on macOS was the first.
+func writeRule(name, iface, domain string, server netip.Addr) error {
+	key, _, err := registry.CreateKey(registry.LOCAL_MACHINE, policyPath+`\`+name, registry.SET_VALUE|registry.QUERY_VALUE)
+	if err != nil {
+		return fmt.Errorf("resolved: creating a name resolution policy for %s: %w", domain, err)
+	}
+	defer func() { _ = key.Close() }()
+
+	if err := errors.Join(
+		key.SetDWordValue("Version", 2),
+		key.SetStringsValue("Name", []string{domain}),
+		key.SetStringValue("GenericDNSServers", server.String()),
+		// 0x8 is "this rule names DNS servers". Without it the rule matches the namespace
+		// and directs it nowhere, which is the black hole described above wearing a
+		// different cause.
+		key.SetDWordValue("ConfigOptions", 0x8),
+		key.SetStringValue(meshpRules, iface),
+	); err != nil {
+		return fmt.Errorf("resolved: writing the policy for %s: %w", domain, err)
+	}
+
+	stored, _, err := key.GetStringValue("GenericDNSServers")
+	if err != nil || stored != server.String() {
+		return fmt.Errorf("resolved: the policy for %s names %q rather than %s, so that "+
+			"domain would resolve to nothing: %w", domain, stored, server, ErrUnsupported)
+	}
+	return nil
+}
+
+// ruleKeyName is the registry key one domain's rule lives under.
+//
+// Braced and upper case, which is the form every rule Windows itself creates uses. Nothing is
+// known to require it, and matching what the platform does costs nothing and avoids finding
+// out that something did.
+func ruleKeyName(iface, domain string) string {
+	id := uuid.NewSHA1(ruleNamespace, []byte(iface+"\x00"+domain))
+	return "{" + strings.ToUpper(id.String()) + "}"
+}
+
+// cleanDomains puts the domains in the form a policy takes.
+//
+// A leading dot is what makes a rule match a suffix rather than one exact name, and it is the
+// difference between resolving everything under a network's domain and resolving only the
+// domain itself. Sorted and deduplicated so the same set configures the same way twice.
+func cleanDomains(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	var out []string
+	for _, domain := range in {
+		trimmed := strings.ToLower(strings.Trim(strings.TrimSpace(domain), "."))
+		if trimmed == "" {
+			continue
+		}
+		suffix := "." + trimmed
+		if seen[suffix] {
+			continue
+		}
+		seen[suffix] = true
+		out = append(out, suffix)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/resolved/nrpt_windows_test.go
+++ b/internal/resolved/nrpt_windows_test.go
@@ -1,0 +1,227 @@
+//go:build windows
+
+package resolved
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+)
+
+// requireAdmin skips what cannot run without it. The policy table is under HKLM.
+func requireAdmin(t *testing.T) {
+	t.Helper()
+	if !windows.GetCurrentProcessToken().IsElevated() {
+		t.Skip("needs administrator: the name resolution policy table is under HKLM")
+	}
+}
+
+// A domain becomes a suffix rule, deduplicated and in a stable order.
+//
+// The leading dot is the whole of split DNS here: without it a rule matches one exact name
+// and everything under the network's domain goes wherever it was already going, which is a
+// resolver that looks configured and answers nothing.
+func TestDomainsBecomeSuffixRules(t *testing.T) {
+	got := cleanDomains([]string{"Example.Meshp", "example.meshp.", "  ", ".other.meshp", ""})
+	want := []string{".example.meshp", ".other.meshp"}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got %v, want %v", got, want)
+			break
+		}
+	}
+}
+
+// The same domain on the same interface is the same rule, and a different one is not.
+//
+// Configure runs on every reconcile. A key name that varied would leave one rule per pass
+// until the policy table was the largest thing in the registry.
+func TestARuleKeyIsAFunctionOfWhatItIsFor(t *testing.T) {
+	first := ruleKeyName("meshp0", ".example.meshp")
+	if first != ruleKeyName("meshp0", ".example.meshp") {
+		t.Error("the same domain produced two different rules, so every reconcile would add one")
+	}
+	if first == ruleKeyName("meshp0", ".other.meshp") {
+		t.Error("two domains share a rule, so configuring one would remove the other")
+	}
+	if first == ruleKeyName("meshp1", ".example.meshp") {
+		t.Error("two interfaces share a rule, so one membership leaving would take another's names")
+	}
+	if !strings.HasPrefix(first, "{") || !strings.HasSuffix(first, "}") {
+		t.Errorf("%q is not the braced form every rule Windows makes uses", first)
+	}
+}
+
+// A resolver on any port but 53 is refused rather than configured.
+//
+// This is the safety property the whole implementation turns on. Windows accepts a rule
+// naming a port, stores an empty server list, and black-holes the namespace while reporting
+// success (ADR-0029) — so a version of this that passed the port through would break exactly
+// the names it was asked to resolve and report that it had configured them.
+func TestAResolverOnTheWrongPortIsRefused(t *testing.T) {
+	err := (&System{}).Configure(t.Context(), "meshp0",
+		netip.MustParseAddrPort("127.0.0.1:15353"), []string{"example.meshp"})
+
+	if err == nil {
+		t.Fatal("a resolver on a high port was accepted; the rule Windows writes for that " +
+			"names no server at all and the domain resolves to nothing")
+	}
+	if !errors.Is(err, ErrUnsupported) {
+		t.Errorf("got %v, want it to say this platform cannot do that", err)
+	}
+}
+
+// The whole of it, against the real policy table and the real resolver.
+//
+// The assertion is that a query arrives, not that a registry key exists. Getting the values
+// almost right produces a rule Windows accepts and does not use, which a structural test
+// would call a pass — the failure mode ADR-0029 exists to describe.
+func TestAConfiguredDomainReachesMeshp(t *testing.T) {
+	requireAdmin(t)
+
+	// A namespace nobody else uses, under a reserved TLD so nothing real is disturbed even
+	// if a rule outlives this test.
+	const domain = "slice.meshp-test.invalid"
+	const iface = "meshptestdns0"
+
+	server, err := net.ListenPacket("udp", "127.0.0.1:53")
+	if err != nil {
+		t.Skipf("something already holds 127.0.0.1:53 on this machine, which is the case "+
+			"ADR-0029 says meshp reports rather than works around: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	sys := &System{}
+	t.Cleanup(func() { _ = sys.Revert(context.WithoutCancel(t.Context()), iface) })
+	if err := sys.Configure(t.Context(), iface,
+		netip.MustParseAddrPort("127.0.0.1:53"), []string{domain}); err != nil {
+		t.Fatalf("configuring: %v", err)
+	}
+
+	arrived := make(chan int, 1)
+	go func() {
+		buf := make([]byte, 1500)
+		_ = server.SetReadDeadline(time.Now().Add(20 * time.Second))
+		if n, _, err := server.ReadFrom(buf); err == nil {
+			arrived <- n
+		} else {
+			arrived <- 0
+		}
+	}()
+
+	// The policy table is read by the DNS client rather than pushed to it, so a rule written
+	// a moment ago may not be in force yet. Asked more than once for that reason.
+	go func() {
+		for range 6 {
+			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+			_, _ = net.DefaultResolver.LookupHost(ctx, "a."+domain)
+			cancel()
+			time.Sleep(time.Second)
+		}
+	}()
+
+	if n := <-arrived; n == 0 {
+		t.Fatal("no query reached meshp's resolver for a domain it was configured to serve. " +
+			"The rule exists — Windows accepts one it cannot use and says nothing — so what " +
+			"this is telling us is that the values written are not the ones the DNS client reads")
+	}
+}
+
+// A rule comes off, and leaves nothing.
+//
+// ADR-0021's test for whether a platform gets an implementation at all is whether there is a
+// real undo. This is that, asserted rather than assumed.
+func TestRevertLeavesNothingBehind(t *testing.T) {
+	requireAdmin(t)
+
+	const iface = "meshptestdns1"
+	sys := &System{}
+	t.Cleanup(func() { _ = sys.Revert(context.WithoutCancel(t.Context()), iface) })
+
+	if err := sys.Configure(t.Context(), iface, netip.MustParseAddrPort("127.0.0.1:53"),
+		[]string{"one.meshp-test.invalid", "two.meshp-test.invalid"}); err != nil {
+		t.Fatalf("configuring: %v", err)
+	}
+	before, err := sys.rulesFor(iface)
+	if err != nil {
+		t.Fatalf("listing: %v", err)
+	}
+	if len(before) != 2 {
+		t.Fatalf("configured two domains and found %d rules", len(before))
+	}
+
+	// Fewer domains than last time: the rule for the one that went away goes with it, or a
+	// name nobody serves any more is directed at meshp forever.
+	if err := sys.Configure(t.Context(), iface, netip.MustParseAddrPort("127.0.0.1:53"),
+		[]string{"one.meshp-test.invalid"}); err != nil {
+		t.Fatalf("reconfiguring: %v", err)
+	}
+	if narrowed, err := sys.rulesFor(iface); err != nil || len(narrowed) != 1 {
+		t.Fatalf("after narrowing: %d rules, err=%v", len(narrowed), err)
+	}
+
+	if err := sys.Revert(t.Context(), iface); err != nil {
+		t.Fatalf("reverting: %v", err)
+	}
+	after, err := sys.rulesFor(iface)
+	if err != nil {
+		t.Fatalf("listing after revert: %v", err)
+	}
+	if len(after) != 0 {
+		t.Errorf("%d rule(s) survived the revert: %v", len(after), after)
+	}
+}
+
+// Reverting an interface that was never configured is success.
+//
+// Teardown always runs. A membership going away asks for this whether or not names were ever
+// configured, and an error there would report a failure to remove something never made.
+func TestRevertingWhatWasNeverConfigured(t *testing.T) {
+	if err := (&System{}).Revert(t.Context(), "meshpnope0"); err != nil {
+		t.Errorf("reverting an interface that never had rules: %v", err)
+	}
+}
+
+// Nobody else's rules are touched.
+//
+// The policy table is shared. meshp finds its own by a marker it writes, and a rule without
+// that marker belongs to whoever made it — a corporate DNS policy, most likely, on exactly
+// the machines meshp most wants not to break.
+func TestSomebodyElsesRuleIsLeftAlone(t *testing.T) {
+	requireAdmin(t)
+
+	const foreign = `{0BADC0DE-0000-4000-8000-00000BADC0DE}`
+	key, _, err := registry.CreateKey(registry.LOCAL_MACHINE, policyPath+`\`+foreign,
+		registry.SET_VALUE)
+	if err != nil {
+		t.Skipf("cannot write to the policy table: %v", err)
+	}
+	_ = key.SetStringsValue("Name", []string{".somebody-else.invalid"})
+	_ = key.Close()
+	t.Cleanup(func() { _ = registry.DeleteKey(registry.LOCAL_MACHINE, policyPath+`\`+foreign) })
+
+	sys := &System{}
+	const iface = "meshptestdns2"
+	if err := sys.Configure(t.Context(), iface, netip.MustParseAddrPort("127.0.0.1:53"),
+		[]string{"ours.meshp-test.invalid"}); err != nil {
+		t.Fatalf("configuring: %v", err)
+	}
+	if err := sys.Revert(t.Context(), iface); err != nil {
+		t.Fatalf("reverting: %v", err)
+	}
+
+	if _, err := registry.OpenKey(registry.LOCAL_MACHINE, policyPath+`\`+foreign, registry.QUERY_VALUE); err != nil {
+		t.Errorf("a rule meshp did not make was removed: %v", err)
+	}
+}

--- a/internal/resolved/unsupported.go
+++ b/internal/resolved/unsupported.go
@@ -1,4 +1,4 @@
-//go:build !linux && !darwin
+//go:build !linux && !darwin && !windows
 
 package resolved
 


### PR DESCRIPTION
Implements ADR-0029. A Windows device configures the Name Resolution Policy Table so only meshp's domains come to meshp, and removes exactly what it wrote when a membership leaves.

## The port is refused, not carried

Windows names a DNS server by address alone. Handed `127.0.0.1:15353` it **accepts the rule, stores an empty server list, and black-holes the namespace while reporting success**.

So `Configure` refuses anything but 53, and `meshpd`'s resolver binds 53 on this platform. That is the one place meshp competes for a well-known port — Linux and macOS deliberately take a spare one — and ADR-0029 accepts it because the alternative is no names at all, and because it fails at start-up rather than resolving into a hole.

## Every rule is read back after it is written

The third time on these platforms that a call has reported success having done nothing; `route(8)` on macOS was the first, and `pfctl` reasoning in ADR-0026 was arguably the second.

A policy that names no server is **worse than no policy**: it matches the namespace and directs it nowhere. So `writeRule` asks what was stored and refuses if it is not what went in.

## meshp finds its own rules by a marker, not a naming convention

`Revert` is called when the domains are already gone — by a membership that has left — so recomputing the key names would need something the caller no longer has. Each rule carries a value naming the interface that made it.

That also means **nobody else's policy is touched**. A corporate DNS rule, on exactly the machines meshp most wants not to break, carries no marker and is left alone. There is a test that plants a foreign rule and checks it survives a configure-and-revert cycle.

## Testing

Seven tests. The one that matters **resolves a name and waits for the query to arrive** at a listener on `127.0.0.1:53`:

> no query reached meshp's resolver for a domain it was configured to serve. The rule exists — Windows accepts one it cannot use and says nothing — so what this is telling us is that the values written are not the ones the DNS client reads

A structural test that checked for a registry key would pass on a rule Windows accepts and never uses, which is the entire failure mode this design is written against.

The rest: a non-53 port is refused; domains become suffix rules, deduplicated and ordered; a rule key is a function of interface and domain, so reconciling does not accumulate one per pass; narrowing the domain set removes the rule for the one that went away; revert leaves nothing; reverting what was never configured is success.

`internal/resolved` joins the Windows CI job. Tests that need HKLM skip without elevation, and a skip is a failure in that job.

## Also

`dnsListenAddr` is now assembled from a platform constant. A test asserts the resolver is on **loopback everywhere** — the fail-closed lock permits loopback unconditionally, and a resolver reachable from the café Wi-Fi would tell anyone there what machines are in a customer's network.
