### PR TITLE
fix(dataplane): remember the control plane's address, so a claim survives losing DNS

### DIFF
--- a/internal/egress/remember.go
+++ b/internal/egress/remember.go
@@ -1,0 +1,117 @@
+package egress
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Remembering answers a name from what it answered last time, when it cannot answer it now.
+//
+// It exists because the carve-out needs the control plane's address and refuses to be built
+// without it — a device that locked itself away from its control plane would be off the
+// network for a reason nobody watching could see. That refusal is right, and combined with a
+// claimed full tunnel it made a cycle a device could not leave (#204):
+//
+//	a claim is in place, so DNS goes through the tunnel
+//	something disturbs it — a route group withdrawn, a change of network
+//	the next pass needs the control plane's address, and cannot resolve it
+//	the claim is abandoned; the device still wants one, so nothing is released
+//	round again, for as long as the device is on
+//
+// Observed on a laptop: no network at all until somebody typed `meshp down`.
+//
+// The address remembered here is the one a working claim was already built on, so using it
+// again is not a guess. It is only reached when DNS has stopped answering, which is a state
+// this cache did not cause and cannot make worse: without it there is no carve-out at all.
+//
+// Kept under /var/run deliberately. A cache that outlived a reboot would answer with a stale
+// address on a machine whose DNS is working perfectly and whose control plane has moved —
+// and a reboot is the one moment no claim is in place, so the name resolves normally.
+func Remembering(next Resolver, path string) Resolver {
+	if next == nil {
+		next = SystemResolver
+	}
+	var mu sync.Mutex
+
+	return func(ctx context.Context, host string) ([]netip.Addr, error) {
+		addrs, err := next(ctx, host)
+		if err == nil && len(addrs) > 0 {
+			mu.Lock()
+			remember(path, host, addrs)
+			mu.Unlock()
+			return addrs, nil
+		}
+
+		mu.Lock()
+		remembered := recall(path, host)
+		mu.Unlock()
+		if len(remembered) > 0 {
+			return remembered, nil
+		}
+		if err == nil {
+			// Answered, with nothing. Reported as the failure it is rather than passed on
+			// as an empty success, which the caller would read as "this name has no
+			// addresses" and refuse the carve-out over.
+			return nil, fmt.Errorf("egress: %q resolved to nothing and nothing was remembered", host)
+		}
+		return nil, err
+	}
+}
+
+// remember writes down what a name resolved to. Best effort: a device that cannot write here
+// still has working DNS today, and the cost is only that it will not have this tomorrow.
+func remember(path, host string, addrs []netip.Addr) {
+	known := recallAll(path)
+	known[host] = addrs
+
+	var b strings.Builder
+	for name, list := range known {
+		if strings.ContainsAny(name, " \t\n") {
+			continue
+		}
+		b.WriteString(name)
+		for _, addr := range list {
+			b.WriteString(" ")
+			b.WriteString(addr.String())
+		}
+		b.WriteString("\n")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return
+	}
+	_ = os.WriteFile(path, []byte(b.String()), 0o600)
+}
+
+func recall(path, host string) []netip.Addr { return recallAll(path)[host] }
+
+// recallAll reads the whole cache. A line that will not parse is skipped rather than failing
+// the read: one bad entry should not cost a device the name it does remember.
+func recallAll(path string) map[string][]netip.Addr {
+	out := map[string][]netip.Addr{}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return out
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		var addrs []netip.Addr
+		for _, field := range fields[1:] {
+			if addr, err := netip.ParseAddr(field); err == nil {
+				addrs = append(addrs, addr)
+			}
+		}
+		if len(addrs) > 0 {
+			out[fields[0]] = addrs
+		}
+	}
+	return out
+}

--- a/internal/egress/remember_test.go
+++ b/internal/egress/remember_test.go
@@ -1,0 +1,204 @@
+package egress
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func addrs(t *testing.T, list ...string) []netip.Addr {
+	t.Helper()
+	var out []netip.Addr
+	for _, s := range list {
+		out = append(out, netip.MustParseAddr(s))
+	}
+	return out
+}
+
+var errNoDNS = errors.New("no DNS today")
+
+// The whole point: a name that resolved once is still answerable when DNS has stopped.
+//
+// #204 — a claimed full tunnel carries DNS, so disturbing the claim takes DNS with it, and
+// the carve-out needed to rebuild the claim cannot be computed without resolving the control
+// plane. A device sat in that cycle with no network until somebody typed `meshp down`.
+func TestANameResolvedOnceIsAnsweredWhenDNSStops(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resolved")
+	working := true
+	resolve := Remembering(func(context.Context, string) ([]netip.Addr, error) {
+		if working {
+			return addrs(t, "168.144.85.34"), nil
+		}
+		return nil, errNoDNS
+	}, path)
+
+	got, err := resolve(context.Background(), "control.meshp.net")
+	if err != nil {
+		t.Fatalf("with DNS working: %v", err)
+	}
+	if len(got) != 1 || got[0].String() != "168.144.85.34" {
+		t.Fatalf("got %v", got)
+	}
+
+	working = false
+	got, err = resolve(context.Background(), "control.meshp.net")
+	if err != nil {
+		t.Fatalf("DNS is down and the name was remembered, yet: %v", err)
+	}
+	if len(got) != 1 || got[0].String() != "168.144.85.34" {
+		t.Errorf("got %v, want the address this name had when it last resolved", got)
+	}
+}
+
+// A name never seen before is still a failure. Inventing an answer would be worse than
+// refusing: the carve-out would pin a route to an address nobody chose.
+func TestANameNeverResolvedIsStillAFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resolved")
+	resolve := Remembering(func(context.Context, string) ([]netip.Addr, error) {
+		return nil, errNoDNS
+	}, path)
+
+	if _, err := resolve(context.Background(), "control.meshp.net"); !errors.Is(err, errNoDNS) {
+		t.Errorf("err = %v, want the resolver's own failure", err)
+	}
+}
+
+// A later answer replaces an earlier one, or a control plane that moves is never followed.
+func TestTheLatestAnswerIsTheOneRemembered(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resolved")
+	answer := addrs(t, "168.144.85.34")
+	working := true
+	resolve := Remembering(func(context.Context, string) ([]netip.Addr, error) {
+		if working {
+			return answer, nil
+		}
+		return nil, errNoDNS
+	}, path)
+
+	if _, err := resolve(context.Background(), "control.meshp.net"); err != nil {
+		t.Fatal(err)
+	}
+	answer = addrs(t, "203.0.113.9")
+	if _, err := resolve(context.Background(), "control.meshp.net"); err != nil {
+		t.Fatal(err)
+	}
+
+	working = false
+	got, err := resolve(context.Background(), "control.meshp.net")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].String() != "203.0.113.9" {
+		t.Errorf("got %v, want the address from the most recent successful lookup", got)
+	}
+}
+
+// The record outlives the process, because a daemon that restarts while a claim is in place
+// is exactly the case that needs it: the claim survives, DNS is still broken, and a cache
+// held only in memory would be gone.
+func TestWhatWasRememberedSurvivesTheProcess(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resolved")
+
+	first := Remembering(func(context.Context, string) ([]netip.Addr, error) {
+		return addrs(t, "168.144.85.34"), nil
+	}, path)
+	if _, err := first(context.Background(), "control.meshp.net"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A different Remembering over the same path, as a restarted daemon would build.
+	second := Remembering(func(context.Context, string) ([]netip.Addr, error) {
+		return nil, errNoDNS
+	}, path)
+	got, err := second(context.Background(), "control.meshp.net")
+	if err != nil {
+		t.Fatalf("a restarted daemon could not recall the address: %v", err)
+	}
+	if len(got) != 1 || got[0].String() != "168.144.85.34" {
+		t.Errorf("got %v", got)
+	}
+}
+
+// One name failing must not cost another that was remembered. Relays and the control plane
+// go through the same resolver.
+func TestOneNameIsNotAnother(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resolved")
+	working := true
+	resolve := Remembering(func(_ context.Context, host string) ([]netip.Addr, error) {
+		if !working {
+			return nil, errNoDNS
+		}
+		switch host {
+		case "control.meshp.net":
+			return addrs(t, "168.144.85.34"), nil
+		case "relay1.meshp.net":
+			return addrs(t, "203.0.113.7"), nil
+		}
+		return nil, errNoDNS
+	}, path)
+
+	for _, host := range []string{"control.meshp.net", "relay1.meshp.net"} {
+		if _, err := resolve(context.Background(), host); err != nil {
+			t.Fatalf("%s: %v", host, err)
+		}
+	}
+
+	working = false
+	control, err := resolve(context.Background(), "control.meshp.net")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if control[0].String() != "168.144.85.34" {
+		t.Errorf("control.meshp.net recalled %v", control)
+	}
+	relay, err := resolve(context.Background(), "relay1.meshp.net")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if relay[0].String() != "203.0.113.7" {
+		t.Errorf("relay1.meshp.net recalled %v, which is another name's address", relay)
+	}
+}
+
+// A resolver answering with nothing is a failure, not an empty success: Compute reads an
+// empty answer as "this name has no addresses" and refuses the whole carve-out over it.
+func TestAnEmptyAnswerIsNotAnAnswer(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resolved")
+	resolve := Remembering(func(context.Context, string) ([]netip.Addr, error) {
+		return nil, nil
+	}, path)
+
+	if _, err := resolve(context.Background(), "control.meshp.net"); err == nil {
+		t.Error("an empty answer was passed on as a success")
+	}
+}
+
+// The reconciler and the control channel both resolve.
+func TestConcurrentLookupsDoNotCorruptTheRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resolved")
+	resolve := Remembering(func(_ context.Context, host string) ([]netip.Addr, error) {
+		return addrs(t, "168.144.85.34"), nil
+	}, path)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				if _, err := resolve(context.Background(), "control.meshp.net"); err != nil {
+					t.Errorf("resolve: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := recall(path, "control.meshp.net"); len(got) != 1 {
+		t.Errorf("the record holds %v after concurrent writes", got)
+	}
+}

--- a/internal/tunnel/egress.go
+++ b/internal/tunnel/egress.go
@@ -3,6 +3,7 @@ package tunnel
 import (
 	"context"
 	"net/netip"
+	"path/filepath"
 
 	"github.com/meshpnet/meshp/internal/egress"
 	"github.com/meshpnet/meshp/internal/logx"
@@ -25,6 +26,14 @@ import (
 // Nothing here is best effort. If the carve-out cannot be computed the group is unhonoured
 // and no lock is installed, because a device that locks itself away from its control plane
 // is off the network for a reason nobody watching can see.
+// resolvedAddressPath is where the names the carve-out depends on are remembered.
+//
+// Beside the claim record and under /var/run for the same reason: it has to survive a daemon
+// restart, because a restart with a claim still installed is exactly when DNS is unavailable
+// and the address is needed. It must not survive a reboot, because a reboot leaves no claim
+// in place, so the name resolves normally and a remembered address could only be stale.
+var resolvedAddressPath = filepath.Join("/var/run/meshp", "resolved-addresses")
+
 // tunnelAddresses is every address on this host that belongs to a tunnel, not only this
 // membership's.
 //
@@ -82,7 +91,7 @@ func (r *Reconciler) applyEgress(ctx context.Context, iface string, own []netip.
 		RelayEndpoints: relays,
 		LocalPrefixes:  egress.LocalNetworks(r.tunnelAddresses(own)),
 		ExtraPrefixes:  excluded,
-	}, nil)
+	}, r.resolve)
 	if err != nil {
 		// The branch that decides whether a mistake here costs a feature or a machine.
 		r.log.Error("not claiming a default route",

--- a/internal/tunnel/egress_test.go
+++ b/internal/tunnel/egress_test.go
@@ -7,10 +7,12 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/meshpnet/meshp/internal/egress"
 	"github.com/meshpnet/meshp/internal/peerset"
 	meshpv1 "github.com/meshpnet/meshp/proto/gen/meshp/v1"
 )
@@ -457,5 +459,67 @@ func TestAHostThatCannotListItsTunnelsStillKnowsItsOwn(t *testing.T) {
 	if !slices.Contains(got, mine) {
 		t.Errorf("with the platform unable to list tunnels, this membership's own address "+
 			"was lost too: %v — which is the failure #200 was about", got)
+	}
+}
+
+// A claim survives DNS going away, which is a state a claim itself produces.
+//
+// #204: the carve-out needs the control plane's address and refuses to be built without it —
+// a device that locked itself away from its control plane would be off the network for a
+// reason nobody watching could see. Right on its own, and with a full tunnel claimed it made
+// a cycle a device could not leave: the claim carries DNS, so disturbing the claim takes DNS
+// with it; the next pass cannot resolve, so it does not claim; the device still wants a claim,
+// so nothing is released; round again. Observed on a laptop with no network at all until
+// somebody typed `meshp down`.
+//
+// Asserted through applyEgress, because a resolver that remembers correctly and is never
+// reached is worth nothing — a mistake made twice in this area already.
+func TestAClaimSurvivesDNSGoingAway(t *testing.T) {
+	answering := true
+	upstream := func(context.Context, string) ([]netip.Addr, error) {
+		if !answering {
+			return nil, errors.New("no DNS while the tunnel is broken")
+		}
+		return []netip.Addr{netip.MustParseAddr("198.51.100.10")}, nil
+	}
+
+	r, _, router, _ := withEgress(t)
+	// A name, not an address. withEgress uses an IP literal, which needs no resolver at all —
+	// so this would pass without any of the behaviour under test.
+	r.membership.ControlURL = "https://control.example.test:8443"
+	r.resolve = egress.Remembering(upstream, filepath.Join(t.TempDir(), "resolved"))
+
+	if failed := r.applyEgress(context.Background(), "meshp0", nil, true, false, false, nil, nil); failed != nil {
+		t.Fatalf("the first claim, with DNS working, did not happen: %v", failed)
+	}
+	first := len(router.events)
+
+	// The claim is in place and now DNS is gone — a change of network, a resolver that has
+	// stopped answering. The device has to be able to claim again.
+	answering = false
+	if failed := r.applyEgress(context.Background(), "meshp0", nil, true, false, false, nil, nil); failed != nil {
+		t.Fatalf("with DNS gone the device could not claim again: %v — and it cannot release "+
+			"either, because it still wants a claim, so it stays with no network", failed)
+	}
+	if len(router.events) <= first {
+		t.Error("the second claim did not reach the router")
+	}
+}
+
+// A name never resolved is still a refusal. Inventing an address would pin a route to
+// something nobody chose, which is worse than not claiming.
+func TestAControlPlaneThatWasNeverResolvedIsStillRefused(t *testing.T) {
+	r, _, _, _ := withEgress(t)
+	r.membership.ControlURL = "https://control.example.test:8443"
+	r.resolve = egress.Remembering(
+		func(context.Context, string) ([]netip.Addr, error) {
+			return nil, errors.New("no DNS, ever")
+		},
+		filepath.Join(t.TempDir(), "resolved"),
+	)
+
+	if failed := r.applyEgress(context.Background(), "meshp0", nil, true, false, false, nil, nil); failed == nil {
+		t.Error("a control plane that has never resolved produced a claim; the carve-out " +
+			"would not know which address to keep off the tunnel")
 	}
 }

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -21,6 +21,7 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"github.com/meshpnet/meshp/internal/egress"
 	"github.com/meshpnet/meshp/internal/logx"
 	"github.com/meshpnet/meshp/internal/peerset"
 	"github.com/meshpnet/meshp/internal/routeprobe"
@@ -106,6 +107,15 @@ type Reconciler struct {
 	// lock refuses egress outside the tunnel, or is nil where this host cannot. Separate
 	// from filter because a platform can have one and not the other — see EgressLock.
 	lock EgressLock
+
+	// resolve turns the control plane's and the relays' names into addresses for the
+	// carve-out, remembering what it answered.
+	//
+	// A field rather than a call, so that what it does can be tested through applyEgress
+	// rather than asserted about in isolation. The distinction matters here: a resolver that
+	// remembers correctly and is not reached is worth nothing, and this file has already
+	// shipped a guard nothing called.
+	resolve egress.Resolver
 
 	// lastFilter is what was last successfully loaded, kept so an unchanged policy is not
 	// reloaded on every reconcile. Reloading is atomic and cheap, but it resets the drop
@@ -268,6 +278,7 @@ func New(link wglink.Link, m Membership, relay Relay, filter Filter, log *slog.L
 		link: link, membership: m, relay: relay, filter: filter,
 		log: log, kind: wglink.KindUnknown,
 		lastProbe: make(map[string]time.Time),
+		resolve:   egress.Remembering(nil, resolvedAddressPath),
 	}
 }
 


### PR DESCRIPTION
Closes #204, which was reopened in scope after #205 landed — see the last section.

## The cycle

The carve-out needs the control plane's address and refuses to be built without it. That is right, and there is a test holding it: a device that locked itself away from its control plane would be off the network for a reason nobody watching could see.

With a full tunnel claimed it also made a cycle a device could not leave:

1. The claim is in place, so DNS goes through the tunnel
2. Something disturbs it — a change of network, a resolver that stops answering
3. The next pass needs the control plane's address and **cannot resolve it**
4. The claim is abandoned; the device still wants one, so `releaseEgress` is never reached
5. Back to 3, for as long as the device is on

```
not claiming a default route
  error="egress: cannot determine the control plane's address: https://control.meshp.net"
  consequence="this device would have had no way back to its control plane"
```

Observed on a laptop with no network at all until somebody typed `meshp down`.

## The fix

The resolver remembers. The address recalled is the one a working claim was already built on, and it is only reached once DNS has stopped answering — a state this cache did not cause and cannot worsen, since without it there is no carve-out at all.

**A name never resolved is still a refusal.** Inventing an address would pin a route to something nobody chose.

**Kept under `/var/run`.** It must survive a daemon restart, because a restart with a claim still installed is exactly when DNS is unavailable and the address is needed. It must *not* survive a reboot, because a reboot leaves no claim in place, so the name resolves normally and a remembered address could only be stale.

## Why not let a device release when it cannot claim

That was the other candidate and it conflicts with ADR-0011. Releasing means traffic leaves outside the tunnel, and refusing is what fail-closed *is*. The stranded state was fail-closed working correctly; what was wrong is that it never recovered.

## The resolver is a field, and that is the point

`Reconciler.resolve`, injected like `link` and `lock`, so the tests go through `applyEgress`.

Not a style preference. **An earlier attempt at this fix added the mechanism and never wired it in** — the tests passed because they asked the mechanism directly, and nothing changed on the machine. That has now happened three times in this area today, and it is the failure this arrangement removes.

Both mutations are covered:

```
FAIL  with DNS gone the device could not claim again: [egress] — and it cannot
      release either, because it still wants a claim, so it stays with no network
```

— once for a resolver that does not remember, once for a carve-out that does not use it.

## Two tests passed for the wrong reason first

`withEgress` sets `ControlURL` to an **IP literal**, which needs no resolver at all. Both new tests were green before any of this existed. They name the control plane now, which is what makes the resolver reachable at all.

## On this issue's original diagnosis

What #204 first described as the cause was not. The trigger in every observed case was a route group deletion that never reached the device — #205, now landed. What remains is this, and it is narrower: a change of network is enough, which is exactly what `docs/testing/macos-laptop.md` check 2 is for and has never been run.