### PR TITLE
fix(deploy): give the control plane somewhere to keep the certificates it obtains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,10 @@ MESHP_ADMIN_TOKEN=
 # MESHP_TLS_CERT=/etc/meshp/tls/fullchain.pem
 # MESHP_TLS_KEY=/etc/meshp/tls/privkey.pem
 # MESHP_TLS_DOMAINS=control.example.com
-# MESHP_TLS_CACHE_DIR=/var/lib/meshp/certs
+# Where obtained certificates are kept. Defaults to the systemd unit's StateDirectory, so
+# leave it alone unless you want them elsewhere — and if you move them, make sure the unit
+# can write there.
+# MESHP_TLS_CACHE_DIR=/var/lib/meshp-control/certs
 
 # --- Relay ----------------------------------------------------------------
 # Where this deployment's relays are, as id=host:port[,host:port][;id=...]. Without

--- a/cmd/meshp-control/main.go
+++ b/cmd/meshp-control/main.go
@@ -55,7 +55,7 @@ func main() {
 			"path to the TLS certificate's private key")
 		tlsDomains = flag.String("tls-domains", os.Getenv("MESHP_TLS_DOMAINS"),
 			"comma-separated names to obtain certificates for automatically (Let's Encrypt)")
-		tlsCacheDir = flag.String("tls-cache-dir", envOr("MESHP_TLS_CACHE_DIR", "/var/lib/meshp/certs"),
+		tlsCacheDir = flag.String("tls-cache-dir", envOr("MESHP_TLS_CACHE_DIR", tlsconf.DefaultCacheDir),
 			"where automatically obtained certificates are kept between restarts")
 		databaseURL = flag.String("database-url", os.Getenv("MESHP_DATABASE_URL"), "PostgreSQL connection string")
 		secretKey   = flag.String("secret-key", os.Getenv("MESHP_SECRET_KEY"), "master secret for enrolment challenges and sessions")

--- a/deploy/systemd/meshp-control.service
+++ b/deploy/systemd/meshp-control.service
@@ -44,5 +44,15 @@ MemoryDenyWriteExecute=yes
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
+# The one writable directory, and the reason this unit needs one: ProtectSystem=strict leaves
+# the whole filesystem read-only, and a control plane obtaining its own certificates has to
+# save them. Without this it starts, binds 443 because of the capability above, and then
+# fails on the first request with a read-only filesystem — or, worse, re-issues on every
+# restart until Let's Encrypt refuses.
+#
+# meshp-control rather than meshp: /var/lib/meshp belongs to the agent, and a host running
+# both would otherwise have systemd hand one service's directory to the other.
+StateDirectory=meshp-control
+
 [Install]
 WantedBy=multi-user.target

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -197,12 +197,20 @@ or have it obtain one from Let's Encrypt:
 
 ```
 MESHP_TLS_DOMAINS=control.example.com
-MESHP_TLS_CACHE_DIR=/var/lib/meshp/certs
 ```
 
-The automatic path needs port 80 reachable for the challenge and a cache directory that
-survives restarts — without one you will re-issue on every restart and meet a rate limit at
-the worst time.
+**Port 443 is enough.** The challenge is answered over TLS itself (`TLS-ALPN-01`), so a host
+that only accepts 443 can still obtain and renew a certificate — which is worth knowing,
+because some providers firewall port 80 by default and the failure would otherwise look like
+a DNS problem. Port 80 is used when it is reachable, both for the other challenge type and to
+redirect anyone who types `http://`.
+
+**The certificate has to be saved somewhere that survives a restart**, or every restart asks
+Let's Encrypt again and a crash loop exhausts a week's rate limit in an afternoon. The unit
+below handles this: `StateDirectory=meshp-control` gives the service `/var/lib/meshp-control`,
+which is where `MESHP_TLS_CACHE_DIR` points by default. Set it only if you want it elsewhere —
+and if you do, make sure the unit can write there, because `ProtectSystem=strict` leaves
+everything else read-only.
 
 Terminating TLS at a reverse proxy instead is a perfectly good choice. The systemd unit does
 not force either way; it just has `CAP_NET_BIND_SERVICE` so it can hold 443 without running
@@ -233,7 +241,7 @@ direct paths yet, so **a deployment with no relay has no data plane**.
 ```bash
 sudo install -m 0755 meshp-control /usr/local/bin/
 sudo useradd --system --no-create-home meshp
-sudo install -d -o meshp -g meshp /etc/meshp /var/lib/meshp
+sudo install -d -o meshp -g meshp /etc/meshp
 sudo install -m 0600 -o meshp -g meshp control.env /etc/meshp/control.env
 sudo install -m 0644 systemd/meshp-control.service /etc/systemd/system/
 sudo systemctl enable --now meshp-control

--- a/internal/deploycheck/deploycheck_test.go
+++ b/internal/deploycheck/deploycheck_test.go
@@ -1,0 +1,135 @@
+// Package deploycheck holds one test: that the units in deploy/systemd can do what the
+// binaries they start will actually try to do.
+//
+// It exists because they could not. The control plane's unit carried
+// CAP_NET_BIND_SERVICE — put there so it could hold 443 and serve HTTPS — alongside
+// ProtectSystem=strict, which leaves the whole filesystem read-only, and no StateDirectory.
+// So a self-hoster following docs/self-hosting.md set MESHP_TLS_DOMAINS and got a control
+// plane that bound 443 and then could not save the certificate it was issued.
+//
+// Nothing caught it because the two halves live in different files and neither is Go. The
+// unit is data to the compiler and the default is a string in a flag call, and they were
+// only ever checked against each other by somebody deploying. This is that person, once,
+// written down.
+package deploycheck
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/meshpnet/meshp/internal/tlsconf"
+)
+
+// unitDir is deploy/systemd, from this package.
+const unitDir = "../../deploy/systemd"
+
+// A certificate the control plane cannot save is worse than one it never asked for: autocert
+// obtains a new one on every restart, and Let's Encrypt's rate limits are low enough that a
+// crash loop exhausts a week's allowance in an afternoon.
+func TestTheControlPlaneCanWriteTheCertificatesItObtains(t *testing.T) {
+	unit := readUnit(t, "meshp-control.service")
+
+	if !strings.Contains(unit, "ProtectSystem=strict") {
+		// The hardening is what makes this a question at all. If it is ever relaxed, this
+		// test is measuring nothing and should be reconsidered rather than left passing.
+		t.Fatal("the unit no longer sets ProtectSystem=strict, so this test proves nothing")
+	}
+
+	writable := stateDirectories(unit)
+	if len(writable) == 0 {
+		t.Fatal("the unit declares no StateDirectory, so nothing under /var is writable and " +
+			"an automatically obtained certificate cannot be saved")
+	}
+
+	if !underAny(tlsconf.DefaultCacheDir, writable) {
+		t.Errorf("certificates default to %s, which is not inside any of the unit's writable "+
+			"directories %v — the control plane will bind 443 and then fail to save what it "+
+			"is issued", tlsconf.DefaultCacheDir, writable)
+	}
+}
+
+// The two services are separate programs run by separate units, and systemd gives a
+// StateDirectory to the user its unit names. One writing inside the other's directory works
+// on a host running only one of them and breaks on a host running both — which is what a
+// small self-hoster does, and what this project's own deployment does.
+func TestTheControlPlaneDoesNotWriteIntoTheAgentsStateDirectory(t *testing.T) {
+	agentState := stateDirFlag(t, readUnit(t, "meshpd.service"))
+
+	if under(tlsconf.DefaultCacheDir, agentState) {
+		t.Errorf("certificates default to %s, which is inside the agent's state directory %s; "+
+			"a host running both services has one writing into the other's",
+			tlsconf.DefaultCacheDir, agentState)
+	}
+}
+
+func readUnit(t *testing.T, name string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(unitDir, name))
+	if err != nil {
+		t.Fatalf("reading %s: %v", name, err)
+	}
+	return string(raw)
+}
+
+// stateDirectories returns the absolute paths systemd will make writable.
+//
+// StateDirectory= names are relative to /var/lib and may be space-separated.
+func stateDirectories(unit string) []string {
+	var dirs []string
+	for _, line := range directives(unit, "StateDirectory") {
+		for _, name := range strings.Fields(line) {
+			dirs = append(dirs, filepath.Join("/var/lib", name))
+		}
+	}
+	return dirs
+}
+
+// stateDirFlag reads the --state-dir the agent's unit passes, which is the directory the
+// agent owns whatever the binary's own default happens to be.
+func stateDirFlag(t *testing.T, unit string) string {
+	t.Helper()
+	for _, line := range directives(unit, "ExecStart") {
+		fields := strings.Fields(line)
+		for i, f := range fields {
+			if f == "--state-dir" && i+1 < len(fields) {
+				return fields[i+1]
+			}
+		}
+	}
+	t.Fatal("the agent's unit no longer passes --state-dir, so this test cannot tell which " +
+		"directory belongs to it")
+	return ""
+}
+
+// directives returns the values of every occurrence of a key, ignoring comments.
+func directives(unit, key string) []string {
+	var out []string
+	for _, line := range strings.Split(unit, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if value, ok := strings.CutPrefix(line, key+"="); ok {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+// under reports whether path is dir or inside it. Compared as path elements, so
+// /var/lib/meshp-control is not "inside" /var/lib/meshp.
+func under(path, dir string) bool {
+	rel, err := filepath.Rel(dir, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, "../")
+}
+
+func underAny(path string, dirs []string) bool {
+	for _, dir := range dirs {
+		if under(path, dir) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tlsconf/tlsconf.go
+++ b/internal/tlsconf/tlsconf.go
@@ -18,6 +18,20 @@ import (
 	"golang.org/x/crypto/acme/autocert"
 )
 
+// DefaultCacheDir is where automatically obtained certificates are kept.
+//
+// Deliberately not /var/lib/meshp, which is the *agent's* state directory: a host running
+// both — which is what a small self-hoster does, and what this project's own deployment
+// does — would have the control plane writing certificates into a directory the agent owns
+// and systemd hands to a different user. Two services, two directories.
+//
+// Exported because the systemd unit has to make it writable: the unit sets
+// ProtectSystem=strict, so nothing under /var is writable without a matching
+// StateDirectory=, and a certificate that cannot be saved is a deployment that asks Let's
+// Encrypt again on every restart until it is rate-limited. internal/deploycheck holds the
+// unit to this value rather than trusting the two to be edited together.
+const DefaultCacheDir = "/var/lib/meshp-control/certs"
+
 // Options are the ways to obtain a certificate. At most one may be set.
 type Options struct {
 	// CertFile and KeyFile are a certificate and its private key on disk.


### PR DESCRIPTION
Found by deploying meshp, not by reading it.

## The bug

`deploy/systemd/meshp-control.service` could not serve automatic TLS. It carries `CAP_NET_BIND_SERVICE`, put there specifically so it can hold 443 — and `ProtectSystem=strict`, which leaves the whole filesystem read-only — and no `StateDirectory`. So a self-hoster following `docs/self-hosting.md` sets `MESHP_TLS_DOMAINS`, watches it bind 443, and then hits a read-only filesystem the moment autocert tries to save the certificate it was issued.

Confirmed on a real host with the exact combination the unit uses, rather than reasoned about:

```
$ systemd-run --property=ProtectSystem=strict --uid=meshp --wait --pipe /bin/mkdir -p /var/lib/meshp-probe/certs
/bin/mkdir: cannot create directory '/var/lib/meshp-probe': Read-only file system
```

The consequence is the worse of the two failure modes autocert has: not "no certificate", but "a new certificate on every restart", until Let's Encrypt's rate limit refuses and the deployment has none at all.

## The second bug, underneath it

Certificates defaulted to `/var/lib/meshp/certs`. `/var/lib/meshp` is the **agent's** state directory — `cmd/meshpd/main.go` returns it, and `deploy/systemd/meshpd.service` passes it as `--state-dir`. On a host running both, which is what a small self-hoster does, the control plane writes inside a directory systemd hands to a different service.

Naming a `StateDirectory` of `meshp` would have fixed the first bug and entrenched this one.

## The fix

- `StateDirectory=meshp-control` in the unit.
- The default moves to `/var/lib/meshp-control/certs` to match, exported as `tlsconf.DefaultCacheDir` rather than written twice.
- `docs/self-hosting.md` and `.env.example` updated.

Nothing that already works breaks: today the default cannot work under the shipped unit, so nobody is relying on it.

## A third thing, in the docs

`docs/self-hosting.md` said the automatic path "needs port 80 reachable for the challenge". It does not. autocert answers **TLS-ALPN-01 on 443**, which is how the deployment this was found on obtained its certificate — port 80 is firewalled there by the provider and unreachable from the internet:

```
$ curl -I http://control.meshp.net/
curl: (28) Failed to connect ... after 75004 ms
$ echo | openssl s_client -connect control.meshp.net:443 ... | openssl x509 -noout -issuer
issuer=C=US, O=Let's Encrypt, CN=YE1
```

Worth stating explicitly, because a provider that firewalls 80 by default would otherwise produce a failure that looks like DNS.

## The guard

`internal/deploycheck` reads the units as data and asserts that what the binaries will try to do is something the units permit:

1. The default cache directory is inside one of the unit's `StateDirectory` entries — and it fails loudly if `ProtectSystem=strict` is ever removed, since the test would then be measuring nothing.
2. The default cache directory is **not** inside the path `meshpd.service` passes as `--state-dir`.

Both mutation-tested. Removing `StateDirectory` from the unit — the bug exactly as it shipped:

```
the unit declares no StateDirectory, so nothing under /var is writable and an
automatically obtained certificate cannot be saved
```

Putting the default back to `/var/lib/meshp/certs` fails both:

```
certificates default to /var/lib/meshp/certs, which is not inside any of the unit's
writable directories [/var/lib/meshp-control]
certificates default to /var/lib/meshp/certs, which is inside the agent's state
directory /var/lib/meshp
```

This is the same shape as `envcheck` and `docscheck`: two artefacts that must agree, in different languages, with nothing checking them. The unit is data to the compiler and the default was a string in a `flag.String` call, and they were only ever compared by somebody deploying.