### PR TITLE
test(web): the page's own controls are checked by a machine

### DIFF
--- a/docs/testing/the-page.md
+++ b/docs/testing/the-page.md
@@ -63,13 +63,11 @@ Each one is a thing the page got wrong before #146, so each one is worth repeati
    them and check the dropdown follows, in both directions, including via the browser's back
    button.
 
-8. **A button that changes identity changes handler.** With every device active, `POST
-   /fixture` with `{"revoked":["bravo"]}` and watch bravo's row: *Revoke* becomes *Forget*
-   without the row blinking. Now click it. The confirmation must say **Forget bravo**, not
-   *Revoke bravo*. *Two `<button class="danger">` elements are `comparable()`, so before both
-   were keyed the reconciler matched them by position and reused the node — relabelling it
-   while keeping the old click listener. The page offered to erase a device and revoked it
-   instead, which is the more alarming direction for that mistake to go in.*
+8. ~~**A button that changes identity changes handler.**~~ *Automated.* `web/render.test.js`
+   builds the row for an active device, morphs in the row for the same device revoked, and
+   requires the button to be a different node — which is what stops the old click listener
+   coming with it. Running it by hand is still the way to see it, but nothing depends on
+   somebody remembering to.
 
 ## What a machine checks now, and what it does not
 
@@ -80,16 +78,15 @@ control with a write in flight is left alone, a node a click left behind survive
 and the picker reads its value before its children are reconciled. Every one of those was
 mutation-tested — the code was broken deliberately and the test was required to fail.
 
-What it cannot reach is everything below. jsdom has no layout, no focus ring and no text
-selection, and it does not run `app.js` at all, so the checks here still cover:
+`web/render.test.js` covers the wiring: that the buttons this page actually builds carry
+those keys, are addressed by the right id — a membership for revoking, a device for
+forgetting — and are drawn only for somebody holding the permission. It reaches them because
+`app.js` no longer starts the page when it is imported; `main.js` does that, and is what
+`index.html` loads.
 
-- **the browser behaviours** — checks 1, 2 and 5, which are about what survives a redraw on a
-  real screen rather than about what the reconciler does to a tree;
-- **the wiring** — that the buttons the page actually builds carry the keys the reconciler
-  needs. The unit test proves keys work; check 8 proves this page uses them.
-
-That second gap is the one to close next, and it needs `app.js` split further before a test
-can reach a renderer.
+What jsdom cannot reach is layout, the focus ring and text selection. So the checks here
+still cover the **browser behaviours** — 1, 2 and 5, which are about what survives a redraw
+on a real screen rather than about what a reconciler does to a tree.
 
 ## Note on running this
 

--- a/internal/api/page_test.go
+++ b/internal/api/page_test.go
@@ -55,8 +55,52 @@ func TestThePageIsServedWithoutACredential(t *testing.T) {
 	if ct := header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
 		t.Errorf("Content-Type = %q, want text/html", ct)
 	}
-	if !strings.Contains(body, "/app.js") {
-		t.Error("the page does not load app.js, so nothing would render")
+	if !strings.Contains(body, "/main.js") {
+		t.Error("the page does not load main.js, so nothing would render")
+	}
+}
+
+// Everything index.html asks for is served.
+//
+// Derived from the page rather than listed, because a list is the thing that went wrong.
+// The embed directive names its files on purpose — so nothing lands in web/ and gets served
+// by accident — and the cost is that a new module is not served until somebody adds it, with
+// nothing failing at build time when they do not. web/testdata/fixture.py serves that
+// directory from disk, so the page works perfectly against the fixture and 404s in the real
+// binary. That has now happened twice, with dom.js and again with main.js.
+func TestEverythingThePageAsksForIsServed(t *testing.T) {
+	ts := pageServerFor(t)
+
+	_, _, page := get(t, ts.URL+"/")
+
+	var refs []string
+	for _, attr := range []string{`src="`, `href="`} {
+		rest := page
+		for {
+			i := strings.Index(rest, attr)
+			if i < 0 {
+				break
+			}
+			rest = rest[i+len(attr):]
+			end := strings.IndexByte(rest, '"')
+			if end < 0 {
+				break
+			}
+			// Local paths only: a link to the repository is not this server's to answer.
+			if ref := rest[:end]; strings.HasPrefix(ref, "/") {
+				refs = append(refs, ref)
+			}
+			rest = rest[end:]
+		}
+	}
+
+	if len(refs) == 0 {
+		t.Fatal("the page references nothing local, which cannot be right")
+	}
+	for _, ref := range refs {
+		if status, _, _ := get(t, ts.URL+ref); status != http.StatusOK {
+			t.Errorf("the page asks for %s and it answers %d — is it in web/embed.go?", ref, status)
+		}
 	}
 }
 
@@ -64,7 +108,9 @@ func TestTheAssetsAreServed(t *testing.T) {
 	ts := pageServerFor(t)
 
 	for _, tc := range []struct{ path, wantType, wantBody string }{
+		{"/main.js", "javascript", "bootstrap"},
 		{"/app.js", "javascript", "poll_after_seconds"},
+		{"/dom.js", "javascript", "morphChildren"},
 		{"/app.css", "text/css", "--bg"},
 	} {
 		status, header, body := get(t, ts.URL+tc.path)

--- a/web/app.js
+++ b/web/app.js
@@ -985,25 +985,42 @@ function restart() {
   start();
 }
 
-signoutEl.addEventListener("click", async () => {
-  stopPolling();
-  try {
-    await api("/api/v1/ui/session", { method: "DELETE" });
-  } catch {
-    // Logging out of a session the server has already forgotten is still logging out.
-  }
-  lastGood = null;
-  lastGoodAt = null;
-  // Forgotten explicitly. A page that kept the last person's permissions in memory would
-  // render their controls for whoever signs in next, for as long as it took the next fetch
-  // to come back.
-  permissions = new Set();
-  unlimited = false;
-  mintedToken = null;
-  shownFor = null;
-  renderFreshness(null);
-  renderSignIn("Signed out.");
-});
+/**
+ * Wires the page up and starts it. Called by main.js, which is what index.html loads.
+ *
+ * Separated so that importing this file does nothing. It used to attach a listener and
+ * start polling at import, which meant no test could reach a renderer without a document
+ * that already had the page's elements in it and a control plane to answer the first poll
+ * — and so the only thing checking that these renderers build what the reconciler needs
+ * was a person following docs/testing/the-page.md.
+ */
+export function bootstrap() {
+  signoutEl.addEventListener("click", async () => {
+    stopPolling();
+    try {
+      await api("/api/v1/ui/session", { method: "DELETE" });
+    } catch {
+      // Logging out of a session the server has already forgotten is still logging out.
+    }
+    lastGood = null;
+    lastGoodAt = null;
+    // Forgotten explicitly. A page that kept the last person's permissions in memory would
+    // render their controls for whoever signs in next, for as long as it took the next
+    // fetch to come back.
+    permissions = new Set();
+    unlimited = false;
+    mintedToken = null;
+    shownFor = null;
+    renderFreshness(null);
+    renderSignIn("Signed out.");
+  });
 
-window.addEventListener("hashchange", start);
-start();
+  window.addEventListener("hashchange", start);
+  start();
+}
+
+// Reached only by web/dom.test.js and web/render.test.js. Exported rather than made public
+// in spirit: these are the renderers whose output the reconciler depends on, and the keys
+// they carry are the difference between a button that means what it says and one that
+// inherited somebody else's click handler (#218).
+export { renderDevices, revokeButton, forgetButton, organizationOf, may, fetchPermissions };

--- a/web/embed.go
+++ b/web/embed.go
@@ -19,7 +19,9 @@ import "embed"
 // That safety has a cost worth knowing about: a new file is not served until it is added
 // here, and nothing fails at build time when it is missing. web/testdata/fixture.py serves
 // this directory from disk, so a page split across a new module works perfectly against the
-// fixture and 404s in the real binary. dom.js was added in exactly that way.
+// fixture and 404s in the real binary. dom.js was added in exactly that way, and main.js
+// after it — which is now the file index.html actually loads, so forgetting it here would
+// leave a blank page rather than a degraded one.
 //
-//go:embed index.html app.css app.js dom.js
+//go:embed index.html app.css main.js app.js dom.js
 var FS embed.FS

--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>meshp</title>
     <link rel="stylesheet" href="/app.css" />
-    <script type="module" src="/app.js"></script>
+    <script type="module" src="/main.js"></script>
   </head>
   <body>
     <header class="bar">

--- a/web/main.js
+++ b/web/main.js
@@ -1,0 +1,11 @@
+/**
+ * What index.html loads.
+ *
+ * The whole page is app.js; this exists so that app.js can be imported without running.
+ * A module that starts polling and attaches listeners the moment it is loaded is a module
+ * a test can only observe through a browser, which is how the renderers went untested
+ * while the reconciler beneath them did not (ADR-0032 §6).
+ */
+import { bootstrap } from "./app.js";
+
+bootstrap();

--- a/web/render.test.js
+++ b/web/render.test.js
@@ -1,0 +1,135 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+
+// app.js reads the page's elements at module scope and used to start polling at import.
+// The bootstrap now lives in main.js, so this only needs a document that has the elements.
+const page = new JSDOM(
+  `<!doctype html><body><div id="view"></div><span id="freshness"></span>
+   <button id="signout"></button></body>`,
+);
+globalThis.document = page.window.document;
+globalThis.Node = page.window.Node;
+globalThis.window = page.window;
+
+const { renderDevices, revokeButton, forgetButton, organizationOf, may, fetchPermissions } =
+  await import("./app.js");
+const { morphChildren, el } = await import("./dom.js");
+
+const ORG = "cccccccc-0000-0000-0000-000000000001";
+const NET = "11111111-2222-3333-4444-555555555555";
+
+/** A device row as the overview endpoint sends one. */
+const device = (over = {}) => ({
+  membership_id: "aaaaaaaa-0000-0000-0000-000000000001",
+  device_id: "dddddddd-0000-0000-0000-000000000001",
+  device_name: "bravo",
+  state: "active",
+  connected: true,
+  applied_version: 7,
+  reported_version: 7,
+  address_v4: "100.80.0.3",
+  tunnel: { peers: 3, talking: 3, relayed: 0 },
+  faults: [],
+  ...over,
+});
+
+/**
+ * Grants a permission set by answering the request app.js actually makes for it.
+ *
+ * Node's Response, not jsdom's — jsdom implements no fetch and no Response, so building
+ * one from `page.window` throws, fetchPermissions swallows it, and every permission comes
+ * back denied. Which looks exactly like a working test for anything asserting that a
+ * control is absent.
+ */
+async function granting(...names) {
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ permissions: names, unlimited: false }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  await fetchPermissions(NET);
+  // Refuses to run the rest of a test against a permission set that was never granted.
+  for (const name of names) {
+    if (!may(name)) throw new Error(`granting(${name}) did not take effect`);
+  }
+}
+
+test("permissions come from the control plane, and decide nothing else", async () => {
+  await granting("network.devices.revoke");
+  assert.equal(may("network.devices.revoke"), true);
+  assert.equal(may("organization.devices.forget"), false);
+});
+
+test("a control somebody may not use is never drawn", async () => {
+  await granting();
+  assert.equal(revokeButton(device()), null);
+  assert.equal(forgetButton(device({ state: "revoked" }), ORG), null);
+});
+
+// The wiring half of #218. dom.test.js proves that keys stop a node being reused; this
+// proves the buttons this page builds actually carry them, which was the part only a
+// person walking docs/testing/the-page.md could check.
+test("the two device actions are keyed apart", async () => {
+  await granting("network.devices.revoke", "organization.devices.forget");
+
+  const revoke = revokeButton(device());
+  const forget = forgetButton(device({ state: "revoked" }), ORG);
+
+  assert.equal(revoke.dataset.key, "revoke");
+  assert.equal(forget.dataset.key, "forget");
+  assert.notEqual(revoke.dataset.key, forget.dataset.key);
+});
+
+test("each action carries the id its endpoint is addressed by", async () => {
+  await granting("network.devices.revoke", "organization.devices.forget");
+  const d = device({ state: "revoked" });
+
+  // Revoking is per membership under a network; forgetting is per device under an
+  // organisation (ADR-0004). Sending one id where the other belongs would address a real
+  // route with a real-looking id and be refused as a 404 rather than as a mistake.
+  assert.equal(revokeButton(device()).dataset.membership, d.membership_id);
+  assert.equal(forgetButton(d, ORG).dataset.device, d.device_id);
+});
+
+test("forgetting is offered only once a device is out of the network", async () => {
+  await granting("network.devices.revoke", "organization.devices.forget");
+  assert.equal(forgetButton(device({ state: "active" }), ORG), null);
+  assert.ok(forgetButton(device({ state: "revoked" }), ORG));
+  // And without an organisation there is nothing to address the request to.
+  assert.equal(forgetButton(device({ state: "revoked" }), null), null);
+});
+
+test("revoking is offered only while a device is still in the network", async () => {
+  await granting("network.devices.revoke");
+  assert.ok(revokeButton(device({ state: "active" })));
+  assert.equal(revokeButton(device({ state: "revoked" })), null);
+});
+
+// Manual check 8, run by a machine: a row whose device has just been revoked must come back
+// with a different button, and the reconciler must not hand the old node over with it.
+test("a row that turns from active to revoked swaps the button rather than relabelling it", async () => {
+  await granting("network.devices.revoke", "organization.devices.forget");
+
+  const live = el("tbody", {});
+  morphChildren(live, el("div", {}, renderDevices([device()], ORG).querySelector("tbody").children[0]));
+
+  const before = live.querySelector("td.actions button");
+  assert.equal(before.textContent, "Revoke");
+
+  const next = renderDevices([device({ state: "revoked", connected: false })], ORG)
+    .querySelector("tbody").children[0];
+  morphChildren(live, el("div", {}, next));
+
+  const after = live.querySelector("td.actions button");
+  assert.equal(after.textContent, "Forget");
+  assert.notEqual(after, before, "the Revoke node was reused, and its listener with it");
+});
+
+test("the organisation is read from the network the page is showing", () => {
+  const data = { network: { id: NET } };
+  const networks = [{ id: NET, organization_id: ORG }, { id: "other", organization_id: "x" }];
+  assert.equal(organizationOf(data, networks), ORG);
+  assert.equal(organizationOf({ network: { id: "missing" } }, networks), null);
+  assert.equal(organizationOf(data, undefined), null);
+});


### PR DESCRIPTION
The reconciler has had tests since #222. The renderers that feed it have not — and the gap was named at the time: `dom.test.js` proves keys stop a node being reused, and nothing proved the buttons *this page builds* carry them. That half was manual check 8, which is to say a person.

## Why nothing could test them

`app.js` attached a listener and called `start()` at module scope, so reaching a renderer meant a document that already had the page's elements *and* a control plane to answer the first poll. The bootstrap moves to `web/main.js`, which `index.html` now loads. Importing `app.js` does nothing.

## Eight tests over the two device actions

Keyed apart · addressed by the id their endpoint actually takes (a **membership** for revoking, a **device** for forgetting) · drawn only for somebody holding the permission · offered only in the state they make sense in.

The last one builds the row for an active device, morphs in the row for the same device revoked, and requires the button to be a **different node**. That is manual check 8, and check 8 is now retired from `docs/testing/the-page.md`.

## Mutation-tested, including the real regression

Dropping either key, swapping the id, offering *Forget* on an active device, or ignoring the permission each fails exactly one test.

Removing **both** keys — the state #218 actually shipped in — also fails the morph test. One key alone keeps the two nodes uncomparable, so only the real regression reproduces the real failure. Worth knowing: a test that only checked one button would have passed through #218.

## Three of them passed for the wrong reason first

The fetch stub built a `Response` from jsdom's window, **which has none**. Every grant threw, `fetchPermissions` swallowed it, and every permission came back denied — indistinguishable from a working test for anything asserting that a control is *absent*. It uses Node's `Response` now, and `granting()` refuses to continue if a grant did not take effect.

## The embed trap is closed

`web/embed.go` names its files deliberately, so nothing lands in `web/` and gets served by accident. The cost: a new module is not served until somebody adds it, and **nothing fails at build time when they do not**. `web/testdata/fixture.py` serves that directory from disk, so the page works perfectly against the fixture and 404s in the real binary.

That has now happened **twice** — `dom.js` in #221, and again with `main.js` here.

`TestEverythingThePageAsksForIsServed` reads `index.html`, extracts every local reference, and requires the server to answer it. Derived from the page rather than listed, because a list is the thing that went wrong. Verified by removing `main.js` from the directive:

```
page_test.go:102: the page asks for /main.js and it answers 404 — is it in web/embed.go?
```

## Checks

`make lint` 0 issues · `go test ./...` clean · 21 page tests pass · `make reachability` clean · cross-compiles for linux/amd64, darwin/arm64, windows/amd64. Driven end to end against the fixture through the new `main.js`: renders, morphs, the Forget flow completes, no console errors.