### PR TITLE
fix(dataplane): another tunnel on the host is not a local network

### DIFF
--- a/internal/tunnel/egress.go
+++ b/internal/tunnel/egress.go
@@ -25,6 +25,34 @@ import (
 // Nothing here is best effort. If the carve-out cannot be computed the group is unhonoured
 // and no lock is installed, because a device that locks itself away from its control plane
 // is off the network for a reason nobody watching can see.
+// tunnelAddresses is every address on this host that belongs to a tunnel, not only this
+// membership's.
+//
+// #207: a device in two networks has two interfaces (ADR-0004), and the carve-out was told
+// about the one it was claiming for. The other looked like an ordinary local network, so the
+// claim tried to pin its address to the LAN gateway — which the kernel refuses, because that
+// address belongs to a point-to-point link. The claim aborted, and with fail-closed enforced
+// the device was left refusing egress with nothing carrying it. So a device in two networks
+// could not claim a full tunnel in either.
+//
+// The #200 fix made the rule "not this tunnel". It has to be "not any tunnel".
+//
+// Falls back to this membership's own addresses when the platform cannot answer. That is what
+// this did before the list existed, so a failure here costs what was already being lost rather
+// than the whole claim — and on a device with one membership the two are the same.
+func (r *Reconciler) tunnelAddresses(own []netip.Prefix) []netip.Prefix {
+	all, err := r.link.TunnelAddresses()
+	if err != nil {
+		r.log.Warn("could not list this host's tunnels; the carve-out will only know about this one",
+			"error", logx.SafeError(err),
+			"consequence", "a device in more than one network may not claim a default route")
+		return own
+	}
+	// Its own as well, in case the platform's list misses it. A claim that carves out its own
+	// tunnel is the failure #200 was about, and this must not reintroduce it.
+	return append(append([]netip.Prefix{}, all...), own...)
+}
+
 func (r *Reconciler) applyEgress(ctx context.Context, iface string, own []netip.Prefix, want bool, failClosed, preventDNSLeaks bool, relays, excluded []string) []string {
 	if !want {
 		r.releaseEgress(ctx)
@@ -52,7 +80,7 @@ func (r *Reconciler) applyEgress(ctx context.Context, iface string, own []netip.
 	carve, err := egress.Compute(ctx, egress.Inputs{
 		ControlURL:     r.membership.ControlURL,
 		RelayEndpoints: relays,
-		LocalPrefixes:  egress.LocalNetworks(own),
+		LocalPrefixes:  egress.LocalNetworks(r.tunnelAddresses(own)),
 		ExtraPrefixes:  excluded,
 	}, nil)
 	if err != nil {

--- a/internal/tunnel/egress_test.go
+++ b/internal/tunnel/egress_test.go
@@ -3,6 +3,11 @@ package tunnel
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/netip"
+	"slices"
 	"strings"
 	"testing"
 
@@ -338,5 +343,119 @@ func TestAHostWithAFilterAndNoLockWillNotClaim(t *testing.T) {
 	}
 	if len(filter.dnsLocked) != 0 {
 		t.Error("something installed a lock through the filter, which is no longer its job")
+	}
+}
+
+// A second tunnel on the host is not a local network, and the carve-out has to say so.
+//
+// #207: a device in two networks has an interface per membership (ADR-0004). The carve-out was
+// told the addresses of the one being claimed for, so the other looked like an ordinary local
+// network — and keeping a local network off the tunnel means routing it through the LAN
+// gateway, which the kernel refuses for an address on a point-to-point link. The claim aborted
+// on it every pass, and with fail-closed enforced the device refused egress with nothing
+// carrying it.
+//
+// Asserted on what Claim is handed, and not on the helper that computes it. The helper being
+// right is not the property that was missing — it did not exist — and a test that calls it
+// directly passes with the call site reverted, which is how three of today's fixes were nearly
+// shipped without their wiring.
+func TestASecondTunnelOnTheHostIsNotCarvedOut(t *testing.T) {
+	// A real address on this host, called a tunnel's. LocalNetworks reads the machine's own
+	// interfaces — it is not injectable and should not be, since what it reports is a fact
+	// about the host — so the way to describe "another tunnel" to it is to name something
+	// that is really there.
+	addr, network := anAddressOnThisHost(t)
+
+	r, _, router, _ := withEgress(t)
+	r.link.(*fakeLink).tunnelAddresses = []netip.Prefix{netip.PrefixFrom(addr, addr.BitLen())}
+
+	failed := r.applyEgress(context.Background(), "meshp0", nil, true, false, false, nil, nil)
+	if failed != nil {
+		t.Fatalf("the claim did not happen: %v", failed)
+	}
+	if slices.Contains(router.claimedPrefixes, network) {
+		t.Errorf("%s belongs to an interface named as a tunnel and was carved out anyway; "+
+			"keeping it off the tunnel means routing it through the LAN gateway, which the "+
+			"kernel refuses for a point-to-point address — the claim fails and the device is "+
+			"left refusing egress. got %v", network, router.claimedPrefixes)
+	}
+}
+
+// anAddressOnThisHost returns a routable address the machine really has, and the network the
+// carve-out would derive from it.
+func anAddressOnThisHost(t *testing.T) (netip.Addr, netip.Prefix) {
+	t.Helper()
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Skip("cannot read this host's interfaces:", err)
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			ipnet, ok := a.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			addr, ok := netip.AddrFromSlice(ipnet.IP)
+			if !ok {
+				continue
+			}
+			addr = addr.Unmap()
+			// Not link-local: fe80::/64 is on nearly every interface, so excluding one
+			// leaves the same network arriving from another and this would measure nothing.
+			if !addr.IsGlobalUnicast() || addr.IsLinkLocalUnicast() {
+				continue
+			}
+			ones, _ := ipnet.Mask.Size()
+			if p := netip.PrefixFrom(addr, ones); p.IsValid() {
+				return addr, p.Masked()
+			}
+		}
+	}
+	t.Skip("no interface on this host carries an address this can use")
+	return netip.Addr{}, netip.Prefix{}
+}
+
+// A platform that answers without mentioning this membership's own tunnel must not lose it.
+//
+// Defensive, and the defence is the one that matters: carving out the tunnel being claimed for
+// is #200, where the claim asked the kernel to route a device's own mesh address through the
+// LAN gateway and the whole claim failed. Widening the list to every tunnel must not open a
+// path back to that.
+func TestTheMembershipsOwnTunnelSurvivesAnIncompleteList(t *testing.T) {
+	mine := netip.MustParsePrefix("100.80.0.3/32")
+	other := netip.MustParsePrefix("100.90.0.7/32")
+
+	link := newFakeLink()
+	link.tunnelAddresses = []netip.Prefix{other} // answered, and does not mention mine
+
+	r := &Reconciler{link: link, log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	got := r.tunnelAddresses([]netip.Prefix{mine})
+
+	if !slices.Contains(got, mine) {
+		t.Errorf("the platform listed %v and this membership's own tunnel %s was dropped; "+
+			"the claim would carve out its own address, which is #200", got, mine)
+	}
+}
+
+// A platform that cannot answer costs what it always cost, not the whole claim.
+func TestAHostThatCannotListItsTunnelsStillKnowsItsOwn(t *testing.T) {
+	mine := netip.MustParsePrefix("100.80.0.3/32")
+
+	link := newFakeLink()
+	link.tunnelAddressesErr = errors.New("no")
+
+	r := &Reconciler{link: link, log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	got := r.tunnelAddresses([]netip.Prefix{mine})
+
+	if !slices.Contains(got, mine) {
+		t.Errorf("with the platform unable to list tunnels, this membership's own address "+
+			"was lost too: %v — which is the failure #200 was about", got)
 	}
 }

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -25,6 +25,10 @@ import (
 // translation — not the kernel. wglink's own tests use a real interface for the parts only
 // a kernel can answer.
 type fakeLink struct {
+	// tunnelAddresses is every tunnel on this host, as the platform would report it.
+	tunnelAddresses    []netip.Prefix
+	tunnelAddressesErr error
+
 	observed wgplan.Observed
 	applied  []wgplan.Op
 	kind     wglink.Kind
@@ -117,7 +121,13 @@ func without(prefixes []netip.Prefix, drop netip.Prefix) []netip.Prefix {
 }
 
 func (f *fakeLink) Kind(string) (wglink.Kind, error) { return f.kind, nil }
-func (f *fakeLink) Close() error                     { f.closed = true; return nil }
+
+// TunnelAddresses is what the host's other tunnels carry, which the carve-out has to know
+// about or it will try to route them through the LAN gateway (#207).
+func (f *fakeLink) TunnelAddresses() ([]netip.Prefix, error) {
+	return f.tunnelAddresses, f.tunnelAddressesErr
+}
+func (f *fakeLink) Close() error { f.closed = true; return nil }
 
 func (f *fakeLink) count(kind wgplan.OpKind) int {
 	var n int
@@ -902,9 +912,15 @@ type fakeEgress struct {
 	claimErr error
 	relErr   error
 	order    *[]string
+
+	// claimedPrefixes is the carve-out the last claim was given. Recorded because what a
+	// device is told to keep off the tunnel is the thing several bugs have been about, and
+	// a router that discards it lets a test assert only that a claim happened (#207).
+	claimedPrefixes []netip.Prefix
 }
 
-func (e *fakeEgress) Claim(iface string, _ []netip.AddrPort, _ []netip.Prefix) error {
+func (e *fakeEgress) Claim(iface string, _ []netip.AddrPort, excluded []netip.Prefix) error {
+	e.claimedPrefixes = excluded
 	if e.claimErr != nil {
 		return e.claimErr
 	}

--- a/internal/wglink/wglink.go
+++ b/internal/wglink/wglink.go
@@ -10,6 +10,7 @@ package wglink
 import (
 	"errors"
 	"fmt"
+	"net/netip"
 
 	"github.com/meshpnet/meshp/internal/wgplan"
 )
@@ -58,6 +59,24 @@ type Link interface {
 
 	// Kind reports which implementation is behind an existing interface.
 	Kind(name string) (Kind, error)
+
+	// TunnelAddresses reports the addresses on every WireGuard interface this host has,
+	// meshp's or anybody's.
+	//
+	// The carve-out needs them, and cannot work them out for itself. Keeping traffic off a
+	// tunnel means routing an address through the local gateway, and a tunnel's own address
+	// is one the kernel will not route that way — it belongs to a point-to-point link. So
+	// every such address has to be recognised and left alone, or the claim fails on it and
+	// the device is left refusing egress with nothing carrying it.
+	//
+	// Asked of WireGuard rather than inferred from names or interface flags, because both
+	// have already been wrong on macOS: a name meshp uses is not one the kernel has, and a
+	// utun number is reissued to whatever asks next. A device that answers on its control
+	// socket is a tunnel that exists.
+	//
+	// Every WireGuard interface, not only meshp's. Somebody else's tunnel is as unroutable
+	// through a gateway as ours, and a claim that fails on it fails the same way (#207).
+	TunnelAddresses() ([]netip.Prefix, error)
 
 	// Close releases the netlink and control sockets.
 	Close() error

--- a/internal/wglink/wglink_darwin.go
+++ b/internal/wglink/wglink_darwin.go
@@ -548,3 +548,44 @@ func ipv4Netmask(bits int) string {
 	mask := net.CIDRMask(bits, 32)
 	return fmt.Sprintf("0x%02x%02x%02x%02x", mask[0], mask[1], mask[2], mask[3])
 }
+
+// TunnelAddresses reports the addresses on every WireGuard interface this host has.
+//
+// wgctrl names the devices, and the platform is asked for each one's addresses. The two
+// halves are separate because they answer different questions — which interfaces are tunnels,
+// and what is on them — and only the first is WireGuard's to know.
+func (l *darwinLink) TunnelAddresses() ([]netip.Prefix, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	devices, err := l.wg.Devices()
+	if err != nil {
+		return nil, fmt.Errorf("wglink: listing WireGuard devices: %w", err)
+	}
+
+	var out []netip.Prefix
+	for _, device := range devices {
+		addrs, err := func() ([]netip.Prefix, error) {
+			real, ok, err := l.resolve(device.Name)
+			if err != nil || !ok {
+				// Not one of ours, or its name file has gone. Read under the name
+				// WireGuard gave, which on a tunnel meshp did not create is the
+				// interface itself.
+				real = device.Name
+			}
+			iface, err := net.InterfaceByName(real)
+			if err != nil {
+				return nil, err
+			}
+			return interfaceAddresses(iface)
+		}()
+		if err != nil {
+			// One interface that cannot be read costs that interface. Refusing the whole
+			// list would take the carve-out with it, and a carve-out that cannot be built
+			// is a device that will not claim at all.
+			continue
+		}
+		out = append(out, addrs...)
+	}
+	return out, nil
+}

--- a/internal/wglink/wglink_linux.go
+++ b/internal/wglink/wglink_linux.go
@@ -447,3 +447,35 @@ func lookup(name string) (*net.Interface, bool, error) {
 // privileged reports whether this process can manage interfaces at all, used by tests to
 // skip rather than fail.
 func privileged() bool { return os.Geteuid() == 0 }
+
+// TunnelAddresses reports the addresses on every WireGuard interface this host has.
+//
+// wgctrl names the devices and netlink is asked for each one's addresses. The two halves
+// answer different questions — which interfaces are tunnels, and what is on them — and only
+// the first is WireGuard's to know.
+func (l *linux) TunnelAddresses() ([]netip.Prefix, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	devices, err := l.wg.Devices()
+	if err != nil {
+		return nil, fmt.Errorf("wglink: listing WireGuard devices: %w", err)
+	}
+
+	var out []netip.Prefix
+	for _, device := range devices {
+		iface, err := net.InterfaceByName(device.Name)
+		if err != nil {
+			// One interface that cannot be read costs that interface. Refusing the whole
+			// list would take the carve-out with it, and a carve-out that cannot be built
+			// is a device that will not claim at all.
+			continue
+		}
+		addrs, err := l.addresses(uint32(iface.Index))
+		if err != nil {
+			continue
+		}
+		out = append(out, addrs...)
+	}
+	return out, nil
+}

--- a/internal/wglink/wglink_windows.go
+++ b/internal/wglink/wglink_windows.go
@@ -583,3 +583,31 @@ func withRestorePrivilege() (func(), error) {
 		_ = token.Close()
 	}, nil
 }
+
+// TunnelAddresses reports the addresses on every WireGuard adapter this agent has.
+//
+// Read from the adapters this process created, rather than from wgctrl as the other two
+// platforms do. wgctrl on Windows talks to the WireGuard service's named pipes, and meshp
+// serves its own adapters through its own UAPI (ADR-0028) — so it would not see them, and
+// asking it would return an empty list that looks like an answer.
+//
+// The cost is that a tunnel some other program is running is not recognised, where on macOS
+// and Linux it is. That is the narrower half of #207 and it is the half that matters: the
+// case this exists for is a device in two networks, which is two adapters in this process.
+func (l *windowsLink) TunnelAddresses() ([]netip.Prefix, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	var out []netip.Prefix
+	for _, device := range l.devices {
+		addrs, err := adapterAddresses(device.luid)
+		if err != nil {
+			// One adapter that cannot be read costs that adapter. Refusing the whole list
+			// would take the carve-out with it, and a carve-out that cannot be built is a
+			// device that will not claim at all.
+			continue
+		}
+		out = append(out, addrs...)
+	}
+	return out, nil
+}


### PR DESCRIPTION
Closes #207. A device in two networks could not claim a full tunnel in **either**.

## What was wrong

A device has an interface per membership (ADR-0004). The carve-out was told about the one it was claiming for, so the other looked like an ordinary local network — and keeping a local network off the tunnel means routing it through the LAN gateway, which the kernel will not do for an address on a point-to-point link:

```
keeping 100.80.0.3/32 off the tunnel: 100.80.0.3/32 was replaced and still
does not go to -gateway 192.168.0.1
```

The claim aborts on it, every pass. With fail-closed enforced the device refuses egress with nothing carrying it.

#200 fixed the case where the tunnel's **own** address arrived in the carve-out, identifying it from an address it carries rather than a name macOS does not have. That was right, and it made the rule *"not this tunnel"*. It has to be *"not any tunnel"*.

## The fix

`wglink` grows `TunnelAddresses`, because only it knows which interfaces are tunnels and it already owns that kind of platform detail.

- **macOS and Linux** ask `wgctrl` and read the addresses of what it names.
- **Windows** reads the adapters this process created instead. `wgctrl` there talks to the WireGuard service's named pipes, and meshp serves its own adapters through its own UAPI (ADR-0028) — so it would answer nothing, which *looks* like an answer. The cost is that another program's tunnel is not recognised there where it is elsewhere, and that is the half of #207 that does not matter: the case this exists for is two memberships, which is two adapters in this process.

**Every WireGuard interface, not only meshp's.** Somebody else's tunnel is as unroutable through a gateway as ours and fails a claim the same way.

**The membership's own addresses are appended** to whatever the platform returns. A list that answered without mentioning them would reopen #200 — a worse failure than the one being fixed — and that path is tested.

## How it was found

By the CI test added in #208, run on a laptop that had a real tunnel up at the time. It cannot be found on a hosted runner, which has no second membership — so that test still skips there, and whatever eventually gives CI a second interface would cover this too.

## Three attempts at the test

The first two called the helper directly and **passed with the call site reverted**. That is the third time today a fix was nearly shipped with its wiring untested, and it is the specific failure this repository keeps producing.

It asserts on what `Claim` is handed now. `fakeEgress` discarded the prefixes it was given, so no test could see the carve-out at all; it records them. And it uses a **real address on the host** rather than a synthetic one, because `LocalNetworks` reads the machine's own interfaces and should — what it reports is a fact about the host, not something to inject.

Mutation-tested both ways:

```
FAIL  fd66:bd20:54a:476a::/64 belongs to an interface named as a tunnel and was
      carved out anyway ... got [100.80.0.3/32 ... fd7c:6d65:7368:80::3/128 ...]

FAIL  the platform listed [100.90.0.7/32] and this membership's own tunnel
      100.80.0.3/32 was dropped; the claim would carve out its own address, #200
```

The first of those is #207 reproducing itself: `100.80.0.3/32` and `fd7c:…::3/128` in that output are a real meshp tunnel on the machine the test ran on.