### PR TITLE
docs: Windows is complete, and its lock has no command to remove it

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,11 @@ default route and fail-closed egress**, the last of these through a pf anchor ra
 nftables (ADR-0026). What macOS still cannot do is enforce a network's packet filter, so a
 network with a policy reports the group unhonoured there rather than half-applying it.
 
-**Windows has a tunnel and names.** A WinTun adapter comes up, carries an address and a
-route, and is configured exactly as the other two are (ADR-0028); mesh names resolve through
-the Name Resolution Policy Table, which routes by name rather than by interface so nothing
-else on the machine is captured (ADR-0029). What it cannot do yet is claim a full tunnel,
-fail closed, or filter — each reported unhonoured rather than half-applied. The mobile
-platforms enrol, hold an address, and report honestly that they have no tunnel at all.
+**Windows is complete too**, by a different route at every layer: a WinTun adapter rather
+than a utun (ADR-0028), the Name Resolution Policy Table rather than a resolver dictionary
+(ADR-0029), and meshp's own filtering-platform provider rather than a pf anchor (ADR-0030).
+Like macOS it cannot enforce a network's packet filter. The mobile platforms enrol, hold an
+address, and report honestly that they have no tunnel at all.
 
 It is public from the first commit because the design decisions are the
 interesting part and we would rather be argued with early.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,8 +33,7 @@ Out of scope: anything you deploy meshp on top of, and the deployment examples u
 
 **Read this before you spend time on it.** meshp is pre-alpha and the README says not to
 deploy it. The data plane exists on Linux, macOS and Windows and nowhere else; macOS cannot
-enforce a network's packet filter, and Windows has a tunnel and name resolution but no
-full-tunnel route, no fail-closed egress and no filtering. Reports are still welcome and
+enforce a network's packet filter, and neither can Windows. Reports are still welcome and
 will be handled as above —
 but a finding that a half-built feature is half-built is not one, and there are several of
 those in the open issues already.

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,9 +34,8 @@ Two worth starting with:
 And the honest one: the [status section of the README](../README.md#status) says what does
 not work. The data plane is complete on Linux and on macOS — a tunnel, working names, a
 full-tunnel route and fail-closed egress, though macOS still cannot enforce a network's
-packet filter. Windows has a tunnel and working names, and cannot yet take a full-tunnel
-route or fail closed; the mobile platforms have no tunnel at all. Nothing discovers direct
-paths anywhere.
+packet filter, and neither can Windows, which is otherwise complete. The mobile platforms
+have no tunnel at all. Nothing discovers direct paths anywhere.
 If you need something that works this afternoon, the README names three projects that will
 serve you better today.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,9 +18,8 @@ bug and worth an issue.
 - Linux, with root. This page is written for Linux because that is where the data plane is
   complete. macOS is complete too — a tunnel, mesh names, a full-tunnel default route and
   fail-closed egress — except that it cannot enforce a network's packet filter. Windows
-  brings a tunnel up and resolves mesh names; what it cannot do yet is take a full tunnel or
-  fail closed. The mobile platforms enrol, hold an address, and report honestly that they have
-  no tunnel.
+  is complete too, by a different mechanism at every layer, and shares the one gap macOS has.
+  The mobile platforms enrol, hold an address, and report honestly that they have no tunnel.
 - Docker with the Compose plugin, for the control plane and its database.
 - A kernel that can create WireGuard interfaces. `sudo ip link add dev wgcheck type
   wireguard && sudo ip link del dev wgcheck` tells you in one line.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -76,10 +76,27 @@ there yet, so a device enrols, holds an address, and reports honestly that it ha
 rather than pretending.
 
 On Windows there **is** a tunnel as of ADR-0028, reported as `userspace`, and names resolve
-as of ADR-0029. What it cannot do yet is claim a full tunnel, fail closed, or filter — each
-reported unhonoured rather than half-applied, so a Windows device can be given a network with
-no policy and no egress group. It needs `wintun.dll` beside `meshpd.exe`; without it the
-tunnel fails with a message naming the file and where to put it.
+as of ADR-0029. It takes a full tunnel and fails closed as well, so the only thing a Windows
+device cannot do is enforce a network's packet filter — reported unhonoured rather than
+half-applied. It needs `wintun.dll` beside `meshpd.exe`; without it the tunnel fails with a
+message naming the file and where to put it.
+
+Failing closed works differently here than anywhere else, and the difference shows up exactly
+once: **there is no command that takes the lock off.** On Linux it is an nftables table and on
+macOS a pf anchor, and both can be removed by hand from a console. Windows' filtering platform
+has no command-line interface that changes anything — netsh shows its state and PowerShell has
+no cmdlet for a provider — so `meshp doctor` offers a restart instead. That is a real undo
+rather than a shrug: meshp's filters are deliberately not persistent (ADR-0030), so a reboot
+clears them exactly as it clears the other two. Starting meshpd is still the first answer and
+costs nobody their open windows.
+
+To see what meshp installed:
+
+```powershell
+netsh wfp show state
+```
+
+Its filters are under a provider named `meshp`, and nothing else in that table is meshp's.
 
 Names work differently here than anywhere else, in one way worth knowing before it surprises
 somebody. **meshp's resolver listens on port 53 on Windows**, where on Linux and macOS it


### PR DESCRIPTION
#182 made the same five documents wrong for the **fourth time today**. Windows takes a full tunnel and fails closed now; the only thing it cannot do is enforce a network's packet filter, which is the one gap it shares with macOS.

## The thing that will surprise somebody at a console

`troubleshooting.md` now says it: **there is no command that takes the Windows lock off.**

Linux has an nftables table and macOS a pf anchor, both removable by hand. Windows' filtering platform has no command-line interface that changes anything — `netsh` shows its state, PowerShell has no cmdlet for a provider — so `meshp doctor` offers a restart.

That is a real undo rather than a shrug: meshp's filters are deliberately **not persistent** (ADR-0030), so a reboot clears them exactly as it clears the other two. Starting meshpd is still the first answer offered, and costs nobody their open windows.

## Four times in a day is not an accident

Every platform slice invalidates the same five status claims and nothing checks them. `internal/platformcheck` exists because a hand-maintained list of packages does not stay in step — this is that failure in prose, and it has now happened after #175, #178, #180 and #182.

I have needed a prompt for three of the four. That is worth its own issue rather than another apology in a commit message, and I would rather file it than keep being the mechanism.