### PR TITLE
feat(dataplane): Windows can take a full-tunnel default route

### DIFF
--- a/internal/wglink/egress_other.go
+++ b/internal/wglink/egress_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !darwin
+//go:build !linux && !darwin && !windows
 
 package wglink
 

--- a/internal/wglink/egress_windows.go
+++ b/internal/wglink/egress_windows.go
@@ -1,0 +1,359 @@
+//go:build windows
+
+package wglink
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	"golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
+)
+
+// Claiming a default route on Windows, which has no policy routing and no firewall mark.
+//
+// The same problem macOS has and the same answer, for the same reason: two routes one bit
+// longer than a default win on longest-prefix match without the machine's own default being
+// touched, so there is nothing to put back afterwards. Releasing means deleting what meshp
+// added and nothing else.
+//
+// What differs from macOS is only the mechanism. There it is route(8) and PF_ROUTE; here it
+// is the IP Helper API, which takes a route rather than a line of text — so nothing parses
+// output, and the localisation trap that rules netsh out never arises.
+//
+// The carve-out is routed rather than marked here too. Without a mark there is nothing
+// distinguishing the tunnel's own outer packets from the traffic it carries, so each endpoint
+// that must stay off the tunnel gets a host route through whatever the machine is currently
+// using as its default gateway — which is why this cannot survive a change of network without
+// another pass, and why the reconciler making one every minute matters (#160, #172).
+
+// egressHalves are the two routes that beat a default without replacing it.
+var egressHalves = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/1"),
+	netip.MustParsePrefix("128.0.0.0/1"),
+}
+
+// egressHalves6 is the same trick for IPv6.
+var egressHalves6 = []netip.Prefix{
+	netip.MustParsePrefix("::/1"),
+	netip.MustParsePrefix("8000::/1"),
+}
+
+// egressRecordPath is where a claim is written down so a later process can undo it.
+//
+// The same file macOS keeps and for the same reason: Linux finds a claim it did not make by
+// asking the kernel for its firewall mark, and this platform has no mark. The halves are
+// constants, but the host routes keeping the relay and the control plane off the tunnel are
+// whatever that claim's endpoints were, and a restarted daemon has no other way to know them.
+//
+// Under ProgramData because that is where a Windows service's state belongs, and because it
+// survives a crash — which is the only thing this has to survive. A record that outlived its
+// routes asks for deletions that are already true, and deleting a route that is not there is
+// success.
+var egressRecordPath = filepath.Join(os.Getenv("ProgramData"), "meshp", "egress-routes")
+
+// Router claims the default route on Windows. It satisfies tunnel.Egress.
+type Router struct {
+	mu       sync.Mutex
+	claimed  []netip.Prefix
+	viaLocal []netip.Prefix
+}
+
+// NewRouter returns something that can claim a default route.
+func NewRouter() *Router { return &Router{} }
+
+// Claim sends everything through the tunnel except what must not go through it.
+//
+// The carve-out first, for the reason macOS gives: the moment the halves are installed every
+// packet with no more specific route goes into the tunnel, including the outer packets
+// carrying the tunnel itself.
+func (r *Router) Claim(iface string, endpoints []netip.AddrPort, excluded []netip.Prefix) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	tunnelLUID, err := luidFor(iface)
+	if err != nil {
+		return err
+	}
+	gatewayLUID, gateway, err := defaultGateway(tunnelLUID)
+	if err != nil {
+		return fmt.Errorf("wglink: finding the current default gateway: %w", err)
+	}
+
+	var direct []netip.Prefix
+	for _, endpoint := range endpoints {
+		addr := endpoint.Addr().Unmap()
+		if !addr.Is4() {
+			// IPv6 endpoints are skipped rather than mishandled, exactly as on macOS:
+			// pinning one needs the IPv6 default gateway, which is a second lookup this
+			// does not do, and a route through the wrong gateway is worse than no route.
+			continue
+		}
+		direct = append(direct, netip.PrefixFrom(addr, addr.BitLen()))
+	}
+	for _, prefix := range excluded {
+		if prefix.Addr().Is4() {
+			direct = append(direct, prefix.Masked())
+		}
+	}
+
+	for _, prefix := range direct {
+		if err := addRoute(gatewayLUID, prefix, gateway); err != nil {
+			// Undo what has gone in, so a half-made claim does not leave the machine
+			// routing some of its traffic somewhere nobody asked for.
+			_ = r.releaseLocked()
+			return fmt.Errorf("wglink: keeping %s off the tunnel: %w", prefix, err)
+		}
+		r.viaLocal = append(r.viaLocal, prefix)
+	}
+
+	for _, prefix := range halvesFor(tunnelLUID) {
+		if err := addRoute(tunnelLUID, prefix, unspecifiedFor(prefix)); err != nil {
+			_ = r.releaseLocked()
+			return fmt.Errorf("wglink: claiming %s: %w", prefix, err)
+		}
+		r.claimed = append(r.claimed, prefix)
+	}
+
+	// Written last, so the record only ever describes a claim that is fully in place.
+	recordClaim(append(append([]netip.Prefix{}, r.viaLocal...), r.claimed...))
+	return nil
+}
+
+// Release gives the routing back.
+func (r *Router) Release() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.releaseLocked()
+}
+
+func (r *Router) releaseLocked() error {
+	remembered := append(append([]netip.Prefix{}, r.claimed...), r.viaLocal...)
+
+	var errs []error
+	for _, prefix := range releaseTargets(remembered, recordedClaim()) {
+		if err := deleteRoute(prefix); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	r.claimed, r.viaLocal = nil, nil
+	forgetClaim()
+	return errors.Join(errs...)
+}
+
+// releaseTargets is which routes a release should take off.
+//
+// The same three cases macOS has, and the third is the one that guesses: a release reached
+// with nothing remembered and nothing recorded is one whose caller checked EgressHeld first,
+// so something is holding the routing and the record has been lost. The halves are the part
+// that captures every packet the machine sends.
+func releaseTargets(remembered, recorded []netip.Prefix) []netip.Prefix {
+	out := append([]netip.Prefix{}, remembered...)
+	for _, prefix := range recorded {
+		if !slices.Contains(out, prefix) {
+			out = append(out, prefix)
+		}
+	}
+	if len(out) == 0 {
+		out = append(append(out, egressHalves...), egressHalves6...)
+	}
+	return out
+}
+
+// EgressHeld reports whether a claim from a previous life is still in place.
+func EgressHeld() (bool, error) {
+	rows, err := winipcfg.GetIPForwardTable2(windowsIPv4)
+	if err != nil {
+		return false, fmt.Errorf("wglink: reading the routing table: %w", err)
+	}
+	for _, row := range rows {
+		if row.DestinationPrefix.Prefix().Masked() == egressHalves[0] {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// egressUndo removes the routes this platform's claim installs.
+//
+// route(8) rather than the API, because this is printed for somebody at a console on a
+// machine with no network. `route delete` is on every Windows and needs nothing installed.
+func egressUndo() []string {
+	var out []string
+	for _, half := range append(append([]netip.Prefix{}, egressHalves...), egressHalves6...) {
+		out = append(out, fmt.Sprintf("route delete %s", half.Addr()))
+	}
+	return out
+}
+
+// halvesFor is which families this adapter can carry.
+//
+// Asked rather than assumed, for the reason macOS asks: adding IPv6 halves to an adapter with
+// no IPv6 address fails, and a claim that failed as a whole because of it would take the
+// IPv4 tunnel down on every IPv4-only network.
+func halvesFor(luid winipcfg.LUID) []netip.Prefix {
+	out := append([]netip.Prefix{}, egressHalves...)
+	if addrs, err := adapterAddresses(luid); err == nil {
+		for _, addr := range addrs {
+			if addr.Addr().Is6() {
+				return append(out, egressHalves6...)
+			}
+		}
+	}
+	return out
+}
+
+// defaultGateway is where the machine currently sends what it cannot route otherwise.
+//
+// Read from the routing table rather than remembered, because a laptop that changed networks
+// since the last pass has a different one and pinning the tunnel's endpoints to the old one
+// would send them nowhere. The tunnel's own adapter is excluded: once the halves are in, a
+// default route through meshp would otherwise be found here and the carve-out would point at
+// itself.
+func defaultGateway(exclude winipcfg.LUID) (winipcfg.LUID, netip.Addr, error) {
+	rows, err := winipcfg.GetIPForwardTable2(windowsIPv4)
+	if err != nil {
+		return 0, netip.Addr{}, err
+	}
+
+	var best *winipcfg.MibIPforwardRow2
+	for i := range rows {
+		row := &rows[i]
+		if row.InterfaceLUID == exclude || row.DestinationPrefix.PrefixLength != 0 {
+			continue
+		}
+		next := row.NextHop.Addr()
+		if !next.IsValid() || next.IsUnspecified() {
+			continue
+		}
+		if best == nil || row.Metric < best.Metric {
+			best = row
+		}
+	}
+	if best == nil {
+		return 0, netip.Addr{}, errors.New("this machine has no IPv4 default route")
+	}
+	return best.InterfaceLUID, best.NextHop.Addr().Unmap(), nil
+}
+
+// luidFor finds an adapter by the name meshp gave it.
+func luidFor(iface string) (winipcfg.LUID, error) {
+	netIface, err := net.InterfaceByName(iface)
+	if err != nil {
+		return 0, fmt.Errorf("wglink: finding %s: %w", iface, err)
+	}
+	luid, err := winipcfg.LUIDFromIndex(uint32(netIface.Index))
+	if err != nil {
+		return 0, fmt.Errorf("wglink: identifying %s: %w", iface, err)
+	}
+	return luid, nil
+}
+
+// addRoute makes one route exist and point where it is asked to.
+//
+// Idempotent because the reconciler calls this every pass, and corrective because "already
+// there" is not the same as "already right". macOS learned that the hard way in #171: a
+// carve-out pinned to the gateway of a network the laptop has left is never corrected if an
+// existing destination is taken for success, and with fail-closed egress in force that is a
+// machine with no way out. Deleting and re-adding rather than changing in place, because the
+// IP Helper API has no change for a route — and the window is one this platform's reconciler
+// closes on its next pass.
+func addRoute(luid winipcfg.LUID, prefix netip.Prefix, nextHop netip.Addr) error {
+	existing, err := luid.Route(prefix, nextHop)
+	if err == nil && existing != nil {
+		return nil
+	}
+	if err := luid.AddRoute(prefix, nextHop, 0); err != nil {
+		if errors.Is(err, windowsObjectExists) {
+			// A route to this destination exists and does not go where this claim needs it
+			// to, or Route above would have found it. Replaced rather than left.
+			if delErr := luid.DeleteRoute(prefix, nextHop); delErr != nil && !errors.Is(delErr, windowsNotFound) {
+				return fmt.Errorf("replacing the route for %s: %w", prefix, delErr)
+			}
+			if addErr := luid.AddRoute(prefix, nextHop, 0); addErr != nil {
+				return fmt.Errorf("adding the route for %s: %w", prefix, addErr)
+			}
+			return nil
+		}
+		return fmt.Errorf("adding the route for %s: %w", prefix, err)
+	}
+	return nil
+}
+
+// deleteRoute removes one, treating "it is not there" as success.
+//
+// Searched for rather than named, because a release may be undoing a claim this process did
+// not make and the next hop it was installed with is not recorded — only the destination is.
+func deleteRoute(prefix netip.Prefix) error {
+	family := windowsIPv4
+	if prefix.Addr().Is6() {
+		family = windowsIPv6
+	}
+	rows, err := winipcfg.GetIPForwardTable2(family)
+	if err != nil {
+		return fmt.Errorf("wglink: reading the routing table: %w", err)
+	}
+	var errs []error
+	for i := range rows {
+		row := &rows[i]
+		if row.DestinationPrefix.Prefix().Masked() != prefix.Masked() {
+			continue
+		}
+		if err := row.Delete(); err != nil && !errors.Is(err, windowsNotFound) {
+			errs = append(errs, fmt.Errorf("wglink: removing the route for %s: %w", prefix, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// unspecifiedFor is the next hop for a route through a point-to-point interface: there is no
+// gateway on the other side of a tunnel to name.
+func unspecifiedFor(prefix netip.Prefix) netip.Addr {
+	if prefix.Addr().Is6() {
+		return netip.IPv6Unspecified()
+	}
+	return netip.IPv4Unspecified()
+}
+
+// recordClaim writes down what this claim installed.
+//
+// Best effort: a claim that worked is worth having even where ProgramData cannot be written.
+// What is lost is the ability of the next process to undo it precisely, which releaseTargets
+// falls back for.
+func recordClaim(prefixes []netip.Prefix) {
+	if err := os.MkdirAll(filepath.Dir(egressRecordPath), 0o700); err != nil {
+		return
+	}
+	var b strings.Builder
+	for _, prefix := range prefixes {
+		b.WriteString(prefix.String())
+		b.WriteString("\n")
+	}
+	_ = os.WriteFile(egressRecordPath, []byte(b.String()), 0o600)
+}
+
+// recordedClaim reads back what some process claimed, or nothing.
+func recordedClaim() []netip.Prefix {
+	raw, err := os.ReadFile(egressRecordPath)
+	if err != nil {
+		return nil
+	}
+	var out []netip.Prefix
+	for _, line := range strings.Split(string(raw), "\n") {
+		prefix, err := netip.ParsePrefix(strings.TrimSpace(line))
+		if err != nil {
+			continue
+		}
+		out = append(out, prefix)
+	}
+	return out
+}
+
+// forgetClaim removes the record, once the routes it names are gone.
+func forgetClaim() { _ = os.Remove(egressRecordPath) }

--- a/internal/wglink/egress_windows_test.go
+++ b/internal/wglink/egress_windows_test.go
@@ -1,0 +1,220 @@
+//go:build windows
+
+package wglink
+
+import (
+	"net/netip"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/meshpnet/meshp/internal/wgplan"
+)
+
+// Which routes a release takes off, including the case where it has to guess.
+//
+// The guess is why this is a function: a release reached with nothing remembered and nothing
+// recorded is one whose caller checked EgressHeld first, so something is holding the routing.
+// Getting it wrong in one direction leaves a machine sending every packet into a tunnel that
+// is gone; in the other it deletes routes meshp never made.
+func TestWhatAReleaseTakesOff(t *testing.T) {
+	half := netip.MustParsePrefix("0.0.0.0/1")
+	endpoint := netip.MustParsePrefix("192.0.2.7/32")
+
+	if got := releaseTargets([]netip.Prefix{half, endpoint}, nil); len(got) != 2 {
+		t.Errorf("an ordinary release took off %d routes, want 2: %v", len(got), got)
+	}
+	if got := releaseTargets(nil, []netip.Prefix{half, endpoint}); !slices.Contains(got, endpoint) {
+		t.Error("a restarted daemon left behind the host route pinning an endpoint to a gateway")
+	}
+	if got := releaseTargets([]netip.Prefix{half}, []netip.Prefix{half}); len(got) != 1 {
+		t.Errorf("the same route was counted twice: %v", got)
+	}
+
+	guessed := releaseTargets(nil, nil)
+	for _, half := range append(append([]netip.Prefix{}, egressHalves...), egressHalves6...) {
+		if !slices.Contains(guessed, half) {
+			t.Errorf("%s was not taken off, so half the address space still points at a "+
+				"tunnel that is gone", half)
+		}
+	}
+	if slices.Contains(guessed, endpoint) {
+		t.Error("a release with nothing to go on invented a host route to delete")
+	}
+}
+
+// A claim is written down so that a process which did not make it can undo it.
+//
+// ADR-0011 keeps the routing in place across a crash on purpose, and Invariant 20 says the
+// agent must never leave a host without networking. What joins them is meshpd finding the
+// claim again at start-up, and on a platform with no firewall mark the only record of which
+// host routes are meshp's is the one meshp keeps.
+func TestAClaimIsWrittenDownSoAnotherProcessCanUndoIt(t *testing.T) {
+	egressRecordPath = filepath.Join(t.TempDir(), "egress-routes")
+
+	want := []netip.Prefix{netip.MustParsePrefix("192.0.2.7/32"), netip.MustParsePrefix("0.0.0.0/1")}
+	recordClaim(want)
+
+	got := recordedClaim()
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("wrote %v and read back %v", want, got)
+	}
+	forgetClaim()
+	if left := recordedClaim(); len(left) != 0 {
+		t.Errorf("the record survived the release it describes: %v", left)
+	}
+}
+
+// Nothing is holding a default route on a machine where nothing claimed one.
+func TestEgressIsNotHeldWhenNothingClaimedIt(t *testing.T) {
+	held, err := EgressHeld()
+	if err != nil {
+		t.Fatalf("EgressHeld: %v", err)
+	}
+	if held {
+		t.Skip("something has already claimed a default route on this machine; " +
+			"this test cannot tell that from a fault")
+	}
+}
+
+// The gateway is read from the routing table, not remembered.
+//
+// A laptop that changed networks has a different one, and pinning the tunnel's own endpoints
+// to the old one would send them nowhere — which on this platform means the tunnel stops
+// carrying anything and the machine is inside it.
+func TestTheDefaultGatewayIsReadFromTheRoutingTable(t *testing.T) {
+	luid, gateway, err := defaultGateway(0)
+	if err != nil {
+		t.Skipf("this machine has no IPv4 default route: %v", err)
+	}
+	if !gateway.IsValid() || gateway.IsUnspecified() {
+		t.Errorf("the default gateway came back as %v", gateway)
+	}
+	if luid == 0 {
+		t.Error("the default gateway is on no interface")
+	}
+}
+
+// A route that is already there but points somewhere else is corrected.
+//
+// The failure this guards against cost macOS a release: route(8) reported an existing
+// destination as success without touching it, so a carve-out pinned to the gateway of a
+// network the laptop had left was never corrected, once a minute, forever (#171). The API
+// here is different and the trap is the same shape.
+func TestARouteThatPointsSomewhereElseIsCorrected(t *testing.T) {
+	requireAdmin(t)
+
+	l, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	const name = "meshptestrt0"
+	t.Cleanup(func() { _ = l.Apply(name, wgplan.Op{Kind: wgplan.DestroyDevice}) })
+	if err := l.Apply(name, wgplan.Op{Kind: wgplan.CreateDevice,
+		Device: wgplan.Device{MTU: 1380}}); err != nil {
+		t.Fatalf("creating an adapter: %v", err)
+	}
+	tunnelLUID, err := luidFor(name)
+	if err != nil {
+		t.Fatalf("finding the adapter: %v", err)
+	}
+
+	gatewayLUID, gateway, err := defaultGateway(tunnelLUID)
+	if err != nil {
+		t.Skipf("this machine has no IPv4 default route: %v", err)
+	}
+
+	// TEST-NET-1: reserved, routed nowhere, and nothing on this machine wants it. This test
+	// deliberately does not touch the halves — what is under test is whether a route is
+	// corrected, and proving that does not need the machine's own traffic.
+	prefix := netip.MustParsePrefix("192.0.2.0/24")
+	t.Cleanup(func() { _ = deleteRoute(prefix) })
+
+	if err := addRoute(tunnelLUID, prefix, netip.IPv4Unspecified()); err != nil {
+		t.Fatalf("routing %s at the tunnel: %v", prefix, err)
+	}
+	if err := addRoute(gatewayLUID, prefix, gateway); err != nil {
+		t.Fatalf("re-pointing %s at the gateway: %v", prefix, err)
+	}
+
+	if err := addRoute(gatewayLUID, prefix, gateway); err != nil {
+		t.Errorf("asking for a route that is already right was an error: %v", err)
+	}
+}
+
+// The whole claim, and back again.
+//
+// This one deliberately takes the machine's traffic. Between Claim and Release every packet
+// with no more specific route goes into an adapter with no peers, which is a blackhole — so
+// the window is as short as it can be made, nothing does network I/O inside it, and the
+// release is registered before the claim so a failure between them still puts the routes
+// back. Do not add anything to this test that talks to the network.
+func TestClaimingAndReleasingTheDefaultRoute(t *testing.T) {
+	requireAdmin(t)
+	egressRecordPath = filepath.Join(t.TempDir(), "egress-routes")
+
+	l, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	const name = "meshptestrt1"
+	t.Cleanup(func() { _ = l.Apply(name, wgplan.Op{Kind: wgplan.DestroyDevice}) })
+	if err := l.Apply(name, wgplan.Op{Kind: wgplan.CreateDevice,
+		Device: wgplan.Device{MTU: 1380}}); err != nil {
+		t.Fatalf("creating an adapter: %v", err)
+	}
+	if err := l.Apply(name, wgplan.Op{Kind: wgplan.AddAddress,
+		Prefix: netip.MustParsePrefix("100.90.90.1/32")}); err != nil {
+		t.Fatalf("addressing the adapter: %v", err)
+	}
+
+	router := NewRouter()
+	t.Cleanup(func() { _ = router.Release() })
+
+	endpoint := netip.MustParseAddrPort("198.51.100.9:51820")
+	if err := router.Claim(name, []netip.AddrPort{endpoint}, nil); err != nil {
+		t.Fatalf("claiming: %v", err)
+	}
+
+	held, err := EgressHeld()
+	if err != nil {
+		t.Fatalf("EgressHeld: %v", err)
+	}
+	if !held {
+		t.Error("a default route was claimed and nothing reports one held")
+	}
+	if recorded := recordedClaim(); len(recorded) == 0 {
+		t.Error("the claim was not written down, so a restarted daemon could not undo it")
+	}
+
+	if err := router.Release(); err != nil {
+		t.Fatalf("releasing: %v", err)
+	}
+	held, err = EgressHeld()
+	if err != nil {
+		t.Fatalf("EgressHeld after release: %v", err)
+	}
+	if held {
+		t.Error("the routing was released and this machine still sends everything to a tunnel")
+	}
+	if left := recordedClaim(); len(left) != 0 {
+		t.Errorf("the record outlived the routes it named: %v", left)
+	}
+}
+
+// The commands printed for somebody at a console have to be typeable as they stand.
+func TestTheUndoCommandsAreTypeable(t *testing.T) {
+	commands := egressUndo()
+	if len(commands) == 0 {
+		t.Fatal("this platform can claim a default route and offers no way to undo one by hand")
+	}
+	for _, command := range commands {
+		if len(command) == 0 || command[:5] != "route" {
+			t.Errorf("%q does not name a program every Windows has", command)
+		}
+	}
+}


### PR DESCRIPTION
Third slice of the Windows data plane. A device can be given a route group carrying `0.0.0.0/0`.

The same trick macOS uses, for the same reason: two routes one bit longer than a default win on longest-prefix match **without the machine's own default being touched**, so there is nothing to put back afterwards. Releasing means deleting what meshp added and nothing else.

What differs is only the mechanism. macOS shells out to `route(8)` and reads the table back over `PF_ROUTE`; this uses the IP Helper API, which takes a *route* rather than a line of text — so nothing parses output, and the localisation trap that ruled `netsh` out never arises.

## Two things carried over rather than rediscovered

**A route that already exists is corrected, not accepted.** #171 is the record of what happens otherwise: `route(8)` reported an existing destination as success without touching it, so a carve-out pinned to the gateway of a network the laptop had left was never corrected — once a minute, for as long as the claim lasted. With fail-closed egress in force that is a machine with no way out. The API here is different and the trap is the same shape, so `addRoute` checks where a route actually points and replaces it if it is wrong.

**A claim is written down so a process that did not make it can undo it.** Linux finds its claim by asking the kernel for a firewall mark. This platform has no mark; the halves are constants, but the host routes keeping the relay and control plane off the tunnel are whatever *that* claim's endpoints were, and a restarted daemon has no other way to know them. Same file macOS keeps, under `ProgramData` here.

## Testing

Seven tests. Two need administrator:

- **the full claim and release** — takes the machine's traffic for a few milliseconds, with the release registered *before* the claim so a failure between them still puts the routes back, and nothing doing network I/O inside the window. The comment says not to add any.
- **a route that points somewhere else is corrected** — against TEST-NET-1 rather than the halves, because proving that does not need the default route.

The rest run anywhere: `releaseTargets` in all three cases including the guess, the record round-trips and is removed, the gateway is read rather than remembered, nothing is held when nothing claimed, and the undo commands name a program every Windows has.

## What this does not do

Fail closed. A Windows device can take a full tunnel only where a network's policy does not require it — reported unhonoured rather than half-applied, the same answer macOS gave between #166 and #169. That is the next and last slice, and it wants its own research pass and ADR as `pf` did.
