### PR TITLE
fix(web): update the page in place instead of rebuilding it every poll

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Start here.
 | [Invariants](INVARIANTS.md) | The claims this system makes, written so they can be checked by machines. |
 | [Decision records](adr/) | Why things are the way they are. |
 | [macOS laptop checks](testing/macos-laptop.md) | The things CI cannot prove, because a hosted runner never sleeps and never changes networks. |
+| [Web page checks](testing/the-page.md) | The other thing CI cannot prove: `web/app.js` is the one file here that runs in a browser and no job runs it. |
 
 ## If you are evaluating meshp
 

--- a/docs/adr/0022-web-view-in-the-control-plane.md
+++ b/docs/adr/0022-web-view-in-the-control-plane.md
@@ -92,6 +92,35 @@ runs it before `go build` — not a `package.json` appearing in a pull request.
 
 The `.gitignore` entries stay. They cost nothing and they will be right.
 
+> *2026-08-31, #146.* The second half of that trigger came up and the answer was still no,
+> which is worth writing down because it will come up again.
+>
+> The page redrew itself by replacing the whole view on every poll. That is fine for a page
+> somebody only reads and wrong for one with controls on it: it wiped a text selection every
+> five seconds, dropped focus, and could swallow a click that straddled a poll. The fix is
+> the thing a framework does — keep the nodes and update them in place — so this looked like
+> the expiry condition arriving.
+>
+> It was not, because the trigger is about hand-written updates *failing*, and this page had
+> never written one. It replaced. Doing it properly turned out to be about seventy lines: one
+> keyed reconciler over the trees the renderers already build, no components, no lifecycle,
+> no state of its own. Set against a lockfile, a Dependabot ecosystem, a CI job and a release
+> ordering change, for one page, it was not close.
+>
+> Two things it did cost, and both are the honest reading of "hand-written":
+>
+> - A node now outlives the render that built it, so a listener must not close over the data
+>   it was built beside. That is a new way to be wrong that a framework would also have,
+>   and it caught the revoke button, which would have named a device by whatever it had been
+>   called when the row was first drawn.
+> - There is nothing in CI that runs any of this. The reconciler was verified in a browser
+>   against a canned control plane, by hand — `web/testdata/fixture.py` and the checks in
+>   [docs/testing/the-page.md](../testing/the-page.md), which is a person doing what a test
+>   would do. That gap is now the strongest argument for the toolchain, and it is an argument
+>   for *tests* rather than for a build step — a smaller decision than this section
+>   anticipated, and one that should be taken on its own rather than arriving attached to a
+>   feature.
+
 ### 4. The page polls, and the server sets the interval
 
 The page calls the overview endpoint on a timer. The response carries
@@ -150,10 +179,19 @@ about and what an operator otherwise reaches for `curl` to do. Publishing an acc
 and editing DNS records are not here — they are documents somebody composes rather than
 buttons, and a form that got them subtly wrong would be worse than the command it replaced.
 
-**A minted token pauses the page.** The control plane stores only a hash, so the moment
-after minting is the only moment that secret exists; the view is replaced wholesale on every
-poll, which would wipe a half-made text selection. So polling stops while it is on screen and
-the page says that it has, which is the same rule about freshness as everywhere else.
+**A minted token is shown once and the page keeps running.** The control plane stores only
+a hash, so the moment after minting is the only moment that secret exists. It is held in the
+page's own state rather than only in the node it was drawn into, so that every later render
+draws it again until it is dismissed.
+
+*Amended 2026-08-31 (#146).* This used to say that polling stopped while a token was on
+screen, because the view was replaced wholesale on every poll and that would wipe a
+half-made text selection — the whole point of showing a secret once being that somebody
+selects it and copies it. Pausing was honest and it said so on screen, but it was a
+workaround for the redraw rather than a property of showing a secret: it covered the one
+case where something was visibly lost and not the click or the focus, and every control
+added after it would have needed its own. The page now updates in place (Decision 3), the
+selection survives, and there is nothing left to pause for.
 
 The login endpoint still refuses to mint a cookie over plaintext to anything but loopback,
 which makes configuring TLS a requirement for any deployment somebody actually browses to.
@@ -220,6 +258,8 @@ discovering `MESHP_TLS_DOMAINS`. Either way it is a step that did not exist befo
 **No build step means no TypeScript, no npm, and hand-written DOM updates.** For one page
 that is a saving. It stops being one at a size this decision does not try to predict, and
 the expiry condition in Decision 3 exists because the cost of noticing late is a rewrite.
+It also means the one file that runs in a browser is the one file nothing in CI executes;
+what holds it up is Go tests asserting the page is served and a person opening it.
 
 **The overview response is public API from its first commit.** ADR-0009 makes the
 commercial layer its consumer, which means field names and shapes carry a compatibility

--- a/docs/testing/the-page.md
+++ b/docs/testing/the-page.md
@@ -1,0 +1,70 @@
+# What the page does while somebody is using it
+
+The page polls, so it redraws itself every few seconds under whoever is reading it. Nothing
+in CI runs it: `web/app.js` is the one file in this repository that executes in a browser and
+the one file no job executes at all. What holds it up is Go tests asserting the control plane
+serves it (`internal/api/page_test.go`) and a person opening it.
+
+This is that person's list. **Run it before merging anything that touches `web/app.js`.**
+
+## Bringing it up
+
+```
+python3 web/testdata/fixture.py web
+open http://localhost:8731/#/networks/11111111-2222-3333-4444-555555555555
+```
+
+That is a canned control plane, not a real one — four devices, one route group, three audit
+events, every permission granted, and a poll every second so that waiting for one is not
+waiting. `POST /fixture` replaces the state its answers are built from:
+
+```
+curl -sX POST localhost:8731/fixture -d '{"fault":"delta"}'          # delta sorts to the top
+curl -sX POST localhost:8731/fixture -d '{"rename":{"charlie":"x"}}' # a device is renamed
+curl -sX POST localhost:8731/fixture -d '{"fault":null,"rename":{},"revoked":[]}'
+```
+
+Against a real control plane everything below still applies except the two checks that need a
+device to change while you watch.
+
+## The checks
+
+Each one is a thing the page got wrong before #146, so each one is worth repeating.
+
+1. **A selection survives a poll.** Create an enrolment token, select the token text, and
+   wait ten seconds without touching anything. The selection is still there, the header still
+   counts up, and the page has not paused. *Before #146 the page had to stop polling to make
+   this true, and said so on screen.*
+
+2. **Focus survives a poll.** Tab to a Revoke button and wait ten seconds. It still has the
+   focus ring. Then `POST /fixture` a fault onto a device below it, so the table reorders
+   under the focused row: the ring is still on the same button.
+
+3. **A row that moves is the row that moved.** With the table sorted by name, make one device
+   develop a fault. It moves to the top, gains its fault text and the `attention` class, and
+   every other row keeps the device it had — no row is rewritten to hold a different device.
+
+4. **A rename lands where it is.** Rename a device and watch its row: the name changes, the
+   row does not blink.
+
+5. **A control with a write in flight is left alone.** `POST /fixture` with
+   `{"slow_mint":4}`, then click *Create an enrolment token* and let the polls land while it
+   waits. The button still says `…` and is still disabled the whole way through. *A page that
+   hands the button back mid-write is one double-click away from a second credential nobody
+   can use.*
+
+6. **A failed write says so for long enough to read.** `POST /fixture` with
+   `{"fail_mint":true}`, then click *Create an enrolment token*. The error appears beside the
+   button, survives the polls that keep landing behind it, and takes itself off about eight
+   seconds later. The poll has to keep succeeding for this to mean anything, which is why the
+   fixture fails the write rather than going offline.
+
+7. **The picker names the network on screen.** With more than one network, switch between
+   them and check the dropdown follows, in both directions, including via the browser's back
+   button.
+
+## What this cannot tell you
+
+That the page is right about a real network. The fixture answers whatever it is asked and
+never disagrees with itself; a control plane under load, mid-migration or behind a proxy
+does. This list is about how the page behaves, not about what it says.

--- a/web/app.js
+++ b/web/app.js
@@ -38,11 +38,13 @@ function may(permission) {
 }
 
 /**
- * A token this page has just minted, held here rather than in the DOM.
+ * A token this page has just minted, held here rather than only in the DOM.
  *
- * The view is replaced wholesale by every poll, and the control plane stores only a hash, so
- * a secret drawn straight into the page would be unrecoverable within a few seconds of
- * existing — and somebody would click again, minting another credential nobody can use.
+ * The control plane stores only a hash, so the moment after minting is the only moment that
+ * secret exists. It lives in state because every render describes the whole page: a token
+ * that existed only in the node it was drawn into would be gone the first time a render
+ * did not know to draw it, and somebody would click again and mint another credential
+ * nobody can use.
  */
 let mintedToken = null;
 /** Which network that token was minted for, so moving away clears it. */
@@ -123,15 +125,159 @@ function el(tag, attrs = {}, ...children) {
 }
 
 /**
+ * Drops the children a renderer declined to produce.
+ *
+ * Nullish children go, the same way el() drops them — and for a reason that only appeared
+ * once the page had controls that are absent for some people. `replaceChildren` stringifies
+ * what it is given, so a panel that renders as null for somebody without the permission for
+ * it put the word "null" on their screen.
+ */
+function wanted(nodes) {
+  return nodes.flat().filter((node) => node !== null && node !== undefined && node !== false);
+}
+
+/**
  * Replaces the view.
  *
- * Nullish children are dropped, the same way el() drops them — and for a reason that only
- * appeared once the page had controls that are absent for some people. `replaceChildren`
- * stringifies what it is given, so a panel that renders as null for somebody without the
- * permission for it put the word "null" on their screen.
+ * For the views drawn once, in answer to something a person did: signing in, picking a
+ * network, an error where a network used to be. The polled view uses update() instead.
  */
 function show(...nodes) {
-  view.replaceChildren(...nodes.filter((node) => node !== null && node !== undefined && node !== false));
+  view.replaceChildren(...wanted(nodes));
+}
+
+// --- keeping the page still -------------------------------------------------------------
+//
+// The polled view is redrawn every few seconds on a screen somebody is reading. Replacing
+// it wholesale is the obvious way to do that, and it is what this file did while the page
+// could only be read. It stopped being tenable when the page gained controls: destroying a
+// node takes with it a half-made text selection, a click that straddles the redraw, and the
+// focus ring.
+//
+// So the polled view is updated in place. Renderers are unchanged and still describe the
+// whole page — nothing above this line knows any of it is happening — and morph() works out
+// the difference. Three things it is careful about, each of them a consequence of a node now
+// outliving the render that built it:
+//
+//   * **A list that reorders needs keys.** Devices with faults sort to the top, so the row
+//     somebody is reading moves at exactly the moment something has gone wrong. `data-key`
+//     says which row is which. Without it, one device developing a fault would rewrite every
+//     row between it and the top, which is the bug this is here to fix wearing a smaller hat.
+//   * **A listener outlives the render that attached it.** It must not close over the data
+//     it was built beside, because that data is now old. A control that acts on something
+//     reads what it is acting on at the moment it is clicked.
+//   * **A control with a write in flight is not the page's to redraw.** It has been disabled
+//     and relabelled by a click that has not finished.
+//
+// This is the hand-written reconciliation ADR-0022 §3 anticipated, in one place rather than
+// spread through twenty renderers. It is deliberately not a framework: it has no components,
+// no state and no lifecycle, and it is only ever called with a tree somebody just built.
+
+/** What identifies a node between renders, where its position is not enough. */
+function keyOf(node) {
+  return node.nodeType === Node.ELEMENT_NODE ? node.getAttribute("data-key") : null;
+}
+
+/**
+ * Something a click put on the page rather than a render — the error shown against the
+ * control that failed. It belongs to no render, so no render takes it away; it removes
+ * itself on a timer. Without this an error would last until the next poll, which is to say
+ * about long enough to notice and not long enough to read.
+ */
+function isTransient(node) {
+  return node.nodeType === Node.ELEMENT_NODE && node.hasAttribute("data-transient");
+}
+
+/** Whether a node that is here can become the one that is wanted, or has to be replaced. */
+function comparable(live, next) {
+  if (live.nodeType !== next.nodeType) return false;
+  if (live.nodeType !== Node.ELEMENT_NODE) return true;
+  return live.tagName === next.tagName && keyOf(live) === keyOf(next);
+}
+
+/** Makes the node that is here into the one that is wanted, without replacing it. */
+function morph(live, next) {
+  if (live.nodeType !== Node.ELEMENT_NODE) {
+    if (live.nodeValue !== next.nodeValue) live.nodeValue = next.nodeValue;
+    return;
+  }
+  // Left exactly as the click left it. Handing back an enabled button for an action already
+  // under way is how somebody mints a second enrolment token nobody asked for.
+  if (live.hasAttribute("data-busy")) return;
+
+  for (const attr of next.attributes) {
+    if (live.getAttribute(attr.name) !== attr.value) live.setAttribute(attr.name, attr.value);
+  }
+  for (const attr of [...live.attributes]) {
+    if (!next.hasAttribute(attr.name)) live.removeAttribute(attr.name);
+  }
+  // Which option is selected is a property, not an attribute, so the loop above cannot see
+  // it, and without it the picker would go on naming the network somebody navigated away
+  // from. Read before the children are reconciled, not after: morphChildren() takes nodes
+  // out of `next` as it uses them, so by the time it returns `next` no longer holds the
+  // option this is asking about.
+  const chosen = live.tagName === "SELECT" ? next.value : null;
+  morphChildren(live, next);
+  if (chosen !== null && live.value !== chosen) live.value = chosen;
+}
+
+/**
+ * Reconciles one element's children against what is wanted.
+ *
+ * Keyed children are found by key wherever they are, so a list that reorders moves nodes
+ * rather than rewriting them. Unkeyed children are matched by position, which is right for
+ * the fixed furniture — a heading, a label, the cells of a row — that never moves.
+ *
+ * Nodes are taken out of `next` as they are used. That tree was built by the caller for this
+ * call and is discarded afterwards.
+ */
+function morphChildren(live, next) {
+  const keyed = new Map();
+  for (let node = live.firstChild; node; node = node.nextSibling) {
+    const key = keyOf(node);
+    if (key !== null && !keyed.has(key)) keyed.set(key, node);
+  }
+
+  let cursor = live.firstChild;
+  const skipHeld = () => {
+    while (cursor && isTransient(cursor)) cursor = cursor.nextSibling;
+  };
+  skipHeld();
+
+  for (const want of [...next.childNodes]) {
+    const key = keyOf(want);
+    let match = null;
+    if (key !== null) {
+      const candidate = keyed.get(key);
+      keyed.delete(key);
+      if (candidate && comparable(candidate, want)) match = candidate;
+    } else if (cursor && keyOf(cursor) === null && comparable(cursor, want)) {
+      match = cursor;
+    }
+
+    if (match === null) {
+      live.insertBefore(want, cursor);
+      continue;
+    }
+    if (match === cursor) {
+      cursor = cursor.nextSibling;
+      skipHeld();
+    } else {
+      live.insertBefore(match, cursor);
+    }
+    morph(match, want);
+  }
+
+  while (cursor) {
+    const stale = cursor;
+    cursor = cursor.nextSibling;
+    if (!isTransient(stale)) live.removeChild(stale);
+  }
+}
+
+/** Updates the view in place. The polled path; see above for why it is not show(). */
+function update(...nodes) {
+  morphChildren(view, el("div", {}, ...wanted(nodes)));
 }
 
 // --- what counts as broken ------------------------------------------------------------
@@ -178,7 +324,7 @@ function renderVerdict(data, faultCount) {
 
   return el(
     "div",
-    { class: `panel verdict ${faultCount ? "problems" : ""}` },
+    { class: `panel verdict ${faultCount ? "problems" : ""}`, "data-key": "verdict" },
     el(
       "h1",
       {},
@@ -222,7 +368,7 @@ function renderGroup(group) {
 
     return el(
       "li",
-      { class: `carrier ${advertiser.viable ? "" : "not-viable"}` },
+      { class: `carrier ${advertiser.viable ? "" : "not-viable"}`, "data-key": advertiser.membership_id },
       dot(HEALTH_CLASS[health] || "unknown", health),
       el("span", { class: "who" }, advertiser.device_name),
       el("span", { class: "why" }, bits.join(" · ")),
@@ -231,7 +377,7 @@ function renderGroup(group) {
 
   return el(
     "div",
-    { class: "panel" },
+    { class: "panel", "data-key": group.id },
     el(
       "div",
       { class: "group" },
@@ -243,7 +389,7 @@ function renderGroup(group) {
         el(
           "ul",
           { class: "prefixes" },
-          group.prefixes.map((prefix) => el("li", {}, prefix)),
+          group.prefixes.map((prefix) => el("li", { "data-key": prefix }, prefix)),
         ),
         group.stable_egress_ip ? el("div", { class: "meta mono" }, `egress ${group.stable_egress_ip}`) : null,
       ),
@@ -287,7 +433,9 @@ function renderDevices(devices) {
 
     return el(
       "tr",
-      { class: faults.length ? "attention" : "" },
+      // Keyed, because this list reorders: a device that develops a fault sorts to the top,
+      // which is the moment somebody is most likely to be reading the row it displaced.
+      { class: faults.length ? "attention" : "", "data-key": device.membership_id },
       el(
         "td",
         {},
@@ -304,7 +452,7 @@ function renderDevices(devices) {
           ? el(
               "ul",
               { class: "faults" },
-              faults.map((fault) => el("li", {}, fault.message)),
+              faults.map((fault) => el("li", { "data-key": fault.message }, fault.message)),
             )
           : el("span", { class: "note" }, "—"),
       ),
@@ -351,29 +499,41 @@ function renderDevices(devices) {
  * Runs a write.
  *
  * `refresh` is opt-in, and the two callers below want opposite things. Revoking a device
- * must refresh: a page that changed something and kept showing the old state makes somebody
- * click twice, and on a revoke the second click is the one that does damage. Minting a token
- * must not: the poll re-renders this whole view every few seconds, so anything drawn here
- * and not held in state is gone within one tick — which for a secret shown exactly once
- * means a person clicking again and leaking another credential nobody can use.
+ * must refresh, and through start() rather than the poll timer: a page that changed
+ * something and kept showing the old state makes somebody click twice, and on a revoke the
+ * second click is the one that does damage. Minting a token must not, because it changes
+ * nothing the overview reports — the poll would fetch an identical answer and the person is
+ * mid-way through copying a secret.
+ *
+ * The control is held still while the write runs. The page updates underneath it every few
+ * seconds and would otherwise hand back an enabled button labelled as though nothing had
+ * been clicked, for an action still in flight.
  */
 async function act(node, run, { refresh = false } = {}) {
   const previous = node.textContent;
   node.disabled = true;
   node.textContent = "…";
+  node.setAttribute("data-busy", "");
   try {
     await run();
-    if (refresh) restart();
-    else {
+    node.removeAttribute("data-busy");
+    if (refresh) {
+      // Left disabled and still saying "…". The refresh is what puts this control back, and
+      // between here and there the write has happened and the button means nothing.
+      restart();
+    } else {
       node.disabled = false;
       node.textContent = previous;
     }
   } catch (err) {
+    node.removeAttribute("data-busy");
     node.disabled = false;
     node.textContent = previous;
     // Shown against the control that failed rather than at the top of the page, because
     // by the time somebody has scrolled to a device the top is not where they are looking.
-    const message = el("span", { class: "error inline" }, ` ${reason(err)}`);
+    // Marked transient so that the next update leaves it alone — an error that vanished at
+    // the next poll would last about long enough to notice and not long enough to read.
+    const message = el("span", { class: "error inline", "data-transient": "" }, ` ${reason(err)}`);
     node.after(message);
     setTimeout(() => message.remove(), 8000);
   }
@@ -383,12 +543,23 @@ async function act(node, run, { refresh = false } = {}) {
 function revokeButton(device) {
   if (!may("network.devices.revoke") || device.state !== "active") return null;
 
-  const button = el("button", { class: "danger", type: "button" }, "Revoke");
+  const button = el(
+    "button",
+    // Which device this is, on the button rather than only in the closure below. The node
+    // outlives the render that made it, so what it was built beside is not what is on the
+    // screen by the time it is clicked.
+    { class: "danger", type: "button", "data-membership": device.membership_id },
+    "Revoke",
+  );
   button.addEventListener("click", () => {
+    const membershipID = button.dataset.membership;
+    const current = lastGood ? lastGood.devices : [];
+    const named = current.find((d) => d.membership_id === membershipID) || device;
     // Confirmed, because this is not undoable: the device has to enrol again with a fresh
     // token, and its addresses go back to the pool. A one-click version of that beside a
-    // device somebody is already worried about is a trap.
-    if (!window.confirm(`Revoke ${device.device_name}? It will lose access immediately and must enrol again.`)) {
+    // device somebody is already worried about is a trap. It names the device as it is
+    // called now — a confirmation naming the wrong one is worse than no confirmation.
+    if (!window.confirm(`Revoke ${named.device_name}? It will lose access immediately and must enrol again.`)) {
       return;
     }
     act(
@@ -396,7 +567,7 @@ function revokeButton(device) {
       () =>
         api(
           `/api/v1/networks/${encodeURIComponent(currentNetworkID())}` +
-            `/devices/${encodeURIComponent(device.membership_id)}`,
+            `/devices/${encodeURIComponent(membershipID)}`,
           { method: "DELETE" },
         ),
       { refresh: true },
@@ -424,22 +595,19 @@ function renderAddDevice() {
           body: JSON.stringify({ max_uses: 1, expires_in_seconds: 3600 }),
         },
       );
-      // Into module state, not into the DOM. This view is replaced wholesale by the next
-      // poll, and the control plane stores only a hash — so a token drawn straight into
-      // the page would be unrecoverable within a few seconds of existing.
+      // Into module state, not only into the DOM, so that every render from here draws it.
       mintedToken = body.token;
-      // Polling stops while it is on screen. Every poll replaces this view wholesale, which
-      // would wipe a half-made text selection — and the whole point of showing a secret once
-      // is that somebody selects it and copies it. A dashboard that refreshes out from under
-      // the one thing it asked you to copy is worse than one that pauses and says so.
-      stopPolling();
+      // Drawn now rather than at the next poll: this response is the only place the token
+      // exists. The page keeps polling underneath it — the selection somebody is making in
+      // order to copy it survives an update, which is the whole reason updates happen in
+      // place (see "keeping the page still").
       renderFromLastGood();
     });
   });
 
   return el(
     "div",
-    { class: "panel" },
+    { class: "panel", "data-key": "add-device" },
     el("h3", {}, "Add a device"),
     button,
     mintedToken ? renderMintedToken() : null,
@@ -451,8 +619,7 @@ function renderMintedToken() {
   const done = el("button", { class: "quiet", type: "button" }, "Done");
   done.addEventListener("click", () => {
     mintedToken = null;
-    // Which also starts the page updating again.
-    restart();
+    renderFromLastGood();
   });
 
   return el(
@@ -470,9 +637,6 @@ function renderMintedToken() {
       "On the device: ",
       el("span", { class: "mono" }, `meshp up --token ${mintedToken}`),
     ),
-    // Said rather than left to be noticed. The page's own rule is that it never lies about
-    // its freshness, and it is deliberately not updating right now.
-    el("p", { class: "note" }, "This page has paused while the token is shown."),
     done,
   );
 }
@@ -497,18 +661,20 @@ function renderOverview(data, networks, history) {
     return a.device_name.localeCompare(b.device_name);
   });
 
-  show(
+  // Keyed section by section, so that a panel which comes and goes — the one that mints a
+  // token exists only for somebody who may mint one — moves nothing else on the page.
+  update(
     renderNetworkBar(data, networks),
     renderVerdict(data, data.fault_count || 0),
-    el("h2", {}, "What is carried, and by what"),
+    el("h2", { "data-key": "carried-heading" }, "What is carried, and by what"),
     data.route_groups.length
-      ? el("div", {}, data.route_groups.map(renderGroup))
-      : el("div", { class: "panel note" }, "This network has no route groups."),
-    el("h2", {}, "Devices"),
+      ? el("div", { "data-key": "groups" }, data.route_groups.map(renderGroup))
+      : el("div", { class: "panel note", "data-key": "groups" }, "This network has no route groups."),
+    el("h2", { "data-key": "devices-heading" }, "Devices"),
     renderAddDevice(),
     el(
       "div",
-      { class: "panel" },
+      { class: "panel", "data-key": "devices" },
       renderDevices(devices),
       data.devices_truncated
         ? el(
@@ -518,7 +684,7 @@ function renderOverview(data, networks, history) {
           )
         : null,
     ),
-    el("h2", {}, "What has happened"),
+    el("h2", { "data-key": "history-heading" }, "What has happened"),
     renderHistory(history),
   );
 }
@@ -539,10 +705,14 @@ const ACTIONS = {
 /** The audit trail, newest first. */
 function renderHistory(history) {
   if (history === null) {
-    return el("div", { class: "panel note" }, "The history could not be read just now.");
+    return el("div", { class: "panel note", "data-key": "history" }, "The history could not be read just now.");
   }
   if (!history.length) {
-    return el("div", { class: "panel note" }, "Nothing has been recorded for this network yet.");
+    return el(
+      "div",
+      { class: "panel note", "data-key": "history" },
+      "Nothing has been recorded for this network yet.",
+    );
   }
 
   const rows = history.map((event) => {
@@ -555,7 +725,7 @@ function renderHistory(history) {
 
     return el(
       "li",
-      { class: "event" },
+      { class: "event", "data-key": event.id },
       el("span", { class: "when mono" }, new Date(event.at).toLocaleString()),
       el("span", { class: "who" }, event.actor_label || event.actor_kind),
       el("span", {}, ACTIONS[event.action] || event.action),
@@ -565,7 +735,7 @@ function renderHistory(history) {
 
   return el(
     "div",
-    { class: "panel" },
+    { class: "panel", "data-key": "history" },
     el("ul", { class: "events" }, rows),
     el(
       "p",
@@ -580,7 +750,7 @@ function renderNetworkBar(data, networks) {
   for (const network of networks) {
     const option = el(
       "option",
-      { value: network.id },
+      { value: network.id, "data-key": network.id },
       `${network.organization_slug} / ${network.slug}`,
     );
     if (network.id === data.network.id) option.selected = true;
@@ -592,7 +762,7 @@ function renderNetworkBar(data, networks) {
 
   return el(
     "div",
-    { class: "panel picker" },
+    { class: "panel picker", "data-key": "picker" },
     el("label", { for: "network" }, "Network"),
     select,
     el("span", { class: "note" }, `state version ${data.network.state_version}`),

--- a/web/testdata/fixture.py
+++ b/web/testdata/fixture.py
@@ -1,0 +1,147 @@
+"""A canned control plane, so the page can be driven in a real browser.
+
+    python3 web/testdata/fixture.py web && open http://localhost:8731/
+
+Serves web/ and just enough of the API for app.js to render an overview, mint an enrolment
+token and revoke a device. Nothing here is a control plane: every answer is made up, the
+cookie is not checked, and it exists so that somebody changing app.js can watch the page do
+what it does. The checks worth running are in docs/testing/the-page.md.
+
+Two things make it useful rather than merely static. It polls once a second rather than
+every five, and `POST /fixture` replaces the state the answers are built from — so a check
+can make a device develop a fault, which sorts it to the top of the table, or rename one,
+between two polls of a page somebody is looking at.
+
+There is deliberately no test runner here. ADR-0022 §3 keeps Node out of this repository,
+and running these checks is a person opening a browser.
+"""
+import json, os, sys, threading, time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+ROOT = os.path.abspath(sys.argv[1])
+NET = "11111111-2222-3333-4444-555555555555"
+NAMES = ["alpha", "bravo", "charlie", "delta"]
+IDS = {n: "%s-0000-0000-0000-00000000000%d" % ("a" * 8, i) for i, n in enumerate(NAMES)}
+
+state = {"fault": None, "rename": {}, "revoked": [], "tick": 0, "fail_mint": False, "slow_mint": 0}
+lock = threading.Lock()
+
+
+def device(name):
+    mid = IDS[name]
+    faults = []
+    if state["fault"] == name:
+        faults = [{"code": "unapplied", "message": "has not applied its configuration"}]
+    return {
+        "membership_id": mid,
+        "device_name": state["rename"].get(name, name),
+        "state": "revoked" if name in state["revoked"] else "active",
+        "connected": True,
+        "applied_version": 7,
+        "reported_version": 7,
+        "address_v4": "100.80.0.%d" % (NAMES.index(name) + 2),
+        "tunnel": {"peers": 3, "talking": 3 - len(faults), "relayed": 0},
+        "faults": faults,
+    }
+
+
+def overview():
+    devices = [device(n) for n in NAMES]
+    return {
+        "as_of": "2026-08-31T12:00:0%dZ" % (state["tick"] % 10),
+        "network": {"id": NET, "slug": "hq", "name": "hq", "state_version": 12},
+        "devices": devices,
+        "devices_truncated": False,
+        "route_groups": [{
+            "id": "99999999-0000-0000-0000-000000000001",
+            "slug": "office", "name": "office", "kind": "subnet",
+            "selection_mode": "priority", "prefixes": ["10.0.0.0/24"], "faults": [],
+            "advertisers": [{
+                "membership_id": IDS[n], "device_name": n, "priority": i, "weight": 1,
+                "admin_state": "enabled", "health": "healthy", "connected": True,
+                "viable": True, "in_use_by": 2 - i,
+            } for i, n in enumerate(NAMES[:2])],
+        }],
+        "fault_count": sum(len(d["faults"]) for d in devices),
+        "poll_after_seconds": 1,
+    }
+
+
+AUDIT = {"events": [
+    {"id": "3", "at": "2026-08-31T11:00:00Z", "actor_kind": "user",
+     "actor_label": "aswin", "action": "device.enrolled", "metadata": {}},
+    {"id": "2", "at": "2026-08-31T10:00:00Z", "actor_kind": "device",
+     "actor_label": "alpha", "action": "route.switched", "metadata": {"reason": "probe failed"}},
+    {"id": "1", "at": "2026-08-31T09:00:00Z", "actor_kind": "user",
+     "actor_label": "aswin", "action": "policy.published", "metadata": {}},
+]}
+
+NETWORKS = {"networks": [{"id": NET, "slug": "hq", "organization_slug": "acme",
+                          "active_device_count": len(NAMES)}]}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def send_json(self, body, code=200):
+        raw = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_GET(self):
+        path = urlparse(self.path).path
+        with lock:
+            if path.endswith("/overview"):
+                state["tick"] += 1
+                return self.send_json(overview())
+            if path.endswith("/audit"):
+                return self.send_json(AUDIT)
+            if path == "/api/v1/me/permissions":
+                return self.send_json({"permissions": [], "unlimited": True})
+            if path == "/api/v1/networks":
+                return self.send_json(NETWORKS)
+        name = "index.html" if path in ("/", "") else path.lstrip("/")
+        try:
+            with open(os.path.join(ROOT, name), "rb") as fh:
+                raw = fh.read()
+        except OSError:
+            return self.send_json({"error": "not_found"}, 404)
+        kind = {"js": "text/javascript", "css": "text/css"}.get(name.rsplit(".", 1)[-1], "text/html")
+        self.send_response(200)
+        self.send_header("content-type", kind + "; charset=utf-8")
+        self.send_header("content-length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_POST(self):
+        raw = self.rfile.read(int(self.headers.get("content-length") or 0))
+        if self.path == "/fixture":
+            with lock:
+                state.update(json.loads(raw or b"{}"))
+            return self.send_json(state)
+        if self.path.endswith("/enrollment-tokens"):
+            # So that a failing write can be watched without taking the page offline with it:
+            # the poll keeps succeeding, which is the case the error has to survive.
+            if state["fail_mint"]:
+                return self.send_json({"error": "boom", "message": "the control plane said no"}, 500)
+            # And so that a slow one can be watched: several polls land while the button is
+            # still waiting, which is the case the button has to survive.
+            time.sleep(state["slow_mint"])
+            return self.send_json({"token": "mp_" + "k" * 40})
+        self.send_json({"error": "not_found"}, 404)
+
+    def do_DELETE(self):
+        with lock:
+            mid = self.path.rsplit("/", 1)[-1]
+            for name, known in IDS.items():
+                if known == mid:
+                    state["revoked"].append(name)
+        self.send_json({"ok": True})
+
+
+ThreadingHTTPServer(("127.0.0.1", 8731), Handler).serve_forever()


### PR DESCRIPTION
Closes #146.

## What was wrong

`renderOverview` called `show()`, which called `view.replaceChildren()`. Every node on the page was destroyed and recreated on every poll — every five seconds by default.

That was harmless while the page could only be read. Since #138 it has controls on it, and the issue lists what that costs: a text selection wiped, a click lost if a poll lands between mousedown and mouseup, focus gone. Minting an enrolment token had to **stop the poll** to work around the first of those, which covered the one case where something was visibly lost and neither of the others — and every future control would have needed its own pause.

## What this does

The polled view is reconciled against the tree the renderers already build. `show()` stays for the views drawn once in answer to something a person did — sign in, the picker, an error where a network used to be. `update()` is the polled path, and `morph()` works out the difference. **No renderer changed how it describes the page**; they gained `data-key` on the lists that reorder and nothing else.

About seventy lines of code. No components, no lifecycle, no state of its own.

Three things fall out of a node now outliving the render that built it. Each was a real bug on the way here, and each is verified below:

- **A listener must not close over the data it was built beside.** The revoke button named the device by whatever it had been called when its row was first drawn. It reads the name at the moment it is clicked.
- **A control with a write in flight is not the page's to redraw.** Without that, a poll landing mid-mint handed back an enabled button for a request still in the air — a second credential nobody can use, one double-click away. (This one pre-dates the change: the old wholesale redraw did it too.)
- **An error shown beside a control that failed belongs to no render**, so no render takes it away. It used to last until the next poll: long enough to notice, not long enough to read.

**The pause is gone.** The selection survives a poll now, which is what it was there to protect.

## ADR-0022

§3 says the trigger to revisit "no build step" is a second view, **or the day hand-written DOM updates start producing the bugs a framework exists to prevent**. That came up, and the answer was still no — the trigger is about hand-written updates *failing*, and this page had never written one, it replaced. Set against a lockfile, a Dependabot ecosystem, a CI job and a release-ordering change, for one page, it was not close. That reasoning is now in the ADR so it does not have to be had again from scratch.

§5's "a minted token pauses the page" is amended, with what it used to say and why it was a workaround rather than a property of showing a secret.

## Verification

`web/app.js` is the one file in this repository that runs in a browser and the one file no CI job runs. That does not change here, and pretending otherwise would be worse than saying so — so what was done instead is committed: `web/testdata/fixture.py` is a canned control plane (four devices, a route group, a poll every second, and a `POST /fixture` that can make a device develop a fault or be renamed between two polls), and `docs/testing/the-page.md` is the list of checks to run against it.

Every check below was run in a real browser against that fixture, on the commit in this PR:

| | |
|---|---|
| 107 of 108 nodes survive three polls | the one that goes is a `—` placeholder replaced by a real fault list; 8 nodes arrive |
| a 43-character selection in a minted token | intact after three polls, same `<code>` node, page still says "updated just now" |
| focus on a Revoke button | still there after the table reorders under it |
| a device developing a fault | sorts to the top; 0 of 4 rows rewritten to hold a different device |
| a rename | lands in the row that is already there |
| a 4-second mint | button stays `…`/disabled across three polls, then returns with the token |
| a failed mint | error survives 4s of successful polling, gone at 8s |
| the network picker | follows the hash in both directions, same `<select>` node |

### Mutation testing

Four deliberate breakages, to check those are measurements and not decorations:

1. **`update()` put back to `replaceChildren`** → 0 of 107 nodes kept, focus lost, selection 43 → 0. That is #146 reproduced.
2. **device rows lose `data-key`** → all 4 rows reused for a *different* device when the table reorders.
3. **the in-flight guard removed** → mid-write the mint button reads "Create an enrolment token" and is **enabled**.
4. **the revoke button reads its closure** → the row says `charlie-renamed`, the confirmation says `Revoke charlie?`.

One bug was found this way and is fixed here rather than shipped: the `<select>` carve-out read `next.value` *after* reconciling children, by which point the option it was asking about had already been moved out of `next`. The picker kept naming the network you had navigated away from.

## Not in scope

The toolchain decision. The gap this PR documents is the strongest argument yet for one, and it is an argument for **tests** rather than for a build step — a smaller decision than ADR-0022 §3 anticipated, and one worth taking on its own rather than attached to a bug fix.