### PR TITLE
feat(deploy): a launchd daemon, so the macOS agent runs without a terminal

### DIFF
--- a/cmd/meshp/doctor.go
+++ b/cmd/meshp/doctor.go
@@ -92,18 +92,27 @@ func (f findings) strandedEgress() bool { return (f.locked || f.claimed) && !f.d
 // screen ADR-0011 says has to carry commands that work, because whoever is reading it has no
 // network and cannot look anything up.
 //
-// Linux gets the unit under deploy/systemd. Nothing else gets a service manager, because
-// meshp does not yet define one: there is no launchd plist and no Windows service in this
-// repository, so naming a label for either would put a command on the screen that fails.
-// Running the binary is what is true on those platforms today, and it is what somebody
-// debugging is doing anyway.
+// Linux gets the unit under deploy/systemd and macOS the daemon under deploy/launchd.
+// Windows still has no service definition — #195 covers it — so it gets the binary, which is
+// what is true there today and what somebody debugging is doing anyway. Naming a service that
+// does not exist would put a command on the screen that fails, which is the one thing this
+// screen must not do.
 //
-// When deploy/ grows a plist or a service definition, this is where the command for it goes.
+// Both names are load-bearing. `meshpd` is the systemd unit's filename and `net.meshp.meshpd`
+// is the plist's Label, and a command naming either wrongly is a command that fails for
+// somebody with no network. internal/deploycheck reads both files and holds these to them.
 func startMeshpdCommand() string {
-	if runtime.GOOS == "linux" {
+	switch runtime.GOOS {
+	case "linux":
 		return "sudo systemctl start meshpd"
+	case "darwin":
+		// kickstart rather than bootstrap: bootstrap is for a plist not yet loaded and fails
+		// with "service already loaded" once it is, which is the state anybody reading this
+		// is most likely in. kickstart starts it either way.
+		return "sudo launchctl kickstart -k system/net.meshp.meshpd"
+	default:
+		return "sudo meshpd"
 	}
-	return "sudo meshpd"
 }
 
 // startMeshpdHint is the same command in a sentence, for the branch that is prose rather

--- a/deploy/launchd/net.meshp.meshpd.plist
+++ b/deploy/launchd/net.meshp.meshpd.plist
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The agent, on a Mac that joins a network.
+
+  Loaded into the *system* domain, not a user's: creating a utun goes through PF_SYSTEM and
+  needs root, and so does everything the agent does afterwards — routes, the pf anchor, the
+  resolver entry in the SystemConfiguration store. A LaunchAgent would start with the wrong
+  privileges and stop when somebody logged out, which is not what a device on a network
+  should do.
+
+      sudo install -m 0644 -o root -g wheel net.meshp.meshpd.plist /Library/LaunchDaemons/
+      sudo launchctl bootstrap system /Library/LaunchDaemons/net.meshp.meshpd.plist
+
+  The label is net.meshp.meshpd, and `meshp doctor` prints commands naming it — the one
+  screen ADR-0011 says has to carry commands that work, because whoever is reading it has no
+  network and cannot look anything up. internal/deploycheck holds the two together.
+-->
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>net.meshp.meshpd</string>
+
+    <!--
+      No --state-dir or --socket. The binary already computes the right paths for this
+      platform, and naming them here would be a second place to be wrong. The systemd unit
+      passes them because Linux's defaults and its StateDirectory have to agree, which is a
+      constraint launchd does not impose.
+    -->
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/bin/meshpd</string>
+      <string>--log-level</string>
+      <string>info</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!--
+      Restarted whenever it stops, however it stopped — the same promise Restart=always makes
+      on Linux, and it matters more here. A device whose agent died has a tunnel nobody is
+      reconciling, and on macOS it may also have a pf anchor and routes left behind that only
+      a running agent will reclaim (ADR-0011).
+
+      Deliberately the boolean and not the SuccessfulExit dictionary. "Restart unless it
+      exited cleanly" sounds more careful and is wrong: a clean exit still leaves a device
+      that has stopped talking to its network, and stopping this on purpose is what
+      `launchctl bootout` is for.
+    -->
+    <key>KeepAlive</key>
+    <true/>
+
+    <!--
+      Ten seconds between restarts. launchd's default is one, and a daemon that cannot start
+      at all — a broken state directory, a missing binary — would otherwise be restarted
+      sixty times a minute, filling the log with one failure and draining the battery of the
+      laptop it is failing on.
+    -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <!--
+      Somewhere for the log to go. There is no journal here, so without this the output of a
+      service nobody is watching is discarded — and an agent whose log goes nowhere can only
+      be debugged by somebody already watching it, which is the gap this file exists to
+      close (#195).
+    -->
+    <key>StandardOutPath</key>
+    <string>/var/log/meshpd.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/meshpd.log</string>
+  </dict>
+</plist>

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -278,9 +278,34 @@ Keep the admin address on loopback. It is diagnostics, not an API anyone else sh
 ```bash
 curl -fsSLO https://raw.githubusercontent.com/meshpnet/meshp/main/scripts/install.sh
 less install.sh && sudo sh install.sh
+```
+
+Then start it the way this machine starts services, and join:
+
+```bash
+# Linux
 sudo systemctl enable --now meshpd
+```
+
+```bash
+# macOS
+sudo install -m 0644 -o root -g wheel deploy/launchd/net.meshp.meshpd.plist /Library/LaunchDaemons/
+sudo launchctl bootstrap system /Library/LaunchDaemons/net.meshp.meshpd.plist
+```
+
+```bash
 sudo meshp join <token> --control-url https://control.example.com
 ```
+
+The Mac daemon is loaded into the **system** domain rather than a user's, because creating a
+utun goes through `PF_SYSTEM` and needs root — and because a device on a network should not
+stop being on it when somebody logs out. Its log goes to `/var/log/meshpd.log`, since there
+is no journal to inherit. `sudo launchctl kickstart -k system/net.meshp.meshpd` restarts it,
+and `sudo launchctl bootout system/net.meshp.meshpd` stops it for good.
+
+**Windows has no service definition yet** ([#195](https://github.com/meshpnet/meshp/issues/195)),
+so the agent runs there only while a terminal holds it. `meshp doctor` says so rather than
+naming a service that does not exist.
 
 The agent runs as root because it creates a WireGuard interface, writes routes and loads
 firewall rules. `meshp` does not: it is a thin client that asks the daemon over a local unix

--- a/internal/deploycheck/deploycheck_test.go
+++ b/internal/deploycheck/deploycheck_test.go
@@ -64,13 +64,68 @@ func TestTheControlPlaneDoesNotWriteIntoTheAgentsStateDirectory(t *testing.T) {
 	}
 }
 
-func readUnit(t *testing.T, name string) string {
+// A command naming a launchd label is a command that fails if the label is not the one the
+// plist declares — and it fails for somebody with no network, reading the one screen ADR-0011
+// says has to carry commands that work. The two live in different files, in different
+// languages, and nothing else compares them.
+//
+// doctor.go is read as text rather than called, because it is package main and cannot be
+// imported, and because what it returns depends on the GOOS this test happens to run under.
+// The claim being checked is about the source, not about this machine.
+func TestDoctorNamesTheLaunchdServiceThatExists(t *testing.T) {
+	plist := readFile(t, "../../deploy/launchd/net.meshp.meshpd.plist")
+	doctor := readFile(t, "../../cmd/meshp/doctor.go")
+
+	label, ok := plistValue(plist, "Label")
+	if !ok {
+		t.Fatal("the plist declares no Label, so nothing can be started by name")
+	}
+	if !strings.Contains(doctor, "system/"+label) {
+		t.Errorf("the plist's Label is %q, and no command in doctor.go names system/%s — "+
+			"whatever it tells a Mac to start, it is not this", label, label)
+	}
+
+	// And the program has to be an absolute path: launchd has no PATH to search, so a bare
+	// name is a daemon that never starts and says so only in a log nobody is reading.
+	program, ok := plistValue(plist, "ProgramArguments")
+	if !ok {
+		t.Fatal("the plist names no program to run")
+	}
+	if !strings.HasPrefix(program, "/") {
+		t.Errorf("the plist runs %q, which launchd cannot find: it has no PATH", program)
+	}
+}
+
+// plistValue returns the first <string> following a <key>, which is enough for the two facts
+// checked here and stops well short of being a plist parser.
+func plistValue(plist, key string) (string, bool) {
+	_, rest, found := strings.Cut(plist, "<key>"+key+"</key>")
+	if !found {
+		return "", false
+	}
+	_, rest, found = strings.Cut(rest, "<string>")
+	if !found {
+		return "", false
+	}
+	value, _, found := strings.Cut(rest, "</string>")
+	if !found {
+		return "", false
+	}
+	return strings.TrimSpace(value), true
+}
+
+func readFile(t *testing.T, path string) string {
 	t.Helper()
-	raw, err := os.ReadFile(filepath.Join(unitDir, name))
+	raw, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("reading %s: %v", name, err)
+		t.Fatalf("reading %s: %v", path, err)
 	}
 	return string(raw)
+}
+
+func readUnit(t *testing.T, name string) string {
+	t.Helper()
+	return readFile(t, filepath.Join(unitDir, name))
 }
 
 // stateDirectories returns the absolute paths systemd will make writable.


### PR DESCRIPTION
The macOS half of #195. Windows lands separately — see the bottom.

## What was missing

`meshpd` ran on a Mac only while somebody held a terminal open. `deploy/` had three systemd units and nothing else, and `cmd/meshp/doctor.go` said so in a comment ending:

> *When `deploy/` grows a plist or a service definition, this is where the command for it goes.*

This is that.

## The log is the point, as much as the restarting

Without `StandardOutPath` there is no journal to inherit, so a service nobody is watching discards its own output. That is not hypothetical: **#193's hot loop — the agent withdrawing kernel routes twice a second, indefinitely — was found because `meshpd` happened to be running in front of a person.** Unattended, it was a warm laptop and nothing else.

An agent whose log goes nowhere can only be debugged by somebody already watching it, which makes every unattended failure invisible by construction.

## Choices worth naming

- **System domain, not a LaunchAgent.** Creating a utun goes through `PF_SYSTEM` and needs root, and a device on a network should not leave it when somebody logs out.
- **`KeepAlive` as a boolean, not `{SuccessfulExit: false}`.** "Restart unless it exited cleanly" sounds more careful and is wrong: a clean exit still leaves a device that has stopped talking to its network. Stopping it deliberately is what `launchctl bootout` is for.
- **`ThrottleInterval` 10.** launchd's default is 1, so a daemon that cannot start at all would restart sixty times a minute, filling the log with one failure and draining the battery of the laptop it is failing on.
- **No `--state-dir` or `--socket`.** The binary computes the right paths per platform already; naming them here is a second place to be wrong. The systemd unit passes them because Linux's defaults and its `StateDirectory` have to agree — a constraint launchd does not impose.
- **`doctor` prints `kickstart`, not `bootstrap`.** `bootstrap` fails with "service already loaded" once it is loaded, which is the state anybody reading that screen is most likely in.

## The guard

The label is now load-bearing across two files in two languages, and nothing else compared them — the same shape as the bug #192 fixed. `internal/deploycheck` now asserts that `doctor.go` names the plist's `Label`, and that the program is an absolute path, since launchd has no `PATH` to search.

Mutation-tested both ways:

```
the plist's Label is "net.meshp.agent", and no command in doctor.go names
system/net.meshp.agent — whatever it tells a Mac to start, it is not this

the plist runs "meshpd", which launchd cannot find: it has no PATH
```

## Verified on a Mac, not reasoned about

```
state = running
program = /usr/local/bin/meshpd
pid = 63426
properties = keepalive | runatload | inferred program
```

The log file received meshpd's startup lines. `sudo pkill -9 -x meshpd` → back on its own as a new pid inside twelve seconds.

**The plist was wrong once on the way here.** I declared `KeepAlive` twice — as a boolean and as a dictionary — which `plutil -lint` reports as `OK` and which silently parses as the second one, quietly turning "always restart" into "restart only on unclean exit". Reading the parsed output back with `plutil -convert json` is what caught it.

One behaviour worth recording: an agent taken down with `meshp down` stays down across a launchd restart, logging `staying off the mesh; this device was taken down deliberately`. A service manager bringing the daemon back does not silently re-claim the network.

## Not in this PR

- **Windows.** A real service needs `svc.Run` scaffolding in `cmd/meshpd` and its own CI verification. `doctor` still prints `sudo meshpd` there, which is what is true.
- **Log rotation.** `/var/log/meshpd.log` grows without bound. macOS has `newsyslog.d` for this and it is a separate, small piece of work.