### PR TITLE
fix(cli): the help offers only what the binary does

### DIFF
--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -368,15 +368,6 @@ func truncate(s string, n int) string {
 	return s[:n] + "…"
 }
 
-func contains(hay []string, needle string) bool {
-	for _, s := range hay {
-		if s == needle {
-			return true
-		}
-	}
-	return false
-}
-
 func envOr(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v

--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -8,16 +8,13 @@
 // local socket. Nothing here generates or stores key material: that belongs to the
 // privileged process, not to whoever happens to run the CLI.
 //
-// Command grammar is noun then verb, without exception:
-//
-//	meshp device list
-//	meshp device revoke <id>
-//	meshp exit use germany
-//
-// Admin and end-user commands share one flat namespace. What a caller may do is
-// decided by the permissions on their token, not by which subcommand tree they
-// found: `meshp device list` shows your own devices as a user and the whole network
-// as an admin.
+// Today it does seven things, all of them about this device: signing in, enrolling,
+// bringing the tunnel up and down, and reporting. Everything an administrator does to a
+// network is on the HTTP API and reachable from the web interface, and not from here yet
+// — ADR-0032 makes closing that a commitment rather than an intention, and says the
+// grammar it will follow when it does: noun then verb, `meshp device list`, in one flat
+// namespace where what a caller may do is decided by the permissions on their token
+// rather than by which subcommand tree they found.
 package main
 
 import (
@@ -36,56 +33,65 @@ import (
 	"github.com/meshpnet/meshp/internal/version"
 )
 
-const usage = `meshp — private mesh networking
-
-Usage:
-  meshp <noun> <verb> [flags]
-  meshp <verb>
-
-Session:
-  login                    Authenticate against a control plane
-  logout                   Forget the credential here, and offer to revoke it
-  join <token>             Enrol this device into a network
-  up                       Bring the tunnel up
-  down                     Take the tunnel down
-  status                   Show connection, peers and active routes
-  doctor                   Collect a diagnostic bundle for a bug report
-
-Nouns:
-  device                   list, show, rename, revoke, approve
-  network                  list, create, show, use
-  user                     list, invite, suspend
-  group                    list, create, add, remove
-  acl                      show, edit, test, apply
-  dns                      list, add, remove
-  route-group              list, create, show, drain, undrain
-  exit                     list, use, clear, status
-  relay                    list, ping
-  token                    create, list, revoke
-
-Run 'meshp <noun> --help' for the verbs a noun supports.
-
-Flags:
-  --version                Print build information
-  --help                   Show this help
-`
-
-// nouns is the authoritative list. Keeping it here means `meshp --help`, completions
-// and the docs generator cannot drift apart.
-var nouns = []string{
-	"device", "network", "user", "group", "acl",
-	"dns", "route-group", "exit", "relay", "token",
+// command is one thing this binary does.
+type command struct {
+	name string
+	// args summarises the positional arguments, shown after the name in the help.
+	args string
+	help string
+	run  func(context.Context, []string) error
 }
 
-// bareVerbs stand alone, without a noun.
-var bareVerbs = []string{
-	"login", "logout", "join", "up", "down", "status", "doctor",
+// commands is every command meshp has. It is the only list of them: main dispatches from
+// it and the help is generated from it, so the two cannot disagree.
+//
+// That is the point. This help used to advertise ten nouns and about thirty-seven verbs —
+// `device list`, `acl edit`, `token revoke` — none of which existed, each answering "not
+// implemented yet" when anybody took it up. A help text is a promise, and one that lists
+// what somebody intends to build makes the gap invisible by describing it as closed
+// (ADR-0032 §4). What is coming is in the decision records and in issues, which is where a
+// roadmap belongs.
+var commands = []command{
+	{name: "login", help: "Authenticate against a control plane", run: cmdLogin},
+	{name: "logout", help: "Forget the credential here, and offer to revoke it", run: cmdLogout},
+	{name: "join", args: "<token>", help: "Enrol this device into a network", run: cmdJoin},
+	{name: "up", help: "Bring the tunnel up", run: cmdUp},
+	{name: "down", help: "Take the tunnel down", run: cmdDown},
+	{name: "status", help: "Show connection, peers and active routes", run: cmdStatus},
+	{name: "doctor", help: "Collect a diagnostic bundle for a bug report", run: cmdDoctor},
+}
+
+// lookup finds a command by name.
+func lookup(name string) (command, bool) {
+	for _, c := range commands {
+		if c.name == name {
+			return c, true
+		}
+	}
+	return command{}, false
+}
+
+// usageText renders the help from the commands that exist.
+func usageText() string {
+	var b strings.Builder
+	b.WriteString("meshp — private mesh networking\n\nUsage:\n  meshp <command> [flags]\n\nCommands:\n")
+	for _, c := range commands {
+		invocation := c.name
+		if c.args != "" {
+			invocation += " " + c.args
+		}
+		fmt.Fprintf(&b, "  %-24s %s\n", invocation, c.help)
+	}
+	b.WriteString("\nFlags:\n")
+	fmt.Fprintf(&b, "  %-24s %s\n", "--version", "Print build information")
+	fmt.Fprintf(&b, "  %-24s %s\n", "--help", "Show this help")
+	return b.String()
 }
 
 func main() {
 	args := os.Args[1:]
 	if len(args) == 0 {
-		fmt.Print(usage)
+		fmt.Print(usageText())
 		os.Exit(2)
 	}
 
@@ -94,42 +100,15 @@ func main() {
 		fmt.Println(version.String("meshp"))
 		return
 	case "--help", "-h", "help":
-		fmt.Print(usage)
-		return
-	case "join":
-		runOrDie(cmdJoin, args[1:])
-		return
-	case "status":
-		runOrDie(cmdStatus, args[1:])
-		return
-	case "doctor":
-		runOrDie(cmdDoctor, args[1:])
-		return
-	case "login":
-		runOrDie(cmdLogin, args[1:])
-		return
-	case "logout":
-		runOrDie(cmdLogout, args[1:])
-		return
-	case "up":
-		runOrDie(cmdUp, args[1:])
-		return
-	case "down":
-		runOrDie(cmdDown, args[1:])
+		fmt.Print(usageText())
 		return
 	}
 
-	if contains(bareVerbs, args[0]) {
-		fail("%q is not implemented yet — see docs/adr for the design it will follow", args[0])
+	cmd, ok := lookup(args[0])
+	if !ok {
+		fail("unknown command %q\n\n%s", args[0], usageText())
 	}
-	if contains(nouns, args[0]) {
-		if len(args) < 2 {
-			fail("%q needs a verb, e.g. 'meshp %s list'", args[0], args[0])
-		}
-		fail("%q is not implemented yet", strings.Join(args[:2], " "))
-	}
-
-	fail("unknown command %q\n\n%s", args[0], usage)
+	runOrDie(cmd.run, args[1:])
 }
 
 // parseFlags parses flags that may appear before, after or among the positional

--- a/cmd/meshp/usage_test.go
+++ b/cmd/meshp/usage_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The help used to advertise ten nouns and about thirty-seven verbs that did not exist,
+// each answering "not implemented yet" when anybody took it up. Generating the text from
+// the dispatch table makes that unexpressible; this checks the generation rather than
+// trusting it, because the cheap way to reintroduce the problem is a hand-written line.
+func TestEveryCommandOfferedCanBeRun(t *testing.T) {
+	text := usageText()
+
+	body, ok := strings.CutPrefix(text[strings.Index(text, "Commands:"):], "Commands:\n")
+	if !ok {
+		t.Fatal("the help has no Commands section")
+	}
+	body, _, _ = strings.Cut(body, "\nFlags:")
+
+	offered := 0
+	for _, line := range strings.Split(strings.TrimSpace(body), "\n") {
+		name, _, _ := strings.Cut(strings.TrimSpace(line), " ")
+		if name == "" {
+			continue
+		}
+		offered++
+		cmd, found := lookup(name)
+		if !found {
+			t.Errorf("the help offers %q and nothing dispatches it", name)
+			continue
+		}
+		if cmd.run == nil {
+			t.Errorf("%q is dispatched to nothing", name)
+		}
+	}
+	if offered != len(commands) {
+		t.Errorf("the help lists %d commands, the table holds %d", offered, len(commands))
+	}
+}
+
+// The other direction: something that exists but is not offered is a command nobody can
+// find, which is the same failure wearing the opposite hat.
+func TestEveryCommandThatExistsIsOffered(t *testing.T) {
+	text := usageText()
+	for _, c := range commands {
+		if !strings.Contains(text, "  "+c.name) {
+			t.Errorf("%q is dispatched and the help does not mention it", c.name)
+		}
+		if c.help == "" {
+			t.Errorf("%q is offered with no description", c.name)
+		}
+	}
+}
+
+// ADR-0032 §4: a verb appears when it works, and until then the answer is that there is no
+// such command — which is true — rather than an apology for an offer that should not have
+// been made.
+func TestTheNounsThatWereNeverBuiltAreNotCommands(t *testing.T) {
+	for _, name := range []string{
+		"device", "network", "user", "group", "acl",
+		"dns", "route-group", "exit", "relay", "token",
+	} {
+		if _, found := lookup(name); found {
+			t.Errorf("%q resolves; if it is implemented it belongs in the help", name)
+		}
+		// The command column, not the whole text. "device" appears in the description of
+		// `join`, which is prose about what the command does rather than an offer to run
+		// something called device.
+		if offers(usageText(), name) {
+			t.Errorf("the help offers %q as a command", name)
+		}
+	}
+}
+
+// offers reports whether the help lists name in its command column.
+func offers(text, name string) bool {
+	body := text[strings.Index(text, "Commands:"):]
+	body, _, _ = strings.Cut(body, "\nFlags:")
+	for _, line := range strings.Split(body, "\n") {
+		first, _, _ := strings.Cut(strings.TrimSpace(line), " ")
+		if first == name {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
`meshp --help` advertised **ten nouns carrying about thirty-seven verbs** — `device list`, `acl edit`, `token revoke` — and implemented **none** of them. Every one answered `"…" is not implemented yet`.

A help text is a promise. One that lists what somebody intends to build is worse than one that lists nothing, because it makes the gap invisible by describing it as already closed — which is why the state of the CLI was a surprise rather than something anybody could see. ADR-0032 §4:

> A verb appears in `--help` when it works. Until then it is absent, and the roadmap lives in issues and in this ADR where a roadmap belongs.

## The help is now generated from the dispatch table

Not written beside it. Offering a command that does not exist stops being something a person can do by editing a string — it would take adding a table entry with no implementation, which does not compile.

```
Commands:
  login                    Authenticate against a control plane
  logout                   Forget the credential here, and offer to revoke it
  join <token>             Enrol this device into a network
  up                       Bring the tunnel up
  down                     Take the tunnel down
  status                   Show connection, peers and active routes
  doctor                   Collect a diagnostic bundle for a bug report
```

Seven, which is what there has always been. `meshp device list` now answers `unknown command "device"` — true — rather than an apology for an offer that should not have been made.

## Tests, in both directions

- nothing offered is undispatched
- nothing dispatched is unoffered
- none of the ten nouns resolves, or appears in the command column

**Mutation-tested.** Adding a phantom `device` line to the help fails two of them; dropping a real command from the rendering fails the other two.

One test caught *itself* first: checking the whole help text for "device" matched the description of `join` — prose about what the command does, not an offer to run something called device. It now reads the command column.

## Dead code that went with it

- **`bareVerbs`** listed the seven commands the switch above it had already handled and returned from, so the branch beneath it was unreachable.
- The comment claiming the noun list kept **"completions and the docs generator"** in step. Neither exists.
- The package comment described a noun-verb grammar *"without exception"* and gave three examples that all answered unknown command. It now says what the binary does today and points at ADR-0032 for what it will do.

## Not a documentation change

No guide tells anybody to run the commands that went — the only references are in decision records, which is where a roadmap belongs. Checked across `docs/` and `README.md`.

## Checks

`go test ./...`, `go vet`, `gofmt`, `make reachability` clean. Cross-compiles for linux/amd64, darwin/arm64 and windows/amd64.