### PR TITLE
feat(agent): rotate the log, because nothing else can

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,11 @@ MESHP_RELAY_ADMIN_ADDR=127.0.0.1:9090
 
 # --- Agent ----------------------------------------------------------------
 # MESHP_STATE_DIR=/var/lib/meshp
+# Where the agent writes its log, rotated at 4MB keeping two previous files. Unset means
+# stderr, which is right wherever something else captures it — systemd's journal does, and
+# so does launchd, but launchd's copy cannot be rotated from outside so the plist names a
+# file here instead. A Windows service has no console and falls back to its state directory.
+# MESHP_LOG_FILE=/var/log/meshpd.log
 # MESHP_SOCKET=/run/meshp/meshpd.sock
 #
 # Relaxes the daemon's socket from owner-only to a group. Read it as the privilege

--- a/cmd/meshpd/log.go
+++ b/cmd/meshpd/log.go
@@ -1,0 +1,15 @@
+package main
+
+// How much log a device keeps, and it is deliberately not much.
+//
+// Four megabytes across three files bounds this at twelve, which on a laptop is somewhere
+// between a few days and a few weeks of an idle agent — and comfortably covers the minutes
+// before somebody noticed something was wrong, which is the only part anybody reads.
+//
+// Larger would be easy and is the wrong instinct: this runs on somebody's machine, not on a
+// log host, and a device that quietly consumed a gigabyte describing its own health would be
+// a worse citizen than one that forgot last month.
+const (
+	logMaxBytes  = 4 << 20
+	logKeepFiles = 2
+)

--- a/cmd/meshpd/log_other.go
+++ b/cmd/meshpd/log_other.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package main
+
+import (
+	"io"
+	"os"
+
+	"github.com/meshpnet/meshp/internal/logfile"
+)
+
+// logWriter is stderr unless somebody named a file.
+//
+// systemd captures stderr into the journal and rotates it there, so a Linux unit names no
+// file and this is the whole story. launchd captures it too — into a path that grows forever
+// and that nothing can rotate from outside, because a rename does not move the descriptor
+// launchd is holding (see internal/logfile). So the macOS daemon passes --log-file and the
+// process rotates its own log, and the plist keeps StandardErrorPath only for what escapes
+// the logger entirely: a panic, or a runtime failure before any of this runs.
+func logWriter(path, _ string) (io.Writer, func(), error) {
+	if path == "" {
+		return os.Stderr, func() {}, nil
+	}
+	f, err := logfile.Open(path, logMaxBytes, logKeepFiles)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, func() { _ = f.Close() }, nil
+}

--- a/cmd/meshpd/main.go
+++ b/cmd/meshpd/main.go
@@ -57,6 +57,8 @@ func main() {
 		socketGroup = flag.String("socket-group", os.Getenv("MESHP_SOCKET_GROUP"),
 			"system group allowed to use the socket; empty means owner only")
 		logLevel = flag.String("log-level", envOr("MESHP_LOG_LEVEL", "info"), "debug, info, warn or error")
+		logPath  = flag.String("log-file", os.Getenv("MESHP_LOG_FILE"),
+			"write the log here and rotate it, instead of to stderr")
 
 		// How often the interface is checked against desired state even when nothing has
 		// changed. A minute is a compromise: drift is corrected without waiting for the
@@ -75,7 +77,7 @@ func main() {
 
 	// Where the log goes is a platform's answer, not a preference: a Windows service has no
 	// console and would otherwise write to a discarded stderr. See logWriter.
-	out, closeLog, err := logWriter(*stateDir)
+	out, closeLog, err := logWriter(*logPath, *stateDir)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/meshpd/service_other.go
+++ b/cmd/meshpd/service_other.go
@@ -4,17 +4,8 @@ package main
 
 import (
 	"context"
-	"io"
 	"log/slog"
-	"os"
 )
-
-// logWriter is stderr everywhere but Windows.
-//
-// systemd captures it into the journal and launchd redirects it to the file named in the
-// plist (ADR-0011's undo commands are only useful if somebody can see what happened), so the
-// daemon has nothing to arrange for itself. Windows has no such mechanism and opens a file.
-func logWriter(string) (io.Writer, func(), error) { return os.Stderr, func() {}, nil }
 
 // supervise runs the daemon. Nothing here supervises a process from inside it: systemd and
 // launchd both send a signal, which main already listens for.

--- a/cmd/meshpd/service_windows.go
+++ b/cmd/meshpd/service_windows.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/sys/windows/svc"
 
 	"github.com/meshpnet/meshp/internal/agentapi"
+	"github.com/meshpnet/meshp/internal/logfile"
 )
 
 // underServiceControl reports whether this process was started by the service control
@@ -31,24 +32,26 @@ var underServiceControl = sync.OnceValue(func() bool {
 // logWriter is where this process's log goes.
 //
 // A service has no console, so stderr is discarded and an agent whose log goes nowhere can
-// only be debugged by somebody already watching it — the gap #195 is about. macOS solves the
-// same problem in the plist with StandardOutPath; Windows has no equivalent, so the daemon
-// opens the file itself.
+// only be debugged by somebody already watching it — the gap #195 is about. Unlike launchd
+// and systemd there is nothing outside the process to capture it, so the daemon opens the
+// file itself and rotates it (internal/logfile).
 //
-// Beside the state directory rather than in a log directory of its own, because that is
-// already this device's private place and already has the mode this deserves: the log names
-// networks, peers and addresses.
-func logWriter(stateDir string) (io.Writer, func(), error) {
-	if !underServiceControl() {
-		return os.Stderr, func() {}, nil
+// --log-file wins where it is given. Where it is not, a service still gets a file rather than
+// nothing, beside the state directory: that is already this device's private place with the
+// mode this deserves, since the log names networks, peers and addresses.
+func logWriter(path, stateDir string) (io.Writer, func(), error) {
+	if path == "" {
+		if !underServiceControl() {
+			return os.Stderr, func() {}, nil
+		}
+		if err := os.MkdirAll(stateDir, 0o700); err != nil {
+			return nil, nil, fmt.Errorf("meshpd: preparing %s for the log: %w", stateDir, err)
+		}
+		path = filepath.Join(stateDir, "meshpd.log")
 	}
-	if err := os.MkdirAll(stateDir, 0o700); err != nil {
-		return nil, nil, fmt.Errorf("meshpd: preparing %s for the log: %w", stateDir, err)
-	}
-	path := filepath.Join(stateDir, "meshpd.log")
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	f, err := logfile.Open(path, logMaxBytes, logKeepFiles)
 	if err != nil {
-		return nil, nil, fmt.Errorf("meshpd: opening %s: %w", path, err)
+		return nil, nil, err
 	}
 	return f, func() { _ = f.Close() }, nil
 }

--- a/deploy/launchd/net.meshp.meshpd.plist
+++ b/deploy/launchd/net.meshp.meshpd.plist
@@ -25,12 +25,21 @@
       platform, and naming them here would be a second place to be wrong. The systemd unit
       passes them because Linux's defaults and its StateDirectory have to agree, which is a
       constraint launchd does not impose.
+
+      --log-file is different, and it is here rather than left to StandardOutPath because a
+      file launchd is holding cannot be rotated from outside. newsyslog rotates by renaming,
+      and a rename does not move an open descriptor: measured on macOS 26, after renaming the
+      file a running job's next lines were in the renamed one and the original was never
+      recreated. So the process owns its log and rotates it (internal/logfile), and the
+      redirection below is left for what never reaches the logger at all.
     -->
     <key>ProgramArguments</key>
     <array>
       <string>/usr/local/bin/meshpd</string>
       <string>--log-level</string>
       <string>info</string>
+      <string>--log-file</string>
+      <string>/var/log/meshpd.log</string>
     </array>
 
     <key>RunAtLoad</key>
@@ -60,14 +69,15 @@
     <integer>10</integer>
 
     <!--
-      Somewhere for the log to go. There is no journal here, so without this the output of a
-      service nobody is watching is discarded — and an agent whose log goes nowhere can only
-      be debugged by somebody already watching it, which is the gap this file exists to
-      close (#195).
+      Somewhere for what the logger never sees. A panic, or a failure before the log file is
+      open, is written to stderr by the runtime and would otherwise be discarded — and the
+      crash nobody can explain is exactly the one worth keeping.
+
+      Deliberately not /var/log/meshpd.log: that file is rotated by the process, and launchd
+      holding a descriptor on it would keep appending to whichever copy it opened first. This
+      one stays small because almost nothing is ever written to it.
     -->
-    <key>StandardOutPath</key>
-    <string>/var/log/meshpd.log</string>
     <key>StandardErrorPath</key>
-    <string>/var/log/meshpd.log</string>
+    <string>/var/log/meshpd.err</string>
   </dict>
 </plist>

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -299,9 +299,16 @@ sudo meshp join <token> --control-url https://control.example.com
 
 The Mac daemon is loaded into the **system** domain rather than a user's, because creating a
 utun goes through `PF_SYSTEM` and needs root — and because a device on a network should not
-stop being on it when somebody logs out. Its log goes to `/var/log/meshpd.log`, since there
-is no journal to inherit. `sudo launchctl kickstart -k system/net.meshp.meshpd` restarts it,
-and `sudo launchctl bootout system/net.meshp.meshpd` stops it for good.
+stop being on it when somebody logs out. `sudo launchctl kickstart -k system/net.meshp.meshpd`
+restarts it, and `sudo launchctl bootout system/net.meshp.meshpd` stops it for good.
+
+Its log goes to `/var/log/meshpd.log`, written by the daemon rather than redirected by
+launchd, and rotated at 4MB keeping two previous files — so a device bounds what it spends on
+describing itself. That is not the obvious arrangement and the obvious one does not work:
+`newsyslog` rotates by renaming, a rename does not move an open file descriptor, and a file
+launchd is holding would go on receiving output under its new name while the path everybody
+reads stayed empty. `/var/log/meshpd.err` keeps whatever never reaches the log at all, such as
+a panic.
 
 ```powershell
 # Windows, as Administrator. wintun.dll ships beside meshpd.exe (ADR-0028).
@@ -311,7 +318,8 @@ sc.exe start meshpd
 
 The space after `binPath=` and `start=` is `sc.exe`'s own syntax and is not a typo; without it
 the command is rejected. The service logs to `meshpd.log` inside its state directory, because a
-Windows service has no console and anything written to stderr is discarded. `sc.exe stop meshpd`
+Windows service has no console and anything written to stderr is discarded; it is rotated the
+same way as on macOS. `--log-file` puts it somewhere else. `sc.exe stop meshpd`
 stops it and `sc.exe delete meshpd` removes it.
 
 The agent runs as root because it creates a WireGuard interface, writes routes and loads

--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -1,0 +1,125 @@
+// Package logfile is a log file that does not grow forever.
+//
+// It exists because the agent's log is the only account of what a device did, and on two of
+// the three platforms that can supervise it the daemon has to keep that account itself.
+// systemd hands stderr to the journal, which rotates it. launchd and the Windows service
+// control manager do not: launchd writes to a path and stops there, and a service has no
+// console at all.
+//
+// Rotation is done here rather than by the system's log rotator, and that is not a
+// preference. newsyslog(8) rotates by renaming, and a rename does not move an open file
+// descriptor — so a file launchd is holding goes on receiving the daemon's output under its
+// new name while the path everybody reads stays empty. Measured on macOS 26 rather than
+// assumed: after renaming the file, the running job's next lines were in the renamed one and
+// the original was never recreated. Whoever owns the descriptor has to be the one to rotate
+// it, and that is this process.
+package logfile
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+// File is an io.WriteCloser that starts a new file once the current one is large enough.
+type File struct {
+	path string
+	max  int64
+	keep int
+
+	mu   sync.Mutex
+	f    *os.File
+	size int64
+}
+
+// Open opens path for appending, rotating it when it passes max bytes and keeping that many
+// previous files beside it.
+//
+// The current size is read from the file rather than counted from zero, so a daemon that
+// restarts every few minutes cannot append forever without ever reaching the threshold.
+func Open(path string, max int64, keep int) (*File, error) {
+	if max <= 0 {
+		return nil, fmt.Errorf("logfile: a maximum size of %d would rotate on every write", max)
+	}
+	if keep < 0 {
+		return nil, fmt.Errorf("logfile: cannot keep %d previous files", keep)
+	}
+	l := &File{path: path, max: max, keep: keep}
+	if err := l.open(); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+func (l *File) open() error {
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("logfile: opening %s: %w", l.path, err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return fmt.Errorf("logfile: measuring %s: %w", l.path, err)
+	}
+	l.f, l.size = f, info.Size()
+	return nil
+}
+
+// Write appends, rotating first if this record would take the file past its limit.
+//
+// Rotation is before the write and not after, so the limit is one a reader can rely on: a
+// file is never larger than max plus the record that filled it, rather than max plus however
+// much arrived before anybody looked.
+func (l *File) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.size > 0 && l.size+int64(len(p)) > l.max {
+		if err := l.rotate(); err != nil {
+			// Reported, but the write still happens. A device whose log cannot be rotated
+			// should keep telling somebody what it is doing; losing the account of an
+			// outage to a full disk is worse than a file that is too big.
+			fmt.Fprintf(os.Stderr, "logfile: %v\n", err)
+		}
+	}
+
+	n, err := l.f.Write(p)
+	l.size += int64(n)
+	return n, err
+}
+
+// rotate closes the current file, shifts the previous ones along, and opens a new one.
+//
+// Oldest first, so nothing is overwritten before it has been moved: shifting .1 to .2 before
+// .2 has become .3 would throw away a file this was asked to keep.
+func (l *File) rotate() error {
+	if err := l.f.Close(); err != nil {
+		return fmt.Errorf("logfile: closing %s: %w", l.path, err)
+	}
+	if l.keep == 0 {
+		// Nothing to keep: the file is emptied rather than moved aside. Truncating an
+		// unlinked file would leave the daemon writing to something with no name.
+		if err := os.Remove(l.path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("logfile: removing %s: %w", l.path, err)
+		}
+		return l.open()
+	}
+	for i := l.keep; i > 1; i-- {
+		older := fmt.Sprintf("%s.%d", l.path, i)
+		newer := fmt.Sprintf("%s.%d", l.path, i-1)
+		if err := os.Rename(newer, older); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("logfile: rotating %s: %w", newer, err)
+		}
+	}
+	if err := os.Rename(l.path, l.path+".1"); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("logfile: rotating %s: %w", l.path, err)
+	}
+	return l.open()
+}
+
+// Close closes the current file. Rotation state is on disk, so a later Open resumes it.
+func (l *File) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.f.Close()
+}

--- a/internal/logfile/logfile_test.go
+++ b/internal/logfile/logfile_test.go
@@ -1,0 +1,214 @@
+package logfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// The whole point: a log that is written to forever does not grow forever.
+func TestTheFileStopsGrowing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "meshpd.log")
+	l, err := Open(path, 100, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	line := strings.Repeat("x", 40) + "\n"
+	for i := 0; i < 50; i++ {
+		if _, err := l.Write([]byte(line)); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	// 50 records of 41 bytes is a little over 2KB. With a 100-byte limit and two previous
+	// files kept, what is on disk has to be bounded by roughly three times the limit —
+	// not by how much was written.
+	var total int64
+	for _, name := range onDisk(t, path) {
+		info, err := os.Stat(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		total += info.Size()
+	}
+	if total > 400 {
+		t.Errorf("wrote ~2KB through a 100-byte file keeping 2, and %d bytes are on disk", total)
+	}
+}
+
+// Rotation has to move the old file aside, not delete it. An agent's log is the only account
+// of what a device did, and the interesting minute is usually the one before somebody looked.
+func TestWhatWasWrittenBeforeRotationIsStillThere(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "meshpd.log")
+	l, err := Open(path, 50, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	if _, err := l.Write([]byte("the first thing that happened\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := l.Write([]byte("the second thing that happened\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	previous, err := os.ReadFile(path + ".1")
+	if err != nil {
+		t.Fatalf("the previous file is not beside the current one: %v", err)
+	}
+	if !strings.Contains(string(previous), "the first thing") {
+		t.Errorf("%s.1 does not hold what was written before the rotation: %q", path, previous)
+	}
+	current, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(current), "the second thing") {
+		t.Errorf("the current file does not hold what was written after: %q", current)
+	}
+}
+
+// Files shift oldest-first, so nothing is overwritten before it has been moved along.
+//
+// Run for more than one value of keep on purpose. At keep=2 there is a single rename and
+// shifting the wrong way round is indistinguishable from shifting the right way — a mutation
+// that reversed the loop passed every test here until this became a table.
+func TestOlderFilesShiftAlongAndTheOldestGoes(t *testing.T) {
+	for _, keep := range []int{2, 3, 4} {
+		t.Run(fmt.Sprintf("keep=%d", keep), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "meshpd.log")
+			l, err := Open(path, 30, keep)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = l.Close() })
+
+			// Enough records to fill every slot and then some, so the oldest has to go.
+			for i := 0; i < keep+4; i++ {
+				if _, err := fmt.Fprintf(l, "record number %d padded out\n", i); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			for i := 1; i <= keep; i++ {
+				if _, err := os.Stat(fmt.Sprintf("%s.%d", path, i)); err != nil {
+					t.Errorf("expected %s.%d to exist: %v", path, i, err)
+				}
+			}
+			if _, err := os.Stat(fmt.Sprintf("%s.%d", path, keep+1)); !os.IsNotExist(err) {
+				t.Errorf("keeping %d files left a %dth: %v", keep, keep+1, err)
+			}
+
+			// The property somebody reading these back relies on: a higher suffix is older.
+			// Asserted as an ordering rather than as particular records, because which
+			// record lands where depends on how many rotations happened.
+			previous := -1
+			for i := keep; i >= 1; i-- {
+				n := recordIn(t, fmt.Sprintf("%s.%d", path, i))
+				if n <= previous {
+					t.Errorf(".%d holds record %d, which is not newer than the %d before it",
+						i, n, previous)
+				}
+				previous = n
+			}
+			if n := recordIn(t, path); n <= previous {
+				t.Errorf("the current file holds record %d, not newer than .1's %d", n, previous)
+			}
+		})
+	}
+}
+
+// A daemon that restarts often must not be able to append forever without ever reaching the
+// threshold, which is what counting from zero on every Open would allow.
+func TestReopeningPicksUpTheSizeAlreadyOnDisk(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "meshpd.log")
+	if err := os.WriteFile(path, []byte(strings.Repeat("y", 90)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := Open(path, 100, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	if _, err := l.Write([]byte("this takes it over the line\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Errorf("a file already at 90 of 100 bytes did not rotate on the next write: %v", err)
+	}
+}
+
+// slog writes from whichever goroutine logged, and the reconciler, the control channel and
+// the socket server all log.
+func TestConcurrentWritersDoNotCorruptTheCount(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "meshpd.log")
+	l, err := Open(path, 200, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				if _, err := fmt.Fprintf(l, "goroutine %d record %d\n", n, j); err != nil {
+					t.Errorf("write: %v", err)
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for _, name := range onDisk(t, path) {
+		info, err := os.Stat(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Each file is bounded by the limit plus the one record that crossed it.
+		if info.Size() > 200+64 {
+			t.Errorf("%s is %d bytes, past a 200-byte limit", name, info.Size())
+		}
+	}
+}
+
+func TestOpenRefusesASizeThatWouldRotateOnEveryWrite(t *testing.T) {
+	if _, err := Open(filepath.Join(t.TempDir(), "l"), 0, 1); err == nil {
+		t.Error("a maximum size of zero was accepted")
+	}
+}
+
+func onDisk(t *testing.T, path string) []string {
+	t.Helper()
+	names, err := filepath.Glob(path + "*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return names
+}
+
+// recordIn returns the number of the first record in a file, so files can be compared by
+// age without depending on how many rotations it took to get there.
+func recordIn(t *testing.T, path string) int {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var n int
+	if _, err := fmt.Sscanf(string(raw), "record number %d", &n); err != nil {
+		t.Fatalf("%s does not start with a record: %q", path, raw)
+	}
+	return n
+}


### PR DESCRIPTION
#195 gave the agent's log somewhere to go on macOS and Windows. It did not give it a size.

## The obvious answer does not work, and I measured that rather than assuming it

`newsyslog(8)` is what macOS provides and what anyone would reach for. It rotates by **renaming**, and a rename does not move an open file descriptor.

A user-domain launchd job, told to log to a path, then the file renamed underneath it:

```
=== does a fresh probe.log exist? ===
-rw-r--r--  1 alexander  wheel  94  probe.log.1
=== new lines went where? ===
--- probe.log (fresh) ---   (does not exist)
--- probe.log.1 (renamed) ---
line 10
line 11
line 12
```

launchd kept writing into the **renamed** file and never recreated the live path. So `newsyslog` rotating a launchd `StandardOutPath` would silently send meshpd's log into an archive and leave nothing where anybody looks — the worst way for a log to fail, because it looks like a quiet daemon.

Whoever owns the descriptor has to rotate it. That is meshpd.

## What is here

**`internal/logfile`** — append, start a new file once this one is large enough, keep a couple beside it. 4 MB across 3 files bounds a device at 12 MB, which covers the minutes before somebody noticed something was wrong. That is the only part anybody reads, and this runs on somebody's laptop rather than on a log host.

**The size is read from disk on open**, not counted from zero. A laptop's agent restarts far more often than it fills a log in one sitting, and counting from zero would let it append forever without ever reaching the threshold.

**`--log-file`**, so the supervisor names the path instead of the daemon guessing. Unset still means stderr, which stays correct on Linux where the journal rotates it already.

**The plist changes from what merged in #197.** It passes `--log-file`, and `StandardErrorPath` moves to a separate `meshpd.err` for panics and anything that never reaches the logger. Pointing both at one file would put launchd's descriptor back on the file the daemon rotates — reintroducing exactly the bug above.

**Windows** keeps its state-directory default, because a service with no console and no flag would otherwise log nowhere, and now goes through the same writer.

## Verified under launchd, on a Mac

```
after start:   meshpd.log        607 bytes   (startup lines)
padded to:     meshpd.log      ~5 MB
after restart: meshpd.log        607 bytes   (fresh)
               meshpd.log.1  5,243,562 bytes (moved aside)
```

The daemon read 5 MB on open, saw it past the limit, and rotated on its first write. That is the reopen case firing on real hardware — the one that matters most for a laptop.

## A mutation that was not caught at first

Four mutations against `internal/logfile`. Three failed immediately: never rotating, counting from zero on open, and dropping the mutex (8 race-detector hits).

The fourth — **shifting newest-first instead of oldest-first, overwriting a file it was asked to keep** — passed everything. The ordering test used `keep=2`, where the two directions are a single rename either way and genuinely indistinguishable. It only diverges at 3.

It is a table over `keep` ∈ {2,3,4} now. The reversed loop fails at 3 and 4 and still passes at 2, which is the proof the original test was blind rather than my assertion that it was.

## Note

`internal/wglink`'s `TestObservingAnAbsentInterface` fails on my machine because `/var/run/wireguard` is `0700 root:daemon` after a `sudo meshpd` run. It fails identically on `main` with this branch stashed, and CI's unprivileged macOS step runs before anything creates that directory as root.