### PR TITLE
docs: the README says which platforms carry traffic, in both directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 <p align="center">
   Self-hostable private networking built on WireGuard.<br>
-  Connect Linux, Windows, macOS, Android and iOS into one private network — with
-  policy, private DNS, LAN gateways and automatic egress failover.
+  Connect Linux, Windows and macOS into one private network — with policy,
+  private DNS, LAN gateways and automatic egress failover.<br>
+  <sub>Android and iOS are committed to and not started (ADR-0015).</sub>
 </p>
 
 <p align="center">
@@ -15,10 +16,12 @@
 
 ## Status
 
-**Pre-alpha, and packets now cross.** On Linux, a device enrols, brings up a kernel
-WireGuard interface, attaches to a relay and carries traffic to its peers through it.
-Everything is relayed: nothing discovers direct paths yet, which is the design working
-as intended rather than a gap to apologise for (ADR-0002).
+**Pre-alpha, and packets now cross.** On Linux, macOS and Windows a device enrols,
+brings up a WireGuard interface, attaches to a relay and carries traffic to its peers
+through it. Everything is relayed: nothing discovers direct paths yet, which is the
+design working as intended rather than a gap to apologise for (ADR-0002) — though it is
+the gap that costs the most, since every packet between two machines in the same room
+still crosses a relay somebody pays for.
 
 What exists: enrolment end to end, a control channel carrying versioned desired state,
 kernel WireGuard interfaces reconciled against what the control plane asked for
@@ -37,7 +40,7 @@ ignoring it.
 The control plane serves TLS, from a certificate you supply or one it obtains from
 Let's Encrypt, and agents refuse a plaintext control URL to anything but loopback.
 
-Full-tunnel egress works on Linux, and fails closed (ADR-0011). A device sending
+Full-tunnel egress works on all three, and fails closed (ADR-0011). A device sending
 everything through the tunnel refuses traffic that would leave any other way, so a dropped
 tunnel cannot quietly put a real address back on the wire — and those rules are firewall
 state, so they survive the agent being killed. `meshp doctor` explains that to whoever


### PR DESCRIPTION
Three claims in `README.md`, wrong in two different directions. Found while fixing the same class of staleness on [meshp.net](https://github.com/meshpnet/meshp-web/pull/4).

### It claimed too much

The header offered *"Connect Linux, Windows, macOS, Android and iOS into one private network"* as a feature list. Android and iOS enrol, hold an address, and report honestly that they have no tunnel — `docs/platforms.md` has them as `no` in every row. Naming them beside three platforms that carry packets is the one place this file claims more than it does.

It is also the repo's **GitHub description**, verbatim. That is a setting rather than a file, so it needs changing by hand — it is the first thing anyone reads and it is not in this diff.

### It claimed too little

The Status section opened with *"On Linux, a device enrols, brings up a kernel WireGuard interface…"* and then, four paragraphs later, correctly said Linux, macOS and Windows all carry traffic. It contradicted itself and the stale half came first.

*"Full-tunnel egress works on Linux, and fails closed"* has been wrong since #166 and #169 gave it to macOS and #180 and #182 gave it to Windows.

### It undersold one cost

*"Nothing discovers direct paths yet, which is the design working as intended rather than a gap to apologise for (ADR-0002)"* is true about the design and reads as though the consequence were small. Every packet between two machines in the same room crosses a relay somebody pays for. A reader deciding whether to try this deserves that in the same breath, so the sentence now carries it.

### Checks

- `go test ./internal/docscheck/...` passes.
- Every platform claim checked against `docs/platforms.md`, which is itself verified against the code.