### PR TITLE
fix(dataplane): a route on the meshp interface is not automatically the plan's

### DIFF
--- a/internal/wglink/egress_darwin_test.go
+++ b/internal/wglink/egress_darwin_test.go
@@ -609,3 +609,55 @@ func TestALabelResolvesThroughItsNameFile(t *testing.T) {
 		t.Errorf("realInterface(%q) = %q, want %q from the name file", label, got, target)
 	}
 }
+
+// The route reader consults the record, which is the half a unit test of the rule cannot see.
+//
+// #202 is only fixed if interfaceRoutes actually asks. An earlier fix in this file added a
+// predicate and never called it, the tests passed because they asked the predicate, and the
+// behaviour on the machine was unchanged — so this exercises the reader against a record on
+// disk rather than the rule in isolation.
+func TestTheRouteReaderExcludesWhatTheEgressRouterRecorded(t *testing.T) {
+	index, routes := anInterfaceWithRoutes(t)
+	victim := routes[0]
+
+	dir := t.TempDir()
+	previous := egressRecordPath
+	egressRecordPath = filepath.Join(dir, "egress-routes")
+	t.Cleanup(func() { egressRecordPath = previous })
+
+	recordClaim([]netip.Prefix{victim})
+
+	after, err := interfaceRoutes(index)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(after, victim) {
+		t.Errorf("%s is recorded as the egress router's and interfaceRoutes still reports it; "+
+			"the planner will withdraw it every pass", victim)
+	}
+
+	// And only that one. Excluding more would hide peer routes from the planner.
+	for _, keep := range routes[1:] {
+		if !slices.Contains(after, keep) {
+			t.Errorf("%s is the interface plan's and was excluded", keep)
+		}
+	}
+}
+
+// anInterfaceWithRoutes finds an interface this host has that carries more than one route,
+// so the test above can tell "excluded the recorded one" from "excluded everything".
+func anInterfaceWithRoutes(t *testing.T) (int, []netip.Prefix) {
+	t.Helper()
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Skip("cannot read this host's interfaces:", err)
+	}
+	for _, iface := range ifaces {
+		routes, err := interfaceRoutes(iface.Index)
+		if err == nil && len(routes) > 1 {
+			return iface.Index, routes
+		}
+	}
+	t.Skip("no interface on this host carries more than one route")
+	return 0, nil
+}

--- a/internal/wglink/routeowner.go
+++ b/internal/wglink/routeowner.go
@@ -1,0 +1,44 @@
+//go:build darwin || windows
+
+package wglink
+
+import "net/netip"
+
+// Two parts of meshp write routes to the tunnel, and only one of them plans.
+//
+// wgplan owns the interface: it decides which peers exist and which prefixes reach them, and
+// it withdraws anything on the interface it did not put there. That rule is what lets the
+// agent clean up after itself on platforms with no protocol number to filter on (#193), and
+// it was true right up until something else started writing to the same interface.
+//
+// The egress router is that something. Claiming a full tunnel installs two halves that beat
+// the default route, and on these platforms they go into the same table, on the same
+// interface, as everything wgplan manages. So every pass, wgplan withdrew them as strays and
+// the egress router put them back: about twice a second on a laptop, at roughly five percent
+// of a CPU, for as long as a full tunnel was claimed (#202).
+//
+// Linux does not have this, and not by luck — it claims with a firewall mark and a routing
+// table of its own, so the two never share a table (docs/platforms.md). These platforms have
+// no equivalent, which is why the claim is expressed as ordinary routes and why ownership has
+// to be recorded rather than inferred.
+//
+// The record already existed. recordClaim has written exactly these prefixes since the claim
+// was first implemented, because ADR-0011 requires a later process to be able to undo what an
+// earlier one installed. Asking it is the difference between "meshp owns every route on this
+// interface" — true, and no longer sufficient — and "this component owns these".
+
+// egressOwned reports whether a prefix belongs to the egress router rather than to the
+// interface plan.
+//
+// Compared exactly rather than by containment. The halves are 0.0.0.0/1 and 128.0.0.0/1,
+// which contain very nearly every address a peer could have: a containment test would hide
+// every peer route from the planner the moment a full tunnel was claimed, and the interface
+// would stop being reconciled at all.
+func egressOwned(claim []netip.Prefix, prefix netip.Prefix) bool {
+	for _, owned := range claim {
+		if owned == prefix {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/wglink/routeowner_test.go
+++ b/internal/wglink/routeowner_test.go
@@ -1,0 +1,80 @@
+//go:build darwin || windows
+
+package wglink
+
+import (
+	"net/netip"
+	"testing"
+)
+
+// The egress router's routes are not the interface plan's to withdraw.
+//
+// #202: wgplan owns the interface and removes anything on it that it did not plan, which is
+// what lets it clean up after itself on platforms with no protocol number to filter on. The
+// egress claim installs two halves onto the same interface, so every pass wgplan withdrew them
+// and the egress router put them back — twice a second, at about five percent of a CPU, for as
+// long as a full tunnel was claimed.
+func TestTheEgressRoutersRoutesAreNotThePlannersToRemove(t *testing.T) {
+	claim := []netip.Prefix{
+		netip.MustParsePrefix("0.0.0.0/1"),
+		netip.MustParsePrefix("128.0.0.0/1"),
+		netip.MustParsePrefix("::/1"),
+		netip.MustParsePrefix("8000::/1"),
+		netip.MustParsePrefix("168.144.85.34/32"),
+	}
+
+	for _, owned := range claim {
+		if !egressOwned(claim, owned) {
+			t.Errorf("%s was installed by the egress router and the planner would withdraw it", owned)
+		}
+	}
+
+	// And the peer routes stay the planner's, or it stops managing the interface at all.
+	for _, planned := range []netip.Prefix{
+		netip.MustParsePrefix("100.80.0.1/32"),
+		netip.MustParsePrefix("100.80.0.2/32"),
+		netip.MustParsePrefix("fd7c:6d65:7368:80::1/128"),
+		netip.MustParsePrefix("10.0.0.0/24"),
+	} {
+		if egressOwned(claim, planned) {
+			t.Errorf("%s is the interface plan's and was taken for the egress router's", planned)
+		}
+	}
+}
+
+// Matched exactly, not by containment — and this is the part that would be catastrophic
+// rather than merely wasteful.
+//
+// The halves are 0.0.0.0/1 and 128.0.0.0/1, which between them contain very nearly every
+// address a peer can have. A containment test would hide every peer route from the planner the
+// moment a full tunnel was claimed, so the interface would stop being reconciled: a peer that
+// went away would keep its route, and a new one would never get one.
+func TestOwnershipIsExactAndNotContainment(t *testing.T) {
+	halves := []netip.Prefix{
+		netip.MustParsePrefix("0.0.0.0/1"),
+		netip.MustParsePrefix("128.0.0.0/1"),
+	}
+
+	for _, peer := range []netip.Prefix{
+		netip.MustParsePrefix("100.80.0.1/32"),  // inside 0.0.0.0/1
+		netip.MustParsePrefix("192.168.0.0/24"), // inside 128.0.0.0/1
+	} {
+		if egressOwned(halves, peer) {
+			t.Errorf("%s is merely inside a half and was taken for the egress router's; "+
+				"the planner would stop managing the interface entirely", peer)
+		}
+	}
+}
+
+// Nothing claimed means nothing is excluded, which is the state of every device that is not
+// carrying a full tunnel — that is to say, most of them.
+func TestWithNoClaimTheInterfacePlanOwnsEverything(t *testing.T) {
+	for _, prefix := range []netip.Prefix{
+		netip.MustParsePrefix("0.0.0.0/1"),
+		netip.MustParsePrefix("100.80.0.1/32"),
+	} {
+		if egressOwned(nil, prefix) {
+			t.Errorf("%s was excluded with no claim recorded", prefix)
+		}
+	}
+}

--- a/internal/wglink/routes_darwin.go
+++ b/internal/wglink/routes_darwin.go
@@ -46,6 +46,9 @@ func interfaceRoutes(index int) ([]netip.Prefix, error) {
 		return nil, fmt.Errorf("wglink: parsing the routing table: %w", err)
 	}
 
+	// Read once rather than per route: it is a file, and this runs on every reconcile.
+	claim := recordedClaim()
+
 	var out []netip.Prefix
 	for _, msg := range msgs {
 		m, ok := msg.(*route.RouteMessage)
@@ -54,6 +57,11 @@ func interfaceRoutes(index int) ([]netip.Prefix, error) {
 		}
 		prefix, ok := prefixOf(m)
 		if !ok {
+			continue
+		}
+		// A route the kernel cloned from one of ours is the kernel's, however much it
+		// looks like a route to a destination somebody chose.
+		if wasCloned(m) {
 			continue
 		}
 		// A host route to one of the interface's own addresses is the kernel's
@@ -67,6 +75,11 @@ func interfaceRoutes(index int) ([]netip.Prefix, error) {
 		// that distinguishes them, which is why this asks what the prefix is rather than
 		// what the routing message says about it.
 		if kernelOwned(prefix) {
+			continue
+		}
+		// Nor anything the egress router installed. It is meshp's, and it is not this
+		// interface's plan to manage — see routeowner.go.
+		if egressOwned(claim, prefix) {
 			continue
 		}
 		out = append(out, prefix)
@@ -144,6 +157,31 @@ func maskBits(a route.Addr, want int) int {
 		return -1
 	}
 	return ones
+}
+
+// wasCloned reports whether the kernel generated this route from one of ours.
+//
+// macOS clones. A route carrying RTF_PRCLONING — which the halves a full tunnel installs do —
+// makes the kernel create a host route for every destination actually contacted through it. So
+// a laptop browsing the web through a claimed tunnel grows a /32 per site, dozens of them,
+// each one a route meshp did not install and the planner would withdraw. The kernel recreates
+// them with the next packet.
+//
+// Measured rather than reasoned about: with a full tunnel claimed and ordinary browsing,
+// interfaceRoutes reported 74 routes where `netstat -rn` showed 5. The other 69 were these —
+// `netstat -rna` shows them, flagged `UHWIig`, or in words:
+//
+//	<UP,HOST,DONE,WASCLONED,IFSCOPE,IFREF,GLOBAL>
+//
+// This is the third time the same rule has been wrong in the same place. "Every route on a
+// meshp interface is meshp's" held until the kernel added link-local and multicast routes
+// (#193), then until the egress router wrote to the same interface (#202), and now until
+// traffic flowed through it. What is different about this one is that it needs *use*: an
+// interface that is up and idle never grows a cloned route, so no test that brings an
+// interface up and looks at it can find this.
+func wasCloned(m *route.RouteMessage) bool {
+	const rtfWasCloned = 0x20000 // RTF_WASCLONED
+	return m.Flags&rtfWasCloned != 0
 }
 
 // isLocalRoute reports whether a route is the kernel's own entry for an interface address.

--- a/internal/wglink/wglink_darwin_test.go
+++ b/internal/wglink/wglink_darwin_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/net/route"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
 	"github.com/meshpnet/meshp/internal/wgplan"
@@ -370,4 +371,36 @@ func hasPrefix(all []netip.Prefix, want netip.Prefix) bool {
 		}
 	}
 	return false
+}
+
+// A route the kernel cloned is the kernel's, not a stray for the planner to withdraw.
+//
+// macOS clones a host route per destination from any route carrying RTF_PRCLONING, which the
+// halves a full tunnel installs do. A laptop browsing through a claimed tunnel therefore grows
+// a /32 per site: measured at 74 routes reported where netstat -rn showed 5, all 69 extras
+// flagged WASCLONED, each one withdrawn every pass and recreated by the next packet (#202).
+func TestClonedRoutesAreTheKernelsNotOurs(t *testing.T) {
+	const (
+		rtfUp        = 0x1
+		rtfHost      = 0x4
+		rtfStatic    = 0x800
+		rtfWasCloned = 0x20000
+	)
+
+	cloned := &route.RouteMessage{Flags: rtfUp | rtfHost | rtfWasCloned}
+	if !wasCloned(cloned) {
+		t.Error("a WASCLONED route was not recognised as the kernel's; the planner will " +
+			"withdraw one per destination the device talks to")
+	}
+
+	// What meshp installs carries no such flag, and must stay the planner's — excluding
+	// these would leave peers unreachable and the interface unmanaged.
+	ours := &route.RouteMessage{Flags: rtfUp | rtfStatic}
+	if wasCloned(ours) {
+		t.Error("a route meshp installed was taken for a cloned one")
+	}
+	host := &route.RouteMessage{Flags: rtfUp | rtfHost | rtfStatic}
+	if wasCloned(host) {
+		t.Error("a host route meshp installed was taken for a cloned one")
+	}
 }

--- a/internal/wglink/wglink_windows.go
+++ b/internal/wglink/wglink_windows.go
@@ -470,6 +470,9 @@ func adapterRoutes(luid winipcfg.LUID) ([]netip.Prefix, error) {
 	if err != nil {
 		return nil, fmt.Errorf("wglink: reading this host's routes: %w", err)
 	}
+	// Read once rather than per route: it is a file, and this runs on every reconcile.
+	claim := recordedClaim()
+
 	var out []netip.Prefix
 	for _, row := range rows {
 		if row.InterfaceLUID != luid {
@@ -490,6 +493,12 @@ func adapterRoutes(luid winipcfg.LUID) ([]netip.Prefix, error) {
 		}
 		prefix := row.DestinationPrefix.Prefix()
 		if !prefix.IsValid() {
+			continue
+		}
+		// The egress router adds its routes through the same API, so they carry the same
+		// protocol as the interface plan's and the filter above cannot tell them apart.
+		// See routeowner.go.
+		if egressOwned(claim, prefix.Masked()) {
 			continue
 		}
 		out = append(out, prefix.Masked())


### PR DESCRIPTION
Closes #202. A macOS device holding a full tunnel spent about **ten percent of a CPU** rewriting its routing table twice a second, for as long as the tunnel was claimed.

Two causes. The one I filed the issue about is the smaller.

## The kernel clones

A route carrying `RTF_PRCLONING` — which the halves a full tunnel installs do — makes macOS create a **host route per destination actually contacted through it**. So a laptop browsing the web through a claimed tunnel grows a `/32` per site, `wgplan` withdraws every one as a stray, and the kernel recreates them with the next packet.

Measured on the affected machine, tunnel claimed, mid-browsing:

```
interfaceRoutes returns 74 routes
netstat -rn  shows 5 on utun6
netstat -rna shows 84
```

The other 69 are these. One of them:

```
8.8.8.8   utun6   UHWIig   utun6
flags: <UP,HOST,DONE,WASCLONED,IFSCOPE,IFREF,GLOBAL>
```

`netstat -rn` hides them, which is why every earlier inspection of that routing table looked clean.

## And two parts of meshp write to the same interface

`wgplan` owns the interface and withdraws what it did not plan — the rule that lets the agent clean up after itself where there is no protocol number to filter on (#193). The egress router installs the halves onto that same interface. Neither is wrong about its own job.

**The record that says which is whose already existed.** `recordClaim` has written exactly those prefixes since the claim was implemented, because ADR-0011 requires a later process to undo an earlier one's work. The readers just were not asking it.

Windows had this half too: `halvesFor` puts the halves on the tunnel adapter, and `adapterRoutes` filters on `RouteProtocolNetMgmt` — which meshp's own `AddRoute` also produces, so the protocol cannot separate them.

**Matched exactly, not by containment.** The halves are `0.0.0.0/1` and `128.0.0.0/1`, which between them contain nearly every address a peer can have. A containment test would hide every peer route from the planner and the interface would stop being reconciled at all — mutation-tested, because that failure would be far worse than the one being fixed.

## Measured, before and after

Same machine, tunnel claimed, traffic actively flowing through it:

| | CPU over 20s |
|---|---|
| before | **2.06s** |
| after | **0.07s** |

Thirty-fold. And the exit IP stayed `168.144.85.34` throughout, so the filters did not cost the claim — that mattered as much as the CPU number, since filtering too much would have looked like success.

## The third time the same line has been wrong

*"Every route on a meshp interface is meshp's"* held until:

1. the kernel added link-local and multicast routes — #193
2. the egress router started writing to the same interface — this PR
3. traffic flowed through it and the kernel began cloning — this PR

The third is the one no test here could have found. **An interface that is up and idle never grows a cloned route**, so bringing one up and inspecting it — which is what every test in this package does — cannot see it. It took a laptop browsing the web through a claimed tunnel.

That is worth more than the fix: the data plane has a class of behaviour that only exists under *use*, and nothing in CI uses anything.

## Note on my own diagnosis

The issue attributed this churn to the egress halves — four routes. The dominant cause is seventy cloned ones. Had I shipped the ownership fix alone, I would have removed about 5% of the churn, measured the CPU, and been puzzled. Both fixes are here and both are needed; the measurement is what separated them.