### PR TITLE
feat(devices): a device can be erased, not only revoked

### DIFF
--- a/docs/testing/the-page.md
+++ b/docs/testing/the-page.md
@@ -63,6 +63,20 @@ Each one is a thing the page got wrong before #146, so each one is worth repeati
    them and check the dropdown follows, in both directions, including via the browser's back
    button.
 
+8. **A button that changes identity changes handler.** With every device active, `POST
+   /fixture` with `{"revoked":["bravo"]}` and watch bravo's row: *Revoke* becomes *Forget*
+   without the row blinking. Now click it. The confirmation must say **Forget bravo**, not
+   *Revoke bravo*. *Two `<button class="danger">` elements are `comparable()`, so before both
+   were keyed the reconciler matched them by position and reused the node — relabelling it
+   while keeping the old click listener. The page offered to erase a device and revoked it
+   instead, which is the more alarming direction for that mistake to go in.*
+
+## Note on running this
+
+The fixture sends `cache-control: no-store`, so an edit to `app.js` is picked up by a reload.
+It did not always, and an ES module is cached per URL beyond an ordinary refresh — if a
+change seems to have no effect, open a new tab before suspecting the change.
+
 ## What this cannot tell you
 
 That the page is right about a real network. The fixture answers whatever it is asked and

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -289,6 +289,11 @@ func (s *Server) routes() []route {
 			handler: s.handleSetUserSuspended, kind: guardOrganization, perm: authz.OrganizationUsersWrite},
 		{pattern: "PUT /api/v1/organizations/{organizationID}/users/{userID}/password",
 			handler: s.handleSetUserPassword, kind: guardOrganization, perm: authz.OrganizationUsersWrite},
+		// Erasing a device, as opposed to revoking a membership. Organisation-scoped
+		// because a device can be in several networks and none of them owns it.
+		{pattern: "DELETE /api/v1/organizations/{organizationID}/devices/{deviceID}",
+			handler: s.handleForgetDevice, kind: guardOrganization, perm: authz.OrganizationDevicesForget},
+
 		{pattern: "DELETE /api/v1/organizations/{organizationID}/users/{userID}",
 			handler: s.handleDeleteUser, kind: guardOrganization, perm: authz.OrganizationUsersWrite},
 

--- a/internal/api/forget.go
+++ b/internal/api/forget.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/meshpnet/meshp/internal/httpx"
+	"github.com/meshpnet/meshp/internal/store"
+)
+
+// handleForgetDevice erases a device from every network at once.
+//
+// The destructive counterpart to handleRevokeMembership, and a different route rather than
+// a flag on that one, because it answers a different question. Revocation is per network
+// and leaves the row visible so an administrator can confirm a device is out. This leaves
+// nothing, and until it existed "remove my laptop from this system" had no answer at all —
+// the listing keeps revoked memberships on purpose, and no query anywhere deleted a device.
+//
+// Organisation-scoped: a device can hold memberships in several networks (ADR-0004), so no
+// one network's permissions should be enough to destroy it.
+//
+// The database commits first, then the other agents are nudged, for the reason revocation
+// gives — the peers are what enforce this, so the gap between the two is the window in
+// which an erased device is still reachable.
+//
+// The device itself is not told. Revocation tells it as a courtesy, addressed to the
+// membership being revoked; here there is no membership left to address and nothing on the
+// control plane still refers to it. A still-running agent finds out the way a revoked one
+// does when it is switched off at the time: its peers stop answering.
+func (s *Server) handleForgetDevice(w http.ResponseWriter, r *http.Request) {
+	orgID, ok := s.pathUUID(w, r, "organizationID")
+	if !ok {
+		return
+	}
+	deviceID, ok := s.pathUUID(w, r, "deviceID")
+	if !ok {
+		return
+	}
+
+	forgotten, err := s.store.ForgetDevice(r.Context(), store.ForgetRequest{
+		OrganizationID: orgID,
+		DeviceID:       deviceID,
+		Actor:          s.actor(r),
+		SourceIP:       sourceAddr(r),
+	})
+	if errors.Is(err, store.ErrNoSuchDevice) {
+		httpx.Error(w, s.log, http.StatusNotFound, "not_found",
+			"no such device in this organisation")
+		return
+	}
+	if err != nil {
+		s.respondError(w, r, err)
+		return
+	}
+
+	s.log.Info("device forgotten",
+		"organization_id", orgID, "device_id", forgotten.DeviceID,
+		"networks", len(forgotten.Networks), "keys", len(forgotten.Keys))
+
+	// Every network it was in, not only the ones whose keys changed: it may have been an
+	// advertiser in a network where its own membership had already been revoked, and the
+	// devices routing through it still have to be told.
+	for _, networkID := range forgotten.Networks {
+		s.tellNetwork(networkID)
+	}
+
+	httpx.WriteJSON(w, s.log, http.StatusOK, map[string]any{
+		"device_id":    forgotten.DeviceID,
+		"name":         forgotten.Name,
+		"networks":     forgotten.Networks,
+		"keys_removed": len(forgotten.Keys),
+	})
+}

--- a/internal/api/forget_test.go
+++ b/internal/api/forget_test.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// orgOf reads the organisation the harness's network belongs to, which is what the forget
+// route is scoped by.
+func (h *harness) orgOf(networkID uuid.UUID) uuid.UUID {
+	h.t.Helper()
+	network, err := h.store.Queries().GetNetwork(h.ctx, networkID)
+	if err != nil {
+		h.t.Fatalf("reading the network: %v", err)
+	}
+	return network.OrganizationID
+}
+
+func (h *harness) forget(orgID, deviceID uuid.UUID) *http.Response {
+	h.t.Helper()
+	req, _ := http.NewRequest(http.MethodDelete,
+		h.server.URL+"/api/v1/organizations/"+orgID.String()+"/devices/"+deviceID.String(), nil)
+	req.Header.Set("Authorization", "Bearer "+testAdminToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	return resp
+}
+
+func (h *harness) countDevices(deviceID uuid.UUID) int {
+	h.t.Helper()
+	var n int
+	if err := h.store.Pool().QueryRow(h.ctx,
+		`SELECT count(*) FROM devices WHERE id = $1`, deviceID).Scan(&n); err != nil {
+		h.t.Fatalf("counting devices: %v", err)
+	}
+	return n
+}
+
+// The whole point: after this the device is not listed, not revoked-and-listed. Revocation
+// deliberately keeps the row so an administrator can see a device is out, which is the right
+// answer to a different question and no answer at all to "take my laptop off this system".
+func TestForgettingADeviceRemovesItEntirely(t *testing.T) {
+	h := newHarness(t)
+	alice := h.enrol("alice")
+	bob := h.enrol("bob")
+	orgID := h.orgOf(h.netID)
+
+	resp := h.forget(orgID, bob.DeviceID)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	if n := h.countDevices(bob.DeviceID); n != 0 {
+		t.Errorf("bob's device rows = %d, want 0", n)
+	}
+	// Alice is untouched, which is the assertion that stops this passing for a handler that
+	// deletes everything it can reach.
+	if n := h.countDevices(alice.DeviceID); n != 1 {
+		t.Errorf("alice's device rows = %d, want 1", n)
+	}
+
+	var listed int
+	if err := h.store.Pool().QueryRow(h.ctx,
+		`SELECT count(*) FROM device_network_memberships WHERE id = $1`,
+		bob.MembershipID).Scan(&listed); err != nil {
+		t.Fatal(err)
+	}
+	if listed != 0 {
+		t.Errorf("bob's membership rows = %d, want 0", listed)
+	}
+}
+
+// Everyone else is told to drop the key. Same enforcement as revocation: the erased device
+// is not reached and does not need to be.
+func TestForgettingADeviceTellsTheOtherPeers(t *testing.T) {
+	h := newHarness(t)
+	h.enrol("alice")
+	bob := h.enrol("bob")
+	orgID := h.orgOf(h.netID)
+
+	resp := h.forget(orgID, bob.DeviceID)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var removals int
+	if err := h.store.Pool().QueryRow(h.ctx,
+		`SELECT count(*) FROM state_changes WHERE network_id = $1 AND kind = 'peer_remove'`,
+		h.netID).Scan(&removals); err != nil {
+		t.Fatal(err)
+	}
+	if removals != 1 {
+		t.Errorf("peer_remove rows = %d, want 1", removals)
+	}
+}
+
+func TestForgettingADeviceThatIsNotThereIs404(t *testing.T) {
+	h := newHarness(t)
+	orgID := h.orgOf(h.netID)
+
+	resp := h.forget(orgID, uuid.New())
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// An id that exists but belongs to another organisation answers the same way, so the route
+// cannot be used to find out which device ids are real.
+func TestForgettingADeviceInAnotherOrganisationIs404(t *testing.T) {
+	h := newHarness(t)
+	bob := h.enrol("bob")
+
+	var otherOrg uuid.UUID
+	if err := h.store.Pool().QueryRow(h.ctx,
+		`INSERT INTO organizations (slug, name) VALUES ('other', 'Other') RETURNING id`,
+	).Scan(&otherOrg); err != nil {
+		t.Fatalf("inserting the other organization: %v", err)
+	}
+
+	resp := h.forget(otherOrg, bob.DeviceID)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+	if n := h.countDevices(bob.DeviceID); n != 1 {
+		t.Errorf("bob's device rows = %d, want 1 — it is not that organisation's to erase", n)
+	}
+}

--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -88,6 +88,16 @@ const (
 	// from every other so that "can change the network" and "can change who may change the
 	// network" are different answers.
 	OrganizationRolesBind Permission = "organization.roles.bind"
+
+	// Erasing a device: its record, its memberships, and its keys, in every network at
+	// once. Organisation-scoped rather than network-scoped because a device is not a
+	// network's to destroy — one can hold memberships in several (ADR-0004), and a
+	// permission granted on one customer's network must not reach into another's.
+	//
+	// Separate from network.devices.revoke, which is the reversible half. Revoking cuts a
+	// device out and leaves it visible so an administrator can see that it is out; this
+	// leaves nothing behind but the audit trail.
+	OrganizationDevicesForget Permission = "organization.devices.forget"
 )
 
 // Entry is a permission and what it means.
@@ -129,6 +139,7 @@ var Catalogue = []Entry{
 	{OrganizationTokensRead, "List the API tokens in an organisation and whose they are"},
 	{OrganizationTokensWrite, "Revoke somebody else's API token"},
 	{OrganizationRolesBind, "Grant and remove roles"},
+	{OrganizationDevicesForget, "Erase a device and its keys from every network permanently"},
 }
 
 // Known reports whether a string names a permission this control plane recognises.

--- a/internal/authz/builtin.go
+++ b/internal/authz/builtin.go
@@ -70,6 +70,7 @@ func Builtins() []Builtin {
 		NetworkEgressWrite,
 		NetworkRoutesWrite,
 		OrganizationNetworksCreate,
+		OrganizationDevicesForget,
 	)
 
 	// Everything, taken from the catalogue rather than listed: an owner who did not

--- a/internal/store/forget.go
+++ b/internal/store/forget.go
@@ -1,0 +1,189 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/netip"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	dbgen "github.com/meshpnet/meshp/internal/store/gen"
+)
+
+// ErrNoSuchDevice means there is no such device in this organisation.
+//
+// One error for "no such id" and "not yours", for the reason ErrNotAMember gives: telling
+// them apart lets somebody holding a credential for one organisation probe for device ids
+// in another.
+var ErrNoSuchDevice = errors.New("store: no such device in this organisation")
+
+// ForgetRequest is who is erasing what.
+type ForgetRequest struct {
+	OrganizationID uuid.UUID
+	DeviceID       uuid.UUID
+
+	// Actor is who is doing this. Required: WriteAudit refuses a zero one rather than
+	// recording an erasure nobody can be asked about.
+	Actor    Actor
+	SourceIP *netip.Addr
+}
+
+// Forgotten is what an erasure removed.
+type Forgotten struct {
+	DeviceID uuid.UUID
+	Name     string
+
+	// Networks the device was a member of, whether or not those memberships were revoked.
+	Networks []uuid.UUID
+
+	// Keys every other device has been told to stop accepting.
+	Keys []string
+}
+
+// ForgetDevice erases a device: its record, its memberships, its keys, and its route
+// advertisements, in every network at once.
+//
+// The destructive counterpart to RevokeMembership, and deliberately a different shape.
+// Revocation is per network and leaves the row visible, because an administrator checking
+// that a device is out needs to see that it is out. This is per device and leaves nothing,
+// because "take my laptop off this system" is a different question and revocation was never
+// an answer to it.
+//
+// Organisation-scoped rather than network-scoped: a device can hold memberships in several
+// networks (ADR-0004), and no single one of them owns it.
+//
+// Everything happens in one transaction, for the reason RevokeMembership gives. Split
+// apart, the failures are silent in both directions: rows deleted without the peer removals
+// logged leaves every other agent holding a key for a device that no longer exists and no
+// record that will ever tell them otherwise, and removals logged without the delete leaves
+// a device that has been cut off but not erased, which is the state this exists to end.
+//
+// What this does not do is reach the device. Like revocation, it is enforced by the peers
+// (ADR-0007's shape): the erased device keeps whatever is on its disk, and what changes is
+// that nobody will talk to it. Removing the software from the machine is a separate act and
+// this does not depend on it having happened.
+func (s *Store) ForgetDevice(ctx context.Context, req ForgetRequest) (Forgotten, error) {
+	var out Forgotten
+
+	err := s.InTx(ctx, func(q *dbgen.Queries) error {
+		// Scoped, though DeleteDevice below is scoped too and the transaction would take
+		// back anything done in between. Both on purpose: this is the check that gives the
+		// refusal its meaning, and relying on the delete alone would mean another tenant's
+		// networks got peer removals bumped for a device that was never theirs to touch,
+		// correct only because the rollback happened to catch it.
+		device, err := q.GetDeviceInOrganization(ctx, dbgen.GetDeviceInOrganizationParams{
+			ID:             req.DeviceID,
+			OrganizationID: req.OrganizationID,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNoSuchDevice
+		}
+		if err != nil {
+			return fmt.Errorf("store: loading the device: %w", err)
+		}
+
+		// Read before the delete destroys it.
+		memberships, err := q.ListMembershipsForForget(ctx, req.DeviceID)
+		if err != nil {
+			return fmt.Errorf("store: listing the device's memberships: %w", err)
+		}
+
+		for _, m := range memberships {
+			out.Networks = append(out.Networks, m.NetworkID)
+
+			// A membership that never completed enrolment has no current key. There is
+			// nothing for anyone to stop accepting, and PeerRemoved("") would be a change
+			// naming no peer.
+			if m.WireguardPublicKey != nil && *m.WireguardPublicKey != "" {
+				key := *m.WireguardPublicKey
+				out.Keys = append(out.Keys, key)
+				if _, err := BumpVersion(ctx, q, m.NetworkID, PeerRemoved(key)); err != nil {
+					return err
+				}
+			}
+
+			// Only when it carried something. Every bump costs every agent in the network a
+			// delta, and a laptop that advertised nothing should not make five hundred
+			// devices recompute their routes.
+			if m.Advertises {
+				if err := BumpRoutesEverywhere(ctx, q, m.NetworkID); err != nil {
+					return err
+				}
+			}
+		}
+
+		rows, err := q.DeleteDevice(ctx, dbgen.DeleteDeviceParams{
+			ID:             req.DeviceID,
+			OrganizationID: req.OrganizationID,
+		})
+		if err != nil {
+			return fmt.Errorf("store: deleting the device: %w", err)
+		}
+		if rows == 0 {
+			// Read a moment ago inside this transaction, so this means a concurrent
+			// erasure got there first rather than a scoping mistake.
+			return ErrNoSuchDevice
+		}
+
+		// In the same transaction as the act. This is the only record that will exist
+		// afterwards — the rows it describes are gone — so an erasure whose audit entry
+		// rolled back would be one nobody could ever account for.
+		//
+		// One row per network rather than one for the organisation, because the only
+		// reader is per network: ListAuditEventsForNetwork and the single `GET
+		// /networks/{id}/audit` route. An organisation-scoped row would be written and
+		// then be unreadable by anything, which is a mechanism nothing reaches (ADR-0018).
+		// It is also where somebody would look — an administrator of one network asking
+		// why a device vanished from it is reading that network's trail, not a list of
+		// everything that ever happened to a tenant.
+		deviceID := req.DeviceID
+		orgID := req.OrganizationID
+		writeOne := func(networkID *uuid.UUID, key string) error {
+			metadata, _ := json.Marshal(map[string]any{
+				"device_name":          device.Name,
+				"wireguard_public_key": key,
+				"networks":             out.Networks,
+			})
+			return WriteAudit(ctx, q, req.Actor, dbgen.CreateAuditEventParams{
+				OrganizationID: &orgID,
+				NetworkID:      networkID,
+				Action:         "device.forgotten",
+				ResourceKind:   "device",
+				ResourceID:     &deviceID,
+				SourceIp:       req.SourceIP,
+				Metadata:       metadata,
+			})
+		}
+
+		for _, m := range memberships {
+			networkID := m.NetworkID
+			key := ""
+			if m.WireguardPublicKey != nil {
+				key = *m.WireguardPublicKey
+			}
+			if err := writeOne(&networkID, key); err != nil {
+				return err
+			}
+		}
+
+		// A device that enrolled and joined nothing has no network whose trail could hold
+		// this. Recorded against the organisation anyway: nothing reads those rows today,
+		// and a destructive act going entirely unrecorded is the worse of the two.
+		if len(memberships) == 0 {
+			if err := writeOne(nil, ""); err != nil {
+				return err
+			}
+		}
+
+		out.DeviceID = req.DeviceID
+		out.Name = device.Name
+		return nil
+	})
+	if err != nil {
+		return Forgotten{}, err
+	}
+	return out, nil
+}

--- a/internal/store/forget_test.go
+++ b/internal/store/forget_test.go
@@ -1,0 +1,245 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// forgetActor is a valid actor: WriteAudit refuses a zero one, so every call here needs a
+// kind the schema allows and a label somebody could read.
+func forgetActor() Actor { return Actor{Kind: "user", Label: "someone@example.com"} }
+
+// forgetFixture seeds a device with one membership, a current key, and the peer_upsert row
+// a real enrolment leaves in the change log. That last row is the point: it is what made a
+// hard delete impossible before migration 0017, so a fixture without it would pass against
+// the schema this feature had to change.
+func forgetFixture(t *testing.T, s *Store) (orgID, networkID, deviceID, membershipID uuid.UUID) {
+	t.Helper()
+	ctx := testContext(t)
+
+	orgID, networkID = insertOrgAndNetwork(t, s)
+
+	err := s.pool.QueryRow(ctx,
+		`INSERT INTO devices (organization_id, name, identity_public_key)
+		 VALUES ($1, 'laptop', '\x0102') RETURNING id`, orgID).Scan(&deviceID)
+	if err != nil {
+		t.Fatalf("inserting device: %v", err)
+	}
+	err = s.pool.QueryRow(ctx,
+		`INSERT INTO device_network_memberships (device_id, network_id, interface_name, dns_label)
+		 VALUES ($1, $2, 'meshp0', 'laptop') RETURNING id`, deviceID, networkID).Scan(&membershipID)
+	if err != nil {
+		t.Fatalf("inserting membership: %v", err)
+	}
+	if _, err := s.pool.Exec(ctx,
+		`INSERT INTO wireguard_keys (membership_id, public_key, state)
+		 VALUES ($1, 'laptop-key', 'current')`, membershipID); err != nil {
+		t.Fatalf("inserting key: %v", err)
+	}
+	if _, err := s.pool.Exec(ctx,
+		`INSERT INTO state_changes (network_id, version, kind, membership_id)
+		 VALUES ($1, 1, 'peer_upsert', $2)`, networkID, membershipID); err != nil {
+		t.Fatalf("inserting the enrolment's change row: %v", err)
+	}
+	return orgID, networkID, deviceID, membershipID
+}
+
+func countRows(t *testing.T, s *Store, query string, args ...any) int {
+	t.Helper()
+	var n int
+	if err := s.pool.QueryRow(testContext(t), query, args...).Scan(&n); err != nil {
+		t.Fatalf("counting: %v", err)
+	}
+	return n
+}
+
+func TestForgetDeviceRemovesTheDeviceAndItsMemberships(t *testing.T) {
+	s := freshStore(t)
+	orgID, _, deviceID, membershipID := forgetFixture(t, s)
+
+	forgotten, err := s.ForgetDevice(testContext(t), ForgetRequest{
+		OrganizationID: orgID,
+		DeviceID:       deviceID,
+		Actor:          forgetActor(),
+	})
+	if err != nil {
+		t.Fatalf("forgetting: %v", err)
+	}
+
+	if forgotten.Name != "laptop" {
+		t.Errorf("name = %q, want laptop", forgotten.Name)
+	}
+	if got := len(forgotten.Keys); got != 1 || forgotten.Keys[0] != "laptop-key" {
+		t.Errorf("keys = %v, want [laptop-key]", forgotten.Keys)
+	}
+
+	if n := countRows(t, s, `SELECT count(*) FROM devices WHERE id = $1`, deviceID); n != 0 {
+		t.Errorf("device rows = %d, want 0", n)
+	}
+	if n := countRows(t, s,
+		`SELECT count(*) FROM device_network_memberships WHERE id = $1`, membershipID); n != 0 {
+		t.Errorf("membership rows = %d, want 0", n)
+	}
+	if n := countRows(t, s,
+		`SELECT count(*) FROM wireguard_keys WHERE membership_id = $1`, membershipID); n != 0 {
+		t.Errorf("key rows = %d, want 0", n)
+	}
+}
+
+// The removal has to outlive the thing it removes. Before 0017 this delete could not happen
+// at all; the risk afterwards is the opposite one — cascading away the very row that tells
+// everybody else to drop the key.
+func TestForgetDeviceLeavesThePeerRemovalBehind(t *testing.T) {
+	s := freshStore(t)
+	orgID, networkID, deviceID, membershipID := forgetFixture(t, s)
+
+	if _, err := s.ForgetDevice(testContext(t), ForgetRequest{
+		OrganizationID: orgID, DeviceID: deviceID, Actor: forgetActor(),
+	}); err != nil {
+		t.Fatalf("forgetting: %v", err)
+	}
+
+	if n := countRows(t, s,
+		`SELECT count(*) FROM state_changes
+		 WHERE network_id = $1 AND kind = 'peer_remove' AND peer_public_key = 'laptop-key'`,
+		networkID); n != 1 {
+		t.Errorf("peer_remove rows naming the key = %d, want 1", n)
+	}
+
+	// And the enrolment's own row is gone, because a peer_upsert pointing at a membership
+	// that no longer exists tells an agent to go and read nothing.
+	if n := countRows(t, s,
+		`SELECT count(*) FROM state_changes WHERE kind = 'peer_upsert' AND membership_id = $1`,
+		membershipID); n != 0 {
+		t.Errorf("stale peer_upsert rows = %d, want 0", n)
+	}
+}
+
+// Removing an advertiser changes where every other device sends traffic. A delete that took
+// a gateway away silently is the failure #206 fixed for route groups.
+func TestForgetDeviceRecomputesRoutesWhenItCarriedAPrefix(t *testing.T) {
+	s := freshStore(t)
+	ctx := testContext(t)
+	orgID, networkID, deviceID, membershipID := forgetFixture(t, s)
+
+	var groupID uuid.UUID
+	err := s.pool.QueryRow(ctx,
+		`INSERT INTO route_groups (network_id, slug, name, kind)
+		 VALUES ($1, 'branch', 'Branch', 'subnet') RETURNING id`, networkID).Scan(&groupID)
+	if err != nil {
+		t.Fatalf("inserting route group: %v", err)
+	}
+	if _, err := s.pool.Exec(ctx,
+		`INSERT INTO route_advertisers (route_group_id, membership_id) VALUES ($1, $2)`,
+		groupID, membershipID); err != nil {
+		t.Fatalf("inserting advertiser: %v", err)
+	}
+
+	if _, err := s.ForgetDevice(ctx, ForgetRequest{
+		OrganizationID: orgID, DeviceID: deviceID, Actor: forgetActor(),
+	}); err != nil {
+		t.Fatalf("forgetting: %v", err)
+	}
+
+	// The kind directly rather than a net count: the cascade deletes the fixture's own
+	// peer_upsert at the same time, so counting rows before and against after understates
+	// what was added and would pass whether or not the routes were recomputed.
+	if n := countRows(t, s,
+		`SELECT count(*) FROM state_changes WHERE network_id = $1 AND kind = 'routes'`,
+		networkID); n < 1 {
+		t.Errorf("routes change rows = %d, want at least 1", n)
+	}
+	if n := countRows(t, s,
+		`SELECT count(*) FROM state_changes
+		 WHERE network_id = $1 AND kind = 'peer_remove' AND peer_public_key = 'laptop-key'`,
+		networkID); n != 1 {
+		t.Errorf("peer_remove rows = %d, want 1", n)
+	}
+	if n := countRows(t, s,
+		`SELECT count(*) FROM route_advertisers WHERE membership_id = $1`, membershipID); n != 0 {
+		t.Errorf("advertiser rows = %d, want 0", n)
+	}
+}
+
+// The counterpart: a device that carried nothing must not make every other device in the
+// network recompute its routes. Without this, the cheap path and the expensive one are
+// indistinguishable and the `advertises` check could be deleted with every test still green.
+func TestForgetDeviceDoesNotRecomputeRoutesWhenItCarriedNothing(t *testing.T) {
+	s := freshStore(t)
+	orgID, networkID, deviceID, _ := forgetFixture(t, s)
+
+	before := countRows(t, s,
+		`SELECT count(*) FROM state_changes WHERE network_id = $1`, networkID)
+
+	if _, err := s.ForgetDevice(testContext(t), ForgetRequest{
+		OrganizationID: orgID, DeviceID: deviceID, Actor: forgetActor(),
+	}); err != nil {
+		t.Fatalf("forgetting: %v", err)
+	}
+
+	if n := countRows(t, s,
+		`SELECT count(*) FROM state_changes WHERE network_id = $1 AND kind = 'peer_remove'`,
+		networkID); n != 1 {
+		t.Errorf("peer_remove rows = %d, want 1", n)
+	}
+	// The assertion that gives the `advertises` check a reason to exist: delete that
+	// branch and this network gets a routes recomputation it did not need.
+	if n := countRows(t, s,
+		`SELECT count(*) FROM state_changes WHERE network_id = $1 AND kind = 'routes'`,
+		networkID); n != 0 {
+		t.Errorf("routes change rows = %d, want 0 — it carried nothing", n)
+	}
+	_ = before
+}
+
+// Every affected network's trail records it, because the only reader is per network.
+func TestForgetDeviceIsAuditedInTheNetworkItAffected(t *testing.T) {
+	s := freshStore(t)
+	orgID, networkID, deviceID, _ := forgetFixture(t, s)
+
+	if _, err := s.ForgetDevice(testContext(t), ForgetRequest{
+		OrganizationID: orgID, DeviceID: deviceID, Actor: forgetActor(),
+	}); err != nil {
+		t.Fatalf("forgetting: %v", err)
+	}
+
+	if n := countRows(t, s,
+		`SELECT count(*) FROM audit_events
+		 WHERE network_id = $1 AND action = 'device.forgotten'`, networkID); n != 1 {
+		t.Errorf("audit rows in the network's trail = %d, want 1", n)
+	}
+}
+
+// A device id from another tenant must not be erasable by whoever can guess one.
+func TestForgetDeviceRefusesADeviceInAnotherOrganisation(t *testing.T) {
+	s := freshStore(t)
+	_, _, deviceID, _ := forgetFixture(t, s)
+
+	var otherOrg uuid.UUID
+	if err := s.pool.QueryRow(testContext(t),
+		`INSERT INTO organizations (slug, name) VALUES ('other', 'Other') RETURNING id`,
+	).Scan(&otherOrg); err != nil {
+		t.Fatalf("inserting the other organization: %v", err)
+	}
+
+	_, err := s.ForgetDevice(testContext(t), ForgetRequest{
+		OrganizationID: otherOrg, DeviceID: deviceID, Actor: forgetActor(),
+	})
+	if err == nil {
+		t.Fatal("forgetting another organisation's device succeeded")
+	}
+
+	if n := countRows(t, s, `SELECT count(*) FROM devices WHERE id = $1`, deviceID); n != 1 {
+		t.Errorf("device rows = %d, want 1 — it should still be there", n)
+	}
+
+	// And nothing was told anything. The refusal happens after the memberships have been
+	// read and their peer removals bumped, so this is the assertion that the transaction
+	// really did take those back rather than leaving another tenant's network carrying
+	// removals for a device that was never touched.
+	if n := countRows(t, s,
+		`SELECT count(*) FROM state_changes WHERE kind = 'peer_remove'`); n != 0 {
+		t.Errorf("peer_remove rows = %d, want 0 — the refusal must leave no trace", n)
+	}
+}

--- a/internal/store/gen/devices.sql.go
+++ b/internal/store/gen/devices.sql.go
@@ -255,6 +255,29 @@ func (q *Queries) CreateWireGuardKey(ctx context.Context, arg CreateWireGuardKey
 	return i, err
 }
 
+const deleteDevice = `-- name: DeleteDevice :execrows
+DELETE FROM devices WHERE id = $1 AND organization_id = $2
+`
+
+type DeleteDeviceParams struct {
+	ID             uuid.UUID
+	OrganizationID uuid.UUID
+}
+
+// Erase a device. Memberships, keys, route advertisements, assignments and presence go
+// with it by cascade; `state_changes` rows naming its memberships go too (migration 0017),
+// while the peer removals bumped just before this keep the key they name.
+//
+// The audit trail does not reference devices and so survives intact: it holds labels rather
+// than foreign keys, which is what lets this be a real delete instead of a tombstone.
+func (q *Queries) DeleteDevice(ctx context.Context, arg DeleteDeviceParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteDevice, arg.ID, arg.OrganizationID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const getDevice = `-- name: GetDevice :one
 SELECT id, organization_id, user_id, name, hostname, os, os_version, agent_version, identity_public_key, capabilities, created_at, updated_at, last_seen_at, revoked_at, revoked_reason FROM devices WHERE id = $1
 `
@@ -294,6 +317,44 @@ WHERE identity_public_key = $1
 
 func (q *Queries) GetDeviceByIdentityKey(ctx context.Context, identityPublicKey []byte) (Device, error) {
 	row := q.db.QueryRow(ctx, getDeviceByIdentityKey, identityPublicKey)
+	var i Device
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.UserID,
+		&i.Name,
+		&i.Hostname,
+		&i.Os,
+		&i.OsVersion,
+		&i.AgentVersion,
+		&i.IdentityPublicKey,
+		&i.Capabilities,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.LastSeenAt,
+		&i.RevokedAt,
+		&i.RevokedReason,
+	)
+	return i, err
+}
+
+const getDeviceInOrganization = `-- name: GetDeviceInOrganization :one
+SELECT id, organization_id, user_id, name, hostname, os, os_version, agent_version, identity_public_key, capabilities, created_at, updated_at, last_seen_at, revoked_at, revoked_reason FROM devices WHERE id = $1 AND organization_id = $2
+`
+
+type GetDeviceInOrganizationParams struct {
+	ID             uuid.UUID
+	OrganizationID uuid.UUID
+}
+
+// One device, scoped to the organisation that is asking.
+//
+// Scoped, unlike GetDevice. That one is reached from a network the caller has already been
+// authorised for, so the id it holds came from a row it was allowed to read. Forgetting a
+// device is organisation-scoped and takes an id straight from the request, so this is the
+// check that stops an id from another tenant being erased by whoever can guess one.
+func (q *Queries) GetDeviceInOrganization(ctx context.Context, arg GetDeviceInOrganizationParams) (Device, error) {
+	row := q.db.QueryRow(ctx, getDeviceInOrganization, arg.ID, arg.OrganizationID)
 	var i Device
 	err := row.Scan(
 		&i.ID,
@@ -417,6 +478,67 @@ func (q *Queries) ListDeviceAddressPools(ctx context.Context, networkID uuid.UUI
 			&i.Family,
 			&i.Purpose,
 			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listMembershipsForForget = `-- name: ListMembershipsForForget :many
+SELECT
+    m.id         AS membership_id,
+    m.network_id,
+    k.public_key AS wireguard_public_key,
+    EXISTS (
+        SELECT 1 FROM route_advertisers a WHERE a.membership_id = m.id
+    ) AS advertises
+FROM device_network_memberships m
+LEFT JOIN wireguard_keys k ON k.membership_id = m.id AND k.state = 'current'
+WHERE m.device_id = $1
+ORDER BY m.joined_at
+`
+
+type ListMembershipsForForgetRow struct {
+	MembershipID       uuid.UUID
+	NetworkID          uuid.UUID
+	WireguardPublicKey *string
+	Advertises         bool
+}
+
+// Everything that has to be told before a device stops existing.
+//
+// Read before the delete, because the delete destroys all of it. Per membership: the
+// network to bump, the key every other agent must stop accepting, and whether this device
+// carried a prefix for anyone.
+//
+// `advertises` decides whether the routes in that network have to be recomputed. Removing
+// an advertiser changes where every *other* device sends traffic, and a delete that took a
+// gateway away without saying so would leave them routing into nothing — the failure #206
+// fixed for route groups, in a second place that could reach it.
+//
+// Revoked memberships are included. Their peer removal was already sent, and sending it
+// again is harmless — an agent dropping a key it does not have is a no-op — whereas
+// skipping one whose revocation never reached a partitioned agent would leave that agent
+// holding a peer forever.
+func (q *Queries) ListMembershipsForForget(ctx context.Context, deviceID uuid.UUID) ([]ListMembershipsForForgetRow, error) {
+	rows, err := q.db.Query(ctx, listMembershipsForForget, deviceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListMembershipsForForgetRow
+	for rows.Next() {
+		var i ListMembershipsForForgetRow
+		if err := rows.Scan(
+			&i.MembershipID,
+			&i.NetworkID,
+			&i.WireguardPublicKey,
+			&i.Advertises,
 		); err != nil {
 			return nil, err
 		}

--- a/migrations/0017_forgetting_a_device.sql
+++ b/migrations/0017_forgetting_a_device.sql
@@ -1,0 +1,51 @@
+-- +goose Up
+
+-- Make a device removable at all.
+--
+-- Until now nothing could delete one. `DELETE /networks/{id}/devices/{id}` revokes, the
+-- listing deliberately keeps revoked memberships so an administrator can see a device is
+-- out, and no query anywhere issued `DELETE FROM devices`. So "take my laptop off this
+-- system" had no answer beyond "mark it revoked and look at it forever" — which for a
+-- product whose argument is that you run your own private network is the wrong answer.
+--
+-- The obstacle was this table. `state_changes.membership_id` was ON DELETE SET NULL, and
+-- the table also carries
+--
+--     CHECK ((kind = 'peer_upsert' AND membership_id IS NOT NULL) OR
+--            (kind = 'peer_remove' AND peer_public_key IS NOT NULL))
+--
+-- A referential SET NULL is an UPDATE, and CHECK constraints are evaluated on UPDATE, so
+-- deleting a device cascaded to its memberships, tried to null out every `peer_upsert` row
+-- naming them, and failed:
+--
+--     ERROR:  new row for relation "state_changes" violates check constraint
+--     CONTEXT: SQL statement "UPDATE ONLY state_changes SET membership_id = NULL ..."
+--
+-- CASCADE rather than a looser CHECK, because the row genuinely has nothing left to say. A
+-- `peer_upsert` is "this membership's peer state changed, go and read it"; once the
+-- membership is gone there is nothing to read and an agent replaying it would be told to
+-- look up a row that does not exist.
+--
+-- What must not be cascaded away is the removal itself, and it is not: PeerRemoved carries
+-- the public key and leaves membership_id NULL (internal/store/statelog.go), precisely so a
+-- removal outlives the thing it removes — the same reason RouteGroupRemoved names its own
+-- id on the way out (#205). Deltas therefore still tell every other agent to drop the key.
+ALTER TABLE state_changes
+    DROP CONSTRAINT state_changes_membership_id_fkey;
+
+ALTER TABLE state_changes
+    ADD CONSTRAINT state_changes_membership_id_fkey
+    FOREIGN KEY (membership_id) REFERENCES device_network_memberships (id) ON DELETE CASCADE;
+
+-- +goose Down
+
+ALTER TABLE state_changes
+    DROP CONSTRAINT state_changes_membership_id_fkey;
+
+-- Deliberately restores the constraint that made the delete impossible. Going back means
+-- going back: a deployment that rolls this off should not keep the behaviour it enables.
+-- Rows whose membership is already gone will fail this, and that is the honest outcome —
+-- there is no membership to point them at any more.
+ALTER TABLE state_changes
+    ADD CONSTRAINT state_changes_membership_id_fkey
+    FOREIGN KEY (membership_id) REFERENCES device_network_memberships (id) ON DELETE SET NULL;

--- a/queries/devices.sql
+++ b/queries/devices.sql
@@ -135,3 +135,49 @@ JOIN devices d ON d.id = m.device_id
 LEFT JOIN wireguard_keys k ON k.membership_id = m.id AND k.state = 'current'
 WHERE m.network_id = $1
 ORDER BY m.joined_at;
+
+-- name: GetDeviceInOrganization :one
+-- One device, scoped to the organisation that is asking.
+--
+-- Scoped, unlike GetDevice. That one is reached from a network the caller has already been
+-- authorised for, so the id it holds came from a row it was allowed to read. Forgetting a
+-- device is organisation-scoped and takes an id straight from the request, so this is the
+-- check that stops an id from another tenant being erased by whoever can guess one.
+SELECT * FROM devices WHERE id = $1 AND organization_id = $2;
+
+-- name: ListMembershipsForForget :many
+-- Everything that has to be told before a device stops existing.
+--
+-- Read before the delete, because the delete destroys all of it. Per membership: the
+-- network to bump, the key every other agent must stop accepting, and whether this device
+-- carried a prefix for anyone.
+--
+-- `advertises` decides whether the routes in that network have to be recomputed. Removing
+-- an advertiser changes where every *other* device sends traffic, and a delete that took a
+-- gateway away without saying so would leave them routing into nothing — the failure #206
+-- fixed for route groups, in a second place that could reach it.
+--
+-- Revoked memberships are included. Their peer removal was already sent, and sending it
+-- again is harmless — an agent dropping a key it does not have is a no-op — whereas
+-- skipping one whose revocation never reached a partitioned agent would leave that agent
+-- holding a peer forever.
+SELECT
+    m.id         AS membership_id,
+    m.network_id,
+    k.public_key AS wireguard_public_key,
+    EXISTS (
+        SELECT 1 FROM route_advertisers a WHERE a.membership_id = m.id
+    ) AS advertises
+FROM device_network_memberships m
+LEFT JOIN wireguard_keys k ON k.membership_id = m.id AND k.state = 'current'
+WHERE m.device_id = $1
+ORDER BY m.joined_at;
+
+-- name: DeleteDevice :execrows
+-- Erase a device. Memberships, keys, route advertisements, assignments and presence go
+-- with it by cascade; `state_changes` rows naming its memberships go too (migration 0017),
+-- while the peer removals bumped just before this keep the key they name.
+--
+-- The audit trail does not reference devices and so survives intact: it holds labels rather
+-- than foreign keys, which is what lets this be a real delete instead of a tombstone.
+DELETE FROM devices WHERE id = $1 AND organization_id = $2;

--- a/web/app.js
+++ b/web/app.js
@@ -405,7 +405,7 @@ function renderGroup(group) {
   );
 }
 
-function renderDevices(devices) {
+function renderDevices(devices, organizationID) {
   const rows = devices.map((device) => {
     const faults = device.faults || [];
     const addresses = [device.address_v4, device.address_v6].filter(Boolean);
@@ -459,7 +459,7 @@ function renderDevices(devices) {
       // Empty for somebody who may not act, rather than absent: a column that appears and
       // disappears between people makes two screenshots of the same page look like two
       // different products.
-      el("td", { class: "actions" }, revokeButton(device)),
+      el("td", { class: "actions" }, revokeButton(device), forgetButton(device, organizationID)),
     );
   });
 
@@ -548,7 +548,12 @@ function revokeButton(device) {
     // Which device this is, on the button rather than only in the closure below. The node
     // outlives the render that made it, so what it was built beside is not what is on the
     // screen by the time it is clicked.
-    { class: "danger", type: "button", "data-membership": device.membership_id },
+    //
+    // Keyed, because the cell beside it can hold a Forget button instead. Two unkeyed
+    // <button class="danger"> elements are comparable(), so the reconciler matched them by
+    // position and reused this node — updating the label to "Forget" and keeping this
+    // click listener, which asked to revoke a device somebody had asked to erase.
+    { class: "danger", type: "button", "data-key": "revoke", "data-membership": device.membership_id },
     "Revoke",
   );
   button.addEventListener("click", () => {
@@ -568,6 +573,66 @@ function revokeButton(device) {
         api(
           `/api/v1/networks/${encodeURIComponent(currentNetworkID())}` +
             `/devices/${encodeURIComponent(membershipID)}`,
+          { method: "DELETE" },
+        ),
+      { refresh: true },
+    );
+  });
+  return button;
+}
+
+/**
+ * The organisation the network on screen belongs to.
+ *
+ * Read from the network list rather than from the overview, which does not carry it: the
+ * list is already fetched for the picker and every row has it, so this needs no new field
+ * on an endpoint polled every few seconds by every open page.
+ */
+function organizationOf(data, networks) {
+  const network = (networks || []).find((n) => n.id === data.network.id);
+  return network ? network.organization_id : null;
+}
+
+/**
+ * The button that erases a device rather than removing it from a network.
+ *
+ * Only once a device is revoked. The two are a sequence, not alternatives: this listing
+ * keeps revoked memberships precisely so somebody can confirm a device is out, and erasing
+ * it is the cleanup after that confirmation. Offering both at once beside a device still
+ * carrying traffic would make the more destructive one a mis-click.
+ *
+ * Organisation-scoped, unlike revoking, because a device can hold memberships in several
+ * networks and no one of them owns it (ADR-0004) — so this removes it from all of them at
+ * once, which is the thing the confirmation has to say out loud.
+ */
+function forgetButton(device, organizationID) {
+  if (!may("organization.devices.forget")) return null;
+  if (device.state === "active" || !organizationID) return null;
+
+  const button = el(
+    "button",
+    { class: "danger", type: "button", "data-key": "forget", "data-device": device.device_id },
+    "Forget",
+  );
+  button.addEventListener("click", () => {
+    const deviceID = button.dataset.device;
+    const current = lastGood ? lastGood.devices : [];
+    const named = current.find((d) => d.device_id === deviceID) || device;
+    if (
+      !window.confirm(
+        `Forget ${named.device_name}? This erases the device, its keys and its ` +
+          `memberships in every network. It cannot be undone, and the audit trail is all ` +
+          `that will be left of it.`,
+      )
+    ) {
+      return;
+    }
+    act(
+      button,
+      () =>
+        api(
+          `/api/v1/organizations/${encodeURIComponent(organizationID)}` +
+            `/devices/${encodeURIComponent(deviceID)}`,
           { method: "DELETE" },
         ),
       { refresh: true },
@@ -675,7 +740,7 @@ function renderOverview(data, networks, history) {
     el(
       "div",
       { class: "panel", "data-key": "devices" },
-      renderDevices(devices),
+      renderDevices(devices, organizationOf(data, networks)),
       data.devices_truncated
         ? el(
             "p",

--- a/web/testdata/fixture.py
+++ b/web/testdata/fixture.py
@@ -24,7 +24,13 @@ NET = "11111111-2222-3333-4444-555555555555"
 NAMES = ["alpha", "bravo", "charlie", "delta"]
 IDS = {n: "%s-0000-0000-0000-00000000000%d" % ("a" * 8, i) for i, n in enumerate(NAMES)}
 
-state = {"fault": None, "rename": {}, "revoked": [], "tick": 0, "fail_mint": False, "slow_mint": 0}
+# Distinct from IDS on purpose. A membership id and a device id are different things —
+# revoking takes one and forgetting takes the other — and a fixture that used the same value
+# for both would pass whichever the page sent.
+DEVICE_IDS = {n: "%s-0000-0000-0000-00000000000%d" % ("d" * 8, i) for i, n in enumerate(NAMES)}
+
+state = {"fault": None, "rename": {}, "revoked": [], "forgotten": [], "tick": 0,
+         "fail_mint": False, "slow_mint": 0}
 lock = threading.Lock()
 
 
@@ -35,6 +41,7 @@ def device(name):
         faults = [{"code": "unapplied", "message": "has not applied its configuration"}]
     return {
         "membership_id": mid,
+        "device_id": DEVICE_IDS[name],
         "device_name": state["rename"].get(name, name),
         "state": "revoked" if name in state["revoked"] else "active",
         "connected": True,
@@ -47,7 +54,7 @@ def device(name):
 
 
 def overview():
-    devices = [device(n) for n in NAMES]
+    devices = [device(n) for n in NAMES if n not in state["forgotten"]]
     return {
         "as_of": "2026-08-31T12:00:0%dZ" % (state["tick"] % 10),
         "network": {"id": NET, "slug": "hq", "name": "hq", "state_version": 12},
@@ -77,7 +84,10 @@ AUDIT = {"events": [
      "actor_label": "aswin", "action": "policy.published", "metadata": {}},
 ]}
 
+ORG = "cccccccc-0000-0000-0000-000000000001"
+
 NETWORKS = {"networks": [{"id": NET, "slug": "hq", "organization_slug": "acme",
+                          "organization_id": ORG,
                           "active_device_count": len(NAMES)}]}
 
 
@@ -114,6 +124,10 @@ class Handler(BaseHTTPRequestHandler):
         kind = {"js": "text/javascript", "css": "text/css"}.get(name.rsplit(".", 1)[-1], "text/html")
         self.send_response(200)
         self.send_header("content-type", kind + "; charset=utf-8")
+        # Without this the browser heuristically caches app.js, and every edit is tested
+        # against the copy from the first page load — which looks exactly like a change
+        # that did not work, and costs an hour before anybody suspects the fixture.
+        self.send_header("cache-control", "no-store")
         self.send_header("content-length", str(len(raw)))
         self.end_headers()
         self.wfile.write(raw)
@@ -136,10 +150,19 @@ class Handler(BaseHTTPRequestHandler):
         self.send_json({"error": "not_found"}, 404)
 
     def do_DELETE(self):
+        path = urlparse(self.path).path
         with lock:
-            mid = self.path.rsplit("/", 1)[-1]
+            last = path.rsplit("/", 1)[-1]
+            # Two different deletes on two different ids. Revoking names a membership under
+            # a network; forgetting names a device under an organisation.
+            if "/organizations/" in path:
+                for name, known in DEVICE_IDS.items():
+                    if known == last:
+                        state["forgotten"].append(name)
+                        return self.send_json({"device_id": last, "name": name})
+                return self.send_json({"error": "not_found"}, 404)
             for name, known in IDS.items():
-                if known == mid:
+                if known == last:
                     state["revoked"].append(name)
         self.send_json({"ok": True})
 


### PR DESCRIPTION
Closes the gap behind "why is my laptop still listed after I uninstalled it".

Nothing could delete a device. `DELETE /api/v1/networks/{networkID}/devices/{membershipID}` maps to `handleRevokeMembership`; the listing keeps revoked memberships deliberately —

> Revoked memberships are included rather than filtered out: an administrator checking that a device really is out needs to see that it is out

— and no query anywhere issued `DELETE FROM devices`. So removing a device from your own control plane had no answer beyond marking it revoked and looking at it forever.

## The schema forbade it

`state_changes.membership_id` was `ON DELETE SET NULL`, and the table also carries

```sql
CHECK ((kind = 'peer_upsert' AND membership_id IS NOT NULL) OR ...)
```

A referential `SET NULL` is an UPDATE and CHECK constraints run on UPDATE, so deleting a device cascaded to its memberships and failed on its own enrolment's change row. Verified against a real PostgreSQL rather than reasoned about:

```
ERROR:  new row for relation "state_changes" violates check constraint "state_changes_identifier_check"
CONTEXT: SQL statement "UPDATE ONLY state_changes SET membership_id = NULL WHERE ..."
```

Migration `0017` makes that FK `CASCADE`. A `peer_upsert` naming a membership that no longer exists tells an agent to go and read nothing. The removal itself survives, which is the property that matters: `PeerRemoved` carries the public key and leaves `membership_id` NULL, precisely so it outlives what it removes — the same reason `RouteGroupRemoved` names its own id on the way out (#205). Confirmed by test: after the delete, the `peer_remove` naming the key is still there and the stale `peer_upsert` is gone.

## Organisation-scoped, not network-scoped

A device holds memberships in several networks (ADR-0004) and no one of them owns it, so `DELETE /api/v1/organizations/{organizationID}/devices/{deviceID}` behind a new `organization.devices.forget`, granted to administrator and owner. One customer's network must not confer the right to destroy a device that is also in another's.

## Route advertisers were the trap

Deleting a device cascades through `route_advertisers`, which changes where every *other* device sends traffic. Left alone this is #206 again in a second place. A membership that advertised something bumps the routes for its network; one that advertised nothing does not, because a laptop should not make five hundred devices recompute. Both directions are tested, and both mutations are caught — see below.

## The audit trail

Written per network rather than per organisation. The only reader is `ListAuditEventsForNetwork` behind one `GET /networks/{id}/audit`; an organisation-scoped row would be written and then be unreadable by anything, which is a mechanism nothing reaches (ADR-0018). It survives the erasure because `audit_events` holds labels rather than foreign keys — the one FK to `devices` is the membership, and it cascades. That is what lets this be a real delete instead of a tombstone.

## On the page

*Forget* appears only once a device is revoked. The two are a sequence rather than alternatives: the listing keeps revoked rows so somebody can confirm a device is out, and erasing it is the cleanup after that confirmation.

**A bug this found by being driven rather than reasoned about.** Two unkeyed `<button class="danger">` elements are `comparable()`, so when a row went from active to revoked the reconciler matched the new *Forget* button onto the old *Revoke* node by position, relabelled it, and kept the old click listener. The page offered to erase a device and revoked it instead. Both buttons are now keyed; manual check 8 pins it.

## The fixture was lying by omission

`web/testdata/fixture.py` served only `membership_id` and no `organization_id`, both of which the real overview returns — so nothing keyed on a device id could be tested against it at all. It now serves both, with device ids deliberately distinct from membership ids so a page that sent the wrong one fails. It also sends `cache-control: no-store`: an edit to `app.js` was otherwise tested against the copy from the first page load, which looks exactly like a change that did not work.

## Checks

- `go test ./...` green, `go vet` clean, `gofmt` clean.
- `make reachability` passes — the new permission is reached by a route and the new queries by the store.
- `scripts/migrate-check.sh` — migrations apply, roll back and re-apply cleanly, 0017 included.
- Mutation-tested. Dropping the `advertises` check fails `TestForgetDeviceDoesNotRecomputeRoutesWhenItCarriedNothing`; forcing it always-true fails `...WhenItCarriedAPrefix`; never emitting the peer removal fails four tests; a no-op audit fails the audit test.
- One mutation deliberately **survives** and is documented in the code: removing the organisation scope from the *read* changes nothing observable, because `DeleteDevice` is scoped too and the transaction takes back anything done in between. Both scopes are kept — relying on the delete alone would mean another tenant's networks got peer removals bumped for a device that was never theirs, correct only because the rollback happened to catch it.
- Driven end to end in the browser against the fixture: the row morphs *Revoke* → *Forget* in place on a poll, the confirmation names the right device and action, and the device leaves the list rather than sitting there revoked.

## Not in this PR

`meshp device forget` — the whole `device` noun is still a stub (`meshp device --help` answers "not implemented yet"), so adding one verb means building the noun. That is the same gap #211/#212 track, from the other side.