### PR TITLE
docs(testing): the first results for the macOS laptop checks, including a failure

### DIFF
--- a/docs/testing/macos-laptop.md
+++ b/docs/testing/macos-laptop.md
@@ -159,4 +159,42 @@ run.
 
 | Date | Build | macOS | 1 Sleep | 2 Networks | 3 kill -9 | 4 Other VPN | 5 connected_since | Notes |
 |---|---|---|---|---|---|---|---|---|
-| | | | | | | | | |
+| 2026-08-31 | v0.1.0-57-geb4d461 | 26.0 (25A354), MacBookPro17,1 | pass | not run | not run | not run | **fail** | First run of this document. 2–4 need an egress route group that this deployment does not have. See below. |
+
+### 2026-08-31, v0.1.0-57-geb4d461
+
+Against `control.meshp.net` over the internet, relay-only paths, no route groups configured.
+
+**1 Sleep and wake — pass.** Lid shut at 13:23:44Z and opened around 13:33:30Z, so nearly ten
+minutes asleep. The agent re-established its control channel at 13:34:53Z with no help, well
+inside the one-minute reconcile interval, and traffic was flowing again by 13:35:15Z. The
+tunnel had kept carrying packets throughout, which is what WireGuard being stateless UDP buys
+and also what makes this check worth doing from both ends: the data plane working proves
+nothing about whether the device is still being configured.
+
+Worth knowing for whoever runs this next: for about ninety seconds after waking, `meshp status`
+still reported `connected since` the pre-sleep session, which by then the control plane had
+already dropped. It is not a lie so much as a thing not yet noticed, and it corrects itself
+within the interval — but somebody debugging in that window will be shown a session that no
+longer exists, and should look at the server rather than believing it.
+
+**5 `connected_since` after sleep — fail.** The bound is wrong, not the behaviour. The control
+plane went on reporting the laptop as connected for roughly **9m35s** after the lid closed,
+against a `readIdleTimeout` of **90 seconds** in `internal/session/server.go`. It did clear
+eventually, so nothing is stuck; what fails is this check's second clause, that the bound is
+what the code says it is.
+
+For those ten minutes the overview endpoint, the page, and anything built on that API would
+have shown a device in a closed bag as connected and healthy. That is the failure ADR-0022 §4
+is about — a monitoring view that lies about when it last heard anything — arriving through
+the server rather than through the page.
+
+The likely cause, which is a hypothesis and not a measurement: macOS keeps the socket alive
+through light sleep, so reads keep succeeding and the deadline never trips until the machine
+sleeps properly. If that is right, a read deadline is the wrong mechanism on a laptop and
+meshp needs liveness it drives itself. Somebody should establish which it is before choosing a
+fix — the number to beat is 90 seconds, and the observed one is six times that.
+
+**2, 3 and 4 — not run.** All three need a route group carrying `0.0.0.0/0` assigned to this
+device with `fail_closed` enforced, and the deployment this was run against has no route groups
+at all. They are not failures and they are not passes; nothing exercised them.


### PR DESCRIPTION
Closes nothing. #160 stays open — three of its five checks still have no data.

## The table is not empty any more

`docs/testing/macos-laptop.md` has had an empty results table since it was written, because it needs a laptop and a control plane reachable over the internet. Both exist as of today (#192), so it was run.

| Date | Build | macOS | 1 Sleep | 2 Networks | 3 kill -9 | 4 Other VPN | 5 `connected_since` |
|---|---|---|---|---|---|---|---|
| 2026-08-31 | `v0.1.0-57-geb4d461` | 26.0, MacBookPro17,1 | pass | not run | not run | not run | **fail** |

## Check 1 — pass

Lid shut at `13:23:44Z`, opened around `13:33:30Z`. Control channel re-established at `13:34:53Z` with nothing touched, and traffic confirmed at `13:35:15Z`. Comfortably inside the one-minute reconcile interval.

The tunnel carried packets the whole time, which is what stateless UDP buys — and is exactly why this check is written to be run from both ends. A working data plane proves nothing about whether the device is still receiving configuration.

One thing recorded for whoever runs it next: for about ninety seconds after waking, `meshp status` still reported `connected since` a session the control plane had already dropped. It corrects itself within the interval. It is a thing not yet noticed rather than a lie, but somebody debugging in that window is being shown a session that does not exist.

## Check 5 — fail, and the bound is what fails

The control plane went on reporting the laptop as connected for **9m35s** after the lid closed, against `readIdleTimeout = 90 * time.Second` in `internal/session/server.go`. Six times over.

It does clear, so nothing is stuck. What fails is this check's second clause — *"the bound is what the code says it is"*. For those ten minutes `GET /overview`, the page, and anything an MSP roll-up builds on that API described a device in a closed bag as connected and healthy. That is ADR-0022 §4's failure — a view that lies about when it last heard anything — arriving through the server rather than the page.

**The cause is written down as a hypothesis and labelled as one**: macOS likely keeps the socket alive through light sleep, so reads keep succeeding and the deadline never trips until the machine sleeps properly. It matters which it is before anybody picks a fix — if that is right, a read deadline is the wrong mechanism on a laptop and no adjustment to the number would help. meshp would need liveness it drives itself.

## Checks 2, 3, 4 — not run, recorded as such

All three need a route group carrying `0.0.0.0/0` assigned to the device with `fail_closed` enforced. The deployment has no route groups at all. The document's own rule is that an empty row is not a pass, so they say `not run` rather than being left blank.

## Why this is a docs change and not a fix

The finding in check 5 is real and it is not obvious what the right fix is. Choosing one before establishing whether the socket is genuinely alive would be guessing at a mechanism, which is the mistake #193 made twice today on Windows. This records what was measured; the fix should follow a measurement of *why*.