### PR TITLE
docs: state what each platform can do once, and check it against the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,17 +62,14 @@ twice. Each colliding prefix is given a mapped range allocated by the control pl
 name layer resolves to the mapped address (ADR-0020), so a technician reaches both rather
 than reaching whichever membership was written last.
 
-What does not, and matters: direct paths are unimplemented, so everything is relayed. The
-data plane is complete on Linux and on macOS — **a tunnel, names that resolve, a full-tunnel
-default route and fail-closed egress**, the last of these through a pf anchor rather than
-nftables (ADR-0026). What macOS still cannot do is enforce a network's packet filter, so a
-network with a policy reports the group unhonoured there rather than half-applying it.
+What does not, and matters: direct paths are unimplemented, so everything is relayed, and
+the data plane exists on three of the five platforms ADR-0015 commits to. **Linux, macOS and
+Windows carry traffic; Android and iOS do not yet** — a device there enrols, holds an address,
+and reports honestly that it has no tunnel rather than pretending.
 
-**Windows is complete too**, by a different route at every layer: a WinTun adapter rather
-than a utun (ADR-0028), the Name Resolution Policy Table rather than a resolver dictionary
-(ADR-0029), and meshp's own filtering-platform provider rather than a pf anchor (ADR-0030).
-Like macOS it cannot enforce a network's packet filter. The mobile platforms enrol, hold an
-address, and report honestly that they have no tunnel at all.
+Which capability each platform has, and which mechanism it reaches it by, is in
+[docs/platforms.md](docs/platforms.md). That page is checked against the code, so it is right
+rather than recent.
 
 It is public from the first commit because the design decisions are the
 interesting part and we would rather be argued with early.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,9 +32,9 @@ Out of scope: anything you deploy meshp on top of, and the deployment examples u
 `deploy/`, which are illustrative and say so.
 
 **Read this before you spend time on it.** meshp is pre-alpha and the README says not to
-deploy it. The data plane exists on Linux, macOS and Windows and nowhere else; macOS cannot
-enforce a network's packet filter, and neither can Windows. Reports are still welcome and
-will be handled as above —
+deploy it, and the data plane is on three platforms of five with gaps on each —
+[docs/platforms.md](docs/platforms.md) says which, and is checked against the code rather than
+written from memory. Reports are still welcome and will be handled as above —
 but a finding that a half-built feature is half-built is not one, and there are several of
 those in the open issues already.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Start here.
 
 | | |
 |---|---|
+| [What each platform can do](platforms.md) | Capability by capability, derived from the code rather than written from memory. |
 | [Invariants](INVARIANTS.md) | The claims this system makes, written so they can be checked by machines. |
 | [Decision records](adr/) | Why things are the way they are. |
 | [macOS laptop checks](testing/macos-laptop.md) | The things CI cannot prove, because a hosted runner never sleeps and never changes networks. |
@@ -32,10 +33,9 @@ Two worth starting with:
   tunnel drops, and why that is worth the support tickets.
 
 And the honest one: the [status section of the README](../README.md#status) says what does
-not work. The data plane is complete on Linux and on macOS — a tunnel, working names, a
-full-tunnel route and fail-closed egress, though macOS still cannot enforce a network's
-packet filter, and neither can Windows, which is otherwise complete. The mobile platforms
-have no tunnel at all. Nothing discovers direct paths anywhere.
+not work, and [what each platform can do](platforms.md) says it capability by capability —
+derived from the code, so it cannot quietly go out of date. Nothing discovers direct paths
+anywhere.
 If you need something that works this afternoon, the README names three projects that will
 serve you better today.
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -1,0 +1,57 @@
+# What each platform can do
+
+meshp has to move packets on Linux, Windows, macOS, Android and iOS (ADR-0015). Three of the
+five do. This page is where that is written down, and it is the only place — the same claim
+repeated across the README, the security policy and three guides went stale five times at a
+time, which is what [#185](https://github.com/meshpnet/meshp/issues/185) is about.
+
+<!-- BEGIN platform-table: derived from the build tags, see internal/docscheck -->
+|  | Linux | macOS | Windows | Android | iOS |
+|---|---|---|---|---|---|
+| **A tunnel** — carries traffic at all | yes | yes | yes | no | no |
+| **Names** — mesh names resolve, and only mesh names (ADR-0021) | yes | yes | yes | no | no |
+| **A full-tunnel route** — everything can be sent through the tunnel | yes | yes | yes | no | no |
+| **Fail-closed egress** — traffic is refused when the tunnel drops (ADR-0011) | yes | yes | yes | no | no |
+| **A packet filter** — a network's policy is enforced on the device (ADR-0007) | yes | no | no | no | no |
+| **Prompt recovery** — a change of network is noticed rather than waited out (#172) | yes | yes | yes | no | no |
+<!-- END platform-table -->
+
+That table is not maintained by hand. Each row is a package with an implementation per
+platform and one stub for everywhere else, and the stub's build tag says which platforms have
+it — a line the compiler already forces to be right, because an implementation that exists and
+is not excluded there does not build. `internal/docscheck` reads those tags and fails if this
+page disagrees.
+
+## What a `no` costs
+
+**A device with no tunnel still enrols**, holds an address, and reports honestly that it has
+no tunnel rather than pretending. That is deliberate: a device that can be seen and named is
+worth having before it can carry traffic.
+
+**A capability a platform lacks makes a network's requirement unhonoured, not half-applied.**
+A macOS or Windows device in a network with a packet-filter policy reports the route group
+unconverged rather than accepting the policy and enforcing none of it — the dishonesty ADR-0007
+and ADR-0011 are both written against.
+
+## Why the same capability is a different mechanism on each
+
+Nothing here is one implementation with three build tags. Each platform reaches the same
+property by whatever it actually offers:
+
+| | Linux | macOS | Windows |
+|---|---|---|---|
+| Tunnel | kernel WireGuard | `wireguard-go` on a utun | `wireguard-go` on WinTun (ADR-0028) |
+| Names | systemd-resolved | the SystemConfiguration store | the Name Resolution Policy Table (ADR-0029) |
+| Full tunnel | a firewall mark and a routing table | two routes beating a default | the same, through the IP Helper API |
+| Fail closed | an nftables table | a `pf` anchor under `com.apple` (ADR-0026) | meshp's own filtering-platform provider (ADR-0030) |
+
+The decision records are where the reasoning is. Each was written before its implementation,
+and each turned on the same question: is there a real undo — can meshp remove what it
+installed without keeping a copy of somebody else's configuration.
+
+## The two that have nothing
+
+Android and iOS. ADR-0010 records why they will wrap the official WireGuard libraries rather
+than porting this data plane, and #144 records the part CI cannot help with: a
+`NEPacketTunnelProvider` does not run in the Simulator, so the packet path there needs
+hardware whatever else is arranged.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,11 +15,9 @@ bug and worth an issue.
 
 ## What you need
 
-- Linux, with root. This page is written for Linux because that is where the data plane is
-  complete. macOS is complete too — a tunnel, mesh names, a full-tunnel default route and
-  fail-closed egress — except that it cannot enforce a network's packet filter. Windows
-  is complete too, by a different mechanism at every layer, and shares the one gap macOS has.
-  The mobile platforms enrol, hold an address, and report honestly that they have no tunnel.
+- Linux, with root. This page is written for Linux because that is where the data plane
+  has been longest; macOS and Windows carry traffic too, and
+  [what each platform can do](platforms.md) says where each still falls short.
 - Docker with the Compose plugin, for the control plane and its database.
 - A kernel that can create WireGuard interfaces. `sudo ip link add dev wgcheck type
   wireguard && sudo ip link del dev wgcheck` tells you in one line.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -75,11 +75,11 @@ sudo meshp status
 there yet, so a device enrols, holds an address, and reports honestly that it has no tunnel
 rather than pretending.
 
-On Windows there **is** a tunnel as of ADR-0028, reported as `userspace`, and names resolve
-as of ADR-0029. It takes a full tunnel and fails closed as well, so the only thing a Windows
-device cannot do is enforce a network's packet filter — reported unhonoured rather than
-half-applied. It needs `wintun.dll` beside `meshpd.exe`; without it the tunnel fails with a
-message naming the file and where to put it.
+On Windows the tunnel is a WinTun adapter, reported as `userspace` (ADR-0028). It needs
+`wintun.dll` beside `meshpd.exe`; without it the tunnel fails with a message naming the file
+and where to put it. What this platform can and cannot do is in
+[what each platform can do](platforms.md), and anything it cannot is reported unhonoured
+rather than half-applied.
 
 Failing closed works differently here than anywhere else, and the difference shows up exactly
 once: **there is no command that takes the lock off.** On Linux it is an nftables table and on
@@ -115,15 +115,18 @@ Get-DnsClientNrptRule | Where-Object { $_.NameServers -contains "127.0.0.1" }
 They are removed when a membership leaves. Nothing else in that table is meshp's, and meshp
 does not touch it: a rule it did not create carries no marker of its own and is left alone.
 
-On macOS there **is** a tunnel, and `meshp status` reports its kind as `userspace` — macOS
-has no WireGuard in the kernel, so wireguard-go moves the packets. Expect lower throughput
-and higher CPU than the same host would manage on Linux; that is the platform, not a fault.
+On macOS `meshp status` reports the tunnel's kind as `userspace` — macOS has no WireGuard in
+the kernel, so wireguard-go moves the packets. Expect lower throughput and higher CPU than
+the same host would manage on Linux; that is the platform, not a fault. The same is true of
+Windows, and [what each platform can do](platforms.md) is where the capability question is
+answered.
 Names resolve on macOS too: the agent writes a supplemental match domain into the
 SystemConfiguration store, so only this network's suffix comes to meshp and everything else
 keeps going wherever it was already going. `scutil --dns` shows it as a resolver with a
 `domain` and a high `order`, which is the thing to look at when a mesh name does not answer.
 
-macOS can also be given a full tunnel now. It has no policy routing, so the claim is made
+A full tunnel on macOS is made without policy routing, which the platform does not have, so
+the claim is made
 the way wg-quick(8) makes it on this platform: `0.0.0.0/1` and `128.0.0.0/1`, which beat any
 default route without replacing it, plus explicit routes keeping the control plane and the
 relays off the tunnel they carry.

--- a/internal/docscheck/docscheck.go
+++ b/internal/docscheck/docscheck.go
@@ -1,0 +1,174 @@
+// Package docscheck keeps the documentation's claims about platforms true.
+//
+// It exists because they kept not being. Five documents said what each platform could do, and
+// every slice that changed one made all five wrong at once — four times in a day after #175,
+// #178, #180 and #182, and once for two days after #169, when the same change updated three
+// of them and missed the fourth (#185).
+//
+// # Where the truth is
+//
+// Not in a list somebody maintains. Every capability here is a package with an
+// implementation per platform and one stub for everywhere else, and that stub's build tag
+// says which platforms have it:
+//
+//	//go:build !linux && !darwin && !windows
+//
+// That line cannot go stale, because a platform whose implementation exists and is not
+// excluded there does not compile — the tag has to be edited in the same change that adds
+// the implementation. It is the one statement of what a platform can do that the compiler
+// already checks.
+//
+// So the table is derived from those tags and the documentation is checked against it. The
+// facts are also stated once rather than five times, which is the other half of the fix: a
+// claim repeated in five places goes stale in five places.
+package docscheck
+
+import (
+	"fmt"
+	"go/build/constraint"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Capability is one thing a platform can or cannot do, and the stub that says which.
+type Capability struct {
+	// Name is how the documentation refers to it.
+	Name string
+
+	// Stub is the file whose build tag excludes every platform that has an implementation.
+	Stub string
+
+	// Why is the one-line reason a reader might want, kept beside the fact so the table can
+	// carry it without anybody writing it twice.
+	Why string
+}
+
+// Capabilities is everything the documentation claims, in the order it is presented.
+//
+// Adding one means adding a row here and a package with a stub. Nothing else: the table
+// renders itself and the test compares it against what is written down.
+var Capabilities = []Capability{
+	{"A tunnel", "internal/wglink/wglink_other.go",
+		"carries traffic at all"},
+	{"Names", "internal/resolved/unsupported.go",
+		"mesh names resolve, and only mesh names (ADR-0021)"},
+	{"A full-tunnel route", "internal/wglink/egress_other.go",
+		"everything can be sent through the tunnel"},
+	{"Fail-closed egress", "internal/egresslock/egresslock_other.go",
+		"traffic is refused when the tunnel drops (ADR-0011)"},
+	{"A packet filter", "internal/nftables/apply_other.go",
+		"a network's policy is enforced on the device (ADR-0007)"},
+	{"Prompt recovery", "internal/netwatch/watch_other.go",
+		"a change of network is noticed rather than waited out (#172)"},
+}
+
+// Platforms is what the documentation talks about, in the order it presents them.
+//
+// The mobile platforms are here because their absence is a claim too, and one people ask
+// about: ADR-0015 says meshp has to move packets on five platforms and two of them still do
+// not.
+var Platforms = []struct{ GOOS, Name string }{
+	{"linux", "Linux"},
+	{"darwin", "macOS"},
+	{"windows", "Windows"},
+	{"android", "Android"},
+	{"ios", "iOS"},
+}
+
+// Has reports whether a platform has a capability, by asking the stub's build tag.
+//
+// The stub applies exactly where there is no implementation, so a platform has the
+// capability when the tag excludes it.
+func Has(root string, c Capability, goos string) (bool, error) {
+	tag, err := buildTag(filepath.Join(root, c.Stub))
+	if err != nil {
+		return false, err
+	}
+	expr, err := constraint.Parse(tag)
+	if err != nil {
+		return false, fmt.Errorf("docscheck: %s has an unreadable build tag %q: %w", c.Stub, tag, err)
+	}
+	// Eval answers whether the stub is built for this platform. Architecture tags are not
+	// consulted: none of these stubs has one, and a capability that existed on some
+	// architectures and not others would be a different kind of claim than this table makes.
+	stubApplies := expr.Eval(func(name string) bool { return name == goos })
+	return !stubApplies, nil
+}
+
+// buildTag reads the //go:build line from a file.
+func buildTag(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("docscheck: reading %s: %w", path, err)
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		if constraint.IsGoBuild(line) {
+			return line, nil
+		}
+		if strings.HasPrefix(line, "package ") {
+			break
+		}
+	}
+	return "", fmt.Errorf("docscheck: %s has no //go:build line, so it cannot say which "+
+		"platforms lack this capability", path)
+}
+
+// Table renders what every platform can do, as the documentation carries it.
+func Table(root string) (string, error) {
+	var b strings.Builder
+	b.WriteString("|  |")
+	for _, p := range Platforms {
+		fmt.Fprintf(&b, " %s |", p.Name)
+	}
+	b.WriteString("\n|---|")
+	for range Platforms {
+		b.WriteString("---|")
+	}
+	b.WriteString("\n")
+
+	for _, c := range Capabilities {
+		fmt.Fprintf(&b, "| **%s** — %s |", c.Name, c.Why)
+		for _, p := range Platforms {
+			has, err := Has(root, c, p.GOOS)
+			if err != nil {
+				return "", err
+			}
+			if has {
+				b.WriteString(" yes |")
+			} else {
+				b.WriteString(" no |")
+			}
+		}
+		b.WriteString("\n")
+	}
+	return b.String(), nil
+}
+
+// MarkedBlock is what the documentation wraps the table in, so a check can find it and a
+// reader can see that it is not written by hand.
+const (
+	BlockStart = "<!-- BEGIN platform-table: derived from the build tags, see internal/docscheck -->"
+	BlockEnd   = "<!-- END platform-table -->"
+)
+
+// BlockIn returns what a document currently has between the markers.
+func BlockIn(document string) (string, error) {
+	start := strings.Index(document, BlockStart)
+	end := strings.Index(document, BlockEnd)
+	if start < 0 || end < 0 || end < start {
+		return "", fmt.Errorf("docscheck: no platform table between %q and %q", BlockStart, BlockEnd)
+	}
+	return strings.TrimSpace(document[start+len(BlockStart) : end]), nil
+}
+
+// SortedGOOS is every platform this table covers, for callers that want to iterate.
+func SortedGOOS() []string {
+	out := make([]string, 0, len(Platforms))
+	for _, p := range Platforms {
+		out = append(out, p.GOOS)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/docscheck/docscheck_test.go
+++ b/internal/docscheck/docscheck_test.go
@@ -1,0 +1,95 @@
+package docscheck
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The page that says what each platform can do says what the code does.
+//
+// This is the check. Not a search for sentences that might have gone stale — that would be a
+// guard nobody trusts, and a guard nobody trusts gets silenced. The table is derived from the
+// build tags on the stubs, which the compiler already forces to be right, and this asserts
+// that what is written down is what came out.
+func TestThePlatformPageMatchesTheCode(t *testing.T) {
+	const page = "../../docs/platforms.md"
+
+	raw, err := os.ReadFile(page)
+	if err != nil {
+		t.Fatalf("reading %s: %v", page, err)
+	}
+	written, err := BlockIn(string(raw))
+	if err != nil {
+		t.Fatalf("%v — if the page was restructured, the markers have to move with it "+
+			"rather than be deleted", err)
+	}
+
+	want, err := Table("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written != strings.TrimSpace(want) {
+		t.Errorf("docs/platforms.md is out of date. Replace what is between the markers with:\n\n%s",
+			want)
+	}
+}
+
+// Every capability names a stub that exists and says something.
+//
+// The table is only as good as the files it reads. A stub that was renamed or lost its build
+// tag would make a capability read as present everywhere, which is the direction that lies.
+func TestEveryCapabilityHasAStubThatSaysSomething(t *testing.T) {
+	for _, c := range Capabilities {
+		if _, err := os.Stat(filepath.Join("../..", c.Stub)); err != nil {
+			t.Errorf("%s names %s, which is not there: %v", c.Name, c.Stub, err)
+			continue
+		}
+		if _, err := buildTag(filepath.Join("../..", c.Stub)); err != nil {
+			t.Errorf("%s: %v", c.Name, err)
+		}
+	}
+}
+
+// A capability nothing has anywhere, or everything has everywhere, is a row worth a second
+// look rather than a row that is wrong — but the detection is what this rests on, so it is
+// checked against a case known to differ.
+//
+// The packet filter is Linux-only and the tunnel is not. If those ever agree, this test is
+// reading something other than the build tags.
+func TestTheDetectionDistinguishesPlatforms(t *testing.T) {
+	var filter, tunnel Capability
+	for _, c := range Capabilities {
+		switch c.Name {
+		case "A packet filter":
+			filter = c
+		case "A tunnel":
+			tunnel = c
+		}
+	}
+
+	filterOnMac, err := Has("../..", filter, "darwin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tunnelOnMac, err := Has("../..", tunnel, "darwin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filterOnMac {
+		t.Error("macOS is reported as able to enforce a packet filter, which it is not")
+	}
+	if !tunnelOnMac {
+		t.Error("macOS is reported as having no tunnel, so this is not reading the build tags")
+	}
+
+	nothingOnIOS, err := Has("../..", tunnel, "ios")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nothingOnIOS {
+		t.Error("iOS is reported as having a tunnel; the stub's build tag excludes it and " +
+			"this should have seen that")
+	}
+}

--- a/internal/docscheck/render_test.go
+++ b/internal/docscheck/render_test.go
@@ -1,0 +1,16 @@
+package docscheck
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Not a check — a way to see the table this derives, so somebody fixing a document can copy
+// what it should say rather than working it out. Run with -v.
+func TestPrintTheTable(t *testing.T) {
+	table, err := Table("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(table)
+}


### PR DESCRIPTION
Closes #185.

Five documents each said what every platform could do, so a slice that changed one made **five wrong at once** — four times in a day after #175, #178, #180 and #182, and once for two days after #169, when a single change updated three of them and missed the fourth.

## Two halves, and the first matters more

**The facts are stated once.** [`docs/platforms.md`](docs/platforms.md) carries them; the README, `SECURITY.md` and the three guides link to it and keep only claims that do not move — that three platforms of five carry traffic, and that a device without a tunnel enrols and says so.

A claim repeated in five places goes stale in five places. **Policing that is worse than removing it.**

**The table is derived, not written.** Every capability is a package with an implementation per platform and one stub for everywhere else, and the stub's build tag says which platforms have it:

```go
//go:build !linux && !darwin && !windows
```

That line **cannot** go stale: an implementation that exists and is not excluded there does not compile, so the tag is edited in the same change that adds the capability. It is the one statement of what a platform can do that the compiler already checks.

`internal/docscheck` reads those tags, renders the table, and fails if the page disagrees — printing what the page should say, so fixing it is a copy rather than a puzzle.

## What it deliberately is not

A search for sentences that might have gone stale. #185 says why: prose is not a list, a keyword check has the failure modes keyword checks have, and **a guard that cries wolf gets muted**, which is worse than none.

This one is exact. Nobody will want to silence it.

## Testing

Mutation-checked in both directions:

- a page claiming a capability the code does not have → **caught**
- code gaining a capability the page does not know about → **caught**

Plus: every capability names a stub that exists and has a build tag (a stub renamed or stripped of its tag would make a capability read as present everywhere, which is the direction that lies), and the detection is checked against a case known to differ — the packet filter is Linux-only and the tunnel is not.
