### PR TITLE
feat(cli): meshp login, and the three server defects it found

### DIFF
--- a/cmd/meshp/login.go
+++ b/cmd/meshp/login.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+
+	"github.com/meshpnet/meshp/internal/cliapi"
+	"github.com/meshpnet/meshp/internal/clicred"
+)
+
+// cmdLogin signs a person in and keeps a token.
+//
+// It opens a session the way the page does, uses it once to mint an API token, and ends it.
+// What is stored is the token: a password on disk is not revocable without changing it
+// everywhere, and it is the one credential that also opens the page (ADR-0031 §1).
+func cmdLogin(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp login", flag.ContinueOnError)
+	controlURL := fs.String("control-url", envOr("MESHP_CONTROL_URL", ""),
+		"the control plane to sign in to")
+	email := fs.String("email", "", "your email address; asked for if not given")
+	token := fs.String("token", "",
+		"an API token to use instead of signing in; for CI, where nobody can type a password")
+	name := fs.String("name", "", "what to call this token; defaults to this machine's name")
+	if _, err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if *controlURL == "" {
+		return errors.New("usage: meshp login --control-url https://control.example.com")
+	}
+
+	// A token given outright is stored as it is. Nothing to mint and nobody to ask.
+	if *token != "" {
+		return signInWithToken(ctx, *controlURL, *token)
+	}
+
+	address, err := askFor("Email", *email)
+	if err != nil {
+		return err
+	}
+	password, err := askForPassword()
+	if err != nil {
+		return err
+	}
+
+	client, err := cliapi.New(*controlURL, "")
+	if err != nil {
+		return err
+	}
+
+	// The session exists for the length of this command. It is not what gets stored.
+	session, err := openSession(ctx, client, address, password)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = session.close(ctx) }()
+
+	minted, err := session.mintToken(ctx, tokenName(*name))
+	if err != nil {
+		return err
+	}
+
+	if err := clicred.Save(clicred.Credential{
+		ControlURL: *controlURL,
+		Token:      minted.Token,
+		TokenID:    minted.ID,
+		Email:      address,
+	}); err != nil {
+		return err
+	}
+
+	path, _ := clicred.Path()
+	fmt.Printf("Signed in to %s as %s.\n\n", *controlURL, address)
+	fmt.Printf("  token     %s\n", minted.Name)
+	fmt.Printf("  kept in   %s\n\n", path)
+	fmt.Println("It is an API token, not your password, and it can be taken away without")
+	fmt.Println("changing one. 'meshp logout' forgets it here and offers to revoke it there,")
+	fmt.Println("which asks for your password again: a token may not revoke itself.")
+	return nil
+}
+
+// cmdLogout removes the credential here, and offers to revoke it there.
+//
+// The local half always happens, first, and cannot fail for anything the network does: a
+// laptop being handed on is exactly when there is no connection, and "signed out" has to mean
+// signed out.
+//
+// The other half needs a password, and that is not an oversight in this command. A token may
+// not revoke itself — the control plane refuses it in those words: "a token that could mint a
+// token would survive its own revocation" — so taking one away is something only the person
+// can do. Asking is the honest consequence of a property worth having.
+func cmdLogout(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp logout", flag.ContinueOnError)
+	local := fs.Bool("local", false,
+		"only forget the credential here; leave it valid on the control plane until it expires")
+	if _, err := parseFlags(fs, args); err != nil {
+		return err
+	}
+
+	cred, err := clicred.Load()
+	if errors.Is(err, clicred.ErrNotSignedIn) {
+		fmt.Println("Not signed in.")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if err := clicred.Forget(); err != nil {
+		return err
+	}
+	fmt.Println("Signed out here.")
+
+	if *local {
+		remainsValid(cred)
+		return nil
+	}
+	if cred.TokenID == "" || cred.Email == "" {
+		// Nothing to revoke by, and nothing to sign in as. Said rather than attempted.
+		remainsValid(cred)
+		return nil
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		fmt.Println("\nThe token is still valid on the control plane. Revoking it needs a")
+		fmt.Println("password, and there is no terminal to ask on.")
+		remainsValid(cred)
+		return nil
+	}
+
+	fmt.Printf("\nThe token is still valid on %s. Revoking it needs your password,\n", cred.ControlURL)
+	fmt.Println("because a token may not revoke itself.")
+	fmt.Println("Press enter to skip.")
+
+	password, err := askForPassword()
+	if err != nil || password == "" {
+		remainsValid(cred)
+		return nil
+	}
+
+	client, err := cliapi.New(cred.ControlURL, "")
+	if err != nil {
+		return err
+	}
+	session, err := openSession(ctx, client, cred.Email, password)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\nCould not sign in to revoke it: %v\n", err)
+		remainsValid(cred)
+		return nil
+	}
+	defer func() { _ = session.close(ctx) }()
+
+	if err := session.revokeToken(ctx, cred.TokenID); err != nil {
+		fmt.Fprintf(os.Stderr, "\nCould not revoke it: %v\n", err)
+		remainsValid(cred)
+		return nil
+	}
+	fmt.Printf("\nRevoked it on %s.\n", cred.ControlURL)
+	return nil
+}
+
+// remainsValid says what is still out there, and where to take it away.
+//
+// Names the API rather than a command, because `meshp token revoke` does not exist. Promising
+// one is the thing #213 is about, and writing a new instance of it into the message that
+// explains a leftover credential would be its own small joke.
+func remainsValid(cred clicred.Credential) {
+	fmt.Printf("\nThe token is still valid until it expires. It is listed at\n")
+	fmt.Printf("  %s/api/v1/me/tokens\n", cred.ControlURL)
+	if cred.TokenID != "" {
+		fmt.Printf("and can be removed with a DELETE to that path plus /%s.\n", cred.TokenID)
+	}
+}
+
+// signInWithToken stores a token somebody already has, checking it first.
+//
+// Checked rather than trusted, because the failure it prevents is a CI job that reports a
+// successful login and then fails on its next command with something less clear.
+func signInWithToken(ctx context.Context, controlURL, token string) error {
+	client, err := cliapi.New(controlURL, token)
+	if err != nil {
+		return err
+	}
+	var me struct {
+		Email string `json:"email"`
+	}
+	if err := client.Do(ctx, http.MethodGet, "/api/v1/me", nil, &me); err != nil {
+		// A refusal and an unanswered call are different things, and only one of them is
+		// about the token. Telling somebody their credential was rejected when the host
+		// never answered sends them to rotate a token that is fine.
+		var apiErr *cliapi.Error
+		if errors.As(err, &apiErr) {
+			return fmt.Errorf("%s refused that token: %w", controlURL, err)
+		}
+		return err
+	}
+	if err := clicred.Save(clicred.Credential{
+		ControlURL: controlURL, Token: token, Email: me.Email,
+	}); err != nil {
+		return err
+	}
+	fmt.Printf("Signed in to %s as %s with the token given.\n", controlURL, me.Email)
+	return nil
+}
+
+// askFor reads a line, or returns what was already supplied.
+func askFor(label, given string) (string, error) {
+	if given != "" {
+		return given, nil
+	}
+	fmt.Printf("%s: ", label)
+	var line string
+	if _, err := fmt.Scanln(&line); err != nil {
+		return "", fmt.Errorf("reading your %s: %w", strings.ToLower(label), err)
+	}
+	return strings.TrimSpace(line), nil
+}
+
+// askForPassword reads without echoing.
+func askForPassword() (string, error) {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return "", errors.New("no terminal to ask for a password; use --token for a script")
+	}
+	fmt.Print("Password: ")
+	raw, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Println()
+	if err != nil {
+		return "", fmt.Errorf("reading your password: %w", err)
+	}
+	return string(raw), nil
+}
+
+// tokenName is what the token is called on the control plane.
+//
+// The machine's name, so that a person looking at a list of their tokens can tell which
+// laptop to revoke. A token called "cli" on five machines is a list nobody can act on.
+func tokenName(given string) string {
+	if given != "" {
+		return given
+	}
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		return "meshp cli"
+	}
+	return "meshp cli on " + host
+}

--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -44,7 +44,7 @@ Usage:
 
 Session:
   login                    Authenticate against a control plane
-  logout                   Discard local credentials
+  logout                   Forget the credential here, and offer to revoke it
   join <token>             Enrol this device into a network
   up                       Bring the tunnel up
   down                     Take the tunnel down
@@ -104,6 +104,12 @@ func main() {
 		return
 	case "doctor":
 		runOrDie(cmdDoctor, args[1:])
+		return
+	case "login":
+		runOrDie(cmdLogin, args[1:])
+		return
+	case "logout":
+		runOrDie(cmdLogout, args[1:])
 		return
 	case "up":
 		runOrDie(cmdUp, args[1:])

--- a/cmd/meshp/session.go
+++ b/cmd/meshp/session.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/meshpnet/meshp/internal/cliapi"
+)
+
+// session is a browser-shaped session, held for the length of one command.
+//
+// It exists only so that a token can be minted: POST /api/v1/me/tokens needs somebody signed
+// in, and signing in needs a password. What is kept afterwards is the token (ADR-0031 §1).
+type session struct {
+	client *cliapi.Client
+	cookie string
+}
+
+// openSession signs in with an email address and a password.
+func openSession(ctx context.Context, client *cliapi.Client, email, password string) (*session, error) {
+	cookie, err := client.OpenSession(ctx, email, password)
+	if err != nil {
+		var apiErr *cliapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == "ambiguous_sign_in" {
+			// The server asks for an organisation only when the address is in more than
+			// one. Passed on as it said it, because it knows which and this does not.
+			return nil, fmt.Errorf("%s; use --organisation", apiErr.Message)
+		}
+		return nil, err
+	}
+	return &session{client: client, cookie: cookie}, nil
+}
+
+// mintedToken is what the control plane hands back once, and never again.
+type mintedToken struct {
+	ID    string
+	Name  string
+	Token string
+}
+
+// permissions is everything this control plane can express.
+//
+// Asked for rather than guessed at, and asked of the server rather than compiled in: a CLI
+// carrying its own copy of the catalogue would grant nothing new on a control plane that had
+// learned a permission, and would fail outright on one that had dropped it.
+func (s *session) permissions(ctx context.Context) ([]string, error) {
+	var out struct {
+		Permissions []struct {
+			Permission string `json:"permission"`
+		} `json:"permissions"`
+	}
+	if err := s.client.DoWithCookie(ctx, http.MethodGet, "/api/v1/permissions", s.cookie, nil, &out); err != nil {
+		return nil, fmt.Errorf("reading what this control plane can grant: %w", err)
+	}
+	names := make([]string, 0, len(out.Permissions))
+	for _, p := range out.Permissions {
+		names = append(names, p.Permission)
+	}
+	if len(names) == 0 {
+		return nil, errors.New("the control plane lists no permissions, so a token could do nothing")
+	}
+	return names, nil
+}
+
+// mintToken creates the API token this machine will keep.
+//
+// Scoped to the whole catalogue, which is not the same as unlimited: the control plane
+// intersects a token's scope with what its owner may do, per request, so this asks for
+// everything and receives what the person actually has. A CLI that could do less than the
+// person driving it is one they will work around (ADR-0031).
+func (s *session) mintToken(ctx context.Context, name string) (mintedToken, error) {
+	scope, err := s.permissions(ctx)
+	if err != nil {
+		return mintedToken{}, err
+	}
+	body := map[string]any{"name": name, "permissions": scope}
+	var out struct {
+		// token_id, not id. Read from the field the control plane actually sends: an
+		// unmarshal into the wrong name is not an error, it is an empty string — and an
+		// empty id is a token this machine holds and can never revoke, which is most of
+		// what ADR-0031 chose a token for.
+		ID    string `json:"token_id"`
+		Name  string `json:"name"`
+		Token string `json:"token"`
+	}
+	if err = s.client.DoWithCookie(ctx, http.MethodPost, "/api/v1/me/tokens", s.cookie, body, &out); err != nil {
+		var apiErr *cliapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == "token_name_taken" {
+			// Signing in again from a machine that already has a token is ordinary: a
+			// token expired, or a logout could not reach the control plane. Names are
+			// unique per person, so the old one is taken away and replaced rather than
+			// leaving somebody to pick a name they do not care about.
+			if err := s.replaceToken(ctx, name); err != nil {
+				return mintedToken{}, err
+			}
+			if err := s.client.DoWithCookie(ctx, http.MethodPost, "/api/v1/me/tokens", s.cookie, body, &out); err != nil {
+				return mintedToken{}, fmt.Errorf("minting a token: %w", err)
+			}
+		} else {
+			return mintedToken{}, fmt.Errorf("minting a token: %w", err)
+		}
+	}
+	if out.Token == "" {
+		return mintedToken{}, errors.New("the control plane minted a token and did not return it")
+	}
+	if out.ID == "" {
+		// Refused rather than stored. A token with no id can be used and never revoked
+		// from here, and somebody would find that out at the moment they most wanted to
+		// revoke it.
+		return mintedToken{}, errors.New(
+			"the control plane minted a token and did not say which one, so it could never be revoked")
+	}
+	return mintedToken{ID: out.ID, Name: out.Name, Token: out.Token}, nil
+}
+
+// close ends the session. Best effort: the token is already minted and stored by the time
+// this runs, and a session left to expire is a smaller problem than a command that reports
+// failure after doing what was asked.
+func (s *session) close(ctx context.Context) error {
+	return s.client.DoWithCookie(ctx, http.MethodDelete, "/api/v1/ui/session", s.cookie, nil, nil)
+}
+
+// replaceToken revokes the token this machine minted before, so a fresh one can take its name.
+//
+// Revoked rather than reused: the secret is shown once and is not stored anywhere this can
+// read it, so an existing token by this name is one nothing holds. Leaving it would be a valid
+// credential nobody has, which is worse than one more entry in the audit trail.
+func (s *session) replaceToken(ctx context.Context, name string) error {
+	var out struct {
+		Tokens []struct {
+			ID   string `json:"token_id"`
+			Name string `json:"name"`
+		} `json:"tokens"`
+	}
+	if err := s.client.DoWithCookie(ctx, http.MethodGet, "/api/v1/me/tokens", s.cookie, nil, &out); err != nil {
+		return fmt.Errorf("listing your tokens to replace the one named %q: %w", name, err)
+	}
+	for _, token := range out.Tokens {
+		if token.Name != name {
+			continue
+		}
+		if err := s.client.DoWithCookie(ctx, http.MethodDelete,
+			"/api/v1/me/tokens/"+token.ID, s.cookie, nil, nil); err != nil {
+			return fmt.Errorf("revoking the previous token named %q: %w", name, err)
+		}
+		return nil
+	}
+	// The name is taken and nothing by that name is listed. Not something to work around by
+	// inventing another name: it means this and the control plane disagree about what
+	// exists, and choosing a different name would leave the disagreement in place.
+	return fmt.Errorf("the control plane says %q is taken and does not list it", name)
+}
+
+// revokeToken takes a token away, as the person who owns it.
+func (s *session) revokeToken(ctx context.Context, id string) error {
+	return s.client.DoWithCookie(ctx, http.MethodDelete, "/api/v1/me/tokens/"+id, s.cookie, nil, nil)
+}

--- a/docs/adr/0031-the-cli-signs-in-with-a-token-it-mints.md
+++ b/docs/adr/0031-the-cli-signs-in-with-a-token-it-mints.md
@@ -1,0 +1,142 @@
+# ADR-0031: `meshp login` mints an API token and keeps it for one person
+
+- **Status:** accepted
+- **Date:** 2026-09-01
+
+## Context
+
+`meshp --help` advertises six nouns — `device`, `network`, `user`, `group`, `acl`, `dns` —
+and none of them exists (#213). They are missing together rather than one at a time, and the
+reason is underneath all of them: the five verbs that do work (`join`, `up`, `down`, `status`,
+`doctor`) talk to **meshpd over a unix socket**, and every noun talks to a **control plane over
+HTTP**, with a credential. `cmd/meshp` has no HTTP client, no base URL and nowhere to keep a
+credential.
+
+So `login` is not one more verb. It is the thing six nouns are waiting for, and what it decides
+they inherit.
+
+ADR-0024 already divides credentials, and a CLI does not obviously land on either side:
+
+- **Sessions** are for people. A row in `user_sessions`, revocable, with a sliding idle window
+  and a fixed ceiling. The browser holds one in an `HttpOnly` cookie it cannot read.
+- **API tokens** are for machines. Hashed, scoped, with an expiry and a last-used-at, carrying
+  the permissions of the user who minted them intersected with a scope. ADR-0024's reasoning is
+  that "a machine cannot answer an MFA prompt, cannot rotate a password, and must not be logged
+  out because a person closed a laptop".
+
+A CLI is a person at a keyboard and a long-lived process on their disk. The last of those three
+reasons applies to it exactly; the first two do not.
+
+## Decision
+
+### 1. `meshp login` authenticates as a person and keeps a token
+
+It asks for an email address and a password, opens a session the way the page does, uses that
+session once to mint an API token, and then ends the session. What it stores is the token.
+
+Three properties follow, and they are the reason for the indirection:
+
+**A password is never stored, and never needed again.** The session exists for the length of
+one command.
+
+**The credential on disk is revocable and enumerable.** `GET /api/v1/me/tokens` lists it,
+`DELETE` removes it, and it carries a `last_used_at`. A person who has lost a laptop can see
+what it holds and take it away, which a stored password would not allow.
+
+**It cannot outlive a demotion.** A token carries its owner's permissions intersected with its
+scope, evaluated per request — so a person whose role is reduced has a CLI that is reduced with
+them, without anybody reissuing anything.
+
+The token is named for the machine it is on and expires. Ninety days, which is the mint
+endpoint's own default: long enough not to be a nuisance, short enough that an abandoned
+laptop stops being a credential within a quarter.
+
+### 2. It is a per-person credential, and the daemon must not use it
+
+`~/.config/meshp/credentials.json`, `0600`, owned by the person who ran `login`.
+
+Deliberately the opposite of the daemon's socket, which is root-only because anything reaching
+it can enrol the device and decide where its traffic goes. This credential administers a
+control plane and must not be reachable by a root daemon on a shared machine; that daemon has
+its own identity and its own key material (Invariant 19), and the two are not the same person.
+
+`XDG_CONFIG_HOME` is honoured where it is set, because a person who has moved their
+configuration has said where they want it.
+
+### 3. One control plane at a time, and it is named in the file
+
+`meshp login --control-url https://control.example.com` records the address beside the token,
+and the nouns use it. `meshp network use` selects the network within it.
+
+Not a per-command flag, because the nouns are what somebody types twenty times during an
+incident, and not an environment variable alone, because a shell that has forgotten it is a
+person wondering why they are unauthorised.
+
+More than one control plane per person is a real case — an MSP is the product — and it is
+deliberately not solved here. The file holds one, and the shape it holds it in is a list of
+one, so that adding profiles later is not a migration.
+
+### 4. The API is still the contract
+
+The CLI is a client with no privileges of its own. Anything it can do, a token can do, and
+nothing is reachable only through it. ADR-0009 makes the HTTP API what the commercial layer
+builds on, and a CLI that grew its own private path would be a second interface to keep honest.
+
+## Consequences
+
+**A person's CLI credential is as strong as their account.** A token minted by an owner can do
+what an owner can do, because `login` scopes it to the whole permission catalogue and the
+control plane intersects that with what the person actually holds, per request. Asking for
+everything is not the same as receiving it, and a CLI that could do less than the person
+driving it is one they will work around.
+
+The catalogue is read from the control plane rather than compiled in. A CLI carrying its own
+copy would grant nothing new against a deployment that had learned a permission, and would be
+refused outright by one that had dropped it — `MintToken` rejects a scope naming anything it
+does not know.
+
+There is no `--permissions` flag yet. A shared machine wants one, and the shape is a narrowing
+of what is asked for rather than a new mechanism.
+
+**`login` needs TLS in practice**, like the page: the control plane refuses to open a session
+over plaintext to anything but loopback. That is the same requirement ADR-0022 already imposes
+and not a new one.
+
+**Signing out asks for a password, and that is a consequence rather than a wart.** A token may
+not revoke itself: the control plane refuses it in those words — "a token that could mint a
+token would survive its own revocation" — so taking one away is something only the person can
+do. `meshp logout` therefore always forgets the credential locally, which needs nothing, and
+then offers to sign in to revoke it. `--local` skips the second half, and so does having no
+terminal; either way it says exactly what is still valid and where to remove it.
+
+Getting this wrong is what the first version did. It presented the stored token to revoke the
+stored token, which is precisely the operation the boundary exists to refuse.
+
+**A stolen credentials file is a valid credential until it is revoked or expires.** This is
+true of every token and is the reason for `last_used_at` and for the expiry. It is worse than a
+browser cookie in that it survives a reboot, and better in that it is listed, named, and
+removable without changing a password.
+
+**Nothing here is multi-tenant yet.** One control plane, one person, one token. An operator
+holding forty customers' networks needs profiles, and the file format leaves room for them.
+
+## Alternatives considered
+
+**Store the password and re-authenticate per command.** Simplest to write and the worst
+outcome: a password on disk is not revocable without changing it everywhere, and it is the one
+credential that also opens the page.
+
+**Keep a session cookie, as the page does.** It is what a person gets in a browser, and it is
+wrong here. Sessions have a sliding idle window and a fixed ceiling, so a CLI would log out
+during a long afternoon; they carry a CSRF story that exists for browsers and costs a CLI
+nothing but confusion; and `SameSite` is meaningless outside one.
+
+**Ask for a token and let people mint it themselves.** `POST /api/v1/me/tokens` already exists
+and an operator can call it with `curl`. Rejected as the *only* answer, not as an answer:
+`meshp login --token` remains the way a CI job authenticates, and it is what somebody
+automating this wants. What it is not is the first thing a new operator should have to do.
+
+**Use the daemon's identity.** The device already has one, and it is already talking to the
+control plane. Rejected because a device's identity says what the device may do, not what the
+person at the keyboard may do — and the two must not be conflated on a machine several people
+can log into.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,6 +39,7 @@ deliberate act with a written reason rather than a drift nobody noticed.
 | [0028](0028-the-windows-data-plane-is-wintun.md) | The Windows data plane is WinTun, shipped beside the binary |
 | [0029](0029-windows-split-dns-is-nrpt-on-port-53.md) | Windows split DNS is NRPT, and the resolver moves to port 53 there |
 | [0030](0030-fail-closed-on-windows.md) | Fail-closed egress on Windows is meshp's own WFP layer |
+| [0031](0031-the-cli-signs-in-with-a-token-it-mints.md) | `meshp login` mints an API token and keeps it for one person |
 
 ## Format
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -571,6 +571,13 @@ var knownFailures = []struct {
 	{store.ErrOrganizationExists, failure{http.StatusConflict, "organization_exists", "an organisation with that name already exists"}},
 	{store.ErrUserExists, failure{http.StatusConflict, "user_exists", "a user with that address already exists in this organisation"}},
 	{store.ErrNoSuchUser, failure{http.StatusNotFound, "no_such_user", "no such user in this organisation"}},
+	// A conflict, not a fault. Without these two, minting a token with a name already used
+	// answered 500 "the request could not be completed" and a caller had to read the
+	// server's log to find the sentence written for them — which is the failure
+	// TestARefusedRequestSaysWhy exists to prevent, arriving through a sentinel rather than
+	// through an unreviewed error.
+	{store.ErrTokenNameTaken, failure{http.StatusConflict, "token_name_taken", "you already have a live token with that name; revoke it or choose another"}},
+	{store.ErrNoSuchToken, failure{http.StatusNotFound, "no_such_token", "no such API token"}},
 	{store.ErrNoSuchRecord, failure{http.StatusNotFound, "no_such_record", "no such record in this network"}},
 	{enroll.ErrChallengeExpired, failure{http.StatusBadRequest, "challenge_expired", "the challenge has expired; request another"}},
 	{enroll.ErrProofFailed, failure{http.StatusUnauthorized, "proof_failed", "the signature over the challenge did not verify"}},

--- a/internal/cliapi/cliapi.go
+++ b/internal/cliapi/cliapi.go
@@ -1,0 +1,223 @@
+// Package cliapi is the CLI's client for a control plane.
+//
+// Separate from internal/enrollclient and internal/sessionclient, which are the *device*
+// talking about itself. This is a person administering a deployment, and the two carry
+// different credentials for different reasons (ADR-0031).
+package cliapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/controlurl"
+)
+
+// Client talks to one control plane as one person.
+type Client struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+// New returns a client for a control plane.
+//
+// The URL is validated here rather than trusted, so a mistyped address is reported by the
+// command that was mistyped rather than as a connection failure later.
+func New(baseURL, token string) (*Client, error) {
+	validated, err := controlurl.Validate(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		baseURL: strings.TrimSuffix(validated, "/"),
+		token:   token,
+		// A person is waiting at a terminal. Long enough for a control plane under load,
+		// short enough that a black-holed address does not look like a hang.
+		http: &http.Client{Timeout: 30 * time.Second},
+	}, nil
+}
+
+// Error is what the control plane said went wrong.
+//
+// Carries the status and the server's own code, so a caller can tell an expired credential
+// from a network that has gone away without matching on prose.
+type Error struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (e *Error) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return fmt.Sprintf("the control plane returned %d", e.Status)
+}
+
+// Unauthorised reports whether the credential was refused, which is the one failure with a
+// specific answer: sign in again.
+func (e *Error) Unauthorised() bool { return e.Status == http.StatusUnauthorized }
+
+// Do makes one request, decoding a JSON response into out when out is not nil.
+func (c *Client) Do(ctx context.Context, method, path string, body, out any) error {
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("cliapi: encoding the request: %w", err)
+		}
+		reader = bytes.NewReader(encoded)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return fmt.Errorf("cliapi: building the request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		// The browser's own wording describes the call this package made rather than what
+		// went wrong, which is not what somebody watching a deployment needs.
+		return fmt.Errorf("cannot reach %s: %w", c.baseURL, err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	raw, err := io.ReadAll(io.LimitReader(res.Body, 8<<20))
+	if err != nil {
+		return fmt.Errorf("cliapi: reading the response: %w", err)
+	}
+
+	if res.StatusCode >= 400 {
+		apiErr := &Error{Status: res.StatusCode}
+		var problem struct {
+			Error   string `json:"error"`
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(raw, &problem) == nil {
+			apiErr.Code, apiErr.Message = problem.Error, problem.Message
+		}
+		return apiErr
+	}
+
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("cliapi: the control plane's answer was not what this expected: %w", err)
+	}
+	return nil
+}
+
+// OpenSession signs in as a person and returns the session cookie.
+//
+// Used once, by `meshp login`, to reach the endpoint that mints a token. The cookie is never
+// written down: a session has a sliding idle window and a fixed ceiling, so a CLI holding one
+// would sign out during a long afternoon, and it carries a CSRF story that exists for browsers
+// (ADR-0031).
+func (c *Client) OpenSession(ctx context.Context, email, password string) (string, error) {
+	body := map[string]string{"email": email, "password": password}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("cliapi: encoding the sign-in: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v1/ui/session",
+		bytes.NewReader(encoded))
+	if err != nil {
+		return "", fmt.Errorf("cliapi: building the sign-in: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("cannot reach %s: %w", c.baseURL, err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	raw, _ := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if res.StatusCode >= 400 {
+		apiErr := &Error{Status: res.StatusCode}
+		var problem struct {
+			Error   string `json:"error"`
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(raw, &problem) == nil {
+			apiErr.Code, apiErr.Message = problem.Error, problem.Message
+		}
+		return "", apiErr
+	}
+
+	for _, cookie := range res.Cookies() {
+		if cookie.Value != "" {
+			return cookie.Name + "=" + cookie.Value, nil
+		}
+	}
+	return "", fmt.Errorf("cliapi: %s accepted the sign-in and set no session cookie", c.baseURL)
+}
+
+// DoWithCookie makes one request carrying a session cookie rather than a token.
+//
+// Only login uses this, and only to mint the token that replaces it. The Origin header is sent
+// because the control plane requires one on an unsafe method authenticated by cookie — a
+// defence written for browsers that a CLI has to satisfy anyway (ADR-0022 §5).
+func (c *Client) DoWithCookie(ctx context.Context, method, path, cookie string, body, out any) error {
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("cliapi: encoding the request: %w", err)
+		}
+		reader = bytes.NewReader(encoded)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return fmt.Errorf("cliapi: building the request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Cookie", cookie)
+	req.Header.Set("Origin", c.baseURL)
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("cannot reach %s: %w", c.baseURL, err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	raw, err := io.ReadAll(io.LimitReader(res.Body, 8<<20))
+	if err != nil {
+		return fmt.Errorf("cliapi: reading the response: %w", err)
+	}
+	if res.StatusCode >= 400 {
+		apiErr := &Error{Status: res.StatusCode}
+		var problem struct {
+			Error   string `json:"error"`
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(raw, &problem) == nil {
+			apiErr.Code, apiErr.Message = problem.Error, problem.Message
+		}
+		return apiErr
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("cliapi: the control plane's answer was not what this expected: %w", err)
+	}
+	return nil
+}

--- a/internal/cliapi/cliapi_test.go
+++ b/internal/cliapi/cliapi_test.go
@@ -1,0 +1,128 @@
+package cliapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// A refusal and an unanswered call are different things, and only one of them is about the
+// credential. Telling somebody their token was rejected when the host never answered sends
+// them to rotate a token that is fine.
+func TestARefusalAndAnUnreachableHostAreNotTheSame(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized","message":"sign in"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(server.URL, "mp_token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = client.Do(context.Background(), http.MethodGet, "/api/v1/me", nil, nil)
+
+	var apiErr *Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("a 401 did not produce an *Error: %v", err)
+	}
+	if !apiErr.Unauthorised() {
+		t.Error("a 401 is not reported as unauthorised")
+	}
+	if apiErr.Code != "unauthorized" {
+		t.Errorf("code = %q, want the server's own code", apiErr.Code)
+	}
+
+	// A host that never answers is not an *Error at all, so a caller cannot mistake it for
+	// a refusal by matching loosely.
+	unreachable, err := New("https://198.51.100.99:1", "mp_token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = unreachable.Do(ctx, http.MethodGet, "/api/v1/me", nil, nil)
+	if errors.As(err, &apiErr) {
+		t.Errorf("an unreachable host produced an *Error, which reads as a refusal: %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "cannot reach") {
+		t.Errorf("an unreachable host said %v; it should name what it could not reach", err)
+	}
+}
+
+// The token goes in the Authorization header, which is what the control plane reads.
+func TestTheTokenIsPresentedAsABearerToken(t *testing.T) {
+	var got string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(server.URL, "mp_secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Do(context.Background(), http.MethodGet, "/api/v1/me", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got != "Bearer mp_secret" {
+		t.Errorf("Authorization = %q, want a bearer token", got)
+	}
+}
+
+// A cookie-authenticated write must carry an Origin naming the host, or the control plane
+// refuses it — a defence written for browsers that a CLI has to satisfy anyway (ADR-0022 §5).
+// login is the only thing that uses a cookie, and it mints the token everything else uses.
+func TestACookieRequestCarriesAnOrigin(t *testing.T) {
+	var origin, cookie string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin, cookie = r.Header.Get("Origin"), r.Header.Get("Cookie")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(server.URL, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = client.DoWithCookie(context.Background(), http.MethodPost, "/api/v1/me/tokens",
+		"meshp_ui=abc", map[string]string{"name": "x"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cookie != "meshp_ui=abc" {
+		t.Errorf("Cookie = %q", cookie)
+	}
+	if origin != server.URL {
+		t.Errorf("Origin = %q, want %q — without it the control plane refuses the write", origin, server.URL)
+	}
+}
+
+// A sign-in that succeeds and sets no cookie is a failure, not a session.
+func TestASignInWithNoCookieIsAnError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(server.URL, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.OpenSession(context.Background(), "a@b.c", "pw"); err == nil {
+		t.Error("a sign-in that set no cookie was treated as a session")
+	}
+}
+
+// A mistyped address is reported by the command that was mistyped, not as a connection
+// failure several steps later.
+func TestABadAddressIsRefusedBeforeAnyRequest(t *testing.T) {
+	if _, err := New("not a url", "t"); err == nil {
+		t.Error("a URL with no scheme was accepted")
+	}
+}

--- a/internal/clicred/clicred.go
+++ b/internal/clicred/clicred.go
@@ -1,0 +1,128 @@
+// Package clicred is where a person's CLI credential lives.
+//
+// Not the daemon's. meshpd runs as root and holds this device's identity and key material,
+// and its socket is owner-only because anything reaching it can enrol the machine and decide
+// where its traffic goes. This is the other thing entirely: what the person at the keyboard
+// may do to a control plane, on a machine several people may log into (ADR-0031 §2).
+package clicred
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ErrNotSignedIn is returned when there is nothing stored.
+//
+// A named error rather than a bare "file not found", because every noun command hits it and
+// the answer somebody needs is "run meshp login", not a path.
+var ErrNotSignedIn = errors.New("clicred: not signed in")
+
+// File is what is on disk.
+//
+// A list of one, so that a second control plane later is a longer list rather than a
+// migration. An MSP holding forty customers is the product, and the day that arrives this
+// should not be a format change (ADR-0031 §3).
+type File struct {
+	Credentials []Credential `json:"credentials"`
+}
+
+// Credential is one person's access to one control plane.
+type Credential struct {
+	ControlURL string `json:"control_url"`
+	Token      string `json:"token"`
+	// TokenID is what `meshp logout` revokes and what a person sees in `meshp token list`.
+	// Kept because a token is a secret that cannot be looked up by its own value.
+	TokenID string `json:"token_id,omitempty"`
+	// Email is who this is, for the CLI to say so without asking the control plane.
+	Email string `json:"email,omitempty"`
+}
+
+// Path is where the credential lives.
+//
+// Under XDG_CONFIG_HOME where somebody has set it, because a person who has moved their
+// configuration has said where they want it.
+func Path() (string, error) {
+	dir := os.Getenv("XDG_CONFIG_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("clicred: finding your home directory: %w", err)
+		}
+		dir = filepath.Join(home, ".config")
+	}
+	return filepath.Join(dir, "meshp", "credentials.json"), nil
+}
+
+// Load reads the stored credential, or ErrNotSignedIn.
+func Load() (Credential, error) {
+	path, err := Path()
+	if err != nil {
+		return Credential{}, err
+	}
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return Credential{}, ErrNotSignedIn
+	}
+	if err != nil {
+		return Credential{}, fmt.Errorf("clicred: reading %s: %w", path, err)
+	}
+
+	var file File
+	if err := json.Unmarshal(raw, &file); err != nil {
+		// Refused rather than repaired. A file that will not parse may hold a token
+		// somebody still needs to revoke, and silently replacing it would take that away.
+		return Credential{}, fmt.Errorf("clicred: %s is not readable as credentials: %w", path, err)
+	}
+	if len(file.Credentials) == 0 {
+		return Credential{}, ErrNotSignedIn
+	}
+	return file.Credentials[0], nil
+}
+
+// Save writes the credential, replacing whatever was there.
+//
+// Owner-only, and the directory too. Written to a temporary file and renamed, so an
+// interrupted write leaves the previous credential rather than half of a new one — losing a
+// token that is still valid on the server means a person cannot revoke what they no longer
+// hold.
+func Save(cred Credential) error {
+	path, err := Path()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("clicred: preparing %s: %w", filepath.Dir(path), err)
+	}
+
+	encoded, err := json.MarshalIndent(File{Credentials: []Credential{cred}}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("clicred: encoding the credential: %w", err)
+	}
+	encoded = append(encoded, '\n')
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, encoded, 0o600); err != nil {
+		return fmt.Errorf("clicred: writing %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("clicred: replacing %s: %w", path, err)
+	}
+	return nil
+}
+
+// Forget removes the stored credential. Absent is success: `meshp logout` twice is not an
+// error, and somebody who has already deleted the file has got what they wanted.
+func Forget() error {
+	path, err := Path()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("clicred: removing %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/clicred/clicred_test.go
+++ b/internal/clicred/clicred_test.go
@@ -1,0 +1,161 @@
+package clicred
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The round trip, and the only thing every noun command depends on.
+func TestACredentialSurvivesBeingWritten(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	want := Credential{
+		ControlURL: "https://control.example.com",
+		Token:      "mp_secret",
+		TokenID:    "0f4b",
+		Email:      "someone@example.com",
+	}
+	if err := Save(want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("loaded %+v, saved %+v", got, want)
+	}
+}
+
+// Nothing stored is a named condition, not a file-not-found. Every noun hits it, and what
+// somebody needs to be told is "run meshp login" rather than a path.
+func TestNothingStoredIsNotSignedIn(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if _, err := Load(); !errors.Is(err, ErrNotSignedIn) {
+		t.Errorf("err = %v, want ErrNotSignedIn", err)
+	}
+}
+
+// A token is a secret on a machine other people may log into.
+func TestTheCredentialIsOwnerOnly(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	if err := Save(Credential{ControlURL: "https://c", Token: "mp_secret"}); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := Path()
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("the credential is mode %o, want 600 — it is a token, on a machine several "+
+			"people may log into", perm)
+	}
+	parent, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := parent.Mode().Perm(); perm != 0o700 {
+		t.Errorf("the directory holding it is mode %o, want 700", perm)
+	}
+}
+
+// A file that will not parse holds a token somebody may still need to revoke. Replacing it
+// silently would take that away.
+func TestAnUnreadableFileIsRefusedRatherThanReplaced(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	path, err := Path()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Load()
+	if err == nil {
+		t.Fatal("a corrupt credential file loaded successfully")
+	}
+	if errors.Is(err, ErrNotSignedIn) {
+		t.Error("a corrupt file was reported as not being signed in, which invites somebody " +
+			"to log in again over a token they can no longer revoke")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("the error does not say which file is unreadable: %v", err)
+	}
+}
+
+// Logging out twice is not an error.
+func TestForgettingWhatIsNotThereIsSuccess(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := Forget(); err != nil {
+		t.Errorf("forgetting an absent credential failed: %v", err)
+	}
+	if err := Save(Credential{ControlURL: "https://c", Token: "t"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Forget(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(); !errors.Is(err, ErrNotSignedIn) {
+		t.Errorf("after forgetting, Load returned %v", err)
+	}
+	if err := Forget(); err != nil {
+		t.Errorf("forgetting twice failed: %v", err)
+	}
+}
+
+// Saving replaces rather than appends, or a person who signs in twice keeps a token they can
+// no longer see.
+func TestSigningInAgainReplacesTheCredential(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := Save(Credential{ControlURL: "https://one", Token: "first"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Save(Credential{ControlURL: "https://two", Token: "second"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Token != "second" {
+		t.Errorf("loaded %q, want the most recent credential", got.Token)
+	}
+
+	raw, err := os.ReadFile(mustPath(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "first") {
+		t.Error("the previous token is still in the file, where nothing will ever use it " +
+			"and nobody will think to revoke it")
+	}
+}
+
+func mustPath(t *testing.T) string {
+	t.Helper()
+	path, err := Path()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/store/apitoken.go
+++ b/internal/store/apitoken.go
@@ -46,7 +46,9 @@ var (
 	ErrNoSuchToken = errors.New("store: no such API token")
 
 	// ErrTokenNameTaken means this person already has a token by that name.
-	ErrTokenNameTaken = errors.New("store: you already have a token with that name")
+	// Live: a revoked token does not hold its name (migration 0016), because a name kept by
+	// something the owner cannot see or revoke again is a refusal they cannot act on.
+	ErrTokenNameTaken = errors.New("store: you already have a live token with that name")
 )
 
 // APIToken is a credential a machine presents.

--- a/migrations/0016_token_names_free_on_revocation.sql
+++ b/migrations/0016_token_names_free_on_revocation.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+
+-- A revoked token holds its name forever, and it should not.
+--
+-- api_tokens is unique on (user_id, name), and revocation is a soft delete: the row stays
+-- with a revoked_at. So a name is consumed permanently the first time it is used, and
+-- `meshp login` from a machine can never be run twice — the CLI names a token after the
+-- host, revokes the old one when it signs in again, and is then told the name is taken by
+-- something that no longer exists.
+--
+-- The error was false as well as inconvenient: "you already have a token with that name"
+-- names a token the owner does not have, cannot see in their list, and cannot revoke again.
+--
+-- Made partial rather than dropped. What the constraint is for is still right — two live
+-- credentials called 'ci' are indistinguishable in the list somebody prunes from — and it
+-- stays exactly that strong for tokens that exist.
+
+ALTER TABLE api_tokens DROP CONSTRAINT IF EXISTS api_tokens_user_id_name_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS api_tokens_live_name_per_user
+    ON api_tokens (user_id, name)
+    WHERE revoked_at IS NULL;
+
+-- +goose Down
+
+DROP INDEX IF EXISTS api_tokens_live_name_per_user;
+
+-- Restoring the total constraint can fail, and that is honest rather than a flaw in this
+-- migration: rolling back is only possible if no two tokens now share a name, and the whole
+-- point of the change above is to allow exactly that. A deployment that has used the freedom
+-- cannot give it back without deciding which rows to rename, which is not a decision a
+-- migration should take on somebody's behalf.
+ALTER TABLE api_tokens ADD CONSTRAINT api_tokens_user_id_name_key UNIQUE (user_id, name);


### PR DESCRIPTION
The first slice of #213. Not `network list` — the thing six nouns are waiting for.

## Why login rather than a noun

`meshp --help` advertises six nouns and none exists. They are missing *together* rather than one at a time: the five verbs that work talk to **meshpd over a unix socket**, and every noun talks to a **control plane over HTTP** with a credential `cmd/meshp` had no way to obtain, carry or keep. `grep http.Client cmd/meshp` returned nothing.

ADR-0031 records what login decides on the nouns' behalf, because it is not obvious: ADR-0024 gives sessions to people and API tokens to machines, and a CLI is a person at a keyboard *and* a long-lived process on their disk.

## What it does

Authenticates as a person, mints an API token, ends the session, keeps the token.

- **A password is never stored.** The session lives for the length of one command.
- **What is stored is revocable and enumerable**, named after the machine so a person can tell which laptop to revoke.
- **It cannot outlive a demotion** — a token carries its owner's permissions intersected per request.
- `~/.config/meshp/credentials.json`, `0600` — deliberately the opposite of the daemon's root-only socket. That one is root-only because anything reaching it can enrol the machine; this one administers a control plane and must **not** be reachable by a root daemon on a shared box.

The scope is read from `GET /api/v1/permissions` rather than compiled in. A CLI holding its own catalogue would grant nothing new against a control plane that had learned a permission, and be refused outright by one that had dropped it — `MintToken` rejects a scope naming anything it does not know.

## Three server defects were in the way

None reachable until something used the API the way a person would.

**A conflict answered 500.** `ErrTokenNameTaken` is a sentinel with reviewed, user-facing text and was never in `knownFailures`, so minting a token with a used name returned *"the request could not be completed"* while the sentence written for the caller stayed in the server's log. That is exactly what `TestARefusedRequestSaysWhy` exists to prevent, arriving by a route it does not cover. `ErrNoSuchToken` was missing too.

**A revoked token held its name forever.** `UNIQUE (user_id, name)` is unconditional and revocation is a soft delete, so a name was consumed permanently — and `meshp login` from a machine could never run twice. Migration 0016 makes the index partial. The constraint's purpose is unchanged; it stops speaking for tokens that do not exist. Its `Down` is allowed to fail and says why: restoring a total constraint is only possible if no two tokens share a name, which is the freedom the change grants.

**A token may not revoke itself — and that one is correct.** The control plane refuses it in those words:

> a token that could mint a token would survive its own revocation

My first `logout` walked straight into it, presenting the stored token to revoke the stored token. It now forgets the credential locally first — which cannot fail for anything the network does, because a laptop being handed on is exactly when there is no connection — then offers to sign in to revoke it. `--local` skips that, and so does having no terminal; either way it says what is still valid and where to remove it.

## Verified end to end

Against the real control plane at `control.meshp.net`: sign in, sign in **again from the same machine** and watch the old token replaced, sign out and watch it revoked.

Confirmed in the database rather than from the CLI's own output:

```
meshp cli on Aswins-MacBook-Pro.local | live=f
meshp cli on Aswins-MacBook-Pro.local | live=f
meshp cli on Aswins-MacBook-Pro.local | live=f
```

Worth doing, because the CLI printed *"Revoked it"* and the server logs revocations at a lower level than mints — so the log alone looked like nothing had happened.

## Not in this PR

The nouns. This is the credential they need; `network list` is the next slice and now has somewhere to get a client from. The five `good first issue` items (#62 #63 #64 #65 #68) are untouched and should stay that way.