### PR TITLE
feat(cli): meshp device, the first noun

### DIFF
--- a/cmd/meshp/device.go
+++ b/cmd/meshp/device.go
@@ -1,0 +1,327 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/meshpnet/meshp/internal/cliapi"
+	"github.com/meshpnet/meshp/internal/clicred"
+)
+
+// The first noun (ADR-0032). Nothing here is new server behaviour: `GET
+// /networks/{id}/devices` has listed memberships since #113, revoking has been a route since
+// #28 and erasing since #218, and the page has done all three for a while. What was missing
+// was a way to do them without a browser, which is half of what parity means.
+//
+// Reading these routes rather than adding to them is deliberate. A verb that needed an
+// endpoint shaped for it would be a verb defining the API, and ADR-0009 makes the API the
+// contract that three clients share.
+
+// network is one row of GET /api/v1/networks.
+type network struct {
+	ID                string `json:"id"`
+	Slug              string `json:"slug"`
+	Name              string `json:"name"`
+	OrganizationID    string `json:"organization_id"`
+	OrganizationSlug  string `json:"organization_slug"`
+	ActiveDeviceCount int    `json:"active_device_count"`
+}
+
+// membership is one row of GET /api/v1/networks/{id}/devices.
+type membership struct {
+	MembershipID string     `json:"membership_id"`
+	DeviceID     string     `json:"device_id"`
+	DeviceName   string     `json:"device_name"`
+	State        string     `json:"state"`
+	AddressV4    string     `json:"address_v4"`
+	AddressV6    string     `json:"address_v6"`
+	JoinedAt     time.Time  `json:"joined_at"`
+	RevokedAt    *time.Time `json:"revoked_at"`
+}
+
+// signedIn builds a client from the stored credential.
+func signedIn() (*cliapi.Client, clicred.Credential, error) {
+	cred, err := clicred.Load()
+	if errors.Is(err, clicred.ErrNotSignedIn) {
+		return nil, cred, errors.New("not signed in; run 'meshp login'")
+	}
+	if err != nil {
+		return nil, cred, err
+	}
+	client, err := cliapi.New(cred.ControlURL, cred.Token)
+	return client, cred, err
+}
+
+// chooseNetwork resolves which network a command is about.
+//
+// Named where a person named one, and otherwise inferred only when there is nothing to
+// infer between. Guessing among several would put the blast radius of `device revoke` on
+// whichever network happened to sort first.
+func chooseNetwork(ctx context.Context, client *cliapi.Client, want string) (network, error) {
+	var body struct {
+		Networks []network `json:"networks"`
+	}
+	if err := client.Do(ctx, "GET", "/api/v1/networks", nil, &body); err != nil {
+		return network{}, err
+	}
+	if len(body.Networks) == 0 {
+		return network{}, errors.New("this account can see no networks")
+	}
+
+	if want == "" {
+		if len(body.Networks) == 1 {
+			return body.Networks[0], nil
+		}
+		names := make([]string, 0, len(body.Networks))
+		for _, n := range body.Networks {
+			names = append(names, n.OrganizationSlug+"/"+n.Slug)
+		}
+		sort.Strings(names)
+		return network{}, fmt.Errorf(
+			"this account can see %d networks, so --network is needed: %s",
+			len(body.Networks), strings.Join(names, ", "))
+	}
+
+	for _, n := range body.Networks {
+		if n.ID == want || n.Slug == want || n.OrganizationSlug+"/"+n.Slug == want {
+			return n, nil
+		}
+	}
+	return network{}, fmt.Errorf("no network called %q", want)
+}
+
+// findDevice resolves an argument that is either an id or a name.
+//
+// Names because that is what a person has: the id is a UUID nobody has memorised, and every
+// other way of naming a device here — the page, an audit line — shows the name. Ambiguity is
+// refused rather than resolved, because picking one of two devices called "laptop" to revoke
+// is the wrong kind of helpful.
+func findDevice(devices []membership, want string) (membership, error) {
+	var byName []membership
+	for _, d := range devices {
+		if d.MembershipID == want || d.DeviceID == want {
+			return d, nil
+		}
+		if strings.EqualFold(d.DeviceName, want) {
+			byName = append(byName, d)
+		}
+	}
+	switch len(byName) {
+	case 1:
+		return byName[0], nil
+	case 0:
+		return membership{}, fmt.Errorf("no device called %q in this network", want)
+	default:
+		return membership{}, fmt.Errorf(
+			"%d devices are called %q; name one by its id instead", len(byName), want)
+	}
+}
+
+// listDevices reads a network's memberships.
+func listDevices(ctx context.Context, client *cliapi.Client, networkID string) ([]membership, error) {
+	var body struct {
+		Devices []membership `json:"devices"`
+	}
+	err := client.Do(ctx, "GET", "/api/v1/networks/"+networkID+"/devices", nil, &body)
+	return body.Devices, err
+}
+
+func cmdDevice(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: meshp device <list|revoke|forget>")
+	}
+	switch args[0] {
+	case "list":
+		return cmdDeviceList(ctx, args[1:])
+	case "revoke":
+		return cmdDeviceRevoke(ctx, args[1:])
+	case "forget":
+		return cmdDeviceForget(ctx, args[1:])
+	default:
+		return fmt.Errorf("unknown verb %q; meshp device takes list, revoke or forget", args[0])
+	}
+}
+
+func cmdDeviceList(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp device list", flag.ContinueOnError)
+	wantNetwork := fs.String("network", "", "Which network, by slug or id")
+	if _, err := parseFlags(fs, args); err != nil {
+		return err
+	}
+
+	client, _, err := signedIn()
+	if err != nil {
+		return err
+	}
+	net, err := chooseNetwork(ctx, client, *wantNetwork)
+	if err != nil {
+		return err
+	}
+	devices, err := listDevices(ctx, client, net.ID)
+	if err != nil {
+		return err
+	}
+	if len(devices) == 0 {
+		fmt.Printf("No devices in %s/%s.\n", net.OrganizationSlug, net.Slug)
+		return nil
+	}
+
+	// Revoked memberships are shown, as the API sends them and the page draws them: an
+	// administrator checking that a device really is out needs to see that it is out.
+	// Discarded explicitly: a tabwriter buffers, so nothing here can fail until Flush, and
+	// Flush is the one whose error is returned.
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "NAME\tADDRESS\tSTATE\tDEVICE ID")
+	for _, d := range devices {
+		address := d.AddressV4
+		if address == "" {
+			address = d.AddressV6
+		}
+		if address == "" {
+			address = "—"
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", d.DeviceName, address, d.State, d.DeviceID)
+	}
+	return w.Flush()
+}
+
+func cmdDeviceRevoke(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp device revoke", flag.ContinueOnError)
+	wantNetwork := fs.String("network", "", "Which network, by slug or id")
+	reason := fs.String("reason", "", "Recorded in the audit trail, and sent to the device")
+	yes := fs.Bool("yes", false, "Do not ask")
+	rest, err := parseFlags(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
+		return errors.New("usage: meshp device revoke <name|id> [--network n] [--reason why]")
+	}
+
+	client, _, err := signedIn()
+	if err != nil {
+		return err
+	}
+	net, err := chooseNetwork(ctx, client, *wantNetwork)
+	if err != nil {
+		return err
+	}
+	devices, err := listDevices(ctx, client, net.ID)
+	if err != nil {
+		return err
+	}
+	target, err := findDevice(devices, rest[0])
+	if err != nil {
+		return err
+	}
+	if target.State == "revoked" {
+		fmt.Printf("%s is already revoked in %s/%s.\n", target.DeviceName, net.OrganizationSlug, net.Slug)
+		return nil
+	}
+
+	if err := confirm(*yes, fmt.Sprintf(
+		"Revoke %s from %s/%s? It loses access immediately and must enrol again.",
+		target.DeviceName, net.OrganizationSlug, net.Slug)); err != nil {
+		return err
+	}
+
+	body := map[string]any{"reason": *reason}
+	if err := client.Do(ctx, "DELETE",
+		"/api/v1/networks/"+net.ID+"/devices/"+target.MembershipID, body, nil); err != nil {
+		return err
+	}
+	// What actually happened, rather than "done": the device keeps its key and its address,
+	// and what changed is that nobody else will accept it (ADR-0007's shape).
+	fmt.Printf("Revoked %s. Every other device in %s/%s has been told to drop its key.\n",
+		target.DeviceName, net.OrganizationSlug, net.Slug)
+	return nil
+}
+
+func cmdDeviceForget(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp device forget", flag.ContinueOnError)
+	wantNetwork := fs.String("network", "", "Which network to find the device in")
+	yes := fs.Bool("yes", false, "Do not ask")
+	rest, err := parseFlags(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
+		return errors.New("usage: meshp device forget <name|id> [--network n]")
+	}
+
+	client, _, err := signedIn()
+	if err != nil {
+		return err
+	}
+	net, err := chooseNetwork(ctx, client, *wantNetwork)
+	if err != nil {
+		return err
+	}
+	devices, err := listDevices(ctx, client, net.ID)
+	if err != nil {
+		return err
+	}
+	target, err := findDevice(devices, rest[0])
+	if err != nil {
+		return err
+	}
+
+	// Offered on a device that has not been revoked, which the page does not do.
+	//
+	// Not a divergence in what the two clients may do — the API allows it either way, and
+	// parity is measured against the API (ADR-0032 §1). The page hides it because a button
+	// beside a device still carrying traffic is one mis-click from erasing it; a command
+	// somebody typed in full and then confirmed is not that. Forgetting emits the peer
+	// removals regardless, so the key is dropped whether or not a revoke came first.
+	//
+	// Erasing is organisation-scoped and reaches every network at once, so the confirmation
+	// says that rather than naming the network the device was found in.
+	if err := confirm(*yes, fmt.Sprintf(
+		"Forget %s? This erases the device, its keys and its memberships in every network. "+
+			"It cannot be undone, and the audit trail is all that will be left of it.",
+		target.DeviceName)); err != nil {
+		return err
+	}
+
+	var out struct {
+		Name     string   `json:"name"`
+		Networks []string `json:"networks"`
+	}
+	if err := client.Do(ctx, "DELETE",
+		"/api/v1/organizations/"+net.OrganizationID+"/devices/"+target.DeviceID, nil, &out); err != nil {
+		return err
+	}
+	fmt.Printf("Forgot %s, which was in %d network(s). The audit trail keeps what it did.\n",
+		out.Name, len(out.Networks))
+	return nil
+}
+
+// confirm asks before something irreversible, unless told not to.
+//
+// A script has no terminal to answer with, so it must pass --yes rather than hang. Refusing
+// is the default for the same reason the page uses window.confirm on these two: they are the
+// most consequential things either client can do.
+func confirm(skip bool, question string) error {
+	if skip {
+		return nil
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return errors.New("no terminal to confirm at; pass --yes if you mean it")
+	}
+	fmt.Printf("%s [y/N]: ", question)
+	var line string
+	_, _ = fmt.Scanln(&line)
+	if !strings.EqualFold(strings.TrimSpace(line), "y") {
+		return errors.New("not confirmed")
+	}
+	return nil
+}

--- a/cmd/meshp/device_test.go
+++ b/cmd/meshp/device_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/meshpnet/meshp/internal/cliapi"
+)
+
+func TestFindDeviceByEitherIdOrName(t *testing.T) {
+	devices := []membership{
+		{MembershipID: "m-1", DeviceID: "d-1", DeviceName: "laptop"},
+		{MembershipID: "m-2", DeviceID: "d-2", DeviceName: "Gateway"},
+	}
+
+	for _, tc := range []struct{ name, want, wantID string }{
+		{"by membership id", "m-2", "d-2"},
+		{"by device id", "d-1", "d-1"},
+		{"by name", "laptop", "d-1"},
+		// Names are what a person has; the case they typed it in is not a second fact.
+		{"by name, whatever case", "GATEWAY", "d-2"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := findDevice(devices, tc.want)
+			if err != nil {
+				t.Fatalf("findDevice(%q): %v", tc.want, err)
+			}
+			if got.DeviceID != tc.wantID {
+				t.Errorf("got %s, want %s", got.DeviceID, tc.wantID)
+			}
+		})
+	}
+}
+
+// An id is checked before a name, so a device perversely named after another's id resolves
+// to the one actually being addressed.
+func TestFindDevicePrefersAnIdOverAName(t *testing.T) {
+	devices := []membership{
+		{MembershipID: "m-1", DeviceID: "d-1", DeviceName: "spare"},
+		{MembershipID: "m-2", DeviceID: "d-2", DeviceName: "d-1"},
+	}
+	got, err := findDevice(devices, "d-1")
+	if err != nil {
+		t.Fatalf("findDevice: %v", err)
+	}
+	if got.MembershipID != "m-1" {
+		t.Errorf("resolved to %s, want the device whose id that is", got.MembershipID)
+	}
+}
+
+// Picking one of two devices called "laptop" to revoke is the wrong kind of helpful.
+func TestFindDeviceRefusesAnAmbiguousName(t *testing.T) {
+	devices := []membership{
+		{MembershipID: "m-1", DeviceID: "d-1", DeviceName: "laptop"},
+		{MembershipID: "m-2", DeviceID: "d-2", DeviceName: "laptop"},
+	}
+	_, err := findDevice(devices, "laptop")
+	if err == nil {
+		t.Fatal("an ambiguous name resolved")
+	}
+	if !strings.Contains(err.Error(), "id") {
+		t.Errorf("the error does not say what to do instead: %v", err)
+	}
+}
+
+func TestFindDeviceSaysWhenThereIsNoSuchThing(t *testing.T) {
+	_, err := findDevice([]membership{{DeviceName: "laptop"}}, "desktop")
+	if err == nil || !strings.Contains(err.Error(), "desktop") {
+		t.Errorf("want an error naming what was asked for, got %v", err)
+	}
+}
+
+// networksServing answers GET /api/v1/networks with the rows given.
+func networksServing(t *testing.T, rows ...network) *cliapi.Client {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/networks" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("content-type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"networks": rows})
+	}))
+	t.Cleanup(ts.Close)
+	client, err := cliapi.New(ts.URL, "a-token")
+	if err != nil {
+		t.Fatalf("cliapi.New: %v", err)
+	}
+	return client
+}
+
+func TestChooseNetworkInfersTheOnlyOne(t *testing.T) {
+	client := networksServing(t, network{ID: "n-1", Slug: "hq", OrganizationSlug: "acme"})
+	got, err := chooseNetwork(context.Background(), client, "")
+	if err != nil {
+		t.Fatalf("chooseNetwork: %v", err)
+	}
+	if got.ID != "n-1" {
+		t.Errorf("got %s, want n-1", got.ID)
+	}
+}
+
+// Guessing among several would put the blast radius of `device revoke` on whichever
+// network happened to sort first.
+func TestChooseNetworkRefusesToGuessAmongSeveral(t *testing.T) {
+	client := networksServing(t,
+		network{ID: "n-1", Slug: "hq", OrganizationSlug: "acme"},
+		network{ID: "n-2", Slug: "branch", OrganizationSlug: "acme"})
+
+	_, err := chooseNetwork(context.Background(), client, "")
+	if err == nil {
+		t.Fatal("it picked one")
+	}
+	// The error has to be actionable: which flag, and what the answers are.
+	for _, want := range []string{"--network", "acme/hq", "acme/branch"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the error does not mention %q: %v", want, err)
+		}
+	}
+}
+
+func TestChooseNetworkTakesASlugOrAQualifiedName(t *testing.T) {
+	client := networksServing(t,
+		network{ID: "n-1", Slug: "hq", OrganizationSlug: "acme"},
+		network{ID: "n-2", Slug: "branch", OrganizationSlug: "acme"})
+
+	for _, want := range []string{"branch", "acme/branch", "n-2"} {
+		got, err := chooseNetwork(context.Background(), client, want)
+		if err != nil {
+			t.Fatalf("chooseNetwork(%q): %v", want, err)
+		}
+		if got.ID != "n-2" {
+			t.Errorf("chooseNetwork(%q) = %s, want n-2", want, got.ID)
+		}
+	}
+}
+
+func TestChooseNetworkSaysWhenThereIsNoSuchNetwork(t *testing.T) {
+	client := networksServing(t, network{ID: "n-1", Slug: "hq", OrganizationSlug: "acme"})
+	if _, err := chooseNetwork(context.Background(), client, "nope"); err == nil {
+		t.Fatal("an unknown network resolved")
+	}
+}
+
+func TestChooseNetworkSaysWhenThereAreNone(t *testing.T) {
+	client := networksServing(t)
+	if _, err := chooseNetwork(context.Background(), client, ""); err == nil {
+		t.Fatal("no networks resolved to something")
+	}
+}

--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -59,6 +59,11 @@ var commands = []command{
 	{name: "down", help: "Take the tunnel down", run: cmdDown},
 	{name: "status", help: "Show connection, peers and active routes", run: cmdStatus},
 	{name: "doctor", help: "Collect a diagnostic bundle for a bug report", run: cmdDoctor},
+	{
+		name: "device", args: "<list|revoke|forget>",
+		help: "List the devices in a network, take one out, or erase it",
+		run:  cmdDevice,
+	},
 }
 
 // lookup finds a command by name.
@@ -75,16 +80,28 @@ func lookup(name string) (command, bool) {
 func usageText() string {
 	var b strings.Builder
 	b.WriteString("meshp — private mesh networking\n\nUsage:\n  meshp <command> [flags]\n\nCommands:\n")
+	// Width from the widest thing being shown rather than a number chosen once. A command
+	// whose arguments push it past a fixed column does not misalign the rest of the list.
+	rows := make([][2]string, 0, len(commands)+2)
 	for _, c := range commands {
 		invocation := c.name
 		if c.args != "" {
 			invocation += " " + c.args
 		}
-		fmt.Fprintf(&b, "  %-24s %s\n", invocation, c.help)
+		rows = append(rows, [2]string{invocation, c.help})
+	}
+	width := 0
+	for _, r := range rows {
+		if len(r[0]) > width {
+			width = len(r[0])
+		}
+	}
+	for _, r := range rows {
+		fmt.Fprintf(&b, "  %-*s  %s\n", width, r[0], r[1])
 	}
 	b.WriteString("\nFlags:\n")
-	fmt.Fprintf(&b, "  %-24s %s\n", "--version", "Print build information")
-	fmt.Fprintf(&b, "  %-24s %s\n", "--help", "Show this help")
+	fmt.Fprintf(&b, "  %-*s  %s\n", width, "--version", "Print build information")
+	fmt.Fprintf(&b, "  %-*s  %s\n", width, "--help", "Show this help")
 	return b.String()
 }
 

--- a/cmd/meshp/usage_test.go
+++ b/cmd/meshp/usage_test.go
@@ -57,8 +57,10 @@ func TestEveryCommandThatExistsIsOffered(t *testing.T) {
 // such command — which is true — rather than an apology for an offer that should not have
 // been made.
 func TestTheNounsThatWereNeverBuiltAreNotCommands(t *testing.T) {
+	// `device` has left this list, which is what closing the gap looks like from here
+	// (#226). The rest are still advertised nowhere and answer unknown command.
 	for _, name := range []string{
-		"device", "network", "user", "group", "acl",
+		"network", "user", "group", "acl",
 		"dns", "route-group", "exit", "relay", "token",
 	} {
 		if _, found := lookup(name); found {


### PR DESCRIPTION
The first capability to land under ADR-0032, and deliberately the cheapest one — **no server work at all**.

`GET /networks/{id}/devices` has listed memberships since #113, revoking has been a route since #28, erasing since #218, and the page has done all three for a while. What was missing was a way to do any of it without a browser, which is half of what parity means.

Reading those routes rather than adding to them is the point: a verb that needed an endpoint shaped for it would be a verb defining the API, and ADR-0009 makes the API the contract three clients share.

```
meshp device list   [--network n]
meshp device revoke <name|id> [--network n] [--reason why] [--yes]
meshp device forget <name|id> [--network n] [--yes]
```

## Two resolutions, and both refuse rather than guess

**Which network.** Named by slug, `org/slug`, or id; inferred only when there is one to infer. With several it lists them and asks — picking whichever sorted first would put the blast radius of `device revoke` on a network nobody chose.

**Which device.** By membership id, device id, or name — the id is a UUID nobody has memorised, and every other place a device appears shows its name. An id is matched *before* a name, so a device perversely named after another's id resolves to the one being addressed. Two devices sharing a name is refused, with the id as the way out.

Both destructive verbs confirm unless told not to, and a script with no terminal must pass `--yes` rather than hang.

## One deliberate difference from the page

`device forget` works on a device that has not been revoked; the page only offers it once one is. **Not a divergence in what the clients may do** — the API allows it either way, and parity is measured against the API (ADR-0032 §1). The page hides it because a button beside a device still carrying traffic is one mis-click from erasing it, and a command typed in full and then confirmed is not that. Forgetting emits the peer removals regardless, so the key is dropped whether or not a revoke came first. That's commented where it happens.

## Driven, not only tested

Bootstrapped a control plane on PostgreSQL, minted a token through the API, and ran all three verbs against it:

- listing **refused to guess** between two networks and named both; resolved by slug, by `acme/branch`, and by id
- revoking by name reported what actually changed, was a **no-op the second time**, and refused with no terminal and no `--yes`
- forgetting removed the rows, **left the audit trail**, and emitted the peer removal even for a device that had never been revoked

## Tests

Ten over the two resolvers. Mutation-tested — resolving an ambiguous name to the first match, picking a network instead of refusing, and matching names case-sensitively each fail exactly one test.

`TestTheNounsThatWereNeverBuiltAreNotCommands` loses `device` from its list, which is what closing the gap looks like from that test's side.

## Also

The help column sizes itself from the widest entry rather than a fixed 24, which `device <list|revoke|forget>` overran.

`make lint` 0 issues · `go test ./...` clean · 21 page tests · `make reachability` clean · cross-compiles for linux/amd64, darwin/arm64, windows/amd64.

## Noticed in passing, not fixed here

`meshp login --token` prints *"Signed in to … as "* with an empty email — it doesn't resolve who the token belongs to. Pre-existing and unrelated to this change; worth its own look.