### PR TITLE
fix(dataplane): claim a full tunnel on macOS, which has never worked

### DIFF
--- a/internal/egress/carveout.go
+++ b/internal/egress/carveout.go
@@ -238,13 +238,24 @@ func resolveHostPort(ctx context.Context, host, port string, resolve Resolver) (
 	return out, nil
 }
 
-// LocalNetworks reports the networks this host is directly attached to.
+// LocalNetworks reports the networks this host is directly attached to, other than the
+// tunnel's own.
 //
-// The tunnel is skipped by name: its own prefix is what the device is joining, and carving
-// it out would leave the mesh unreachable through the interface that serves it. Interfaces
-// that are down are skipped too, since a prefix on a link with no carrier is a hole in the
-// lock for a network that is not there.
-func LocalNetworks(skip string) []netip.Prefix {
+// The tunnel is identified by the addresses it carries rather than by its name, and that is
+// the whole of #200. It used to take the interface name, which is correct on Linux — where
+// the interface really is called meshp0 — and matches nothing on macOS, where meshp0 is a
+// label in a name file and the kernel knows a utunN. So the tunnel was not skipped, its own
+// address was collected as a network to keep off the tunnel, and the claim then asked the
+// kernel to route the device's own mesh address via the LAN gateway. It refuses, correctly,
+// and a laptop in a network with an egress group had no internet at all.
+//
+// An address is a fact about an interface that every platform agrees on. A name is not: this
+// project already carries a translation layer for exactly that reason (wglink's resolve), and
+// anything comparing names here would need to know about it.
+//
+// Interfaces that are down are skipped too, since a prefix on a link with no carrier is a
+// hole in the lock for a network that is not there.
+func LocalNetworks(own []netip.Prefix) []netip.Prefix {
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return nil
@@ -252,13 +263,14 @@ func LocalNetworks(skip string) []netip.Prefix {
 
 	var out []netip.Prefix
 	for _, iface := range ifaces {
-		if iface.Name == skip || iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
 			continue
 		}
 		addrs, err := iface.Addrs()
 		if err != nil {
 			continue
 		}
+		carried := make([]netip.Prefix, 0, len(addrs))
 		for _, a := range addrs {
 			ipnet, ok := a.(*net.IPNet)
 			if !ok {
@@ -269,11 +281,54 @@ func LocalNetworks(skip string) []netip.Prefix {
 				continue
 			}
 			ones, _ := ipnet.Mask.Size()
-			p := netip.PrefixFrom(addr.Unmap(), ones)
-			if p.IsValid() {
-				out = append(out, p.Masked())
+			if p := netip.PrefixFrom(addr.Unmap(), ones); p.IsValid() {
+				carried = append(carried, p)
 			}
 		}
+		out = append(out, contributes(carried, own)...)
 	}
 	return normalise(out)
+}
+
+// contributes returns the networks one interface adds to the carve-out.
+//
+// Separate from LocalNetworks so the decision can be tested without needing a machine whose
+// interfaces happen to be arranged the right way. That is not tidiness: a mutation that
+// excluded only the matching prefix instead of the whole interface passed every test here,
+// because the host it ran on carried exactly one global prefix per interface and the two
+// behaviours are identical in that case.
+//
+// carried holds the interface's addresses as unmasked prefixes, so each one still knows both
+// the address and the mask.
+//
+// An interface carrying one of the tunnel's addresses contributes nothing at all, not merely
+// the prefix that matched. A tunnel with several addresses — every device has at least a v4
+// and a v6 — would otherwise have the rest of them carved out and routed direct, which sends
+// part of the mesh out of the wrong door.
+func contributes(carried, own []netip.Prefix) []netip.Prefix {
+	for _, p := range carried {
+		if holds(own, p.Addr()) {
+			return nil
+		}
+	}
+	out := make([]netip.Prefix, 0, len(carried))
+	for _, p := range carried {
+		out = append(out, p.Masked())
+	}
+	return out
+}
+
+// holds reports whether one of the tunnel's own prefixes is this exact address.
+//
+// Compared as an address rather than by prefix containment, because containment would match
+// far too much: the tunnel's addresses come from the network's range (ADR-0005), and a
+// device whose LAN happened to overlap it would have its real network mistaken for the
+// tunnel and quietly dropped from the carve-out.
+func holds(own []netip.Prefix, addr netip.Addr) bool {
+	for _, p := range own {
+		if p.Addr() == addr {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/egress/carveout_test.go
+++ b/internal/egress/carveout_test.go
@@ -3,7 +3,9 @@ package egress
 import (
 	"context"
 	"errors"
+	"net"
 	"net/netip"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -215,17 +217,42 @@ func TestTheCarveoutIsStable(t *testing.T) {
 // The tunnel's own interface must not be carved out: its prefix is the mesh the device is
 // joining, and excluding it would leave every peer unreachable through the interface that
 // serves them.
-func TestTheTunnelsOwnNetworkIsNotTreatedAsLocal(t *testing.T) {
-	all := LocalNetworks("")
-	withoutLo := LocalNetworks("lo")
-
-	// Loopback is skipped whatever is named, so naming it must change nothing. This is the
-	// cheap half of the property; the real one needs an interface named meshp0 to exist,
-	// which is the data-plane container's job rather than this test's.
-	if len(all) != len(withoutLo) {
-		t.Errorf("naming loopback changed the result: %v vs %v", all, withoutLo)
+//
+// This used to be a test that could not test the thing. LocalNetworks took an interface name,
+// so proving the tunnel was skipped needed an interface actually called meshp0 — which the
+// test said out loud was "the data-plane container's job rather than this test's", and which
+// meant the property went unchecked on the platform where it was broken. macOS calls the
+// interface utunN and never matched the name at all (#200).
+//
+// Identifying the tunnel by an address it carries makes it checkable anywhere: take an
+// address this machine really has, call it the tunnel's, and require that interface's
+// networks to disappear from the answer.
+func TestAnInterfaceCarryingTheTunnelsAddressIsNotTreatedAsLocal(t *testing.T) {
+	all := LocalNetworks(nil)
+	if len(all) == 0 {
+		t.Skip("this machine reports no local networks to exclude one from")
 	}
-	for _, p := range all {
+
+	// Any address that is genuinely on this host, standing in for the tunnel's.
+	pretendTunnel, networks := anInterfacesAddress(t)
+	got := LocalNetworks([]netip.Prefix{netip.PrefixFrom(pretendTunnel, pretendTunnel.BitLen())})
+
+	for _, p := range networks {
+		if slices.Contains(got, p) {
+			t.Errorf("%s belongs to the interface carrying %s, which was named as the "+
+				"tunnel's own, and it is still reported as a local network",
+				p, pretendTunnel)
+		}
+	}
+	if len(got) >= len(all) {
+		t.Errorf("naming a real address as the tunnel's excluded nothing: %d before, %d after",
+			len(all), len(got))
+	}
+}
+
+// Loopback and default routes are never local networks, whatever is passed.
+func TestLoopbackAndDefaultsAreNeverLocalNetworks(t *testing.T) {
+	for _, p := range LocalNetworks(nil) {
 		if p.Addr().IsLoopback() {
 			t.Errorf("loopback %s was reported as a local network", p)
 		}
@@ -233,6 +260,126 @@ func TestTheTunnelsOwnNetworkIsNotTreatedAsLocal(t *testing.T) {
 			t.Errorf("a default route was reported as a local network: %s", p)
 		}
 	}
+}
+
+// The tunnel is matched by address and not by containment, and the difference is not
+// academic: a device's addresses come from the network's own range (ADR-0005), so a
+// deployment whose LAN overlapped that range would have its real network mistaken for the
+// tunnel and silently dropped from the carve-out — which is a hole in a fail-closed lock.
+func TestTheTunnelIsMatchedByAddressAndNotByContainment(t *testing.T) {
+	own := []netip.Prefix{netip.MustParsePrefix("100.80.0.3/32")}
+
+	if !holds(own, netip.MustParseAddr("100.80.0.3")) {
+		t.Error("the tunnel's own address was not recognised")
+	}
+	if holds(own, netip.MustParseAddr("100.80.0.9")) {
+		t.Error("another address in the same range was taken for the tunnel's")
+	}
+
+	wide := []netip.Prefix{netip.MustParsePrefix("100.80.0.0/24")}
+	if holds(wide, netip.MustParseAddr("100.80.0.9")) {
+		t.Error("an address merely inside the tunnel's prefix was taken for the tunnel's; " +
+			"a LAN overlapping the mesh range would be dropped from the carve-out")
+	}
+}
+
+// An interface carrying the tunnel contributes nothing, not just the address that matched.
+//
+// Deterministic, because the property only shows on a tunnel with more than one address —
+// which every device has, a v4 and a v6, but which the host running the tests may not arrange
+// for any single interface. A mutation that excluded only the matching prefix passed the
+// machine-dependent test above.
+func TestATunnelWithSeveralAddressesContributesNoneOfThem(t *testing.T) {
+	// Only the addresses the control plane assigned are the tunnel's, as far as this knows.
+	tunnel := []netip.Prefix{netip.MustParsePrefix("100.80.0.3/32")}
+
+	// What the interface actually carries is more than that: the other assigned address, and
+	// the link-local one the kernel adds to every interface by itself. Recognising the
+	// interface by one address has to disqualify all of them — the fixture matters, because
+	// a list where every entry matched could not tell "skip the interface" from "skip each
+	// matching address".
+	carried := []netip.Prefix{
+		netip.MustParsePrefix("100.80.0.3/32"),
+		netip.MustParsePrefix("fd7c:6d65:7368:80::3/128"),
+		netip.MustParsePrefix("fe80::1c9d:8f2:1b3c:4d5e/64"),
+	}
+
+	if got := contributes(carried, tunnel); len(got) != 0 {
+		t.Errorf("the tunnel's own interface contributed %v; carving any of it out sends "+
+			"part of the mesh out of the wrong door", got)
+	}
+}
+
+// And an interface that is not the tunnel contributes everything it carries.
+func TestAnOrdinaryInterfaceContributesEveryNetworkItCarries(t *testing.T) {
+	tunnel := []netip.Prefix{netip.MustParsePrefix("100.80.0.3/32")}
+	carried := []netip.Prefix{
+		netip.MustParsePrefix("192.168.0.102/24"),
+		netip.MustParsePrefix("2001:db8::5/64"),
+	}
+
+	got := contributes(carried, tunnel)
+	want := []netip.Prefix{
+		netip.MustParsePrefix("192.168.0.0/24"),
+		netip.MustParsePrefix("2001:db8::/64"),
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("contributes = %v, want %v", got, want)
+	}
+}
+
+// anInterfacesAddress returns one address this host really has, and every network the
+// interface carrying it contributes.
+func anInterfacesAddress(t *testing.T) (netip.Addr, []netip.Prefix) {
+	t.Helper()
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Skip("cannot read this host's interfaces:", err)
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		var (
+			first     netip.Addr
+			prefixes  []netip.Prefix
+			haveFirst bool
+		)
+		for _, a := range addrs {
+			ipnet, ok := a.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			addr, ok := netip.AddrFromSlice(ipnet.IP)
+			if !ok {
+				continue
+			}
+			addr = addr.Unmap()
+			// Not a link-local one. fe80::/64 is on nearly every interface, so excluding
+			// the one carrying it leaves the same prefix arriving from another and the
+			// test measures nothing. A tunnel's address is never link-local anyway — it
+			// comes out of the network's own range (ADR-0005).
+			if !addr.IsGlobalUnicast() || addr.IsLinkLocalUnicast() {
+				continue
+			}
+			if !haveFirst {
+				first, haveFirst = addr, true
+			}
+			ones, _ := ipnet.Mask.Size()
+			if p := netip.PrefixFrom(addr, ones); p.IsValid() {
+				prefixes = append(prefixes, p.Masked())
+			}
+		}
+		if haveFirst && len(prefixes) > 0 {
+			return first, prefixes
+		}
+	}
+	t.Skip("no interface on this host carries an address this can use")
+	return netip.Addr{}, nil
 }
 
 func TestAMissingControlURLIsRefused(t *testing.T) {

--- a/internal/tunnel/egress.go
+++ b/internal/tunnel/egress.go
@@ -25,7 +25,7 @@ import (
 // Nothing here is best effort. If the carve-out cannot be computed the group is unhonoured
 // and no lock is installed, because a device that locks itself away from its control plane
 // is off the network for a reason nobody watching can see.
-func (r *Reconciler) applyEgress(ctx context.Context, iface string, want bool, failClosed, preventDNSLeaks bool, relays, excluded []string) []string {
+func (r *Reconciler) applyEgress(ctx context.Context, iface string, own []netip.Prefix, want bool, failClosed, preventDNSLeaks bool, relays, excluded []string) []string {
 	if !want {
 		r.releaseEgress(ctx)
 		return nil
@@ -52,7 +52,7 @@ func (r *Reconciler) applyEgress(ctx context.Context, iface string, want bool, f
 	carve, err := egress.Compute(ctx, egress.Inputs{
 		ControlURL:     r.membership.ControlURL,
 		RelayEndpoints: relays,
-		LocalPrefixes:  egress.LocalNetworks(iface),
+		LocalPrefixes:  egress.LocalNetworks(own),
 		ExtraPrefixes:  excluded,
 	}, nil)
 	if err != nil {

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -479,7 +479,7 @@ func (r *Reconciler) Apply(ctx context.Context, state *peerset.Set) ([]string, e
 	// After the interface exists and before the filter, because claiming a default route
 	// installs its own lock and the two must not fight over the order they load in.
 	wantEgress, excluded := wantsEgress(state)
-	if failed := r.applyEgress(ctx, want.Name, wantEgress, failClosedFor(state.Tunnel()),
+	if failed := r.applyEgress(ctx, want.Name, want.Addresses, wantEgress, failClosedFor(state.Tunnel()),
 		state.DNS().GetPreventLeaks(), relayEndpointsOf(state.Relays()), excluded); failed != nil {
 		unapplied = append(unapplied, failed...)
 	}

--- a/internal/wglink/egress_darwin.go
+++ b/internal/wglink/egress_darwin.go
@@ -102,8 +102,54 @@ func (r *Router) Claim(iface string, endpoints []netip.AddrPort, excluded []neti
 		return fmt.Errorf("wglink: finding the current default gateway: %w", err)
 	}
 
-	// Everything that must stay off the tunnel, pinned to the gateway the machine is using
-	// now. Endpoints become host routes; excluded prefixes are already prefixes.
+	// The kernel's name for this tunnel, which is not the one meshp calls it. Resolved once
+	// here and used for everything below that names an interface — halvesFor reads the
+	// device's addresses and the route commands attach to a link, and both are talking to
+	// the kernel rather than to meshp.
+	device, err := realInterface(iface)
+	if err != nil {
+		return err
+	}
+
+	direct := directRoutes(endpoints, excluded)
+	for _, prefix := range direct {
+		if err := addRoute(prefix, "-gateway", gateway.String()); err != nil {
+			// Undo what has gone in, so a half-made claim does not leave the machine
+			// routing some of its traffic somewhere nobody asked for.
+			_ = r.releaseLocked()
+			return fmt.Errorf("wglink: keeping %s off the tunnel: %w", prefix, err)
+		}
+		r.viaLocal = append(r.viaLocal, prefix)
+	}
+
+	halves, err := halvesFor(device)
+	if err != nil {
+		_ = r.releaseLocked()
+		return err
+	}
+	for _, prefix := range halves {
+		if err := addRoute(prefix, "-interface", device); err != nil {
+			_ = r.releaseLocked()
+			return fmt.Errorf("wglink: claiming %s: %w", prefix, err)
+		}
+		r.claimed = append(r.claimed, prefix)
+	}
+
+	// Written last, so the record only ever describes a claim that is fully in place. A
+	// half-made claim has already been undone by the error paths above.
+	recordClaim(append(append([]netip.Prefix{}, r.viaLocal...), r.claimed...))
+	return nil
+}
+
+// directRoutes is everything that must stay off the tunnel, as prefixes this platform can
+// actually be told to route.
+//
+// Separate from Claim so the list can be checked without a utun, a gateway and root. That is
+// not tidiness: the first attempt at the fix below added the predicate and never called it,
+// and the test passed because it asked the predicate rather than asking what Claim would
+// install. A mechanism nothing reaches is what ADR-0018 is about, and a test shaped like that
+// cannot tell.
+func directRoutes(endpoints []netip.AddrPort, excluded []netip.Prefix) []netip.Prefix {
 	var direct []netip.Prefix
 	for _, endpoint := range endpoints {
 		addr := endpoint.Addr().Unmap()
@@ -116,38 +162,64 @@ func (r *Router) Claim(iface string, endpoints []netip.AddrPort, excluded []neti
 		direct = append(direct, netip.PrefixFrom(addr, addr.BitLen()))
 	}
 	for _, prefix := range excluded {
-		if prefix.Addr().Is4() {
+		if prefix.Addr().Is4() && routableViaGateway(prefix) {
 			direct = append(direct, prefix)
 		}
 	}
+	return direct
+}
 
-	for _, prefix := range direct {
-		if err := addRoute(prefix, "-gateway", gateway.String()); err != nil {
-			// Undo what has gone in, so a half-made claim does not leave the machine
-			// routing some of its traffic somewhere nobody asked for.
-			_ = r.releaseLocked()
-			return fmt.Errorf("wglink: keeping %s off the tunnel: %w", prefix, err)
-		}
-		r.viaLocal = append(r.viaLocal, prefix)
+// routableViaGateway reports whether macOS will accept a route for a prefix at all.
+//
+// The limited broadcast is the one that does not. route(8) rejects it outright —
+// `route: bad address: 255.255.255.255/32`, exit status 68 — and the carve-out lists it for
+// good reason: DHCP is broadcast, and a device that pushed it into a tunnel would be one that
+// could not renew a lease.
+//
+// Skipping it costs nothing, which is the part worth being sure of rather than assuming.
+// 255.255.255.255 is link-scoped by definition: the kernel never consults a gateway for it,
+// so a host route pointing at one would not change where it went. And the carve-out has two
+// consumers, not one — the same prefixes go to the pf lock, which is what actually decides
+// whether a packet is permitted to leave. The route is the half with nothing to say about
+// this address; the half that does is untouched.
+//
+// Found by running it. Claim aborts on the first prefix it cannot install, so this was the
+// second bug standing behind #200 and invisible until the first was fixed.
+func routableViaGateway(prefix netip.Prefix) bool {
+	return prefix != limitedBroadcast
+}
+
+// limitedBroadcast is 255.255.255.255/32, named because a bare literal in the comparison
+// above would read as an arbitrary exclusion rather than as the one address this is about.
+var limitedBroadcast = netip.MustParsePrefix("255.255.255.255/32")
+
+// realInterface is the kernel's name for a tunnel that meshp calls something else.
+//
+// The third face of the same bug (#200). meshp names its interfaces meshp0, meshp1 and so on,
+// and on Linux those are the interfaces. On macOS they are labels: the kernel makes a utunN
+// and wglink records the mapping in a name file, which is the thing that survives a restart.
+// Everything in this file that names an interface is talking to the kernel — net.Interface,
+// route(8) — so all of it needs the real one.
+//
+// wglink's own resolve does this already, and is a method on the link rather than on the
+// egress router, so the router never had it. That is why the same mistake arrived three times
+// in one claim path: nothing made the translation hard to skip.
+//
+// Tries the name as given first, so a platform where the name is already real costs nothing
+// and a test can pass a genuine interface.
+func realInterface(name string) (string, error) {
+	if _, err := net.InterfaceByName(name); err == nil {
+		return name, nil
 	}
-
-	halves, err := halvesFor(iface)
+	raw, err := os.ReadFile(filepath.Join(wireguardRunDir, name+".name"))
 	if err != nil {
-		_ = r.releaseLocked()
-		return err
+		return "", fmt.Errorf("wglink: finding the interface behind %s: %w", name, err)
 	}
-	for _, prefix := range halves {
-		if err := addRoute(prefix, "-interface", iface); err != nil {
-			_ = r.releaseLocked()
-			return fmt.Errorf("wglink: claiming %s: %w", prefix, err)
-		}
-		r.claimed = append(r.claimed, prefix)
+	device := string(trimNewline(raw))
+	if device == "" {
+		return "", fmt.Errorf("wglink: the name file for %s is empty, so its interface is unknown", name)
 	}
-
-	// Written last, so the record only ever describes a claim that is fully in place. A
-	// half-made claim has already been undone by the error paths above.
-	recordClaim(append(append([]netip.Prefix{}, r.viaLocal...), r.claimed...))
-	return nil
+	return device, nil
 }
 
 // halvesFor is the halves to claim, for the address families this tunnel actually carries.

--- a/internal/wglink/egress_darwin_test.go
+++ b/internal/wglink/egress_darwin_test.go
@@ -3,6 +3,7 @@
 package wglink
 
 import (
+	"net"
 	"net/netip"
 	"os"
 	"os/exec"
@@ -490,5 +491,121 @@ func TestWhetherARouteAlreadyGoesWhereAsked(t *testing.T) {
 		if got := tc.end.goesTo(tc.via); got != tc.want {
 			t.Errorf("%s: goesTo = %v, want %v", tc.name, got, tc.want)
 		}
+	}
+}
+
+// The carve-out contains one prefix macOS will not route, and Claim must not abort on it.
+//
+// route(8) rejects 255.255.255.255/32 with "bad address", and Claim gives up on the first
+// prefix it cannot install — so a device in a network with an egress group never claimed the
+// default route at all, and with fail-closed enforced had no internet.
+//
+// Asked of directRoutes, which is the list Claim installs, rather than of the predicate.
+// The first version of this fix added the predicate and never called it: the behaviour was
+// unchanged on the machine that found the bug while this test passed, because it was asking
+// the wrong question. ADR-0018 is about mechanisms nothing reaches, and a test that calls the
+// mechanism directly cannot notice that nothing else does.
+func TestClaimDoesNotTryToRouteTheLimitedBroadcast(t *testing.T) {
+	carveOut := []netip.Prefix{
+		netip.MustParsePrefix("169.254.0.0/16"),
+		netip.MustParsePrefix("224.0.0.0/4"),
+		netip.MustParsePrefix("255.255.255.255/32"),
+		netip.MustParsePrefix("192.168.0.0/24"),
+		// A single host an operator asked to keep direct. Here because without a /32 that
+		// must be kept, "skip the broadcast" and "skip every host route" are the same
+		// answer, and a rule that dropped every /32 would pass.
+		netip.MustParsePrefix("10.7.7.7/32"),
+		netip.MustParsePrefix("fe80::/10"),
+	}
+	endpoints := []netip.AddrPort{netip.MustParseAddrPort("168.144.85.34:3478")}
+
+	got := directRoutes(endpoints, carveOut)
+
+	for _, p := range got {
+		if p == netip.MustParsePrefix("255.255.255.255/32") {
+			t.Error("Claim would try to route 255.255.255.255/32; route(8) refuses it and " +
+				"the whole claim fails, leaving the device refusing egress with nothing " +
+				"carrying it")
+		}
+	}
+
+	// Everything else that keeps the machine's own network working while a full tunnel is
+	// claimed still gets a route. Skipping any of these would be a hole in the thing the
+	// carve-out exists to protect.
+	for _, want := range []netip.Prefix{
+		netip.MustParsePrefix("169.254.0.0/16"),
+		netip.MustParsePrefix("224.0.0.0/4"),
+		netip.MustParsePrefix("192.168.0.0/24"),
+		netip.MustParsePrefix("10.7.7.7/32"),
+		netip.MustParsePrefix("168.144.85.34/32"),
+	} {
+		if !slices.Contains(got, want) {
+			t.Errorf("%s must be kept off the tunnel and Claim would not route it", want)
+		}
+	}
+
+	// IPv6 is left alone here, which is a separate deliberate limitation of this platform's
+	// claim rather than something this change touches.
+	for _, p := range got {
+		if p.Addr().Is6() {
+			t.Errorf("an IPv6 prefix %s reached the v4 gateway loop", p)
+		}
+	}
+}
+
+// meshp's name for a tunnel is not the kernel's, and everything here talks to the kernel.
+//
+// The third instance of one root cause (#200): meshp0 is a real interface on Linux and a
+// label on macOS, where the kernel makes a utunN. LocalNetworks was fixed by identifying the
+// tunnel by address; halvesFor and the route commands genuinely need the device's name, so
+// Claim resolves it.
+func TestTheKernelsNameIsUsedNotMeshpsLabel(t *testing.T) {
+	// A name the kernel really has resolves to itself, which is both the Linux case and what
+	// lets this be checked without a tunnel.
+	ifaces, err := net.Interfaces()
+	if err != nil || len(ifaces) == 0 {
+		t.Skip("no interfaces to check against")
+	}
+	real := ifaces[0].Name
+	got, err := realInterface(real)
+	if err != nil {
+		t.Fatalf("realInterface(%q): %v", real, err)
+	}
+	if got != real {
+		t.Errorf("realInterface(%q) = %q, want it unchanged", real, got)
+	}
+
+	// A label with no interface and no name file is an error rather than a name passed
+	// through — passing it through is what produced "no such network interface" from three
+	// different callers.
+	if got, err := realInterface("meshp-nonexistent-" + t.Name()); err == nil {
+		t.Errorf("a label with no interface behind it resolved to %q instead of failing", got)
+	}
+}
+
+// The name file is what survives a restart, and is how a label is translated.
+func TestALabelResolvesThroughItsNameFile(t *testing.T) {
+	if _, err := os.Stat(wireguardRunDir); err != nil {
+		t.Skip("no", wireguardRunDir, "on this host")
+	}
+	ifaces, err := net.Interfaces()
+	if err != nil || len(ifaces) == 0 {
+		t.Skip("no interfaces to point a name file at")
+	}
+	target := ifaces[0].Name
+
+	label := "meshptest-" + strings.ReplaceAll(t.Name(), "/", "-")
+	path := filepath.Join(wireguardRunDir, label+".name")
+	if err := os.WriteFile(path, []byte(target+"\n"), 0o600); err != nil {
+		t.Skip("cannot write a name file here:", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(path) })
+
+	got, err := realInterface(label)
+	if err != nil {
+		t.Fatalf("realInterface(%q): %v", label, err)
+	}
+	if got != target {
+		t.Errorf("realInterface(%q) = %q, want %q from the name file", label, got, target)
 	}
 }


### PR DESCRIPTION
Three of the four bugs in #200. The fourth is #202 and is a different kind of problem.

Found by running it against a real control plane. Each bug hid the next, because `Claim` aborts on the first prefix it cannot install — which is also why a single incompatibility cost a laptop its entire internet rather than one route.

## 1. The tunnel was identified by a name macOS does not have

`applyEgress` passes `want.Name` — `meshp0` — and `LocalNetworks` skipped the interface whose `Name` matched.

On Linux `meshp0` **is** the interface. On macOS it is a label in a name file and the kernel has a `utunN`:

```
$ ifconfig meshp0
ifconfig: interface meshp0 does not exist
```

So nothing was skipped, the tunnel's own address was collected as a network to keep *off* the tunnel, and `Claim` asked the kernel to route the device's own mesh address via the LAN gateway:

```
"keeping 100.80.0.3/32 off the tunnel: 100.80.0.3/32 was replaced and still
 does not go to -gateway 192.168.0.1"
```

It refuses, correctly. `LocalNetworks` now identifies the tunnel by **an address it carries**. An address is a fact every platform agrees on; a name is not, and this repository already carries a translation layer for exactly that reason.

## 2. `route(8)` will not route `255.255.255.255/32`

```
route delete 255.255.255.255/32: exit status 68: route: bad address
```

The carve-out lists the limited broadcast because DHCP is broadcast and a device that tunnelled it could not renew a lease. But the address is link-scoped — the kernel never consults a gateway for it, so the route was never doing anything. The **pf lock**, which is what actually decides whether the packet may leave, receives the same prefixes and is untouched.

Same address that broke the Windows route reader in #193. Two platforms, two subsystems, one address.

## 3. `halvesFor` and `route -interface` also had the label

```
"reading meshp0: route ip+net: no such network interface"
```

Same root cause, third face. These genuinely need the device's *name* rather than an address, so `Claim` resolves it once and uses it throughout.

`wglink`'s own `resolve` already does this — and is a method on the **link**, while the egress **router** is a different type that never got one. Nothing made the translation hard to skip, which is why one mistake arrived three times in a single function.

## Verified end to end

A MacBook in a network with an egress group, advertiser on a DigitalOcean droplet:

```
=== droplet via LAN gateway? ===
168.144.85.34/32   192.168.0.1   UGSc   en0
=== exit IP ===
168.144.85.34
```

Traffic exiting in Bangalore, through the tunnel. That had never happened before.

## A test shaped by my own mistake

The first attempt at fix 2 added the predicate and **never called it**. The patch that would have wired it in failed an assertion partway and wrote nothing; the behaviour on the machine was unchanged; and the test passed, because it asked the predicate a question instead of asking what `Claim` would install.

That is ADR-0018's failure mode — a mechanism nothing reaches — in a repository with a CI job named *"everything defined is reached"*.

`directRoutes` is the seam that makes the real question askable. The mutation reproducing the mistake exactly — guard present, call site unmodified — now fails:

```
Claim would try to route 255.255.255.255/32; route(8) refuses it and the whole
claim fails, leaving the device refusing egress with nothing carrying it
```

Every fix here is mutation-tested in both directions. Two of the fixtures needed strengthening before they could tell: one had no legitimate `/32` in the carve-out, so "skip the broadcast" and "skip every host route" were the same answer; another made every carried address the tunnel's, so "skip the interface" and "skip each matching address" were indistinguishable.

## Not in this PR

**#202** — the interface planner withdraws the egress router's routes on every pass, because both write to the same interface and neither knows the other does. ~5% CPU, twice a second, on a laptop. It is a question about ownership rather than a patch, and it deserves deciding rather than fixing quietly.
