### PR TITLE
feat(dataplane): Windows refuses egress that does not go through the tunnel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -769,10 +769,10 @@ jobs:
       # reads the policy meshp writes cannot be reasoned about. ADR-0029 records that Windows
       # accepts a rule it cannot use and reports success, so the test that matters resolves a
       # name and waits for the query to arrive rather than checking that a registry key exists.
-      - name: an adapter comes up, is configured through wgctrl, and a configured name reaches meshp
+      - name: an adapter comes up, names reach meshp, and a lock refuses what it does not name
         shell: pwsh
         run: |
-          go test ./internal/wglink/ ./internal/resolved/ ./internal/version/ -count=1 -v 2>&1 | Tee-Object windows.log
+          go test ./internal/wglink/ ./internal/resolved/ ./internal/wfp/ ./internal/egresslock/ ./internal/version/ -count=1 -v 2>&1 | Tee-Object windows.log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: report, and refuse a test that did not run

--- a/internal/egresslock/egresslock_other.go
+++ b/internal/egresslock/egresslock_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !darwin
+//go:build !linux && !darwin && !windows
 
 package egresslock
 

--- a/internal/egresslock/egresslock_test.go
+++ b/internal/egresslock/egresslock_test.go
@@ -28,7 +28,7 @@ func TestAPlatformThatCanLockSaysHowToStop(t *testing.T) {
 	commands := Undo()
 
 	switch runtime.GOOS {
-	case "linux", "darwin":
+	case "linux", "darwin", "windows":
 		if len(commands) == 0 {
 			t.Fatal("this platform has a lock and offers no way to take it off by hand")
 		}
@@ -43,7 +43,9 @@ func TestAPlatformThatCanLockSaysHowToStop(t *testing.T) {
 		if strings.Contains(command, "%!") {
 			t.Errorf("%q has a formatting error in it", command)
 		}
-		if !strings.HasPrefix(command, "sudo ") {
+		// Root is asked for where asking is how it is done. Windows has no sudo: the undo
+		// there is a restart, which an administrator's console runs as it stands.
+		if runtime.GOOS != "windows" && !strings.HasPrefix(command, "sudo ") {
 			t.Errorf("%q is printed to somebody at a console and does not ask for root", command)
 		}
 	}

--- a/internal/egresslock/egresslock_windows.go
+++ b/internal/egresslock/egresslock_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package egresslock
+
+import (
+	"context"
+
+	"github.com/meshpnet/meshp/internal/wfp"
+)
+
+// New returns this host's lock, or nil where it has none — which on Windows means an agent
+// without the administrative rights the filtering platform requires.
+//
+// Nil returned explicitly for the reason the other two files give: a nil *wfp.Lock assigned
+// straight to an interface is a non-nil interface holding a nil pointer.
+func New(ctx context.Context) Lock {
+	if l := wfp.New(ctx); l != nil {
+		return l
+	}
+	return nil
+}
+
+// Held reports whether a lock left by any process is currently installed.
+func Held(ctx context.Context) bool { return wfp.Held(ctx) }
+
+// Undo is the exact commands that take the lock off by hand.
+//
+// meshp's filters hang beneath a provider of its own, so removing the provider takes them and
+// nothing else — which is why this is one command rather than a list. netsh is on every
+// Windows and needs nothing installed, which matters because whoever reads this is at a
+// console on a machine with no network.
+func Undo() []string {
+	return []string{`netsh wfp show state` + " (meshp's filters are under the provider named meshp)"}
+}

--- a/internal/egresslock/egresslock_windows.go
+++ b/internal/egresslock/egresslock_windows.go
@@ -23,12 +23,18 @@ func New(ctx context.Context) Lock {
 // Held reports whether a lock left by any process is currently installed.
 func Held(ctx context.Context) bool { return wfp.Held(ctx) }
 
-// Undo is the exact commands that take the lock off by hand.
+// Undo is the exact command that takes the lock off by hand.
 //
-// meshp's filters hang beneath a provider of its own, so removing the provider takes them and
-// nothing else — which is why this is one command rather than a list. netsh is on every
-// Windows and needs nothing installed, which matters because whoever reads this is at a
-// console on a machine with no network.
-func Undo() []string {
-	return []string{`netsh wfp show state` + " (meshp's filters are under the provider named meshp)"}
-}
+// A restart, which is not a cop-out on this platform: the filtering platform has no
+// command-line interface that deletes anything. netsh can show the state and not change it,
+// and PowerShell has no cmdlet for a WFP provider — the objects are reachable only through
+// the API meshp calls.
+//
+// What makes a restart an answer rather than a shrug is that meshp's filters are deliberately
+// not persistent (ADR-0030). They are lost when the filter engine stops, so a reboot clears
+// them exactly as it clears an nftables table on Linux or a pf anchor on macOS. The
+// difference is only that on those platforms there is also a command, and here there is not.
+//
+// Printed second, after `meshp doctor` has already said that starting meshpd removes it —
+// which is the answer that does not cost somebody their open windows.
+func Undo() []string { return []string{"shutdown /r /t 0"} }

--- a/internal/platformcheck/platformcheck_test.go
+++ b/internal/platformcheck/platformcheck_test.go
@@ -1,5 +1,5 @@
 // Package platformcheck holds one test: every package whose behaviour depends on the
-// operating system is tested on macOS in CI, not only on Linux.
+// operating system is tested somewhere it actually runs, not only on Linux.
 //
 // It exists because CI reported a change as good when it was not. #156 makes `meshp doctor`
 // stop recommending `systemctl` where there is no systemd, and it breaks a test that asserts
@@ -18,6 +18,7 @@ package platformcheck
 
 import (
 	"go/ast"
+	"go/build"
 	"go/parser"
 	"go/token"
 	"os"
@@ -30,29 +31,29 @@ import (
 // repoRoot is where the module lives, from this package's directory.
 const repoRoot = "../.."
 
-// macOSJobPackages finds the packages a `go test` line runs.
+// jobPackages finds the packages a `go test` line runs.
 //
 // Read out of the workflow rather than duplicated here, because a copy would be one more
 // thing to keep in step and this test exists because that does not work.
 //
-// Applied to the macOS job's block alone, which the first version of this got wrong: run
+// Applied to one job's block at a time, which the first version of this got wrong: run
 // against the whole file it also matched the Linux job, so internal/nftables and
 // internal/pathprobe counted as covered on macOS while being tested only on Linux — the
 // exact thing this is here to catch, satisfied by the thing it is checking against.
-var macOSJobPackages = regexp.MustCompile(`go test ((?:\./[^\s]+/ )+)-count=1`)
+var jobPackages = regexp.MustCompile(`go test ((?:\./[^\s]+/ )+)-count=1`)
 
-// macOSJob is the block of the workflow belonging to the macOS job.
+// job is the block of the workflow belonging to one job.
 //
 // By indentation, because that is what YAML gives us and pulling in a parser for one field
 // would be a dependency for a test. A job ends where the next one at the same indentation
 // begins.
-func macOSJob(t *testing.T, workflow string) string {
+func job(t *testing.T, workflow, name string) string {
 	t.Helper()
-	const header = "\n  dataplane-macos:\n"
+	header := "\n  " + name + ":\n"
 	start := strings.Index(workflow, header)
 	if start < 0 {
-		t.Fatal("no dataplane-macos job in the workflow; if it was renamed, this test needs " +
-			"to learn the new name rather than be deleted")
+		t.Fatalf("no %s job in the workflow; if it was renamed, this test needs to learn the "+
+			"new name rather than be deleted", name)
 	}
 	rest := workflow[start+len(header):]
 
@@ -176,26 +177,64 @@ func hasTests(t *testing.T, pkg string) bool {
 	return false
 }
 
-func TestEveryPlatformSensitivePackageIsTestedOnMacOS(t *testing.T) {
+// buildableOn reports whether a package has any file the given platform would compile.
+//
+// Asked of go/build rather than worked out from filenames, because working it out from
+// filenames is what this test was doing wrong: it required internal/wfp to run on macOS,
+// where the package has no files at all and `go test` would fail rather than test anything.
+//
+// The question a guard about platform coverage should ask is "can this run there", and the
+// only thing that answers it correctly is the same code the toolchain uses.
+func buildableOn(t *testing.T, pkg, goos, goarch string) bool {
+	t.Helper()
+	ctx := build.Default
+	ctx.GOOS, ctx.GOARCH = goos, goarch
+	ctx.CgoEnabled = false
+
+	dir := filepath.Join(repoRoot, pkg)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", pkg, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") {
+			continue
+		}
+		if ok, err := ctx.MatchFile(dir, entry.Name()); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// packagesRunBy reads the packages one job's `go test` lines name.
+func packagesRunBy(t *testing.T, workflow, jobName string) map[string]bool {
+	t.Helper()
+	matches := jobPackages.FindAllStringSubmatch(job(t, workflow, jobName), -1)
+	if len(matches) == 0 {
+		t.Fatalf("found no `go test ./pkg/ ... -count=1` line in the %s job; if it changed "+
+			"shape, this test needs to learn the new one rather than be deleted", jobName)
+	}
+	out := map[string]bool{}
+	for _, match := range matches {
+		for _, pkg := range strings.Fields(match[1]) {
+			out[strings.Trim(pkg, "./")] = true
+		}
+	}
+	return out
+}
+
+func TestEveryPlatformSensitivePackageIsTestedWhereItRuns(t *testing.T) {
 	workflow, err := os.ReadFile(filepath.Join(repoRoot, ".github/workflows/ci.yml"))
 	if err != nil {
 		t.Fatalf("reading the workflow: %v", err)
 	}
 
-	// The macOS job runs the same package list twice, privileged and not. Either occurrence
-	// answers the question; taking the union means a package named in only one of them
-	// still counts, which is right — it ran somewhere on macOS.
-	matches := macOSJobPackages.FindAllStringSubmatch(macOSJob(t, string(workflow)), -1)
-	if len(matches) == 0 {
-		t.Fatal("found no `go test ./pkg/ ... -count=1` line in the workflow; if the macOS " +
-			"job changed shape, this test needs to learn the new one rather than be deleted")
-	}
-	tested := map[string]bool{}
-	for _, match := range matches {
-		for _, pkg := range strings.Fields(match[1]) {
-			tested[strings.Trim(pkg, "./")] = true
-		}
-	}
+	// Each job runs the same package list more than once — privileged and not on macOS.
+	// Either occurrence answers the question; the union is right, because a package named in
+	// only one of them still ran there.
+	onMacOS := packagesRunBy(t, string(workflow), "dataplane-macos")
+	onWindows := packagesRunBy(t, string(workflow), "dataplane-windows")
 
 	for pkg := range platformSensitive(t) {
 		if !hasTests(t, pkg) {
@@ -206,11 +245,27 @@ func TestEveryPlatformSensitivePackageIsTestedOnMacOS(t *testing.T) {
 			t.Logf("%s decides something from the operating system and has no tests at all", pkg)
 			continue
 		}
-		if !tested[pkg] {
-			t.Errorf("%s decides something from the operating system and is not run by the "+
-				"macOS job in .github/workflows/ci.yml.\n"+
-				"Add ./%s/ to both `go test` lines there, or explain here why it does not "+
-				"need to run on macOS.", pkg, pkg)
+
+		// Where a package can run decides where it must be tested. Requiring macOS of a
+		// package with no macOS files is how this test asked for a job that could only fail:
+		// internal/wfp is the filtering platform and exists on exactly one operating system.
+		switch {
+		case buildableOn(t, pkg, "darwin", "arm64"):
+			if !onMacOS[pkg] {
+				t.Errorf("%s decides something from the operating system, builds on macOS, "+
+					"and is not run by the macOS job in .github/workflows/ci.yml.\n"+
+					"Add ./%s/ to both `go test` lines there, or explain here why it does "+
+					"not need to run on macOS.", pkg, pkg)
+			}
+		case buildableOn(t, pkg, "windows", "amd64"):
+			if !onWindows[pkg] {
+				t.Errorf("%s decides something from the operating system, builds only on "+
+					"Windows, and is not run by the Windows job in .github/workflows/ci.yml.\n"+
+					"Add ./%s/ to the `go test` line there.", pkg, pkg)
+			}
+		default:
+			t.Logf("%s decides something from the operating system and builds on neither "+
+				"macOS nor Windows, so no job here can run it", pkg)
 		}
 	}
 }

--- a/internal/wfp/filters_windows.go
+++ b/internal/wfp/filters_windows.go
@@ -1,0 +1,257 @@
+//go:build windows
+
+package wfp
+
+import (
+	"fmt"
+	"net/netip"
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+	"golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
+)
+
+// One filter, at both address families where that makes sense.
+//
+// Everything here goes at ALE_AUTH_CONNECT, which is where Windows decides whether a
+// connection may be made — the outbound equivalent of the hook nftables and pf use. Both
+// families get their own filter because the layers are separate; a policy installed at one
+// says nothing about the other, and a device that refused IPv4 and permitted IPv6 would leak
+// exactly the traffic the lock exists to stop.
+
+// addFilter installs one filter and gives it a name meshp can find again.
+func addFilter(session uintptr, slot string, layer windows.GUID, action wtFwpActionType,
+	weight uint8, conditions []wtFwpmFilterCondition0, description string) error {
+
+	displayData, err := createWtFwpmDisplayData0("meshp", description)
+	if err != nil {
+		return wrapErr(err)
+	}
+
+	filter := wtFwpmFilter0{
+		filterKey:           filterKey(slot),
+		displayData:         *displayData,
+		providerKey:         &providerKey,
+		layerKey:            layer,
+		subLayerKey:         sublayerKey,
+		weight:              filterWeight(weight),
+		numFilterConditions: uint32(len(conditions)),
+		action:              wtFwpmAction0{_type: action},
+	}
+	if len(conditions) > 0 {
+		filter.filterCondition = &conditions[0]
+	}
+
+	var id uint64
+	err = fwpmFilterAdd0(session, &filter, 0, &id)
+	// The conditions are pointed at by the structure the kernel just read. Held until after
+	// the call so nothing moves underneath it.
+	runtime.KeepAlive(conditions)
+	runtime.KeepAlive(displayData)
+	if err != nil && !isAlreadyExists(err) {
+		return fmt.Errorf("wfp: installing the %s filter: %w", slot, err)
+	}
+	return nil
+}
+
+// permitLoopback lets the machine talk to itself.
+//
+// Unconditional and first. The agent's own resolver is on loopback — on this platform on port
+// 53 (ADR-0029) — and so is everything a desktop does with 127.0.0.1. A lock that broke them
+// would break the machine rather than its egress.
+func permitLoopback(session uintptr) error {
+	condition := []wtFwpmFilterCondition0{{
+		fieldKey:  cFWPM_CONDITION_FLAGS,
+		matchType: cFWP_MATCH_FLAGS_ALL_SET,
+		conditionValue: wtFwpConditionValue0{
+			_type: cFWP_UINT32,
+			value: uintptr(cFWP_CONDITION_FLAG_IS_LOOPBACK),
+		},
+	}}
+	for _, layer := range bothLayers() {
+		if err := addFilter(session, "loopback", layer.key, cFWP_ACTION_PERMIT, weightLoopback,
+			condition, "permit loopback"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// permitInterface lets everything out through the tunnel, which is the point of claiming a
+// default route in the first place.
+func permitInterface(session uintptr, luid winipcfg.LUID) error {
+	value := uint64(luid)
+	for _, layer := range bothLayers() {
+		condition := []wtFwpmFilterCondition0{{
+			fieldKey:  cFWPM_CONDITION_IP_LOCAL_INTERFACE,
+			matchType: cFWP_MATCH_EQUAL,
+			conditionValue: wtFwpConditionValue0{
+				_type: cFWP_UINT64,
+				value: uintptr(unsafe.Pointer(&value)),
+			},
+		}}
+		if err := addFilter(session, "interface-"+layer.suffix, layer.key, cFWP_ACTION_PERMIT,
+			weightInterface, condition, "permit the tunnel"); err != nil {
+			return err
+		}
+	}
+	runtime.KeepAlive(value)
+	return nil
+}
+
+// permitAddress keeps one address or network reachable directly.
+//
+// Used for both halves of the carve-out: the endpoints that make the tunnel possible, and the
+// networks an administrator said to leave alone. They differ only in weight, so that a DNS
+// refusal can sit between them.
+func permitAddress(session uintptr, addr netip.Addr, bits int, weight uint8, slot string) error {
+	layer, ok := layerFor(addr)
+	if !ok {
+		return nil
+	}
+
+	if addr.Is4() {
+		value := wtFwpV4AddrAndMask{
+			addr: beUint32(addr.As4()),
+			mask: ^uint32(0) << (32 - bits),
+		}
+		condition := []wtFwpmFilterCondition0{{
+			fieldKey:  cFWPM_CONDITION_IP_REMOTE_ADDRESS,
+			matchType: cFWP_MATCH_EQUAL,
+			conditionValue: wtFwpConditionValue0{
+				_type: cFWP_V4_ADDR_MASK,
+				value: uintptr(unsafe.Pointer(&value)),
+			},
+		}}
+		err := addFilter(session, slot+"-v4", layer, cFWP_ACTION_PERMIT, weight, condition,
+			"keep off the tunnel")
+		runtime.KeepAlive(value)
+		return err
+	}
+
+	value := wtFwpV6AddrAndMask{addr: addr.As16(), prefixLength: uint8(bits)}
+	condition := []wtFwpmFilterCondition0{{
+		fieldKey:  cFWPM_CONDITION_IP_REMOTE_ADDRESS,
+		matchType: cFWP_MATCH_EQUAL,
+		conditionValue: wtFwpConditionValue0{
+			_type: cFWP_V6_ADDR_MASK,
+			value: uintptr(unsafe.Pointer(&value)),
+		},
+	}}
+	err := addFilter(session, slot+"-v6", layer, cFWP_ACTION_PERMIT, weight, condition,
+		"keep off the tunnel")
+	runtime.KeepAlive(value)
+	return err
+}
+
+// blockDNS refuses plaintext DNS that is not going through the tunnel.
+//
+// Above the carve-out and below the tunnel, which is the whole of it: the resolver lives on
+// the local network and the carve-out permits the local network, so a refusal placed after it
+// would refuse nothing. Plaintext only — DNS over TLS on 853 does not disclose the query to
+// the network it crosses, and DNS over HTTPS is indistinguishable from any other HTTPS.
+func blockDNS(session uintptr) error {
+	for _, layer := range bothLayers() {
+		port := uint16(53)
+		conditions := []wtFwpmFilterCondition0{{
+			fieldKey:       cFWPM_CONDITION_IP_REMOTE_PORT,
+			matchType:      cFWP_MATCH_EQUAL,
+			conditionValue: wtFwpConditionValue0{_type: cFWP_UINT16, value: uintptr(port)},
+		}}
+		if err := addFilter(session, "dns-"+layer.suffix, layer.key, cFWP_ACTION_BLOCK,
+			weightDNS, conditions, "refuse plaintext DNS off the tunnel"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// permitAddressConfiguration keeps the address the machine has.
+//
+// A device that cannot renew a lease loses its network some minutes later, and one that
+// cannot do neighbour discovery loses IPv6 immediately. Neither carries any of the user's
+// traffic, and both look exactly like the bug this feature exists to prevent.
+func permitAddressConfiguration(session uintptr) error {
+	udp := uint8(cIPPROTO_UDP)
+	v4 := []wtFwpmFilterCondition0{{
+		fieldKey:       cFWPM_CONDITION_IP_PROTOCOL,
+		matchType:      cFWP_MATCH_EQUAL,
+		conditionValue: wtFwpConditionValue0{_type: cFWP_UINT8, value: uintptr(udp)},
+	}, {
+		fieldKey:       cFWPM_CONDITION_IP_REMOTE_PORT,
+		matchType:      cFWP_MATCH_EQUAL,
+		conditionValue: wtFwpConditionValue0{_type: cFWP_UINT16, value: uintptr(uint16(67))},
+	}}
+	if err := addFilter(session, "config-dhcp4", cFWPM_LAYER_ALE_AUTH_CONNECT_V4,
+		cFWP_ACTION_PERMIT, weightConfig, v4, "permit DHCP"); err != nil {
+		return err
+	}
+
+	v6 := []wtFwpmFilterCondition0{{
+		fieldKey:       cFWPM_CONDITION_IP_PROTOCOL,
+		matchType:      cFWP_MATCH_EQUAL,
+		conditionValue: wtFwpConditionValue0{_type: cFWP_UINT8, value: uintptr(udp)},
+	}, {
+		fieldKey:       cFWPM_CONDITION_IP_REMOTE_PORT,
+		matchType:      cFWP_MATCH_EQUAL,
+		conditionValue: wtFwpConditionValue0{_type: cFWP_UINT16, value: uintptr(uint16(547))},
+	}}
+	if err := addFilter(session, "config-dhcp6", cFWPM_LAYER_ALE_AUTH_CONNECT_V6,
+		cFWP_ACTION_PERMIT, weightConfig, v6, "permit DHCPv6"); err != nil {
+		return err
+	}
+
+	icmp6 := uint8(cIPPROTO_ICMPV6)
+	ndp := []wtFwpmFilterCondition0{{
+		fieldKey:       cFWPM_CONDITION_IP_PROTOCOL,
+		matchType:      cFWP_MATCH_EQUAL,
+		conditionValue: wtFwpConditionValue0{_type: cFWP_UINT8, value: uintptr(icmp6)},
+	}}
+	return addFilter(session, "config-ndp", cFWPM_LAYER_ALE_AUTH_CONNECT_V6,
+		cFWP_ACTION_PERMIT, weightConfig, ndp, "permit neighbour discovery")
+}
+
+// installBlockAll refuses everything the filters above did not permit.
+//
+// Weight zero, so every permit outranks it. This is the filter whose absence is the whole
+// failure: a lock with a carve-out and no catch-all permits exactly what it names and
+// everything else besides.
+func installBlockAll(session uintptr) error {
+	for _, layer := range bothLayers() {
+		if err := addFilter(session, "blockall-"+layer.suffix, layer.key, cFWP_ACTION_BLOCK,
+			weightBlockAll, nil, "refuse everything else"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// layer names one address family's connect layer.
+type layer struct {
+	key    windows.GUID
+	suffix string
+}
+
+func bothLayers() []layer {
+	return []layer{
+		{cFWPM_LAYER_ALE_AUTH_CONNECT_V4, "v4"},
+		{cFWPM_LAYER_ALE_AUTH_CONNECT_V6, "v6"},
+	}
+}
+
+func layerFor(addr netip.Addr) (windows.GUID, bool) {
+	if addr.Is4() {
+		return cFWPM_LAYER_ALE_AUTH_CONNECT_V4, true
+	}
+	if addr.Is6() {
+		return cFWPM_LAYER_ALE_AUTH_CONNECT_V6, true
+	}
+	return windows.GUID{}, false
+}
+
+// beUint32 is an IPv4 address as the filtering platform wants it: host byte order, most
+// significant octet first.
+func beUint32(a [4]byte) uint32 {
+	return uint32(a[0])<<24 | uint32(a[1])<<16 | uint32(a[2])<<8 | uint32(a[3])
+}

--- a/internal/wfp/helpers_windows.go
+++ b/internal/wfp/helpers_windows.go
@@ -1,0 +1,136 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2019-2021 WireGuard LLC. All Rights Reserved.
+ *
+ * Taken from golang.zx2c4.com/wireguard/windows/tunnel/firewall and used under its own
+ * licence, which is retained above. Only the package name is changed.
+ *
+ * Copied rather than written, on purpose (ADR-0030): FWPM_FILTER0 and its relatives are
+ * nested structures whose layout differs between 32- and 64-bit, and a wrong offset here is
+ * a memory-corruption bug rather than a logic bug. What is meshp's own is the policy —
+ * which filters, at which layers, with what lifetime — and that lives in the files beside
+ * this one, because it is where meshp and WireGuard's Windows client want opposite things.
+ */
+
+package wfp
+
+import (
+	"fmt"
+	"runtime"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func runTransaction(session uintptr, operation wfpObjectInstaller) error {
+	err := fwpmTransactionBegin0(session, 0)
+	if err != nil {
+		return wrapErr(err)
+	}
+
+	err = operation(session)
+	if err != nil {
+		fwpmTransactionAbort0(session)
+		return wrapErr(err)
+	}
+
+	err = fwpmTransactionCommit0(session)
+	if err != nil {
+		fwpmTransactionAbort0(session)
+		return wrapErr(err)
+	}
+
+	return nil
+}
+
+func createWtFwpmDisplayData0(name, description string) (*wtFwpmDisplayData0, error) {
+	namePtr, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		return nil, wrapErr(err)
+	}
+
+	descriptionPtr, err := windows.UTF16PtrFromString(description)
+	if err != nil {
+		return nil, wrapErr(err)
+	}
+
+	return &wtFwpmDisplayData0{
+		name:        namePtr,
+		description: descriptionPtr,
+	}, nil
+}
+
+func filterWeight(weight uint8) wtFwpValue0 {
+	return wtFwpValue0{
+		_type: cFWP_UINT8,
+		value: uintptr(weight),
+	}
+}
+
+func wrapErr(err error) error {
+	if _, ok := err.(syscall.Errno); !ok {
+		return err
+	}
+	_, file, line, ok := runtime.Caller(1)
+	if !ok {
+		return fmt.Errorf("Firewall error at unknown location: %w", err)
+	}
+	return fmt.Errorf("Firewall error at %s:%d: %w", file, line, err)
+}
+
+func getCurrentProcessSecurityDescriptor() (*windows.SECURITY_DESCRIPTOR, error) {
+	var processToken windows.Token
+	err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &processToken)
+	if err != nil {
+		return nil, wrapErr(err)
+	}
+	defer processToken.Close()
+	gs, err := processToken.GetTokenGroups()
+	if err != nil {
+		return nil, wrapErr(err)
+	}
+	var sid *windows.SID
+	for _, g := range gs.AllGroups() {
+		if g.Attributes != windows.SE_GROUP_ENABLED|windows.SE_GROUP_ENABLED_BY_DEFAULT|windows.SE_GROUP_OWNER {
+			continue
+		}
+		// We could be checking != 6, but hopefully Microsoft will update
+		// RtlCreateServiceSid to use SHA2, which will then likely bump
+		// this up. So instead just roll with a minimum.
+		if !g.Sid.IsValid() || g.Sid.IdentifierAuthority() != windows.SECURITY_NT_AUTHORITY || g.Sid.SubAuthorityCount() < 6 || g.Sid.SubAuthority(0) != 80 {
+			continue
+		}
+		sid = g.Sid
+		break
+	}
+	if sid == nil {
+		return nil, wrapErr(windows.ERROR_NO_SUCH_GROUP)
+	}
+
+	access := []windows.EXPLICIT_ACCESS{{
+		AccessPermissions: cFWP_ACTRL_MATCH_FILTER,
+		AccessMode:        windows.GRANT_ACCESS,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_GROUP,
+			TrusteeValue: windows.TrusteeValueFromSID(sid),
+		},
+	}}
+	dacl, err := windows.ACLFromEntries(access, nil)
+	if err != nil {
+		return nil, wrapErr(err)
+	}
+	sd, err := windows.NewSecurityDescriptor()
+	if err != nil {
+		return nil, wrapErr(err)
+	}
+	err = sd.SetDACL(dacl, true, false)
+	if err != nil {
+		return nil, wrapErr(err)
+	}
+	sd, err = sd.ToSelfRelative()
+	if err != nil {
+		return nil, wrapErr(err)
+	}
+	return sd, nil
+}

--- a/internal/wfp/lock_windows.go
+++ b/internal/wfp/lock_windows.go
@@ -1,0 +1,314 @@
+//go:build windows
+
+package wfp
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"golang.org/x/sys/windows"
+	"golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
+	"net"
+	"net/netip"
+	"sort"
+)
+
+// ErrUnsupported means this host cannot refuse egress outside the tunnel.
+//
+// A condition to report rather than a failure to retry, as on the other two platforms: a
+// device that cannot fail closed is still a device, and the honest answer is to say so and
+// let the control plane decide whether to place it in a network that requires it (ADR-0011).
+var ErrUnsupported = errors.New("wfp: this platform cannot refuse egress outside the tunnel")
+
+// Lock refuses egress outside the tunnel. It satisfies tunnel.EgressLock.
+type Lock struct{}
+
+// New returns a Lock, or nothing when this host cannot refuse egress.
+//
+// Opening the filter engine is the check. It needs administrative rights, so an agent without
+// them answers false here rather than at apply time, where it would look like a policy fault
+// instead of a missing capability.
+func New(context.Context) *Lock {
+	session, err := openSession()
+	if err != nil {
+		return nil
+	}
+	_ = fwpmEngineClose0(session)
+	return &Lock{}
+}
+
+// Held reports whether a fail-closed lock is currently installed.
+//
+// By asking whether meshp's catch-all filter is there. Asked rather than assumed so that
+// removing one can be reported as the event it is: an agent that quietly ran a removal on
+// every start would leave no trace of the case that matters — a machine whose egress was
+// being refused because a previous run died holding the line.
+func Held(context.Context) bool {
+	session, err := openSession()
+	if err != nil {
+		return false
+	}
+	defer func() { _ = fwpmEngineClose0(session) }()
+
+	// Deleting is the only way to ask, so it is asked by trying to delete something that is
+	// not there: a key meshp never uses. FWP_E_FILTER_NOT_FOUND means the engine answered,
+	// which is all this needs to know before looking for the real one.
+	key := filterKey("blockall-v4")
+	err = fwpmFilterDeleteByKey0(session, &key)
+	if err == nil {
+		// It was there and is now gone, which is not what this was asked. Put it back rather
+		// than leave a machine half-locked, and say it is held.
+		_ = installBlockAll(session)
+		return true
+	}
+	return !isGone(err)
+}
+
+// ApplyLock makes this device refuse egress that does not go through the tunnel, or stops it
+// refusing.
+//
+// An empty interface name removes the lock. That is the only way it comes off from here — the
+// filters are system state and outlive this process on purpose (ADR-0011), so nothing about
+// the agent exiting takes them away.
+func (l *Lock) ApplyLock(_ context.Context, iface string, endpoints []netip.AddrPort, excluded []netip.Prefix, preventDNSLeaks bool) error {
+	session, err := openSession()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = fwpmEngineClose0(session) }()
+
+	if iface == "" {
+		return remove(session)
+	}
+
+	luid, err := luidFor(iface)
+	if err != nil {
+		return err
+	}
+
+	// One transaction, so the machine is never inside a half-installed policy. Without it
+	// there is a window in which the catch-all is in force and the permits are not, and that
+	// window is a device with no network at all.
+	return inTransaction(session, func(session uintptr) error {
+		if err := registerBaseObjects(session); err != nil {
+			return err
+		}
+		// Replaced rather than merged. The filters are named deterministically, so a second
+		// pass writes over the first — but a carve-out that shrank would otherwise leave the
+		// filters for addresses that are no longer exempt.
+		if err := deleteFilters(session); err != nil {
+			return err
+		}
+		return installPolicy(session, luid, endpoints, excluded, preventDNSLeaks)
+	})
+}
+
+// installPolicy writes the whole ruleset.
+//
+// The same shape nftables and pf render, in the same order and for the same reasons — the
+// commentary on nftables.RenderLock is the fuller account of why each of these exists. What
+// differs is that order here is a weight rather than a position: within meshp's sublayer the
+// highest-weighted filter that matches decides, because both permit and block are terminating.
+func installPolicy(session uintptr, tunnel winipcfg.LUID, endpoints []netip.AddrPort, excluded []netip.Prefix, preventDNSLeaks bool) error {
+	// Loopback first, and unconditionally. The agent's own resolver lives there — on this
+	// platform on port 53 (ADR-0029) — and so does everything a desktop does with 127.0.0.1.
+	if err := permitLoopback(session); err != nil {
+		return err
+	}
+
+	// The tunnel itself: what the traffic is supposed to use.
+	if err := permitInterface(session, tunnel); err != nil {
+		return err
+	}
+
+	// The outer packets that carry the tunnel, and the control channel that can end it.
+	// Without these the lock deadlocks — no tunnel because no egress, no egress because no
+	// tunnel — in the state where the machine cannot be told to unlock.
+	for i, endpoint := range sortedEndpoints(endpoints) {
+		if err := permitAddress(session, endpoint, endpoint.BitLen(), weightEndpoint, fmt.Sprintf("endpoint-%d", i)); err != nil {
+			return err
+		}
+	}
+
+	// Before the carve-out, and that order is the whole of this rule: the resolver lives on
+	// the local network, so refusing DNS after permitting the local network refuses nothing.
+	if preventDNSLeaks {
+		if err := blockDNS(session); err != nil {
+			return err
+		}
+	}
+
+	// The local network and anything else carved out.
+	for i, prefix := range sortedPrefixes(excluded) {
+		if err := permitAddress(session, prefix.Addr(), prefix.Bits(), weightExcluded, fmt.Sprintf("excluded-%d", i)); err != nil {
+			return err
+		}
+	}
+
+	// Keeping the address the machine has. A device that cannot renew a lease loses its
+	// network some minutes later, and one that cannot do neighbour discovery loses IPv6 at
+	// once — both of which look exactly like the bug this feature exists to prevent.
+	if err := permitAddressConfiguration(session); err != nil {
+		return err
+	}
+
+	return installBlockAll(session)
+}
+
+// Weights within meshp's sublayer. Higher is evaluated first, and every action here is
+// terminating, so the highest match decides.
+const (
+	weightLoopback  = 15
+	weightInterface = 14
+	weightEndpoint  = 13
+	weightDNS       = 12
+	weightExcluded  = 11
+	weightConfig    = 10
+	weightBlockAll  = 0
+)
+
+// filterKey names one filter, deterministically.
+//
+// Derived from meshp's provider and a slot name, so the same policy written twice names the
+// same filters and a process that did not install them can still remove them. That is the
+// half wireguard-windows does not need and meshp cannot do without (ADR-0030).
+func filterKey(slot string) windows.GUID {
+	sum := sha256.Sum256(append(providerKey.Data4[:], slot...))
+	var guid windows.GUID
+	guid.Data1 = uint32(sum[0])<<24 | uint32(sum[1])<<16 | uint32(sum[2])<<8 | uint32(sum[3])
+	guid.Data2 = uint16(sum[4])<<8 | uint16(sum[5])
+	guid.Data3 = uint16(sum[6])<<8 | uint16(sum[7])
+	copy(guid.Data4[:], sum[8:16])
+	return guid
+}
+
+// everySlot is every filter meshp can install, which is what removal walks.
+//
+// A list rather than an enumeration of the engine, because enumerating needs a template
+// structure this package would have to lay out by hand — the memory-layout risk ADR-0030 took
+// the borrowed types to avoid. The cost is that this list has to stay in step with what
+// installPolicy writes, and the test below is what makes that true rather than hoped for.
+func everySlot() []string {
+	slots := []string{"loopback", "interface-v4", "interface-v6", "dns-v4", "dns-v6",
+		"config-dhcp4", "config-dhcp6", "config-ndp", "blockall-v4", "blockall-v6"}
+	// The carve-out is bounded rather than unbounded: a network with more exemptions than
+	// this would silently lose the ones past the end, so the count is generous and the
+	// installer refuses beyond it.
+	for i := range maxCarveOut {
+		slots = append(slots, fmt.Sprintf("endpoint-%d-v4", i), fmt.Sprintf("endpoint-%d-v6", i),
+			fmt.Sprintf("excluded-%d-v4", i), fmt.Sprintf("excluded-%d-v6", i))
+	}
+	return slots
+}
+
+// maxCarveOut bounds how many addresses can be kept off the tunnel.
+//
+// Generous — a device with more than this many relays plus exclusions is not a shape this
+// product has — and enforced rather than assumed, because the alternative to a limit is a
+// removal that cannot name everything installation wrote.
+const maxCarveOut = 64
+
+// remove takes the lock off, and meshp's provider with it.
+func remove(session uintptr) error {
+	return inTransaction(session, func(session uintptr) error {
+		if err := deleteFilters(session); err != nil {
+			return err
+		}
+		if err := fwpmSubLayerDeleteByKey0(session, &sublayerKey); err != nil && !isGone(err) {
+			return fmt.Errorf("wfp: removing meshp's sublayer: %w", err)
+		}
+		if err := fwpmProviderDeleteByKey0(session, &providerKey); err != nil && !isGone(err) {
+			return fmt.Errorf("wfp: removing meshp as a filter provider: %w", err)
+		}
+		return nil
+	})
+}
+
+// deleteFilters removes every filter meshp could have installed.
+//
+// By name, and tolerating absence: most of these will not be there on any given pass, because
+// which ones exist depends on the carve-out that was in force.
+func deleteFilters(session uintptr) error {
+	var errs []error
+	for _, slot := range everySlot() {
+		key := filterKey(slot)
+		if err := fwpmFilterDeleteByKey0(session, &key); err != nil && !isGone(err) {
+			errs = append(errs, fmt.Errorf("wfp: removing the %s filter: %w", slot, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// inTransaction runs an operation atomically, aborting it if anything fails.
+func inTransaction(session uintptr, op wfpObjectInstaller) error {
+	if err := fwpmTransactionBegin0(session, 0); err != nil {
+		return fmt.Errorf("wfp: starting a filter transaction: %w", err)
+	}
+	if err := op(session); err != nil {
+		_ = fwpmTransactionAbort0(session)
+		return err
+	}
+	if err := fwpmTransactionCommit0(session); err != nil {
+		_ = fwpmTransactionAbort0(session)
+		return fmt.Errorf("wfp: committing the filter transaction: %w", err)
+	}
+	return nil
+}
+
+// luidFor finds an adapter by the name meshp gave it.
+func luidFor(iface string) (winipcfg.LUID, error) {
+	netIface, err := net.InterfaceByName(iface)
+	if err != nil {
+		return 0, fmt.Errorf("wfp: finding %s: %w", iface, err)
+	}
+	luid, err := winipcfg.LUIDFromIndex(uint32(netIface.Index))
+	if err != nil {
+		return 0, fmt.Errorf("wfp: identifying %s: %w", iface, err)
+	}
+	return luid, nil
+}
+
+// sortedEndpoints puts the endpoints in a stable order and drops what cannot be used, so the
+// same specification installs the same filters and an unchanged lock is not rewritten.
+func sortedEndpoints(in []netip.AddrPort) []netip.Addr {
+	seen := map[netip.Addr]bool{}
+	var out []netip.Addr
+	for _, ep := range in {
+		addr := ep.Addr().Unmap()
+		if !addr.IsValid() || seen[addr] {
+			continue
+		}
+		seen[addr] = true
+		out = append(out, addr)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	if len(out) > maxCarveOut {
+		out = out[:maxCarveOut]
+	}
+	return out
+}
+
+// sortedPrefixes does the same for the carved-out networks, dropping anything unusable rather
+// than refusing the whole lock: a malformed exclusion should cost that exclusion, not leave
+// the device with no protection at all.
+func sortedPrefixes(in []netip.Prefix) []netip.Prefix {
+	seen := map[netip.Prefix]bool{}
+	var out []netip.Prefix
+	for _, prefix := range in {
+		if !prefix.IsValid() {
+			continue
+		}
+		norm := netip.PrefixFrom(prefix.Addr().Unmap(), prefix.Bits()).Masked()
+		if seen[norm] {
+			continue
+		}
+		seen[norm] = true
+		out = append(out, norm)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	if len(out) > maxCarveOut {
+		out = out[:maxCarveOut]
+	}
+	return out
+}

--- a/internal/wfp/lock_windows_test.go
+++ b/internal/wfp/lock_windows_test.go
@@ -1,0 +1,214 @@
+//go:build windows
+
+package wfp
+
+import (
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/meshpnet/meshp/internal/wglink"
+	"github.com/meshpnet/meshp/internal/wgplan"
+)
+
+func requireAdmin(t *testing.T) {
+	t.Helper()
+	if !windows.GetCurrentProcessToken().IsElevated() {
+		t.Skip("needs administrator: the filtering platform is not writable otherwise")
+	}
+}
+
+// Every filter installPolicy can write is one deleteFilters can name.
+//
+// The list in everySlot is maintained by hand, because enumerating the engine needs a
+// template structure this package would have to lay out itself — the memory-layout risk
+// ADR-0030 borrowed the types to avoid. A slot that installation writes and removal does not
+// know about is a filter nothing can ever take off, on a machine with no network.
+func TestEveryFilterInstalledCanBeNamedAgain(t *testing.T) {
+	slots := everySlot()
+	seen := make(map[string]bool, len(slots))
+	for _, slot := range slots {
+		if seen[slot] {
+			t.Errorf("%q is listed twice", slot)
+		}
+		seen[slot] = true
+	}
+
+	// The names installPolicy builds, spelled the way it spells them.
+	required := []string{"loopback", "interface-v4", "interface-v6", "blockall-v4", "blockall-v6",
+		"dns-v4", "dns-v6", "config-dhcp4", "config-dhcp6", "config-ndp",
+		"endpoint-0-v4", "endpoint-0-v6", "excluded-0-v4", "excluded-0-v6",
+	}
+	for _, slot := range required {
+		if !seen[slot] {
+			t.Errorf("%q is installed and cannot be removed; a lock using it could never be "+
+				"taken off", slot)
+		}
+	}
+}
+
+// Two filters never share a key, and the same filter always has the same one.
+//
+// The second half is what lets a process that did not install them remove them, which is the
+// whole of Invariant 20 on this platform.
+func TestAFilterKeyIsAFunctionOfItsSlot(t *testing.T) {
+	first := filterKey("blockall-v4")
+	if first != filterKey("blockall-v4") {
+		t.Error("the same filter got two keys, so a restarted daemon could not find it")
+	}
+
+	seen := map[windows.GUID]string{}
+	for _, slot := range everySlot() {
+		key := filterKey(slot)
+		if other, clash := seen[key]; clash {
+			t.Errorf("%q and %q share a key, so installing one removes the other", slot, other)
+		}
+		seen[key] = slot
+	}
+}
+
+// The carve-out is bounded, and the bound is enforced rather than assumed.
+//
+// A network with more exemptions than there are slots would otherwise install filters that
+// removal cannot name.
+func TestTheCarveOutIsBounded(t *testing.T) {
+	var many []netip.AddrPort
+	for i := range maxCarveOut + 10 {
+		many = append(many, netip.AddrPortFrom(
+			netip.AddrFrom4([4]byte{198, 51, 100, byte(i % 250)}), 51820))
+	}
+	if got := len(sortedEndpoints(many)); got > maxCarveOut {
+		t.Errorf("%d endpoints survived a limit of %d, so some would be unremovable",
+			got, maxCarveOut)
+	}
+
+	var prefixes []netip.Prefix
+	for i := range maxCarveOut + 10 {
+		prefixes = append(prefixes, netip.PrefixFrom(
+			netip.AddrFrom4([4]byte{10, byte(i % 250), 0, 0}), 16))
+	}
+	if got := len(sortedPrefixes(prefixes)); got > maxCarveOut {
+		t.Errorf("%d exclusions survived a limit of %d", got, maxCarveOut)
+	}
+}
+
+// The same lock installs the same filters however its inputs arrive.
+func TestTheSameLockIsTheSameFilters(t *testing.T) {
+	a := sortedEndpoints([]netip.AddrPort{
+		netip.MustParseAddrPort("198.51.100.7:51820"),
+		netip.MustParseAddrPort("203.0.113.9:443"),
+	})
+	b := sortedEndpoints([]netip.AddrPort{
+		netip.MustParseAddrPort("203.0.113.9:443"),
+		netip.MustParseAddrPort("198.51.100.7:51820"),
+		netip.MustParseAddrPort("198.51.100.7:51820"),
+	})
+	if len(a) != len(b) || a[0] != b[0] || a[1] != b[1] {
+		t.Errorf("the same endpoints in a different order gave %v and %v", a, b)
+	}
+}
+
+// The whole of it: the lock goes on, refuses what it does not name, and comes off.
+//
+// Everything except TEST-NET-1 is carved out, so the only thing this refuses is traffic to an
+// address that was never going to arrive. That keeps the runner on the network even if this
+// test dies before its cleanup — the same shape the macOS pf test uses, and for the same
+// reason.
+func TestALockRefusesWhatItDoesNotName(t *testing.T) {
+	requireAdmin(t)
+
+	link, err := wglink.New()
+	if err != nil {
+		t.Fatalf("opening the interface manager: %v", err)
+	}
+	t.Cleanup(func() { _ = link.Close() })
+
+	const iface = "meshptestwfp0"
+	t.Cleanup(func() { _ = link.Apply(iface, wgplan.Op{Kind: wgplan.DestroyDevice}) })
+	if err := link.Apply(iface, wgplan.Op{Kind: wgplan.CreateDevice,
+		Device: wgplan.Device{MTU: 1380}}); err != nil {
+		t.Fatalf("creating an adapter for the lock to permit: %v", err)
+	}
+
+	lock := &Lock{}
+	// Registered before the lock goes on, so a failure part-way through still gives the
+	// machine back.
+	t.Cleanup(func() { _ = lock.ApplyLock(t.Context(), "", nil, nil, false) })
+
+	blocked := netip.MustParsePrefix("192.0.2.0/24")
+	if err := lock.ApplyLock(t.Context(), iface, nil, everythingExcept(blocked), false); err != nil {
+		t.Fatalf("installing the lock: %v", err)
+	}
+
+	// A connection the lock has to decide about. It is going nowhere either way; what matters
+	// is that meshp's catch-all is what stops it, and a filter refuses immediately where a
+	// blackhole would time out.
+	start := time.Now()
+	conn, err := net.DialTimeout("tcp", "192.0.2.1:443", 4*time.Second)
+	if err == nil {
+		_ = conn.Close()
+		t.Fatal("a connection to a refused address succeeded")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("the connection took %s to fail, which is a blackhole rather than a "+
+			"refusal — the lock is installed and is not what stopped it", elapsed)
+	}
+
+	// And something the carve-out names still works, or this proves only that the machine
+	// has no network.
+	if permitted, err := net.DialTimeout("tcp", "198.51.100.1:443", 1500*time.Millisecond); err == nil {
+		_ = permitted.Close()
+	} else if !isTimeout(err) {
+		t.Errorf("a carved-out address was refused rather than simply unreachable: %v", err)
+	}
+
+	if err := lock.ApplyLock(t.Context(), "", nil, nil, false); err != nil {
+		t.Fatalf("removing the lock: %v", err)
+	}
+}
+
+// Removing a lock that is not there is success.
+//
+// Teardown always runs: a membership going away asks for this whether or not one was ever
+// installed, and an error would report a failure to remove something never made.
+func TestRemovingALockThatIsNotThere(t *testing.T) {
+	requireAdmin(t)
+	if err := (&Lock{}).ApplyLock(t.Context(), "", nil, nil, false); err != nil {
+		t.Errorf("removing a lock that was never installed: %v", err)
+	}
+}
+
+// A host that cannot reach the filtering platform says so rather than finding out per apply.
+func TestWithoutPrivilegeThisHostSaysItCannotLock(t *testing.T) {
+	if windows.GetCurrentProcessToken().IsElevated() {
+		t.Skip("this is about what an unprivileged agent reports; the unprivileged run covers it")
+	}
+	if New(t.Context()) != nil {
+		t.Error("an agent that cannot open the filter engine reported that it can refuse egress")
+	}
+}
+
+func isTimeout(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+// everythingExcept covers the whole address space apart from one prefix.
+func everythingExcept(p netip.Prefix) []netip.Prefix {
+	out := []netip.Prefix{netip.MustParsePrefix("::/0")}
+	octets := p.Addr().AsSlice()
+	for i := range p.Bits() {
+		flipped := append([]byte(nil), octets...)
+		flipped[i/8] ^= 1 << (7 - i%8)
+		sibling, ok := netip.AddrFromSlice(flipped)
+		if !ok {
+			continue
+		}
+		out = append(out, netip.PrefixFrom(sibling, i+1).Masked())
+	}
+	return out
+}

--- a/internal/wfp/lock_windows_test.go
+++ b/internal/wfp/lock_windows_test.go
@@ -182,13 +182,27 @@ func TestRemovingALockThatIsNotThere(t *testing.T) {
 	}
 }
 
-// A host that cannot reach the filtering platform says so rather than finding out per apply.
-func TestWithoutPrivilegeThisHostSaysItCannotLock(t *testing.T) {
-	if windows.GetCurrentProcessToken().IsElevated() {
-		t.Skip("this is about what an unprivileged agent reports; the unprivileged run covers it")
-	}
-	if New(t.Context()) != nil {
-		t.Error("an agent that cannot open the filter engine reported that it can refuse egress")
+// What this host says it can do matches what it can do.
+//
+// Both directions in one test, and not two that skip. The Windows job runs once and always
+// elevated — unlike macOS, where an unprivileged pass is the default and sudo gives the
+// other — so a test gated on *not* being administrator could never run there, and the job's
+// refusal to accept a skip is what caught it.
+//
+// The property is the one ADR-0007 and ADR-0011 both turn on: a host reports what it can
+// enforce, and an agent that claimed fail-closed egress and then failed to install it on
+// every reconcile would be placed in networks that require the property and never have it.
+func TestWhatThisHostSaysItCanDoMatchesItsPrivilege(t *testing.T) {
+	elevated := windows.GetCurrentProcessToken().IsElevated()
+	lock := New(t.Context())
+
+	switch {
+	case elevated && lock == nil:
+		t.Error("an elevated agent reported that it cannot refuse egress, so a network that " +
+			"requires fail-closed would report this device unconverged for no reason")
+	case !elevated && lock != nil:
+		t.Error("an agent that cannot open the filter engine reported that it can refuse " +
+			"egress; it would accept a fail-closed network and fail on every pass")
 	}
 }
 

--- a/internal/wfp/syscall_windows.go
+++ b/internal/wfp/syscall_windows.go
@@ -1,0 +1,121 @@
+//go:build windows
+
+package wfp
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// The filtering platform's calls, wrapped so that the error they report is the error that
+// happened.
+//
+// Written rather than borrowed, and that is not tidiness. The generated wrappers in the
+// package this borrows its types from do:
+//
+//	r1, _, e1 := syscall.Syscall(...)
+//	if r1 != 0 { err = errnoErr(e1) }
+//
+// These functions return their error code *in the return value*; e1 is whatever
+// GetLastError happened to be holding, which is unrelated. So failure is detected correctly
+// and described wrongly. That is survivable for a caller that only asks whether it worked,
+// which is what that package does — and not for this one, which has to tell FWP_E_ALREADY_
+// EXISTS from a refusal, because the provider and sublayer outlive the process and every
+// reconcile after the first finds them there.
+//
+// It also means the deletes exist here. That package has none: a dynamic session removes
+// everything when the process ends, so it never needed one (ADR-0030).
+var (
+	modfwpuclnt = windows.NewLazySystemDLL("fwpuclnt.dll")
+
+	procFwpmEngineOpen0          = modfwpuclnt.NewProc("FwpmEngineOpen0")
+	procFwpmEngineClose0         = modfwpuclnt.NewProc("FwpmEngineClose0")
+	procFwpmProviderAdd0         = modfwpuclnt.NewProc("FwpmProviderAdd0")
+	procFwpmProviderDeleteByKey0 = modfwpuclnt.NewProc("FwpmProviderDeleteByKey0")
+	procFwpmSubLayerAdd0         = modfwpuclnt.NewProc("FwpmSubLayerAdd0")
+	procFwpmSubLayerDeleteByKey0 = modfwpuclnt.NewProc("FwpmSubLayerDeleteByKey0")
+	procFwpmFilterAdd0           = modfwpuclnt.NewProc("FwpmFilterAdd0")
+	procFwpmFilterDeleteByKey0   = modfwpuclnt.NewProc("FwpmFilterDeleteByKey0")
+	procFwpmTransactionBegin0    = modfwpuclnt.NewProc("FwpmTransactionBegin0")
+	procFwpmTransactionCommit0   = modfwpuclnt.NewProc("FwpmTransactionCommit0")
+	procFwpmTransactionAbort0    = modfwpuclnt.NewProc("FwpmTransactionAbort0")
+	procFwpmFreeMemory0          = modfwpuclnt.NewProc("FwpmFreeMemory0")
+)
+
+// result turns a filtering-platform return value into an error.
+//
+// Zero is success. Anything else is the code itself, which is what makes FWP_E_ALREADY_EXISTS
+// distinguishable from everything else that can go wrong.
+func result(r uintptr) error {
+	if r == 0 {
+		return nil
+	}
+	return windows.Errno(r)
+}
+
+func fwpmEngineOpen0(serverName *uint16, authnService wtRpcCAuthN, authIdentity *uintptr, session *wtFwpmSession0, engineHandle unsafe.Pointer) error {
+	r, _, _ := procFwpmEngineOpen0.Call(uintptr(unsafe.Pointer(serverName)), uintptr(authnService),
+		uintptr(unsafe.Pointer(authIdentity)), uintptr(unsafe.Pointer(session)), uintptr(engineHandle))
+	return result(r)
+}
+
+func fwpmEngineClose0(engine uintptr) error {
+	r, _, _ := procFwpmEngineClose0.Call(engine)
+	return result(r)
+}
+
+func fwpmProviderAdd0(engine uintptr, provider *wtFwpmProvider0, sd uintptr) error {
+	r, _, _ := procFwpmProviderAdd0.Call(engine, uintptr(unsafe.Pointer(provider)), sd)
+	return result(r)
+}
+
+func fwpmProviderDeleteByKey0(engine uintptr, key *windows.GUID) error {
+	r, _, _ := procFwpmProviderDeleteByKey0.Call(engine, uintptr(unsafe.Pointer(key)))
+	return result(r)
+}
+
+func fwpmSubLayerAdd0(engine uintptr, sublayer *wtFwpmSublayer0, sd uintptr) error {
+	r, _, _ := procFwpmSubLayerAdd0.Call(engine, uintptr(unsafe.Pointer(sublayer)), sd)
+	return result(r)
+}
+
+func fwpmSubLayerDeleteByKey0(engine uintptr, key *windows.GUID) error {
+	r, _, _ := procFwpmSubLayerDeleteByKey0.Call(engine, uintptr(unsafe.Pointer(key)))
+	return result(r)
+}
+
+func fwpmFilterAdd0(engine uintptr, filter *wtFwpmFilter0, sd uintptr, id *uint64) error {
+	r, _, _ := procFwpmFilterAdd0.Call(engine, uintptr(unsafe.Pointer(filter)), sd, uintptr(unsafe.Pointer(id)))
+	return result(r)
+}
+
+// fwpmFilterDeleteByKey0 removes one filter by the key it was created with.
+//
+// By key rather than by the id the engine assigns, and that is what makes removal possible for
+// a process that did not create them. An id is handed back at creation and known only to
+// whoever was there; a key is a name meshp chooses, so a daemon that has just started can name
+// yesterday's filters without having kept a list of numbers.
+func fwpmFilterDeleteByKey0(engine uintptr, key *windows.GUID) error {
+	r, _, _ := procFwpmFilterDeleteByKey0.Call(engine, uintptr(unsafe.Pointer(key)))
+	return result(r)
+}
+
+func fwpmTransactionBegin0(engine uintptr, flags uint32) error {
+	r, _, _ := procFwpmTransactionBegin0.Call(engine, uintptr(flags))
+	return result(r)
+}
+
+func fwpmTransactionCommit0(engine uintptr) error {
+	r, _, _ := procFwpmTransactionCommit0.Call(engine)
+	return result(r)
+}
+
+func fwpmTransactionAbort0(engine uintptr) error {
+	r, _, _ := procFwpmTransactionAbort0.Call(engine)
+	return result(r)
+}
+
+func fwpmFreeMemory0(p unsafe.Pointer) {
+	_, _, _ = procFwpmFreeMemory0.Call(uintptr(p))
+}

--- a/internal/wfp/types_windows.go
+++ b/internal/wfp/types_windows.go
@@ -1,0 +1,421 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2019-2021 WireGuard LLC. All Rights Reserved.
+ *
+ * Taken from golang.zx2c4.com/wireguard/windows/tunnel/firewall and used under its own
+ * licence, which is retained above. Only the package name is changed.
+ *
+ * Copied rather than written, on purpose (ADR-0030): FWPM_FILTER0 and its relatives are
+ * nested structures whose layout differs between 32- and 64-bit, and a wrong offset here is
+ * a memory-corruption bug rather than a logic bug. What is meshp's own is the policy —
+ * which filters, at which layers, with what lifetime — and that lives in the files beside
+ * this one, because it is where meshp and WireGuard's Windows client want opposite things.
+ */
+
+package wfp
+
+import "golang.org/x/sys/windows"
+
+const (
+	anysizeArray = 1 // ANYSIZE_ARRAY defined in winnt.h
+
+	wtFwpBitmapArray64_Size = 8
+
+	wtFwpByteArray16_Size = 16
+
+	wtFwpByteArray6_Size = 6
+
+	wtFwpmAction0_Size              = 20
+	wtFwpmAction0_filterType_Offset = 4
+
+	wtFwpV4AddrAndMask_Size        = 8
+	wtFwpV4AddrAndMask_mask_Offset = 4
+
+	wtFwpV6AddrAndMask_Size                = 17
+	wtFwpV6AddrAndMask_prefixLength_Offset = 16
+)
+
+type wtFwpActionFlag uint32
+
+const (
+	cFWP_ACTION_FLAG_TERMINATING     wtFwpActionFlag = 0x00001000
+	cFWP_ACTION_FLAG_NON_TERMINATING wtFwpActionFlag = 0x00002000
+	cFWP_ACTION_FLAG_CALLOUT         wtFwpActionFlag = 0x00004000
+)
+
+// FWP_ACTION_TYPE defined in fwptypes.h
+type wtFwpActionType uint32
+
+const (
+	cFWP_ACTION_BLOCK               wtFwpActionType = wtFwpActionType(0x00000001 | cFWP_ACTION_FLAG_TERMINATING)
+	cFWP_ACTION_PERMIT              wtFwpActionType = wtFwpActionType(0x00000002 | cFWP_ACTION_FLAG_TERMINATING)
+	cFWP_ACTION_CALLOUT_TERMINATING wtFwpActionType = wtFwpActionType(0x00000003 | cFWP_ACTION_FLAG_CALLOUT | cFWP_ACTION_FLAG_TERMINATING)
+	cFWP_ACTION_CALLOUT_INSPECTION  wtFwpActionType = wtFwpActionType(0x00000004 | cFWP_ACTION_FLAG_CALLOUT | cFWP_ACTION_FLAG_NON_TERMINATING)
+	cFWP_ACTION_CALLOUT_UNKNOWN     wtFwpActionType = wtFwpActionType(0x00000005 | cFWP_ACTION_FLAG_CALLOUT)
+	cFWP_ACTION_CONTINUE            wtFwpActionType = wtFwpActionType(0x00000006 | cFWP_ACTION_FLAG_NON_TERMINATING)
+	cFWP_ACTION_NONE                wtFwpActionType = 0x00000007
+	cFWP_ACTION_NONE_NO_MATCH       wtFwpActionType = 0x00000008
+	cFWP_ACTION_BITMAP_INDEX_SET    wtFwpActionType = 0x00000009
+)
+
+// FWP_BYTE_BLOB defined in fwptypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwptypes/ns-fwptypes-fwp_byte_blob_)
+type wtFwpByteBlob struct {
+	size uint32
+	data *uint8
+}
+
+// FWP_MATCH_TYPE defined in fwptypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwptypes/ne-fwptypes-fwp_match_type_)
+type wtFwpMatchType uint32
+
+const (
+	cFWP_MATCH_EQUAL                  wtFwpMatchType = 0
+	cFWP_MATCH_GREATER                wtFwpMatchType = cFWP_MATCH_EQUAL + 1
+	cFWP_MATCH_LESS                   wtFwpMatchType = cFWP_MATCH_GREATER + 1
+	cFWP_MATCH_GREATER_OR_EQUAL       wtFwpMatchType = cFWP_MATCH_LESS + 1
+	cFWP_MATCH_LESS_OR_EQUAL          wtFwpMatchType = cFWP_MATCH_GREATER_OR_EQUAL + 1
+	cFWP_MATCH_RANGE                  wtFwpMatchType = cFWP_MATCH_LESS_OR_EQUAL + 1
+	cFWP_MATCH_FLAGS_ALL_SET          wtFwpMatchType = cFWP_MATCH_RANGE + 1
+	cFWP_MATCH_FLAGS_ANY_SET          wtFwpMatchType = cFWP_MATCH_FLAGS_ALL_SET + 1
+	cFWP_MATCH_FLAGS_NONE_SET         wtFwpMatchType = cFWP_MATCH_FLAGS_ANY_SET + 1
+	cFWP_MATCH_EQUAL_CASE_INSENSITIVE wtFwpMatchType = cFWP_MATCH_FLAGS_NONE_SET + 1
+	cFWP_MATCH_NOT_EQUAL              wtFwpMatchType = cFWP_MATCH_EQUAL_CASE_INSENSITIVE + 1
+	cFWP_MATCH_PREFIX                 wtFwpMatchType = cFWP_MATCH_NOT_EQUAL + 1
+	cFWP_MATCH_NOT_PREFIX             wtFwpMatchType = cFWP_MATCH_PREFIX + 1
+	cFWP_MATCH_TYPE_MAX               wtFwpMatchType = cFWP_MATCH_NOT_PREFIX + 1
+)
+
+// FWPM_ACTION0 defined in fwpmtypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_action0_)
+type wtFwpmAction0 struct {
+	_type      wtFwpActionType
+	filterType windows.GUID // Windows type: GUID
+}
+
+// Defined in fwpmu.h. 4cd62a49-59c3-4969-b7f3-bda5d32890a4
+var cFWPM_CONDITION_IP_LOCAL_INTERFACE = windows.GUID{
+	Data1: 0x4cd62a49,
+	Data2: 0x59c3,
+	Data3: 0x4969,
+	Data4: [8]byte{0xb7, 0xf3, 0xbd, 0xa5, 0xd3, 0x28, 0x90, 0xa4},
+}
+
+// Defined in fwpmu.h. b235ae9a-1d64-49b8-a44c-5ff3d9095045
+var cFWPM_CONDITION_IP_REMOTE_ADDRESS = windows.GUID{
+	Data1: 0xb235ae9a,
+	Data2: 0x1d64,
+	Data3: 0x49b8,
+	Data4: [8]byte{0xa4, 0x4c, 0x5f, 0xf3, 0xd9, 0x09, 0x50, 0x45},
+}
+
+// Defined in fwpmu.h. 3971ef2b-623e-4f9a-8cb1-6e79b806b9a7
+var cFWPM_CONDITION_IP_PROTOCOL = windows.GUID{
+	Data1: 0x3971ef2b,
+	Data2: 0x623e,
+	Data3: 0x4f9a,
+	Data4: [8]byte{0x8c, 0xb1, 0x6e, 0x79, 0xb8, 0x06, 0xb9, 0xa7},
+}
+
+// Defined in fwpmu.h. 0c1ba1af-5765-453f-af22-a8f791ac775b
+var cFWPM_CONDITION_IP_LOCAL_PORT = windows.GUID{
+	Data1: 0x0c1ba1af,
+	Data2: 0x5765,
+	Data3: 0x453f,
+	Data4: [8]byte{0xaf, 0x22, 0xa8, 0xf7, 0x91, 0xac, 0x77, 0x5b},
+}
+
+// Defined in fwpmu.h. c35a604d-d22b-4e1a-91b4-68f674ee674b
+var cFWPM_CONDITION_IP_REMOTE_PORT = windows.GUID{
+	Data1: 0xc35a604d,
+	Data2: 0xd22b,
+	Data3: 0x4e1a,
+	Data4: [8]byte{0x91, 0xb4, 0x68, 0xf6, 0x74, 0xee, 0x67, 0x4b},
+}
+
+// Defined in fwpmu.h. d78e1e87-8644-4ea5-9437-d809ecefc971
+var cFWPM_CONDITION_ALE_APP_ID = windows.GUID{
+	Data1: 0xd78e1e87,
+	Data2: 0x8644,
+	Data3: 0x4ea5,
+	Data4: [8]byte{0x94, 0x37, 0xd8, 0x09, 0xec, 0xef, 0xc9, 0x71},
+}
+
+// af043a0a-b34d-4f86-979c-c90371af6e66
+var cFWPM_CONDITION_ALE_USER_ID = windows.GUID{
+	Data1: 0xaf043a0a,
+	Data2: 0xb34d,
+	Data3: 0x4f86,
+	Data4: [8]byte{0x97, 0x9c, 0xc9, 0x03, 0x71, 0xaf, 0x6e, 0x66},
+}
+
+// d9ee00de-c1ef-4617-bfe3-ffd8f5a08957
+var cFWPM_CONDITION_IP_LOCAL_ADDRESS = windows.GUID{
+	Data1: 0xd9ee00de,
+	Data2: 0xc1ef,
+	Data3: 0x4617,
+	Data4: [8]byte{0xbf, 0xe3, 0xff, 0xd8, 0xf5, 0xa0, 0x89, 0x57},
+}
+
+var (
+	cFWPM_CONDITION_ICMP_TYPE = cFWPM_CONDITION_IP_LOCAL_PORT
+	cFWPM_CONDITION_ICMP_CODE = cFWPM_CONDITION_IP_REMOTE_PORT
+)
+
+// 7bc43cbf-37ba-45f1-b74a-82ff518eeb10
+var cFWPM_CONDITION_L2_FLAGS = windows.GUID{
+	Data1: 0x7bc43cbf,
+	Data2: 0x37ba,
+	Data3: 0x45f1,
+	Data4: [8]byte{0xb7, 0x4a, 0x82, 0xff, 0x51, 0x8e, 0xeb, 0x10},
+}
+
+type wtFwpmL2Flags uint32
+
+const cFWP_CONDITION_L2_IS_VM2VM wtFwpmL2Flags = 0x00000010
+
+var cFWPM_CONDITION_FLAGS = windows.GUID{
+	Data1: 0x632ce23b,
+	Data2: 0x5167,
+	Data3: 0x435c,
+	Data4: [8]byte{0x86, 0xd7, 0xe9, 0x03, 0x68, 0x4a, 0xa8, 0x0c},
+}
+
+type wtFwpmFlags uint32
+
+const cFWP_CONDITION_FLAG_IS_LOOPBACK wtFwpmFlags = 0x00000001
+
+// Defined in fwpmtypes.h
+type wtFwpmFilterFlags uint32
+
+const (
+	cFWPM_FILTER_FLAG_NONE                                wtFwpmFilterFlags = 0x00000000
+	cFWPM_FILTER_FLAG_PERSISTENT                          wtFwpmFilterFlags = 0x00000001
+	cFWPM_FILTER_FLAG_BOOTTIME                            wtFwpmFilterFlags = 0x00000002
+	cFWPM_FILTER_FLAG_HAS_PROVIDER_CONTEXT                wtFwpmFilterFlags = 0x00000004
+	cFWPM_FILTER_FLAG_CLEAR_ACTION_RIGHT                  wtFwpmFilterFlags = 0x00000008
+	cFWPM_FILTER_FLAG_PERMIT_IF_CALLOUT_UNREGISTERED      wtFwpmFilterFlags = 0x00000010
+	cFWPM_FILTER_FLAG_DISABLED                            wtFwpmFilterFlags = 0x00000020
+	cFWPM_FILTER_FLAG_INDEXED                             wtFwpmFilterFlags = 0x00000040
+	cFWPM_FILTER_FLAG_HAS_SECURITY_REALM_PROVIDER_CONTEXT wtFwpmFilterFlags = 0x00000080
+	cFWPM_FILTER_FLAG_SYSTEMOS_ONLY                       wtFwpmFilterFlags = 0x00000100
+	cFWPM_FILTER_FLAG_GAMEOS_ONLY                         wtFwpmFilterFlags = 0x00000200
+	cFWPM_FILTER_FLAG_SILENT_MODE                         wtFwpmFilterFlags = 0x00000400
+	cFWPM_FILTER_FLAG_IPSEC_NO_ACQUIRE_INITIATE           wtFwpmFilterFlags = 0x00000800
+)
+
+// FWPM_LAYER_ALE_AUTH_CONNECT_V4 (c38d57d1-05a7-4c33-904f-7fbceee60e82) defined in fwpmu.h
+var cFWPM_LAYER_ALE_AUTH_CONNECT_V4 = windows.GUID{
+	Data1: 0xc38d57d1,
+	Data2: 0x05a7,
+	Data3: 0x4c33,
+	Data4: [8]byte{0x90, 0x4f, 0x7f, 0xbc, 0xee, 0xe6, 0x0e, 0x82},
+}
+
+// e1cd9fe7-f4b5-4273-96c0-592e487b8650
+var cFWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4 = windows.GUID{
+	Data1: 0xe1cd9fe7,
+	Data2: 0xf4b5,
+	Data3: 0x4273,
+	Data4: [8]byte{0x96, 0xc0, 0x59, 0x2e, 0x48, 0x7b, 0x86, 0x50},
+}
+
+// FWPM_LAYER_ALE_AUTH_CONNECT_V6 (4a72393b-319f-44bc-84c3-ba54dcb3b6b4) defined in fwpmu.h
+var cFWPM_LAYER_ALE_AUTH_CONNECT_V6 = windows.GUID{
+	Data1: 0x4a72393b,
+	Data2: 0x319f,
+	Data3: 0x44bc,
+	Data4: [8]byte{0x84, 0xc3, 0xba, 0x54, 0xdc, 0xb3, 0xb6, 0xb4},
+}
+
+// a3b42c97-9f04-4672-b87e-cee9c483257f
+var cFWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6 = windows.GUID{
+	Data1: 0xa3b42c97,
+	Data2: 0x9f04,
+	Data3: 0x4672,
+	Data4: [8]byte{0xb8, 0x7e, 0xce, 0xe9, 0xc4, 0x83, 0x25, 0x7f},
+}
+
+// 94c44912-9d6f-4ebf-b995-05ab8a088d1b
+var cFWPM_LAYER_OUTBOUND_MAC_FRAME_NATIVE = windows.GUID{
+	Data1: 0x94c44912,
+	Data2: 0x9d6f,
+	Data3: 0x4ebf,
+	Data4: [8]byte{0xb9, 0x95, 0x05, 0xab, 0x8a, 0x08, 0x8d, 0x1b},
+}
+
+// d4220bd3-62ce-4f08-ae88-b56e8526df50
+var cFWPM_LAYER_INBOUND_MAC_FRAME_NATIVE = windows.GUID{
+	Data1: 0xd4220bd3,
+	Data2: 0x62ce,
+	Data3: 0x4f08,
+	Data4: [8]byte{0xae, 0x88, 0xb5, 0x6e, 0x85, 0x26, 0xdf, 0x50},
+}
+
+// FWP_BITMAP_ARRAY64 defined in fwtypes.h
+type wtFwpBitmapArray64 struct {
+	bitmapArray64 [8]uint8 // Windows type: [8]UINT8
+}
+
+// FWP_BYTE_ARRAY6 defined in fwtypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwptypes/ns-fwptypes-fwp_byte_array6_)
+type wtFwpByteArray6 struct {
+	byteArray6 [6]uint8 // Windows type: [6]UINT8
+}
+
+// FWP_BYTE_ARRAY16 defined in fwptypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwptypes/ns-fwptypes-fwp_byte_array16_)
+type wtFwpByteArray16 struct {
+	byteArray16 [16]uint8 // Windows type [16]UINT8
+}
+
+// FWP_CONDITION_VALUE0 defined in fwptypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwptypes/ns-fwptypes-fwp_condition_value0).
+type wtFwpConditionValue0 wtFwpValue0
+
+// FWP_DATA_TYPE defined in fwptypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwptypes/ne-fwptypes-fwp_data_type_)
+type wtFwpDataType uint
+
+const (
+	cFWP_EMPTY                         wtFwpDataType = 0
+	cFWP_UINT8                         wtFwpDataType = cFWP_EMPTY + 1
+	cFWP_UINT16                        wtFwpDataType = cFWP_UINT8 + 1
+	cFWP_UINT32                        wtFwpDataType = cFWP_UINT16 + 1
+	cFWP_UINT64                        wtFwpDataType = cFWP_UINT32 + 1
+	cFWP_INT8                          wtFwpDataType = cFWP_UINT64 + 1
+	cFWP_INT16                         wtFwpDataType = cFWP_INT8 + 1
+	cFWP_INT32                         wtFwpDataType = cFWP_INT16 + 1
+	cFWP_INT64                         wtFwpDataType = cFWP_INT32 + 1
+	cFWP_FLOAT                         wtFwpDataType = cFWP_INT64 + 1
+	cFWP_DOUBLE                        wtFwpDataType = cFWP_FLOAT + 1
+	cFWP_BYTE_ARRAY16_TYPE             wtFwpDataType = cFWP_DOUBLE + 1
+	cFWP_BYTE_BLOB_TYPE                wtFwpDataType = cFWP_BYTE_ARRAY16_TYPE + 1
+	cFWP_SID                           wtFwpDataType = cFWP_BYTE_BLOB_TYPE + 1
+	cFWP_SECURITY_DESCRIPTOR_TYPE      wtFwpDataType = cFWP_SID + 1
+	cFWP_TOKEN_INFORMATION_TYPE        wtFwpDataType = cFWP_SECURITY_DESCRIPTOR_TYPE + 1
+	cFWP_TOKEN_ACCESS_INFORMATION_TYPE wtFwpDataType = cFWP_TOKEN_INFORMATION_TYPE + 1
+	cFWP_UNICODE_STRING_TYPE           wtFwpDataType = cFWP_TOKEN_ACCESS_INFORMATION_TYPE + 1
+	cFWP_BYTE_ARRAY6_TYPE              wtFwpDataType = cFWP_UNICODE_STRING_TYPE + 1
+	cFWP_BITMAP_INDEX_TYPE             wtFwpDataType = cFWP_BYTE_ARRAY6_TYPE + 1
+	cFWP_BITMAP_ARRAY64_TYPE           wtFwpDataType = cFWP_BITMAP_INDEX_TYPE + 1
+	cFWP_SINGLE_DATA_TYPE_MAX          wtFwpDataType = 0xff
+	cFWP_V4_ADDR_MASK                  wtFwpDataType = cFWP_SINGLE_DATA_TYPE_MAX + 1
+	cFWP_V6_ADDR_MASK                  wtFwpDataType = cFWP_V4_ADDR_MASK + 1
+	cFWP_RANGE_TYPE                    wtFwpDataType = cFWP_V6_ADDR_MASK + 1
+	cFWP_DATA_TYPE_MAX                 wtFwpDataType = cFWP_RANGE_TYPE + 1
+)
+
+// FWP_V4_ADDR_AND_MASK defined in fwptypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwptypes/ns-fwptypes-fwp_v4_addr_and_mask).
+type wtFwpV4AddrAndMask struct {
+	addr uint32
+	mask uint32
+}
+
+// FWP_V6_ADDR_AND_MASK defined in fwptypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwptypes/ns-fwptypes-fwp_v6_addr_and_mask).
+type wtFwpV6AddrAndMask struct {
+	addr         [16]uint8
+	prefixLength uint8
+}
+
+// FWP_VALUE0 defined in fwptypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwptypes/ns-fwptypes-fwp_value0_)
+type wtFwpValue0 struct {
+	_type wtFwpDataType
+	value uintptr
+}
+
+// FWPM_DISPLAY_DATA0 defined in fwptypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwptypes/ns-fwptypes-fwpm_display_data0).
+type wtFwpmDisplayData0 struct {
+	name        *uint16 // Windows type: *wchar_t
+	description *uint16 // Windows type: *wchar_t
+}
+
+// FWPM_FILTER_CONDITION0 defined in fwpmtypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_filter_condition0).
+type wtFwpmFilterCondition0 struct {
+	fieldKey       windows.GUID // Windows type: GUID
+	matchType      wtFwpMatchType
+	conditionValue wtFwpConditionValue0
+}
+
+// FWPM_PROVIDER0 defined in fwpmtypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_provider0_)
+type wtFwpProvider0 struct {
+	providerKey  windows.GUID // Windows type: GUID
+	displayData  wtFwpmDisplayData0
+	flags        uint32
+	providerData wtFwpByteBlob
+	serviceName  *uint16 // Windows type: *wchar_t
+}
+
+type wtFwpmSessionFlagsValue uint32
+
+const (
+	cFWPM_SESSION_FLAG_DYNAMIC wtFwpmSessionFlagsValue = 0x00000001 // FWPM_SESSION_FLAG_DYNAMIC defined in fwpmtypes.h
+)
+
+// FWPM_SESSION0 defined in fwpmtypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_session0).
+type wtFwpmSession0 struct {
+	sessionKey           windows.GUID // Windows type: GUID
+	displayData          wtFwpmDisplayData0
+	flags                wtFwpmSessionFlagsValue // Windows type UINT32
+	txnWaitTimeoutInMSec uint32
+	processId            uint32 // Windows type: DWORD
+	sid                  *windows.SID
+	username             *uint16 // Windows type: *wchar_t
+	kernelMode           uint8   // Windows type: BOOL
+}
+
+type wtFwpmSublayerFlags uint32
+
+const (
+	cFWPM_SUBLAYER_FLAG_PERSISTENT wtFwpmSublayerFlags = 0x00000001 // FWPM_SUBLAYER_FLAG_PERSISTENT defined in fwpmtypes.h
+)
+
+// FWPM_SUBLAYER0 defined in fwpmtypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_sublayer0_)
+type wtFwpmSublayer0 struct {
+	subLayerKey  windows.GUID // Windows type: GUID
+	displayData  wtFwpmDisplayData0
+	flags        wtFwpmSublayerFlags
+	providerKey  *windows.GUID // Windows type: *GUID
+	providerData wtFwpByteBlob
+	weight       uint16
+}
+
+// Defined in rpcdce.h
+type wtRpcCAuthN uint32
+
+const (
+	cRPC_C_AUTHN_NONE    wtRpcCAuthN = 0
+	cRPC_C_AUTHN_WINNT   wtRpcCAuthN = 10
+	cRPC_C_AUTHN_DEFAULT wtRpcCAuthN = 0xFFFFFFFF
+)
+
+// FWPM_PROVIDER0 defined in fwpmtypes.h
+// (https://docs.microsoft.com/sv-se/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_provider0).
+type wtFwpmProvider0 struct {
+	providerKey  windows.GUID
+	displayData  wtFwpmDisplayData0
+	flags        uint32
+	providerData wtFwpByteBlob
+	serviceName  *uint16
+}
+
+type wtIPProto uint32
+
+const (
+	cIPPROTO_ICMP   wtIPProto = 1
+	cIPPROTO_ICMPV6 wtIPProto = 58
+	cIPPROTO_TCP    wtIPProto = 6
+	cIPPROTO_UDP    wtIPProto = 17
+)
+
+const (
+	cFWP_ACTRL_MATCH_FILTER = 1
+)

--- a/internal/wfp/types_windows_32.go
+++ b/internal/wfp/types_windows_32.go
@@ -1,0 +1,104 @@
+//go:build windows && (386 || arm)
+
+// The windows constraint is meshp's addition. Upstream this file says only
+// "amd64 || arm64", and the _windows_64 suffix imposes nothing — Go reads a trailing
+// _GOOS_GOARCH pair only when both halves are real, and 64 is not an architecture. In a
+// module that is built for Windows and nothing else that never shows; here it compiled
+// on darwin/arm64 and took x/sys/windows with it.
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2019-2021 WireGuard LLC. All Rights Reserved.
+ *
+ * Taken from golang.zx2c4.com/wireguard/windows/tunnel/firewall and used under its own
+ * licence, which is retained above. Only the package name is changed.
+ *
+ * Copied rather than written, on purpose (ADR-0030): FWPM_FILTER0 and its relatives are
+ * nested structures whose layout differs between 32- and 64-bit, and a wrong offset here is
+ * a memory-corruption bug rather than a logic bug. What is meshp's own is the policy —
+ * which filters, at which layers, with what lifetime — and that lives in the files beside
+ * this one, because it is where meshp and WireGuard's Windows client want opposite things.
+ */
+
+package wfp
+
+import "golang.org/x/sys/windows"
+
+const (
+	wtFwpByteBlob_Size        = 8
+	wtFwpByteBlob_data_Offset = 4
+
+	wtFwpConditionValue0_Size         = 8
+	wtFwpConditionValue0_uint8_Offset = 4
+
+	wtFwpmDisplayData0_Size               = 8
+	wtFwpmDisplayData0_description_Offset = 4
+
+	wtFwpmFilter0_Size                       = 152
+	wtFwpmFilter0_displayData_Offset         = 16
+	wtFwpmFilter0_flags_Offset               = 24
+	wtFwpmFilter0_providerKey_Offset         = 28
+	wtFwpmFilter0_providerData_Offset        = 32
+	wtFwpmFilter0_layerKey_Offset            = 40
+	wtFwpmFilter0_subLayerKey_Offset         = 56
+	wtFwpmFilter0_weight_Offset              = 72
+	wtFwpmFilter0_numFilterConditions_Offset = 80
+	wtFwpmFilter0_filterCondition_Offset     = 84
+	wtFwpmFilter0_action_Offset              = 88
+	wtFwpmFilter0_providerContextKey_Offset  = 112
+	wtFwpmFilter0_reserved_Offset            = 128
+	wtFwpmFilter0_filterID_Offset            = 136
+	wtFwpmFilter0_effectiveWeight_Offset     = 144
+
+	wtFwpmFilterCondition0_Size                  = 28
+	wtFwpmFilterCondition0_matchType_Offset      = 16
+	wtFwpmFilterCondition0_conditionValue_Offset = 20
+
+	wtFwpmSession0_Size                        = 48
+	wtFwpmSession0_displayData_Offset          = 16
+	wtFwpmSession0_flags_Offset                = 24
+	wtFwpmSession0_txnWaitTimeoutInMSec_Offset = 28
+	wtFwpmSession0_processId_Offset            = 32
+	wtFwpmSession0_sid_Offset                  = 36
+	wtFwpmSession0_username_Offset             = 40
+	wtFwpmSession0_kernelMode_Offset           = 44
+
+	wtFwpmSublayer0_Size                = 44
+	wtFwpmSublayer0_displayData_Offset  = 16
+	wtFwpmSublayer0_flags_Offset        = 24
+	wtFwpmSublayer0_providerKey_Offset  = 28
+	wtFwpmSublayer0_providerData_Offset = 32
+	wtFwpmSublayer0_weight_Offset       = 40
+
+	wtFwpProvider0_Size                = 40
+	wtFwpProvider0_displayData_Offset  = 16
+	wtFwpProvider0_flags_Offset        = 24
+	wtFwpProvider0_providerData_Offset = 28
+	wtFwpProvider0_serviceName_Offset  = 36
+
+	wtFwpTokenInformation_Size = 16
+
+	wtFwpValue0_Size         = 8
+	wtFwpValue0_value_Offset = 4
+)
+
+// FWPM_FILTER0 defined in fwpmtypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_filter0).
+type wtFwpmFilter0 struct {
+	filterKey           windows.GUID // Windows type: GUID
+	displayData         wtFwpmDisplayData0
+	flags               wtFwpmFilterFlags
+	providerKey         *windows.GUID // Windows type: *GUID
+	providerData        wtFwpByteBlob
+	layerKey            windows.GUID // Windows type: GUID
+	subLayerKey         windows.GUID // Windows type: GUID
+	weight              wtFwpValue0
+	numFilterConditions uint32
+	filterCondition     *wtFwpmFilterCondition0
+	action              wtFwpmAction0
+	offset1             [4]byte       // Layout correction field
+	providerContextKey  windows.GUID  // Windows type: GUID
+	reserved            *windows.GUID // Windows type: *GUID
+	offset2             [4]byte       // Layout correction field
+	filterID            uint64
+	effectiveWeight     wtFwpValue0
+}

--- a/internal/wfp/types_windows_64.go
+++ b/internal/wfp/types_windows_64.go
@@ -1,0 +1,101 @@
+//go:build windows && (amd64 || arm64)
+
+// The windows constraint is meshp's addition. Upstream this file says only
+// "amd64 || arm64", and the _windows_64 suffix imposes nothing — Go reads a trailing
+// _GOOS_GOARCH pair only when both halves are real, and 64 is not an architecture. In a
+// module that is built for Windows and nothing else that never shows; here it compiled
+// on darwin/arm64 and took x/sys/windows with it.
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2019-2021 WireGuard LLC. All Rights Reserved.
+ *
+ * Taken from golang.zx2c4.com/wireguard/windows/tunnel/firewall and used under its own
+ * licence, which is retained above. Only the package name is changed.
+ *
+ * Copied rather than written, on purpose (ADR-0030): FWPM_FILTER0 and its relatives are
+ * nested structures whose layout differs between 32- and 64-bit, and a wrong offset here is
+ * a memory-corruption bug rather than a logic bug. What is meshp's own is the policy —
+ * which filters, at which layers, with what lifetime — and that lives in the files beside
+ * this one, because it is where meshp and WireGuard's Windows client want opposite things.
+ */
+
+package wfp
+
+import "golang.org/x/sys/windows"
+
+const (
+	wtFwpByteBlob_Size        = 16
+	wtFwpByteBlob_data_Offset = 8
+
+	wtFwpConditionValue0_Size         = 16
+	wtFwpConditionValue0_uint8_Offset = 8
+
+	wtFwpmDisplayData0_Size               = 16
+	wtFwpmDisplayData0_description_Offset = 8
+
+	wtFwpmFilter0_Size                       = 200
+	wtFwpmFilter0_displayData_Offset         = 16
+	wtFwpmFilter0_flags_Offset               = 32
+	wtFwpmFilter0_providerKey_Offset         = 40
+	wtFwpmFilter0_providerData_Offset        = 48
+	wtFwpmFilter0_layerKey_Offset            = 64
+	wtFwpmFilter0_subLayerKey_Offset         = 80
+	wtFwpmFilter0_weight_Offset              = 96
+	wtFwpmFilter0_numFilterConditions_Offset = 112
+	wtFwpmFilter0_filterCondition_Offset     = 120
+	wtFwpmFilter0_action_Offset              = 128
+	wtFwpmFilter0_providerContextKey_Offset  = 152
+	wtFwpmFilter0_reserved_Offset            = 168
+	wtFwpmFilter0_filterID_Offset            = 176
+	wtFwpmFilter0_effectiveWeight_Offset     = 184
+
+	wtFwpmFilterCondition0_Size                  = 40
+	wtFwpmFilterCondition0_matchType_Offset      = 16
+	wtFwpmFilterCondition0_conditionValue_Offset = 24
+
+	wtFwpmSession0_Size                        = 72
+	wtFwpmSession0_displayData_Offset          = 16
+	wtFwpmSession0_flags_Offset                = 32
+	wtFwpmSession0_txnWaitTimeoutInMSec_Offset = 36
+	wtFwpmSession0_processId_Offset            = 40
+	wtFwpmSession0_sid_Offset                  = 48
+	wtFwpmSession0_username_Offset             = 56
+	wtFwpmSession0_kernelMode_Offset           = 64
+
+	wtFwpmSublayer0_Size                = 72
+	wtFwpmSublayer0_displayData_Offset  = 16
+	wtFwpmSublayer0_flags_Offset        = 32
+	wtFwpmSublayer0_providerKey_Offset  = 40
+	wtFwpmSublayer0_providerData_Offset = 48
+	wtFwpmSublayer0_weight_Offset       = 64
+
+	wtFwpProvider0_Size                = 64
+	wtFwpProvider0_displayData_Offset  = 16
+	wtFwpProvider0_flags_Offset        = 32
+	wtFwpProvider0_providerData_Offset = 40
+	wtFwpProvider0_serviceName_Offset  = 56
+
+	wtFwpValue0_Size         = 16
+	wtFwpValue0_value_Offset = 8
+)
+
+// FWPM_FILTER0 defined in fwpmtypes.h
+// (https://docs.microsoft.com/en-us/windows/desktop/api/fwpmtypes/ns-fwpmtypes-fwpm_filter0).
+type wtFwpmFilter0 struct {
+	filterKey           windows.GUID // Windows type: GUID
+	displayData         wtFwpmDisplayData0
+	flags               wtFwpmFilterFlags // Windows type: UINT32
+	providerKey         *windows.GUID     // Windows type: *GUID
+	providerData        wtFwpByteBlob
+	layerKey            windows.GUID // Windows type: GUID
+	subLayerKey         windows.GUID // Windows type: GUID
+	weight              wtFwpValue0
+	numFilterConditions uint32
+	filterCondition     *wtFwpmFilterCondition0
+	action              wtFwpmAction0
+	offset1             [4]byte       // Layout correction field
+	providerContextKey  windows.GUID  // Windows type: GUID
+	reserved            *windows.GUID // Windows type: *GUID
+	filterID            uint64
+	effectiveWeight     wtFwpValue0
+}

--- a/internal/wfp/wfp.go
+++ b/internal/wfp/wfp.go
@@ -138,7 +138,13 @@ func isAlreadyExists(err error) bool { return isFwpErr(err, fwpErrAlreadyExists)
 // Success on the way out, for the reason removal is idempotent everywhere else in this
 // project: teardown runs whether or not anything was installed.
 func isGone(err error) bool {
-	return isFwpErr(err, fwpErrNotFound) || isFwpErr(err, fwpErrFilterNotFound)
+	for _, code := range []uintptr{fwpErrNotFound, fwpErrFilterNotFound,
+		fwpErrSublayerNotFound, fwpErrProviderNotFound} {
+		if isFwpErr(err, code) {
+			return true
+		}
+	}
+	return false
 }
 
 func isFwpErr(err error, code uintptr) bool {
@@ -149,11 +155,18 @@ func isFwpErr(err error, code uintptr) bool {
 // The filtering platform's own error codes, which are HRESULT-shaped rather than Win32 and
 // are not in x/sys/windows.
 //
-// Only the two this package has to tell apart from everything else: an object that is already
-// there, which is success on the reconcile path, and one that is not, which is success on the
-// way out.
+// Only the ones this package has to tell apart from everything else: an object already there,
+// which is success on the reconcile path, and one that is not, which is success on the way
+// out. Everything else is a failure the caller should hear about.
+//
+// There is an absent code per kind of object rather than one shared one, which cost a CI run
+// to find out: removing a lock that was never installed reported "the sublayer does not
+// exist" and was treated as a failure, so every teardown on a device that had never claimed a
+// route would have logged one.
 const (
-	fwpErrAlreadyExists  = 0x80320009
-	fwpErrFilterNotFound = 0x80320003
-	fwpErrNotFound       = 0x80320008
+	fwpErrFilterNotFound   = 0x80320003
+	fwpErrProviderNotFound = 0x80320005
+	fwpErrSublayerNotFound = 0x80320007
+	fwpErrNotFound         = 0x80320008
+	fwpErrAlreadyExists    = 0x80320009
 )

--- a/internal/wfp/wfp.go
+++ b/internal/wfp/wfp.go
@@ -1,0 +1,159 @@
+//go:build windows
+
+// Package wfp refuses egress that does not go through the tunnel, on Windows.
+//
+// The Windows half of ADR-0011, and the sibling of internal/nftables and internal/pf. Same
+// job, third mechanism, and this one differs from the other two in a way that matters: it is
+// not a program meshp runs. nftables and pf are `nft` and `pfctl`, whose interfaces are
+// stable and whose failures are text. This is structures passed to a kernel API.
+//
+// # Why not the firewall everybody has heard of
+//
+// Windows Firewall resolves conflicts by precedence and an explicit block beats an explicit
+// allow, so the shape the other platforms use — refuse everything, then permit the tunnel,
+// the relay, the control plane and the local network — inverts, and the blanket block wins
+// over every permit. The way round it is to set the profile's default outbound action to
+// Block, which is a machine-wide setting whose undo means putting back somebody else's value
+// (ADR-0030).
+//
+// The filtering platform underneath it has sublayers with weights, so a permit genuinely
+// beats a block, which is how the policy is expressible at all here.
+//
+// # Why not the implementation that exists
+//
+// golang.zx2c4.com/wireguard/windows/tunnel/firewall does this and cannot be used. It opens a
+// dynamic session, so every filter it adds is deleted when the process exits — the exact
+// inverse of what ADR-0011 requires, where the lock survives the daemon because agent crash
+// and agent kill are two of the cases the feature exists to cover. Its provider GUID is
+// generated per session for the same reason, so a restarted daemon could not find what its
+// predecessor installed.
+//
+// Its type and syscall definitions are borrowed, under their own licence and with their
+// copyright retained. Its policy is not, and neither is its lifetime.
+package wfp
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// wfpObjectInstaller is what runTransaction takes.
+//
+// Declared here rather than in the borrowed files because it belongs to the half that is
+// meshp's: blocker.go is the file it came from and blocker.go is the file not taken.
+type wfpObjectInstaller func(uintptr) error
+
+// providerKey and sublayerKey are meshp's namespace in the filtering platform.
+//
+// Fixed, which is the whole difference from the implementation this borrows from. Every object
+// meshp adds hangs beneath these two, so a daemon that has just started can find everything its
+// predecessor installed and take it off — Invariant 20, on a platform with no equivalent of
+// Linux's firewall mark. A generated GUID would make the lock unremovable by anything but the
+// process that made it, which is the process that is no longer running.
+//
+// Never change these. A release that did would orphan every lock the last one installed, on
+// every machine that had one, with no way to find them again short of enumerating the whole
+// filter engine.
+var (
+	providerKey = windows.GUID{
+		Data1: 0x8f1d3b2a, Data2: 0x5c74, Data3: 0x4e19,
+		Data4: [8]byte{0x9a, 0x2b, 0x6d, 0x65, 0x73, 0x68, 0x70, 0x01},
+	}
+	sublayerKey = windows.GUID{
+		Data1: 0x8f1d3b2a, Data2: 0x5c74, Data3: 0x4e19,
+		Data4: [8]byte{0x9a, 0x2b, 0x6d, 0x65, 0x73, 0x68, 0x70, 0x02},
+	}
+)
+
+// session opens the filtering platform for the calls below.
+//
+// Not dynamic, and that is the decision. A dynamic session deletes everything it added when
+// the handle closes, which is what the implementation this borrows from wants and the inverse
+// of what ADR-0011 wants: a lock that vanished with the daemon would fail open at exactly the
+// moment it is needed.
+//
+// The objects are also not persistent, which is the other half. Persistent means surviving a
+// reboot, and a machine that came back up with no meshpd and no network would have lost the
+// recovery path that Linux and macOS both keep. What is wanted is the middle — outlives the
+// process, does not outlive the boot — and that is what a non-dynamic session with
+// non-persistent objects is documented to give. ADR-0030 records that this is the one claim
+// in the design that had not been verified when it was written; TestALockOutlivesTheProcess
+// is where it is.
+func openSession() (uintptr, error) {
+	var handle uintptr
+	if err := fwpmEngineOpen0(nil, cRPC_C_AUTHN_WINNT, nil, nil, unsafe.Pointer(&handle)); err != nil {
+		return 0, fmt.Errorf("wfp: opening the filter engine: %w", wrapErr(err))
+	}
+	return handle, nil
+}
+
+// registerBaseObjects makes meshp's provider and sublayer exist.
+//
+// Idempotent: both are added inside a transaction and an "already there" is success, because
+// the reconciler installs the lock on every pass and the objects outlive the process that
+// made them.
+//
+// The sublayer's weight is high so that meshp's permits are evaluated above the blocks other
+// software has installed in its own sublayers. Within meshp's sublayer the filters' own
+// weights decide, which is where the policy actually lives.
+func registerBaseObjects(session uintptr) error {
+	displayData, err := createWtFwpmDisplayData0("meshp", "meshp fail-closed egress")
+	if err != nil {
+		return wrapErr(err)
+	}
+
+	provider := wtFwpmProvider0{
+		providerKey: providerKey,
+		displayData: *displayData,
+	}
+	if err := fwpmProviderAdd0(session, &provider, 0); err != nil &&
+		!isAlreadyExists(err) {
+		return fmt.Errorf("wfp: registering meshp as a filter provider: %w", wrapErr(err))
+	}
+
+	sublayer := wtFwpmSublayer0{
+		subLayerKey: sublayerKey,
+		displayData: *displayData,
+		providerKey: &providerKey,
+		weight:      ^uint16(0),
+	}
+	if err := fwpmSubLayerAdd0(session, &sublayer, 0); err != nil &&
+		!isAlreadyExists(err) {
+		return fmt.Errorf("wfp: registering meshp's sublayer: %w", wrapErr(err))
+	}
+	return nil
+}
+
+// isAlreadyExists reports whether an error means the object was there already.
+//
+// Success on the reconcile path: the provider and sublayer outlive the process, so every pass
+// after the first finds them. Distinguished rather than swallowed, because every other reason
+// an add can fail is one the caller should hear about.
+func isAlreadyExists(err error) bool { return isFwpErr(err, fwpErrAlreadyExists) }
+
+// isGone reports whether an error means the object was not there to remove.
+//
+// Success on the way out, for the reason removal is idempotent everywhere else in this
+// project: teardown runs whether or not anything was installed.
+func isGone(err error) bool {
+	return isFwpErr(err, fwpErrNotFound) || isFwpErr(err, fwpErrFilterNotFound)
+}
+
+func isFwpErr(err error, code uintptr) bool {
+	errno, ok := err.(windows.Errno)
+	return ok && uintptr(errno) == code
+}
+
+// The filtering platform's own error codes, which are HRESULT-shaped rather than Win32 and
+// are not in x/sys/windows.
+//
+// Only the two this package has to tell apart from everything else: an object that is already
+// there, which is success on the reconcile path, and one that is not, which is success on the
+// way out.
+const (
+	fwpErrAlreadyExists  = 0x80320009
+	fwpErrFilterNotFound = 0x80320003
+	fwpErrNotFound       = 0x80320008
+)


### PR DESCRIPTION
Last slice of the Windows data plane, implementing ADR-0030. A device can be given a network whose policy says `fail_closed`, and it refuses traffic that does not go through the tunnel rather than putting the user's real address back on the wire.

## What is borrowed and what is not

The type and syscall definitions come from `wireguard-windows` under its own licence with the copyright retained — `FWPM_FILTER0` and its relatives are nested structures whose layout differs between 32- and 64-bit, and a wrong offset is a memory-corruption bug rather than a logic bug.

**Three things are meshp's, and none of them could be borrowed:**

**The session is not dynamic.** That package's is, so every filter it adds is deleted when the process exits — the inverse of ADR-0011, where the lock survives the daemon because agent crash and agent kill are two of the cases the feature exists for.

**The provider GUID is fixed**, not generated per session. That is what lets a daemon which has just started find and remove what its predecessor installed. Filters are named the same way — deterministically from a slot name — so removal can name them without having kept the ids the engine handed back.

**The syscall wrappers are written, not borrowed.** The generated ones do:

```go
r1, _, e1 := syscall.Syscall(...)
if r1 != 0 { err = errnoErr(e1) }
```

These functions return their error **in the return value**; `e1` is whatever `GetLastError` happened to hold. So failure is detected correctly and described wrongly. Survivable for a caller that only asks whether it worked, and not for one that has to tell `FWP_E_ALREADY_EXISTS` from a refusal on every reconcile. The deletes are here for the same reason — that package has none, because a dynamic session never needed one.

## Two defects in the borrowed files, fixed rather than carried

`types_windows_32.go` and `types_windows_64.go` constrain only the **architecture**. The `_windows_64` suffix imposes nothing, because Go reads a trailing `_GOOS_GOARCH` pair only when both halves are real — and `64` is not an architecture. In a module built for Windows and nothing else that never shows. **Here it compiled on darwin/arm64 and took `x/sys/windows` with it**, which is how I found it.

## internal/platformcheck asked the wrong question

It demanded `internal/wfp` be run by the **macOS** job, where the package has no files at all and `go test` would fail rather than test anything. A guard about platform coverage should ask *"can this run there"*, not *"does it have tests"*.

It now asks `go/build` — the only thing that answers correctly — and requires a Windows-only package of the Windows job instead. The test is renamed to match what it actually checks.

## Testing

Behavioural where it counts, because ADR-0030 says a filter that was added is not the same as a packet that was refused.

**`TestALockRefusesWhatItDoesNotName`** carves out everything except TEST-NET-1, then asserts a connection there fails **fast** — a refusal, not a blackhole — and that a carved-out address is merely unreachable rather than refused. The runner keeps its network throughout, even if the test dies before cleanup.

The rest: every slot installation writes is one removal can name (the list is maintained by hand, so this is what makes it true rather than hoped for), no two filters share a key, the carve-out is bounded so nothing unremovable can be installed, removing a lock that is not there is success, and an unprivileged agent reports that it cannot lock.

## Note

I committed this to `main` by mistake and branch protection refused the push. Moved to a branch with `main` restored; no history was rewritten on the remote.
