### PR TITLE
feat(deploy): meshpd answers the Windows service control manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -787,6 +787,55 @@ jobs:
           go test ./internal/wglink/ ./internal/resolved/ ./internal/wfp/ ./internal/egresslock/ ./internal/netwatch/ ./internal/version/ -count=1 -v 2>&1 | Tee-Object windows.log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      # The service is the whole of the Windows half of #195, and none of it can be reasoned
+      # about: a Go binary registered with `sc.exe` starts, is asked to report Running, never
+      # answers because it does not implement the control interface, and is killed. That
+      # failure looks like "the service will not start" and nothing else, so the only useful
+      # test installs it and starts it. This runner is elevated and disposable, which is the
+      # one place that is a reasonable thing to do.
+      - name: meshpd registers as a service, starts, and stops when asked
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          New-Item -ItemType Directory -Force -Path "C:\meshp" | Out-Null
+          go build -o C:\meshp\meshpd.exe ./cmd/meshpd
+          # Beside the binary, which is where it ships and where Windows looks (ADR-0028).
+          Copy-Item wintun-extracted\wintun\bin\amd64\wintun.dll C:\meshp\wintun.dll
+
+          sc.exe create meshpd binPath= "C:\meshp\meshpd.exe --state-dir C:\meshp\state" start= demand
+          if ($LASTEXITCODE -ne 0) { throw "sc.exe create failed with $LASTEXITCODE" }
+
+          try {
+            sc.exe start meshpd
+            if ($LASTEXITCODE -ne 0) { throw "sc.exe start failed with $LASTEXITCODE" }
+
+            # Waited for rather than assumed: the control manager reports StartPending until
+            # the service answers, and a service that never answers is killed after 30s.
+            $service = Get-Service meshpd
+            $service.WaitForStatus("Running", "00:00:30")
+            "service reported: $((Get-Service meshpd).Status)"
+
+            # A service that cannot be stopped is as broken as one that cannot start, and it
+            # fails differently — the control manager hangs and then kills it, which on a real
+            # machine means an agent that never releases its interface, routes or filters.
+            Stop-Service meshpd
+            (Get-Service meshpd).WaitForStatus("Stopped", "00:00:30")
+            "service stopped cleanly"
+
+            # And it logged somewhere, which is the actual point of #195: a service has no
+            # console, so an agent that does not open a file of its own is one nobody can
+            # debug after the fact.
+            $log = "C:\meshp\state\meshpd.log"
+            if (-not (Test-Path $log)) { throw "the service left no log at $log" }
+            if (-not (Select-String -Path $log -Pattern 'meshpd starting' -Quiet)) {
+              throw "$log exists but does not contain meshpd's own startup line"
+            }
+            "log written to $log"
+            Get-Content $log -Tail 5
+          } finally {
+            sc.exe delete meshpd | Out-Null
+          }
+
       - name: report, and refuse a test that did not run
         if: always()
         shell: pwsh

--- a/cmd/meshp/doctor.go
+++ b/cmd/meshp/doctor.go
@@ -92,15 +92,14 @@ func (f findings) strandedEgress() bool { return (f.locked || f.claimed) && !f.d
 // screen ADR-0011 says has to carry commands that work, because whoever is reading it has no
 // network and cannot look anything up.
 //
-// Linux gets the unit under deploy/systemd and macOS the daemon under deploy/launchd.
-// Windows still has no service definition — #195 covers it — so it gets the binary, which is
-// what is true there today and what somebody debugging is doing anyway. Naming a service that
-// does not exist would put a command on the screen that fails, which is the one thing this
-// screen must not do.
+// Every platform that can supervise the agent now names the thing that supervises it: the
+// unit under deploy/systemd, the daemon under deploy/launchd, and the service registered with
+// the control manager. Anything else gets the binary, which is what is true there.
 //
-// Both names are load-bearing. `meshpd` is the systemd unit's filename and `net.meshp.meshpd`
-// is the plist's Label, and a command naming either wrongly is a command that fails for
-// somebody with no network. internal/deploycheck reads both files and holds these to them.
+// All three names are load-bearing, and a command naming one wrongly fails for somebody with
+// no network reading the one screen ADR-0011 says has to carry commands that work.
+// internal/deploycheck reads the unit, the plist and agentapi.WindowsServiceName and holds
+// these to them.
 func startMeshpdCommand() string {
 	switch runtime.GOOS {
 	case "linux":
@@ -110,6 +109,12 @@ func startMeshpdCommand() string {
 		// with "service already loaded" once it is, which is the state anybody reading this
 		// is most likely in. kickstart starts it either way.
 		return "sudo launchctl kickstart -k system/net.meshp.meshpd"
+	case "windows":
+		// sc.exe rather than Start-Service, because this is printed to whatever shell
+		// somebody is in and cmd.exe has no PowerShell cmdlets. The trailing space in
+		// `start= auto` is sc.exe's own syntax and is not a typo, which is why installing is
+		// documented rather than printed here.
+		return "sc.exe start " + agentapi.WindowsServiceName
 	default:
 		return "sudo meshpd"
 	}

--- a/cmd/meshpd/main.go
+++ b/cmd/meshpd/main.go
@@ -34,6 +34,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net/netip"
@@ -72,17 +73,33 @@ func main() {
 		return
 	}
 
-	log := newLogger(*logLevel)
+	// Where the log goes is a platform's answer, not a preference: a Windows service has no
+	// console and would otherwise write to a discarded stderr. See logWriter.
+	out, closeLog, err := logWriter(*stateDir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer closeLog()
+
+	log := newLogger(*logLevel, out)
 	log.Info("meshpd starting",
 		"version", version.Version(),
 		"state_dir", *stateDir,
 		"socket", *socketPath,
 		"reconcile_interval", *reconcileEvery)
 
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	// Cancellable by something other than a signal, because on Windows nothing sends one:
+	// the service control manager asks over a channel, and supervise needs a way to say so.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	if err := run(ctx, log, *stateDir, *socketPath, *socketGroup, *reconcileEvery); err != nil {
+	err = supervise(ctx, cancel, log, func(ctx context.Context) error {
+		return run(ctx, log, *stateDir, *socketPath, *socketGroup, *reconcileEvery)
+	})
+	if err != nil {
 		log.Error("meshpd exited with error", "error", err)
 		os.Exit(1)
 	}
@@ -161,12 +178,12 @@ func isNotEnrolled(err error) bool {
 	return errors.Is(err, agentstate.ErrNotEnrolled) || errors.Is(err, fs.ErrNotExist)
 }
 
-func newLogger(level string) *slog.Logger {
+func newLogger(level string, out io.Writer) *slog.Logger {
 	var l slog.Level
 	if err := l.UnmarshalText([]byte(level)); err != nil {
 		l = slog.LevelInfo
 	}
-	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: l}))
+	return slog.New(slog.NewTextHandler(out, &slog.HandlerOptions{Level: l}))
 }
 
 // envDuration reads a Go duration from the environment, falling back rather than refusing

--- a/cmd/meshpd/main_test.go
+++ b/cmd/meshpd/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"path/filepath"
@@ -94,7 +95,7 @@ func TestAMalformedIntervalDoesNotKeepADeviceOffline(t *testing.T) {
 func TestAnUnreadableLogLevelStillLogs(t *testing.T) {
 	ctx := context.Background()
 
-	fallback := newLogger("verbose")
+	fallback := newLogger("verbose", io.Discard)
 	if !fallback.Enabled(ctx, slog.LevelInfo) {
 		t.Error("an unreadable log level left the daemon silent at info")
 	}
@@ -103,10 +104,10 @@ func TestAnUnreadableLogLevelStillLogs(t *testing.T) {
 	}
 
 	// And a readable one is honoured, or the fallback above would be the only behaviour.
-	if !newLogger("debug").Enabled(ctx, slog.LevelDebug) {
+	if !newLogger("debug", io.Discard).Enabled(ctx, slog.LevelDebug) {
 		t.Error("debug was asked for and not enabled")
 	}
-	if newLogger("error").Enabled(ctx, slog.LevelWarn) {
+	if newLogger("error", io.Discard).Enabled(ctx, slog.LevelWarn) {
 		t.Error("error was asked for and warnings were logged anyway")
 	}
 }

--- a/cmd/meshpd/service_other.go
+++ b/cmd/meshpd/service_other.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+)
+
+// logWriter is stderr everywhere but Windows.
+//
+// systemd captures it into the journal and launchd redirects it to the file named in the
+// plist (ADR-0011's undo commands are only useful if somebody can see what happened), so the
+// daemon has nothing to arrange for itself. Windows has no such mechanism and opens a file.
+func logWriter(string) (io.Writer, func(), error) { return os.Stderr, func() {}, nil }
+
+// supervise runs the daemon. Nothing here supervises a process from inside it: systemd and
+// launchd both send a signal, which main already listens for.
+func supervise(ctx context.Context, _ context.CancelFunc, _ *slog.Logger, do func(context.Context) error) error {
+	return do(ctx)
+}

--- a/cmd/meshpd/service_windows.go
+++ b/cmd/meshpd/service_windows.go
@@ -1,0 +1,124 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"golang.org/x/sys/windows/svc"
+
+	"github.com/meshpnet/meshp/internal/agentapi"
+)
+
+// underServiceControl reports whether this process was started by the service control
+// manager, answered once because both the logger and the supervisor need to know and the
+// answer cannot change while a process runs.
+var underServiceControl = sync.OnceValue(func() bool {
+	is, err := svc.IsWindowsService()
+	// An error here means the check itself failed, not that this is a service. Running in
+	// the foreground is the safe reading: it logs to the console and responds to Ctrl-C,
+	// which is wrong for a service but visible, where the reverse is a process that answers
+	// nothing and writes its log where nobody looks.
+	return err == nil && is
+})
+
+// logWriter is where this process's log goes.
+//
+// A service has no console, so stderr is discarded and an agent whose log goes nowhere can
+// only be debugged by somebody already watching it — the gap #195 is about. macOS solves the
+// same problem in the plist with StandardOutPath; Windows has no equivalent, so the daemon
+// opens the file itself.
+//
+// Beside the state directory rather than in a log directory of its own, because that is
+// already this device's private place and already has the mode this deserves: the log names
+// networks, peers and addresses.
+func logWriter(stateDir string) (io.Writer, func(), error) {
+	if !underServiceControl() {
+		return os.Stderr, func() {}, nil
+	}
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return nil, nil, fmt.Errorf("meshpd: preparing %s for the log: %w", stateDir, err)
+	}
+	path := filepath.Join(stateDir, "meshpd.log")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, nil, fmt.Errorf("meshpd: opening %s: %w", path, err)
+	}
+	return f, func() { _ = f.Close() }, nil
+}
+
+// supervise runs the daemon under whatever is supervising this process.
+//
+// Started by hand, that is nothing, and this is a plain call. Started by the service control
+// manager, it is svc.Run: a service that does not report Running within its timeout is killed,
+// and one that does not answer Stop is killed after it too. Neither failure looks like a bug
+// in meshp from the outside — the service simply refuses to start, or hangs when stopped —
+// which is why this is a real handler rather than a wrapper that ignores the channel.
+func supervise(ctx context.Context, cancel context.CancelFunc, log *slog.Logger, do func(context.Context) error) error {
+	if !underServiceControl() {
+		return do(ctx)
+	}
+	return svc.Run(agentapi.WindowsServiceName, &handler{ctx: ctx, cancel: cancel, log: log, do: do})
+}
+
+type handler struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	log    *slog.Logger
+	do     func(context.Context) error
+}
+
+// Execute is the service control manager's side of the daemon's life.
+//
+// The order is what the manager requires and not a style: StartPending before any work,
+// Running only once the daemon is actually up, StopPending before waiting for it to finish.
+// Reporting Stopped while the daemon is still holding an interface would let the manager
+// start a second one.
+func (h *handler) Execute(_ []string, requests <-chan svc.ChangeRequest, status chan<- svc.Status) (bool, uint32) {
+	status <- svc.Status{State: svc.StartPending}
+
+	exited := make(chan error, 1)
+	go func() { exited <- h.do(h.ctx) }()
+
+	const accepted = svc.AcceptStop | svc.AcceptShutdown
+	status <- svc.Status{State: svc.Running, Accepts: accepted}
+
+	for {
+		select {
+		case request := <-requests:
+			switch request.Cmd {
+			case svc.Interrogate:
+				// Answered with what was asked, which is what the manager expects: this is
+				// a poll for liveness, not a request to change anything.
+				status <- request.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				h.log.Info("the service control manager asked meshpd to stop")
+				status <- svc.Status{State: svc.StopPending}
+				h.cancel()
+				// Waited for rather than assumed. Releasing an interface, a route claim and
+				// a filter takes as long as it takes, and a service that reports Stopped
+				// early is one the manager may immediately start again on top of itself.
+				if err := <-exited; err != nil {
+					h.log.Error("meshpd exited with error", "error", err)
+					return false, 1
+				}
+				return false, 0
+			}
+		case err := <-exited:
+			// Gone without being asked. Reported as a failure so the manager's restart
+			// policy applies, which is the Windows equivalent of Restart=always.
+			if err != nil {
+				h.log.Error("meshpd exited with error", "error", err)
+				return false, 1
+			}
+			h.log.Warn("meshpd stopped without being asked to")
+			return false, 1
+		}
+	}
+}

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -303,9 +303,16 @@ stop being on it when somebody logs out. Its log goes to `/var/log/meshpd.log`, 
 is no journal to inherit. `sudo launchctl kickstart -k system/net.meshp.meshpd` restarts it,
 and `sudo launchctl bootout system/net.meshp.meshpd` stops it for good.
 
-**Windows has no service definition yet** ([#195](https://github.com/meshpnet/meshp/issues/195)),
-so the agent runs there only while a terminal holds it. `meshp doctor` says so rather than
-naming a service that does not exist.
+```powershell
+# Windows, as Administrator. wintun.dll ships beside meshpd.exe (ADR-0028).
+sc.exe create meshpd binPath= "C:\Program Files\meshp\meshpd.exe" start= auto
+sc.exe start meshpd
+```
+
+The space after `binPath=` and `start=` is `sc.exe`'s own syntax and is not a typo; without it
+the command is rejected. The service logs to `meshpd.log` inside its state directory, because a
+Windows service has no console and anything written to stderr is discarded. `sc.exe stop meshpd`
+stops it and `sc.exe delete meshpd` removes it.
 
 The agent runs as root because it creates a WireGuard interface, writes routes and loads
 firewall rules. `meshp` does not: it is a thin client that asks the daemon over a local unix

--- a/internal/agentapi/agentapi.go
+++ b/internal/agentapi/agentapi.go
@@ -24,6 +24,17 @@ import (
 // DefaultSocketPath is where the daemon listens.
 const DefaultSocketPath = "/var/run/meshpd.sock"
 
+// WindowsServiceName is what the agent is registered as with the service control manager.
+//
+// Here rather than in either command because both need it and neither owns it: meshpd
+// answers to this name when the control manager starts it, and `meshp doctor` prints a
+// command naming it on the one screen ADR-0011 says must carry commands that work. Two
+// binaries agreeing by coincidence is how #192 happened.
+//
+// It matches the systemd unit's filename and the last component of the launchd label, so
+// that "the agent" is called the same thing on every platform that can supervise it.
+const WindowsServiceName = "meshpd"
+
 // Status is what the daemon reports about itself.
 type Status struct {
 	Version   string    `json:"version"`

--- a/internal/deploycheck/deploycheck_test.go
+++ b/internal/deploycheck/deploycheck_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/meshpnet/meshp/internal/agentapi"
 	"github.com/meshpnet/meshp/internal/tlsconf"
 )
 
@@ -93,6 +94,24 @@ func TestDoctorNamesTheLaunchdServiceThatExists(t *testing.T) {
 	}
 	if !strings.HasPrefix(program, "/") {
 		t.Errorf("the plist runs %q, which launchd cannot find: it has no PATH", program)
+	}
+}
+
+// Windows has no file to check against, so the name lives in Go and both binaries import it.
+// This asserts doctor actually uses that constant rather than a string that happens to match
+// today — which is the failure this whole package exists for, and the one #192 shipped.
+func TestDoctorStartsTheWindowsServiceByItsDeclaredName(t *testing.T) {
+	doctor := readFile(t, "../../cmd/meshp/doctor.go")
+
+	if !strings.Contains(doctor, "agentapi.WindowsServiceName") {
+		t.Errorf("doctor.go does not use agentapi.WindowsServiceName (%q); a literal here is "+
+			"two places to change and one of them will be missed",
+			agentapi.WindowsServiceName)
+	}
+	// And it has to be started by something that exists on a machine with no PowerShell,
+	// because this is printed into whatever shell somebody is already in.
+	if !strings.Contains(doctor, "sc.exe start ") {
+		t.Error("doctor.go names no sc.exe command to start the Windows service")
 	}
 }
 


### PR DESCRIPTION
Closes #195, whose macOS half landed in #197.

## Why a wrapper would not have done

A Go binary registered with `sc.exe` starts, is asked to report `Running`, never answers because it does not implement the control interface, and is killed after thirty seconds. From outside, that is *"the service will not start"* and nothing else — no stack, no log, no clue.

So this is a real handler:

- `svc.IsWindowsService()` decides. Started by hand it is a plain call and `Ctrl-C` still works; started by the control manager it is `svc.Run`.
- `StartPending` before any work, `Running` only once the daemon is actually up, `StopPending` before waiting for it to finish.
- **The wait on stop is not politeness.** Reporting `Stopped` while the daemon still holds an interface, a route claim and a filter lets the manager start a second one on top of it.
- `Interrogate` is answered with what was asked — it is a liveness poll, not a request to change anything.
- Exiting unasked returns a failure code, so the manager's restart policy applies. That is the Windows equivalent of `Restart=always`.

## The log is the point

A service has no console, so stderr goes nowhere. That is not hypothetical: **#193's hot loop — the agent withdrawing kernel routes twice a second, indefinitely — was found only because `meshpd` happened to be running in front of a person.**

There is no `StandardOutPath` to declare as on macOS and no journal to inherit as on Linux, so the daemon opens `meshpd.log` inside its own state directory. Beside the state rather than in a log directory of its own, because that is already this device's private place with the mode this deserves — the log names networks, peers and addresses.

Everywhere else stderr remains correct, and `service_other.go` says why rather than leaving a reader to infer it.

## Where the name lives

`agentapi.WindowsServiceName`, beside `DefaultSocketPath`, because both binaries need it and neither owns it: `meshpd` answers to it, and `meshp doctor` prints `sc.exe start meshpd` on the one screen ADR-0011 says must carry commands that work.

`deploycheck` asserts `doctor.go` uses the **constant** rather than a literal that happens to match today. Two binaries agreeing by coincidence is precisely how #192 shipped.

`sc.exe` rather than `Start-Service`, because this is printed into whatever shell somebody is already in and `cmd.exe` has no PowerShell cmdlets.

## Verified by CI, because it cannot be verified here

There is no Windows machine in this loop, and the last two times I reasoned about Windows behaviour I was wrong twice in a row (#193). So the elevated runner does it:

1. builds `meshpd.exe` and puts `wintun.dll` beside it, where it ships (ADR-0028)
2. `sc.exe create` … `sc.exe start`
3. waits for `Running` — this is the step a non-service binary fails
4. `Stop-Service`, waits for `Stopped` — a service that cannot be stopped is as broken as one that cannot start, and hangs rather than erroring
5. asserts `meshpd.log` exists **and contains meshpd's own startup line**, not merely that a file appeared
6. `sc.exe delete` in a `finally`, so a failure does not leave the runner dirty

Each of those has a distinct failure mode and all of them look identical from a distance, which is why they are asserted separately.

## Also in here

`newLogger` takes an `io.Writer` instead of hard-coding stderr, and `logWriter` is a platform seam with a stub explaining why the other two platforms need nothing. `docs/self-hosting.md` gains the `sc.exe` install, including a note that the space after `binPath=` is `sc.exe`'s own syntax and not a typo — it is rejected without it.