### PR TITLE
docs: Windows resolves names now, and its resolver is on 53

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,12 @@ default route and fail-closed egress**, the last of these through a pf anchor ra
 nftables (ADR-0026). What macOS still cannot do is enforce a network's packet filter, so a
 network with a policy reports the group unhonoured there rather than half-applying it.
 
-**Windows has a tunnel and nothing above it yet.** A WinTun adapter comes up, carries an
-address and a route, and is configured exactly as the other two are (ADR-0028) — but names
-do not resolve, a full tunnel cannot be claimed, and it cannot fail closed or filter. Each
-of those is reported unhonoured rather than half-applied. The mobile platforms enrol, hold
-an address, and report honestly that they have no tunnel at all.
+**Windows has a tunnel and names.** A WinTun adapter comes up, carries an address and a
+route, and is configured exactly as the other two are (ADR-0028); mesh names resolve through
+the Name Resolution Policy Table, which routes by name rather than by interface so nothing
+else on the machine is captured (ADR-0029). What it cannot do yet is claim a full tunnel,
+fail closed, or filter — each reported unhonoured rather than half-applied. The mobile
+platforms enrol, hold an address, and report honestly that they have no tunnel at all.
 
 It is public from the first commit because the design decisions are the
 interesting part and we would rather be argued with early.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ Out of scope: anything you deploy meshp on top of, and the deployment examples u
 
 **Read this before you spend time on it.** meshp is pre-alpha and the README says not to
 deploy it. The data plane exists on Linux, macOS and Windows and nowhere else; macOS cannot
-enforce a network's packet filter, and Windows has only a tunnel — no name resolution, no
+enforce a network's packet filter, and Windows has a tunnel and name resolution but no
 full-tunnel route, no fail-closed egress and no filtering. Reports are still welcome and
 will be handled as above —
 but a finding that a half-built feature is half-built is not one, and there are several of

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,8 +34,9 @@ Two worth starting with:
 And the honest one: the [status section of the README](../README.md#status) says what does
 not work. The data plane is complete on Linux and on macOS — a tunnel, working names, a
 full-tunnel route and fail-closed egress, though macOS still cannot enforce a network's
-packet filter. Windows has a tunnel and nothing above it yet, and the mobile platforms have
-none. Nothing discovers direct paths anywhere.
+packet filter. Windows has a tunnel and working names, and cannot yet take a full-tunnel
+route or fail closed; the mobile platforms have no tunnel at all. Nothing discovers direct
+paths anywhere.
 If you need something that works this afternoon, the README names three projects that will
 serve you better today.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,9 +18,9 @@ bug and worth an issue.
 - Linux, with root. This page is written for Linux because that is where the data plane is
   complete. macOS is complete too — a tunnel, mesh names, a full-tunnel default route and
   fail-closed egress — except that it cannot enforce a network's packet filter. Windows
-  brings a tunnel up and has nothing above it yet: no names, no full tunnel, no fail-closed
-  egress. The mobile platforms enrol, hold an address, and report honestly that they have no
-  tunnel.
+  brings a tunnel up and resolves mesh names; what it cannot do yet is take a full tunnel or
+  fail closed. The mobile platforms enrol, hold an address, and report honestly that they have
+  no tunnel.
 - Docker with the Compose plugin, for the control plane and its database.
 - A kernel that can create WireGuard interfaces. `sudo ip link add dev wgcheck type
   wireguard && sudo ip link del dev wgcheck` tells you in one line.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -75,12 +75,28 @@ sudo meshp status
 there yet, so a device enrols, holds an address, and reports honestly that it has no tunnel
 rather than pretending.
 
-On Windows there **is** a tunnel as of ADR-0028, reported as `userspace`, and nothing above
-it: names do not resolve, a full tunnel cannot be claimed, and it can neither fail closed nor
-filter. Each of those is reported unhonoured rather than half-applied, so a Windows device
-can be given a network with no policy and no egress group and nothing else. It needs
-`wintun.dll` beside `meshpd.exe`; without it the tunnel fails with a message naming the file
-and where to put it.
+On Windows there **is** a tunnel as of ADR-0028, reported as `userspace`, and names resolve
+as of ADR-0029. What it cannot do yet is claim a full tunnel, fail closed, or filter — each
+reported unhonoured rather than half-applied, so a Windows device can be given a network with
+no policy and no egress group. It needs `wintun.dll` beside `meshpd.exe`; without it the
+tunnel fails with a message naming the file and where to put it.
+
+Names work differently here than anywhere else, in one way worth knowing before it surprises
+somebody. **meshp's resolver listens on port 53 on Windows**, where on Linux and macOS it
+takes whatever port the kernel has spare. Windows names a DNS server by address alone: a rule
+naming a port is accepted, stores no server, and silently answers nothing for that domain — so
+53 is the only thing expressible (ADR-0029). If something else on the machine already holds
+`127.0.0.1:53`, and WSL and Docker Desktop both can, meshpd says so at start-up and carries on
+without names rather than configuring something that does not work.
+
+To see the rules meshp installed:
+
+```powershell
+Get-DnsClientNrptRule | Where-Object { $_.NameServers -contains "127.0.0.1" }
+```
+
+They are removed when a membership leaves. Nothing else in that table is meshp's, and meshp
+does not touch it: a rule it did not create carries no marker of its own and is left alone.
 
 On macOS there **is** a tunnel, and `meshp status` reports its kind as `userspace` — macOS
 has no WireGuard in the kernel, so wireguard-go moves the packets. Expect lower throughput


### PR DESCRIPTION
#178 made the same five documents wrong that #175 did. **Third time in a day**, which is a pattern rather than an accident — see below.

The claim everywhere is now: Windows has a tunnel and names; it cannot yet take a full tunnel or fail closed.

| file | was |
|---|---|
| `README.md` | "a tunnel and nothing above it yet" |
| `SECURITY.md` | "only a tunnel — no name resolution…" |
| `docs/README.md` | "a tunnel and nothing above it yet" |
| `docs/quickstart.md` | "nothing above it yet: no names…" |
| `docs/troubleshooting.md` | "names do not resolve" |

## The thing that will surprise somebody

`troubleshooting.md` now says it plainly: **meshp's resolver listens on port 53 on Windows**, where on Linux and macOS it takes whatever port the kernel has spare.

Windows names a DNS server by address alone — a rule naming a port is accepted, stores no server, and silently answers nothing for that domain (ADR-0029). So 53 is the only thing expressible. If something already holds `127.0.0.1:53`, and **WSL and Docker Desktop both can**, meshpd says so at start-up and carries on without names rather than configuring something that does not work.

It also documents how to see the rules, and that meshp leaves everything else in that table alone — it is shared with whatever corporate DNS policy the machine already had, which is exactly what meshp most wants not to break.

## On this happening three times

Every platform slice invalidates the same five status claims, and nothing checks them. I have now missed a file once (`docs/quickstart.md` said macOS could not fail closed for two days after #169) and needed a prompt twice.

`internal/platformcheck` exists because a hand-maintained list of packages does not stay in step. This is the same failure in prose, and it is now three occurrences rather than two — which was the threshold I said I would want before designing a guard rather than guessing at one from a single example. Worth its own issue; not folded in here, because a guard for documentation wants thinking about rather than bolting on at the end of a docs fix.