### PR TITLE
fix(control): tell devices when a route group is deleted

### DIFF
--- a/internal/api/routegroup_test.go
+++ b/internal/api/routegroup_test.go
@@ -200,12 +200,16 @@ func TestRouteChangesMoveTheStateVersion(t *testing.T) {
 		}
 	}
 
-	// And the change names no peer, because it is about every device at once.
+	// And a routes change names no peer, because it is about every device at once.
+	//
+	// Read by kind rather than by "the most recent row": deleting a group records a routes
+	// change *and* a tombstone naming the group, at the same version, and which of the two
+	// comes last is an ordering this test has no business depending on (#205).
 	var kind string
 	var membershipID, peerKey *string
 	if err := h.store.Pool().QueryRow(h.ctx,
 		`SELECT kind, membership_id::text, peer_public_key FROM state_changes
-		 WHERE network_id = $1 ORDER BY version DESC LIMIT 1`, h.netID).
+		 WHERE network_id = $1 AND kind = 'routes' ORDER BY version DESC LIMIT 1`, h.netID).
 		Scan(&kind, &membershipID, &peerKey); err != nil {
 		t.Fatal(err)
 	}
@@ -214,6 +218,19 @@ func TestRouteChangesMoveTheStateVersion(t *testing.T) {
 	}
 	if membershipID != nil || peerKey != nil {
 		t.Errorf("a route change named a peer: %v %v", membershipID, peerKey)
+	}
+
+	// The deletion also names the group it removed, which is what lets a delta withdraw it
+	// from a device that is already connected (#205).
+	var tombstones int
+	if err := h.store.Pool().QueryRow(h.ctx,
+		`SELECT count(*) FROM state_changes
+		 WHERE network_id = $1 AND kind = 'route_group_remove' AND route_group_id IS NOT NULL`,
+		h.netID).Scan(&tombstones); err != nil {
+		t.Fatal(err)
+	}
+	if tombstones != 1 {
+		t.Errorf("deleting a route group recorded %d removals naming the group, want 1", tombstones)
 	}
 }
 

--- a/internal/session/routes_test.go
+++ b/internal/session/routes_test.go
@@ -466,6 +466,13 @@ func TestADeletedRouteGroupIsWithdrawnByADelta(t *testing.T) {
 	f := newFixture(t)
 	alice := f.enrolDevice("alice")
 	bob := f.enrolDevice("bob")
+	// Four devices, so alice has three peers. The builder sends a snapshot when a delta
+	// would carry more entries than the peer list — "a delta with more entries than the
+	// snapshot it replaces is a worse answer" — and deleting a group writes two changes.
+	// With one peer that rule chooses a snapshot, which has no withdrawals because the set
+	// is complete, and this would pass without testing anything.
+	f.enrolDevice("carol")
+	f.enrolDevice("dave")
 
 	group := f.subnetGroup("branch-lan", "10.0.0.0/24")
 	f.advertise("branch-lan", bob, 1)
@@ -506,6 +513,13 @@ func TestADeletedEgressGroupIsWithdrawnByADelta(t *testing.T) {
 	f := newFixture(t)
 	alice := f.enrolDevice("alice")
 	bob := f.enrolDevice("bob")
+	// Four devices, so alice has three peers. The builder sends a snapshot when a delta
+	// would carry more entries than the peer list — "a delta with more entries than the
+	// snapshot it replaces is a worse answer" — and deleting a group writes two changes.
+	// With one peer that rule chooses a snapshot, which has no withdrawals because the set
+	// is complete, and this would pass without testing anything.
+	f.enrolDevice("carol")
+	f.enrolDevice("dave")
 
 	group, err := f.store.CreateRouteGroup(f.ctx, store.CreateRouteGroupRequest{
 		NetworkID: f.netID, Slug: "internet", Kind: store.KindEgress,
@@ -544,6 +558,13 @@ func TestDeletingOneGroupLeavesTheOthers(t *testing.T) {
 	f := newFixture(t)
 	alice := f.enrolDevice("alice")
 	bob := f.enrolDevice("bob")
+	// Four devices, so alice has three peers. The builder sends a snapshot when a delta
+	// would carry more entries than the peer list — "a delta with more entries than the
+	// snapshot it replaces is a worse answer" — and deleting a group writes two changes.
+	// With one peer that rule chooses a snapshot, which has no withdrawals because the set
+	// is complete, and this would pass without testing anything.
+	f.enrolDevice("carol")
+	f.enrolDevice("dave")
 
 	going := f.subnetGroup("going", "10.0.0.0/24")
 	staying := f.subnetGroup("staying", "10.1.0.0/24")

--- a/internal/session/routes_test.go
+++ b/internal/session/routes_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"net/netip"
+	"slices"
 	"testing"
 
 	"github.com/meshpnet/meshp/internal/store"
@@ -450,5 +451,130 @@ func TestAnEgressAdvertiserCarriesBothDefaultRoutes(t *testing.T) {
 	}
 	if p := groups[0].GetPrefixes(); len(p) != 2 || p[0] != "0.0.0.0/0" || p[1] != "::/0" {
 		t.Errorf("prefixes = %v, want both default routes", p)
+	}
+}
+
+// A deleted route group is withdrawn by a delta, not only by the next snapshot.
+//
+// #205: withdrawals were worked out by listing the groups that still exist and seeing which
+// produced no assignment for a device. A deleted group is in no such list, so it appeared in
+// neither the assignments nor the withdrawals — and a connected device went on carrying it
+// indefinitely, because only a reconnect replaces the set wholesale. Observed on a laptop
+// still sending everything through an exit node ten minutes after the group was deleted;
+// version 36 as a delta left it claiming, version 36 as a snapshot released it.
+func TestADeletedRouteGroupIsWithdrawnByADelta(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+	bob := f.enrolDevice("bob")
+
+	group := f.subnetGroup("branch-lan", "10.0.0.0/24")
+	f.advertise("branch-lan", bob, 1)
+
+	builder := NewStateBuilder(f.store)
+	before, err := builder.Snapshot(f.ctx, alice.membershipID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(before.GetRouteGroups()) != 1 {
+		t.Fatalf("alice was not assigned the group to begin with: %v", before.GetRouteGroups())
+	}
+
+	if err := f.store.DeleteRouteGroup(f.ctx, f.netID, "branch-lan"); err != nil {
+		t.Fatalf("DeleteRouteGroup: %v", err)
+	}
+
+	delta, err := builder.For(f.ctx, alice.membershipID, before.GetToVersion())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delta.GetFromVersion() == 0 {
+		t.Fatal("deleting a group produced a snapshot; the delta path was not exercised, " +
+			"which is the only path where this was broken")
+	}
+	if !slices.Contains(delta.GetRemovedRouteGroupIds(), group.ID.String()) {
+		t.Errorf("the deleted group %s is not withdrawn: assigned=%v withdrawn=%v — a "+
+			"connected device keeps carrying it",
+			group.ID, delta.GetRouteGroups(), delta.GetRemovedRouteGroupIds())
+	}
+	if len(delta.GetRouteGroups()) != 0 {
+		t.Errorf("the deleted group is still assigned: %v", delta.GetRouteGroups())
+	}
+}
+
+// An egress group is the case that hurts, because the device claims a default route for it.
+func TestADeletedEgressGroupIsWithdrawnByADelta(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+	bob := f.enrolDevice("bob")
+
+	group, err := f.store.CreateRouteGroup(f.ctx, store.CreateRouteGroupRequest{
+		NetworkID: f.netID, Slug: "internet", Kind: store.KindEgress,
+	})
+	if err != nil {
+		f.t.Fatalf("CreateRouteGroup: %v", err)
+	}
+	f.advertise("internet", bob, 1)
+
+	builder := NewStateBuilder(f.store)
+	before, err := builder.Snapshot(f.ctx, alice.membershipID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(before.GetRouteGroups()) != 1 {
+		t.Fatalf("alice was not assigned the egress group: %v", before.GetRouteGroups())
+	}
+
+	if err := f.store.DeleteRouteGroup(f.ctx, f.netID, "internet"); err != nil {
+		t.Fatalf("DeleteRouteGroup: %v", err)
+	}
+
+	delta, err := builder.For(f.ctx, alice.membershipID, before.GetToVersion())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(delta.GetRemovedRouteGroupIds(), group.ID.String()) {
+		t.Errorf("a deleted egress group is not withdrawn, so the device goes on sending "+
+			"everything through an exit node the control plane has forgotten: %v",
+			delta.GetRemovedRouteGroupIds())
+	}
+}
+
+// Deleting one group must not withdraw another. The tombstone names an id for a reason.
+func TestDeletingOneGroupLeavesTheOthers(t *testing.T) {
+	f := newFixture(t)
+	alice := f.enrolDevice("alice")
+	bob := f.enrolDevice("bob")
+
+	going := f.subnetGroup("going", "10.0.0.0/24")
+	staying := f.subnetGroup("staying", "10.1.0.0/24")
+	f.advertise("going", bob, 1)
+	f.advertise("staying", bob, 1)
+
+	builder := NewStateBuilder(f.store)
+	before, err := builder.Snapshot(f.ctx, alice.membershipID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := f.store.DeleteRouteGroup(f.ctx, f.netID, "going"); err != nil {
+		t.Fatal(err)
+	}
+
+	delta, err := builder.For(f.ctx, alice.membershipID, before.GetToVersion())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(delta.GetRemovedRouteGroupIds(), going.ID.String()) {
+		t.Errorf("the deleted group was not withdrawn: %v", delta.GetRemovedRouteGroupIds())
+	}
+	if slices.Contains(delta.GetRemovedRouteGroupIds(), staying.ID.String()) {
+		t.Errorf("a group that still exists was withdrawn: %v", delta.GetRemovedRouteGroupIds())
+	}
+	var assigned []string
+	for _, a := range delta.GetRouteGroups() {
+		assigned = append(assigned, a.GetRouteGroupId())
+	}
+	if !slices.Contains(assigned, staying.ID.String()) {
+		t.Errorf("the surviving group is no longer assigned: %v", assigned)
 	}
 }

--- a/internal/session/state.go
+++ b/internal/session/state.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"slices"
 	"sort"
 
 	"github.com/google/uuid"
@@ -294,6 +295,9 @@ func (b *StateBuilder) delta(ctx context.Context, membership dbgen.GetMembership
 	removes := make(map[string]struct{})
 	policyChanged := false
 	routesChanged := false
+	// Groups that no longer exist, so the builder below cannot find them by listing what
+	// does. Collected rather than counted: the delta withdraws a group by naming it.
+	deletedGroups := map[string]struct{}{}
 
 	for _, change := range changes {
 		switch change.Kind {
@@ -329,6 +333,16 @@ func (b *StateBuilder) delta(ctx context.Context, membership dbgen.GetMembership
 				continue
 			}
 			removes[*change.PeerPublicKey] = struct{}{}
+
+		case "route_group_remove":
+			// Names the group, because it is gone: routeGroupsFor works out withdrawals by
+			// listing the groups that exist, and a deleted one is in no such list. Without
+			// this the device is told nothing and keeps carrying it (#205).
+			if change.RouteGroupID == nil {
+				continue
+			}
+			routesChanged = true
+			deletedGroups[change.RouteGroupID.String()] = struct{}{}
 		}
 	}
 
@@ -377,6 +391,20 @@ func (b *StateBuilder) delta(ctx context.Context, membership dbgen.GetMembership
 		delta.RouteGroups = assignments
 		delta.RemovedRouteGroupIds = withdrawn
 		delta.Advertised = advertised
+
+		// And the ones that no longer exist. Appended rather than merged into routeGroupsFor,
+		// because that function answers "what does this device get from the groups there are"
+		// and a deleted group is not one of them — asking it to also remember what used to
+		// exist would give it two jobs and one name.
+		for id := range deletedGroups {
+			if !slices.Contains(delta.RemovedRouteGroupIds, id) {
+				delta.RemovedRouteGroupIds = append(delta.RemovedRouteGroupIds, id)
+			}
+		}
+		// Ordered, so two deltas describing the same change are the same message. A map's
+		// iteration order is not, and a delta that differs only by ordering would make an
+		// agent's diff look like a change.
+		slices.Sort(delta.RemovedRouteGroupIds)
 	}
 
 	if policyChanged {

--- a/internal/store/gen/models.go
+++ b/internal/store/gen/models.go
@@ -313,6 +313,7 @@ type StateChange struct {
 	MembershipID  *uuid.UUID
 	PeerPublicKey *string
 	CreatedAt     time.Time
+	RouteGroupID  *uuid.UUID
 }
 
 type User struct {

--- a/internal/store/gen/routegroups.sql.go
+++ b/internal/store/gen/routegroups.sql.go
@@ -240,8 +240,8 @@ func (q *Queries) DeleteRouteAdvertiser(ctx context.Context, arg DeleteRouteAdve
 	return result.RowsAffected(), nil
 }
 
-const deleteRouteGroup = `-- name: DeleteRouteGroup :execrows
-DELETE FROM route_groups WHERE network_id = $1 AND slug = $2
+const deleteRouteGroup = `-- name: DeleteRouteGroup :many
+DELETE FROM route_groups WHERE network_id = $1 AND slug = $2 RETURNING id
 `
 
 type DeleteRouteGroupParams struct {
@@ -249,12 +249,27 @@ type DeleteRouteGroupParams struct {
 	Slug      string
 }
 
-func (q *Queries) DeleteRouteGroup(ctx context.Context, arg DeleteRouteGroupParams) (int64, error) {
-	result, err := q.db.Exec(ctx, deleteRouteGroup, arg.NetworkID, arg.Slug)
+// Returns the ids it removed, because a delta withdraws a group by naming it and by the time
+// one is built the row is gone (#205). :many rather than :one so that deleting nothing is an
+// empty result rather than an error the caller has to tell apart from a real failure.
+func (q *Queries) DeleteRouteGroup(ctx context.Context, arg DeleteRouteGroupParams) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, deleteRouteGroup, arg.NetworkID, arg.Slug)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	return result.RowsAffected(), nil
+	defer rows.Close()
+	var items []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getAdvertiserForReport = `-- name: GetAdvertiserForReport :one

--- a/internal/store/gen/state.sql.go
+++ b/internal/store/gen/state.sql.go
@@ -129,7 +129,7 @@ func (q *Queries) ListNetworksWithPrunableChanges(ctx context.Context, olderThan
 }
 
 const listStateChangesSince = `-- name: ListStateChangesSince :many
-SELECT id, version, kind, membership_id, peer_public_key
+SELECT id, version, kind, membership_id, peer_public_key, route_group_id
 FROM state_changes
 WHERE network_id = $1
   AND version > $2
@@ -149,6 +149,7 @@ type ListStateChangesSinceRow struct {
 	Kind          string
 	MembershipID  *uuid.UUID
 	PeerPublicKey *string
+	RouteGroupID  *uuid.UUID
 }
 
 // The rows a delta is built from.
@@ -171,6 +172,7 @@ func (q *Queries) ListStateChangesSince(ctx context.Context, arg ListStateChange
 			&i.Kind,
 			&i.MembershipID,
 			&i.PeerPublicKey,
+			&i.RouteGroupID,
 		); err != nil {
 			return nil, err
 		}
@@ -244,8 +246,8 @@ func (q *Queries) RaiseDeltaFloor(ctx context.Context, arg RaiseDeltaFloorParams
 }
 
 const recordStateChange = `-- name: RecordStateChange :one
-INSERT INTO state_changes (network_id, version, kind, membership_id, peer_public_key)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO state_changes (network_id, version, kind, membership_id, peer_public_key, route_group_id)
+VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING id
 `
 
@@ -255,6 +257,7 @@ type RecordStateChangeParams struct {
 	Kind          string
 	MembershipID  *uuid.UUID
 	PeerPublicKey *string
+	RouteGroupID  *uuid.UUID
 }
 
 // Written in the same transaction as the version bump it describes. A change recorded
@@ -267,6 +270,7 @@ func (q *Queries) RecordStateChange(ctx context.Context, arg RecordStateChangePa
 		arg.Kind,
 		arg.MembershipID,
 		arg.PeerPublicKey,
+		arg.RouteGroupID,
 	)
 	var id int64
 	err := row.Scan(&id)

--- a/internal/store/routegroup.go
+++ b/internal/store/routegroup.go
@@ -229,17 +229,29 @@ func (s *Store) Withdraw(ctx context.Context, networkID uuid.UUID, groupSlug str
 // DeleteRouteGroup removes a group and everything that advertised it.
 func (s *Store) DeleteRouteGroup(ctx context.Context, networkID uuid.UUID, slug string) error {
 	return s.InTx(ctx, func(q *dbgen.Queries) error {
-		rows, err := q.DeleteRouteGroup(ctx, dbgen.DeleteRouteGroupParams{
+		removed, err := q.DeleteRouteGroup(ctx, dbgen.DeleteRouteGroupParams{
 			NetworkID: networkID, Slug: slug,
 		})
 		if err != nil {
 			return fmt.Errorf("store: deleting the route group: %w", err)
 		}
-		if rows == 0 {
+		if len(removed) == 0 {
 			return ErrNoSuchRouteGroup
 		}
-		err = BumpRoutesEverywhere(ctx, q, networkID)
-		return err
+		// Named on the way out, and not left to the routes bump alone. A delta withdraws a
+		// group by naming it, and the builder finds which to name by listing the groups that
+		// still exist — so a deleted one is in neither the assignments nor the withdrawals,
+		// and every connected device goes on carrying it until it happens to reconnect
+		// (#205).
+		changes := []Change{RoutesChanged()}
+		for _, id := range removed {
+			changes = append(changes, RouteGroupRemoved(id))
+		}
+		if _, err := BumpVersion(ctx, q, networkID, changes...); err != nil {
+			return err
+		}
+		// The other networks a shared device sits in still only need to recompute.
+		return bumpRoutesForSharedNetworks(ctx, q, networkID)
 	})
 }
 

--- a/internal/store/statelog.go
+++ b/internal/store/statelog.go
@@ -22,6 +22,13 @@ type Change struct {
 	// never told to remove a peer keeps a tunnel configured to a device that does not.
 	PeerPublicKey *string
 
+	// RouteGroupID names a route group that is gone. Required for removals, for the reason
+	// PeerPublicKey is: by the time a delta is built the row has been deleted, so a builder
+	// listing the groups that exist cannot find it — and a device that is never told to drop
+	// a group keeps carrying it, which on an egress group means routing everything through
+	// an exit node the control plane no longer knows about (#205).
+	RouteGroupID *uuid.UUID
+
 	// Policy marks a change to the network's ACL policy, which names no peer because it
 	// changes what every device may do.
 	Policy bool
@@ -57,6 +64,13 @@ func PeerRemoved(publicKey string) Change {
 // desired state for every device in the network, not only for the advertiser. Everyone
 // else has to be told where to send that traffic.
 func RoutesChanged() Change { return Change{Routes: true} }
+
+// RouteGroupRemoved records that a group is gone, naming it.
+//
+// Distinct from RoutesChanged, which says "recompute the assignments" and is answered by
+// listing the groups that exist. A deleted group is in no such list, so it needs to name
+// itself on the way out — the same reason peer removal carries a public key (#205).
+func RouteGroupRemoved(id uuid.UUID) Change { return Change{RouteGroupID: &id} }
 
 // PolicyChanged records that the network's ACL policy changed.
 //
@@ -112,6 +126,7 @@ func BumpVersion(ctx context.Context, q *dbgen.Queries, networkID uuid.UUID, cha
 			Kind:          kind,
 			MembershipID:  change.MembershipID,
 			PeerPublicKey: change.PeerPublicKey,
+			RouteGroupID:  change.RouteGroupID,
 		}); err != nil {
 			return 0, fmt.Errorf("store: recording change %d: %w", i, err)
 		}
@@ -146,6 +161,9 @@ func (c Change) kind() (string, error) {
 	if c.PeerPublicKey != nil {
 		kinds = append(kinds, "peer_remove")
 	}
+	if c.RouteGroupID != nil {
+		kinds = append(kinds, "route_group_remove")
+	}
 
 	switch len(kinds) {
 	case 1:
@@ -175,6 +193,13 @@ func BumpRoutesEverywhere(ctx context.Context, q *dbgen.Queries, networkID uuid.
 	if _, err := BumpVersion(ctx, q, networkID, RoutesChanged()); err != nil {
 		return err
 	}
+	return bumpRoutesForSharedNetworks(ctx, q, networkID)
+}
+
+// bumpRoutesForSharedNetworks tells the other networks a shared device sits in that routes
+// moved. Split out because a deletion bumps this network with an extra change of its own and
+// still owes the others an ordinary routes bump.
+func bumpRoutesForSharedNetworks(ctx context.Context, q *dbgen.Queries, networkID uuid.UUID) error {
 	sharing, err := q.NetworksSharingADeviceWith(ctx, networkID)
 	if err != nil {
 		return fmt.Errorf("store: finding networks that share a device: %w", err)

--- a/migrations/0015_route_group_removals.sql
+++ b/migrations/0015_route_group_removals.sql
@@ -1,0 +1,77 @@
+-- +goose Up
+
+-- A deleted route group is a sixth kind of change.
+--
+-- The bug this closes: deleting a route group bumped the version and told nobody. Deltas
+-- withdraw a group by naming it, and the builder worked out which to name by listing the
+-- groups that still exist and seeing which produced no assignment for a device. A group that
+-- has been deleted is in no such list, so it appeared in neither the assignments nor the
+-- withdrawals, and every connected device went on carrying it — indefinitely, since only a
+-- reconnect replaces the set wholesale. On an egress group that means a laptop sending all
+-- of its traffic through an exit node the control plane no longer knows about (#205).
+--
+-- It names the group, for the reason 'peer_remove' names a public key: by the time a delta
+-- is built the row is gone, so the identifier has to be in the log rather than looked up.
+-- That is the whole shape of this change — the mechanism already existed for peers and was
+-- missing here.
+--
+-- Constraints are dropped and rebuilt wholesale rather than altered, following 0005 and
+-- 0009: a CHECK cannot be extended in place, and naming them individually has gone wrong
+-- once in this table's history.
+
+ALTER TABLE state_changes ADD COLUMN route_group_id uuid;
+
+DO $$
+DECLARE c record;
+BEGIN
+    FOR c IN
+        SELECT conname FROM pg_constraint
+        WHERE conrelid = 'state_changes'::regclass AND contype = 'c'
+    LOOP
+        EXECUTE format('ALTER TABLE state_changes DROP CONSTRAINT %I', c.conname);
+    END LOOP;
+END $$;
+
+ALTER TABLE state_changes
+    ADD CONSTRAINT state_changes_kind_check
+    CHECK (kind IN ('peer_upsert', 'peer_remove', 'policy', 'routes', 'tunnel', 'dns',
+                    'route_group_remove'));
+
+ALTER TABLE state_changes
+    ADD CONSTRAINT state_changes_identifier_check CHECK (
+        (kind = 'peer_upsert' AND membership_id IS NOT NULL) OR
+        (kind = 'peer_remove' AND peer_public_key IS NOT NULL) OR
+        (kind = 'route_group_remove' AND route_group_id IS NOT NULL) OR
+        (kind IN ('policy', 'routes', 'tunnel', 'dns')
+            AND membership_id IS NULL AND peer_public_key IS NULL
+            AND route_group_id IS NULL)
+    );
+
+-- +goose Down
+
+DELETE FROM state_changes WHERE kind = 'route_group_remove';
+
+DO $$
+DECLARE c record;
+BEGIN
+    FOR c IN
+        SELECT conname FROM pg_constraint
+        WHERE conrelid = 'state_changes'::regclass AND contype = 'c'
+    LOOP
+        EXECUTE format('ALTER TABLE state_changes DROP CONSTRAINT %I', c.conname);
+    END LOOP;
+END $$;
+
+ALTER TABLE state_changes
+    ADD CONSTRAINT state_changes_kind_check
+    CHECK (kind IN ('peer_upsert', 'peer_remove', 'policy', 'routes', 'tunnel', 'dns'));
+
+ALTER TABLE state_changes
+    ADD CONSTRAINT state_changes_identifier_check CHECK (
+        (kind = 'peer_upsert' AND membership_id IS NOT NULL) OR
+        (kind = 'peer_remove' AND peer_public_key IS NOT NULL) OR
+        (kind IN ('policy', 'routes', 'tunnel', 'dns')
+            AND membership_id IS NULL AND peer_public_key IS NULL)
+    );
+
+ALTER TABLE state_changes DROP COLUMN route_group_id;

--- a/queries/routegroups.sql
+++ b/queries/routegroups.sql
@@ -73,8 +73,11 @@ FROM route_group_prefixes
 WHERE route_group_id = ANY($1::uuid[])
 ORDER BY route_group_id, prefix;
 
--- name: DeleteRouteGroup :execrows
-DELETE FROM route_groups WHERE network_id = $1 AND slug = $2;
+-- name: DeleteRouteGroup :many
+-- Returns the ids it removed, because a delta withdraws a group by naming it and by the time
+-- one is built the row is gone (#205). :many rather than :one so that deleting nothing is an
+-- empty result rather than an error the caller has to tell apart from a real failure.
+DELETE FROM route_groups WHERE network_id = $1 AND slug = $2 RETURNING id;
 
 -- name: UpsertRouteAdvertiser :one
 -- A device offering to carry a group's prefixes.

--- a/queries/state.sql
+++ b/queries/state.sql
@@ -2,8 +2,8 @@
 -- Written in the same transaction as the version bump it describes. A change recorded
 -- without its bump, or a bump without its change, would leave agents converging on a
 -- version whose contents nobody can reconstruct.
-INSERT INTO state_changes (network_id, version, kind, membership_id, peer_public_key)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO state_changes (network_id, version, kind, membership_id, peer_public_key, route_group_id)
+VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING id;
 
 -- name: ListStateChangesSince :many
@@ -12,7 +12,7 @@ RETURNING id;
 -- Ordered by version then id so that two changes at the same version are applied in the
 -- order they were recorded: a removal followed by an upsert of the same key means
 -- something different from the reverse.
-SELECT id, version, kind, membership_id, peer_public_key
+SELECT id, version, kind, membership_id, peer_public_key, route_group_id
 FROM state_changes
 WHERE network_id = $1
   AND version > sqlc.arg(from_version)


### PR DESCRIPTION
Closes #205. The root cause behind a day of egress testing in which every teardown left a device claiming a tunnel it had been told to drop.

## What was wrong

Deleting a route group bumped the state version and told nobody. Every connected device went on holding the assignment — indefinitely, because only a **snapshot** replaces the set. A reconnect fixed it; nothing else did.

On an egress group that means a laptop sending all of its traffic through an exit node the control plane no longer knows about.

Observed as the same version delivered twice, with opposite results:

```
14:28:53  applied desired state version=36 snapshot=false   → device kept claiming
14:38:30  applied desired state version=36 snapshot=true    → released, exit IP back to normal
```

Nothing changed between those lines but the delivery.

## Why

`routeGroupsFor`'s own comment is right about the case it was written for:

> Groups that **exist** and produce no assignment for this device come back as withdrawn ids rather than as silence. Proto3 cannot tell an empty repeated field from an absent one […] and a device that lost its last advertiser would keep routing to it forever.

That covers a group which survives but stops applying to a device. `DeleteRouteGroup` hard-deletes the row, so a deleted group is in no list of groups that exist — it appeared in neither the assignments nor the withdrawals, and the agent merges.

## The fix

A deletion names itself on the way out, which is what `peer_remove` has always done with a public key, for the same reason: by the time a delta is built the row is gone, so the identifier has to be in the log rather than looked up.

- **Migration 0015** adds the `route_group_remove` kind and a `route_group_id` column, rebuilding the CHECK constraints wholesale as 0005 and 0009 established.
- `DeleteRouteGroup` returns the ids it removed and records one change per id.
- The builder appends them to the withdrawals and **sorts**, so two deltas describing one change are the same message — a map's iteration order is not stable, and a delta differing only in ordering would make an agent's diff look like a change.

## Why not the alternatives

**Send route-group state whole on every delta** — gives up ADR-0008's incrementality, and the existing comment already argues against it: an agent diffing a resent set reinstalls routes it has.

**Have the agent replace rather than merge** — cannot be expressed. Proto3 cannot distinguish an empty repeated field from an absent one, which is *why* `removed_route_group_ids` exists; an agent replacing wholesale would wipe every assignment on any unrelated peer delta.

The proto does have a shape that fixes the whole class, and `advertised` already uses it — a message wrapping the list, where present-but-empty means "none". Worth doing if this recurs. It is a wire change with agents in the field, and its extra coverage over a tombstone is small, since a group that stops *applying* is already handled.

## Tests

Three, on the delta path specifically — the snapshot path was never broken:

- a deleted group is withdrawn by a delta, and no longer assigned
- the same for an egress group, which is the case that hurts
- deleting one group withdraws that one and leaves the others assigned

**They skip without a database rather than passing**, so a green run without Postgres is not a false signal. Verified locally that they skip; CI's `integration (postgres)` job is what actually runs them, since Docker is broken on the machine this was written on.

## Related

#204 describes a DNS cycle in which a device that cannot resolve its control plane can neither claim nor release. That is real, and it is downstream of this: the "something disturbs the claim" trigger was always a deletion that never arrived. #204 has been corrected to say so, and its fix is unpushed pending this.