### PR TITLE
feat(cli): meshp network, and a choice that sticks

### DIFF
--- a/cmd/meshp/device.go
+++ b/cmd/meshp/device.go
@@ -36,6 +36,10 @@ type network struct {
 	ActiveDeviceCount int    `json:"active_device_count"`
 }
 
+// qualified is how a network is named to a person: organisation and slug, because a slug
+// alone is only unique within one and an MSP's whole point is holding several.
+func (n network) qualified() string { return n.OrganizationSlug + "/" + n.Slug }
+
 // membership is one row of GET /api/v1/networks/{id}/devices.
 type membership struct {
 	MembershipID string     `json:"membership_id"`
@@ -63,10 +67,15 @@ func signedIn() (*cliapi.Client, clicred.Credential, error) {
 
 // chooseNetwork resolves which network a command is about.
 //
-// Named where a person named one, and otherwise inferred only when there is nothing to
-// infer between. Guessing among several would put the blast radius of `device revoke` on
-// whichever network happened to sort first.
-func chooseNetwork(ctx context.Context, client *cliapi.Client, want string) (network, error) {
+// Three sources, in this order: what the command said, what `meshp network use` chose, and
+// — only when there is exactly one — inference. Guessing among several would put the blast
+// radius of `device revoke` on whichever network happened to sort first.
+//
+// A remembered choice that no longer resolves is an error rather than a fallback to
+// inference. It names a network somebody deliberately selected, and quietly acting on a
+// different one because that selection went stale is the failure this ordering exists to
+// prevent.
+func chooseNetwork(ctx context.Context, client *cliapi.Client, want, remembered string) (network, error) {
 	var body struct {
 		Networks []network `json:"networks"`
 	}
@@ -78,6 +87,9 @@ func chooseNetwork(ctx context.Context, client *cliapi.Client, want string) (net
 	}
 
 	if want == "" {
+		want = remembered
+	}
+	if want == "" {
 		if len(body.Networks) == 1 {
 			return body.Networks[0], nil
 		}
@@ -87,14 +99,19 @@ func chooseNetwork(ctx context.Context, client *cliapi.Client, want string) (net
 		}
 		sort.Strings(names)
 		return network{}, fmt.Errorf(
-			"this account can see %d networks, so --network is needed: %s",
+			"this account can see %d networks, so --network or 'meshp network use' is needed: %s",
 			len(body.Networks), strings.Join(names, ", "))
 	}
 
 	for _, n := range body.Networks {
-		if n.ID == want || n.Slug == want || n.OrganizationSlug+"/"+n.Slug == want {
+		if n.ID == want || n.Slug == want || n.qualified() == want {
 			return n, nil
 		}
+	}
+	if want == remembered {
+		return network{}, fmt.Errorf(
+			"'meshp network use' chose %q and there is no such network now; "+
+				"pick another with 'meshp network use', or 'meshp network use --clear'", want)
 	}
 	return network{}, fmt.Errorf("no network called %q", want)
 }
@@ -158,11 +175,11 @@ func cmdDeviceList(ctx context.Context, args []string) error {
 		return err
 	}
 
-	client, _, err := signedIn()
+	client, cred, err := signedIn()
 	if err != nil {
 		return err
 	}
-	net, err := chooseNetwork(ctx, client, *wantNetwork)
+	net, err := chooseNetwork(ctx, client, *wantNetwork, cred.Network)
 	if err != nil {
 		return err
 	}
@@ -207,11 +224,11 @@ func cmdDeviceRevoke(ctx context.Context, args []string) error {
 		return errors.New("usage: meshp device revoke <name|id> [--network n] [--reason why]")
 	}
 
-	client, _, err := signedIn()
+	client, cred, err := signedIn()
 	if err != nil {
 		return err
 	}
-	net, err := chooseNetwork(ctx, client, *wantNetwork)
+	net, err := chooseNetwork(ctx, client, *wantNetwork, cred.Network)
 	if err != nil {
 		return err
 	}
@@ -258,11 +275,11 @@ func cmdDeviceForget(ctx context.Context, args []string) error {
 		return errors.New("usage: meshp device forget <name|id> [--network n]")
 	}
 
-	client, _, err := signedIn()
+	client, cred, err := signedIn()
 	if err != nil {
 		return err
 	}
-	net, err := chooseNetwork(ctx, client, *wantNetwork)
+	net, err := chooseNetwork(ctx, client, *wantNetwork, cred.Network)
 	if err != nil {
 		return err
 	}

--- a/cmd/meshp/device_test.go
+++ b/cmd/meshp/device_test.go
@@ -95,7 +95,7 @@ func networksServing(t *testing.T, rows ...network) *cliapi.Client {
 
 func TestChooseNetworkInfersTheOnlyOne(t *testing.T) {
 	client := networksServing(t, network{ID: "n-1", Slug: "hq", OrganizationSlug: "acme"})
-	got, err := chooseNetwork(context.Background(), client, "")
+	got, err := chooseNetwork(context.Background(), client, "", "")
 	if err != nil {
 		t.Fatalf("chooseNetwork: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestChooseNetworkRefusesToGuessAmongSeveral(t *testing.T) {
 		network{ID: "n-1", Slug: "hq", OrganizationSlug: "acme"},
 		network{ID: "n-2", Slug: "branch", OrganizationSlug: "acme"})
 
-	_, err := chooseNetwork(context.Background(), client, "")
+	_, err := chooseNetwork(context.Background(), client, "", "")
 	if err == nil {
 		t.Fatal("it picked one")
 	}
@@ -129,7 +129,7 @@ func TestChooseNetworkTakesASlugOrAQualifiedName(t *testing.T) {
 		network{ID: "n-2", Slug: "branch", OrganizationSlug: "acme"})
 
 	for _, want := range []string{"branch", "acme/branch", "n-2"} {
-		got, err := chooseNetwork(context.Background(), client, want)
+		got, err := chooseNetwork(context.Background(), client, want, "")
 		if err != nil {
 			t.Fatalf("chooseNetwork(%q): %v", want, err)
 		}
@@ -141,14 +141,69 @@ func TestChooseNetworkTakesASlugOrAQualifiedName(t *testing.T) {
 
 func TestChooseNetworkSaysWhenThereIsNoSuchNetwork(t *testing.T) {
 	client := networksServing(t, network{ID: "n-1", Slug: "hq", OrganizationSlug: "acme"})
-	if _, err := chooseNetwork(context.Background(), client, "nope"); err == nil {
+	if _, err := chooseNetwork(context.Background(), client, "nope", ""); err == nil {
 		t.Fatal("an unknown network resolved")
 	}
 }
 
 func TestChooseNetworkSaysWhenThereAreNone(t *testing.T) {
 	client := networksServing(t)
-	if _, err := chooseNetwork(context.Background(), client, ""); err == nil {
+	if _, err := chooseNetwork(context.Background(), client, "", ""); err == nil {
 		t.Fatal("no networks resolved to something")
+	}
+}
+
+// --- what `meshp network use` changes -----------------------------------------------------
+
+func TestARememberedNetworkIsUsedWhenNothingWasNamed(t *testing.T) {
+	client := networksServing(t,
+		network{ID: "n-1", Slug: "hq", OrganizationSlug: "acme"},
+		network{ID: "n-2", Slug: "branch", OrganizationSlug: "acme"})
+
+	got, err := chooseNetwork(context.Background(), client, "", "branch")
+	if err != nil {
+		t.Fatalf("chooseNetwork: %v", err)
+	}
+	if got.ID != "n-2" {
+		t.Errorf("got %s, want the remembered one", got.ID)
+	}
+}
+
+// The flag is what somebody typed for this command, so it wins over a choice they made once.
+func TestAnExplicitNetworkBeatsARememberedOne(t *testing.T) {
+	client := networksServing(t,
+		network{ID: "n-1", Slug: "hq", OrganizationSlug: "acme"},
+		network{ID: "n-2", Slug: "branch", OrganizationSlug: "acme"})
+
+	got, err := chooseNetwork(context.Background(), client, "hq", "branch")
+	if err != nil {
+		t.Fatalf("chooseNetwork: %v", err)
+	}
+	if got.ID != "n-1" {
+		t.Errorf("got %s, want the one named on the command", got.ID)
+	}
+}
+
+// A selection that has gone stale is an error, not a fallback. Quietly acting on a different
+// network because the chosen one was deleted is the failure the ordering exists to prevent.
+func TestARememberedNetworkThatIsGoneIsRefused(t *testing.T) {
+	client := networksServing(t,
+		network{ID: "n-1", Slug: "hq", OrganizationSlug: "acme"})
+
+	_, err := chooseNetwork(context.Background(), client, "", "branch")
+	if err == nil {
+		t.Fatal("a stale choice fell back to the only network")
+	}
+	// It has to say how to get out of the state, since the file that holds it is not
+	// somewhere a person would think to look.
+	if !strings.Contains(err.Error(), "network use") {
+		t.Errorf("the error does not say how to fix it: %v", err)
+	}
+}
+
+func TestQualifiedNamesAreOrganisationThenSlug(t *testing.T) {
+	n := network{Slug: "hq", OrganizationSlug: "acme"}
+	if n.qualified() != "acme/hq" {
+		t.Errorf("qualified() = %q, want acme/hq", n.qualified())
 	}
 }

--- a/cmd/meshp/login.go
+++ b/cmd/meshp/login.go
@@ -186,8 +186,15 @@ func signInWithToken(ctx context.Context, controlURL, token string) error {
 	if err != nil {
 		return err
 	}
+	// Both names, because this endpoint answers with different ones depending on what is
+	// asking: a session is a person and carries `email`, a token is a person acting through
+	// a machine and carries `owner` (internal/api/usersession.go). Reading only `email` is
+	// not an error when a token is used — it is an empty string, which is how `meshp login
+	// --token` came to report "Signed in to … as " with nobody named. The same trap the
+	// token id fell into in ADR-0031's implementation.
 	var me struct {
 		Email string `json:"email"`
+		Owner string `json:"owner"`
 	}
 	if err := client.Do(ctx, http.MethodGet, "/api/v1/me", nil, &me); err != nil {
 		// A refusal and an unanswered call are different things, and only one of them is
@@ -199,12 +206,16 @@ func signInWithToken(ctx context.Context, controlURL, token string) error {
 		}
 		return err
 	}
+	who := me.Email
+	if who == "" {
+		who = me.Owner
+	}
 	if err := clicred.Save(clicred.Credential{
-		ControlURL: controlURL, Token: token, Email: me.Email,
+		ControlURL: controlURL, Token: token, Email: who,
 	}); err != nil {
 		return err
 	}
-	fmt.Printf("Signed in to %s as %s with the token given.\n", controlURL, me.Email)
+	fmt.Printf("Signed in to %s as %s with the token given.\n", controlURL, who)
 	return nil
 }
 

--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -64,6 +64,11 @@ var commands = []command{
 		help: "List the devices in a network, take one out, or erase it",
 		run:  cmdDevice,
 	},
+	{
+		name: "network", args: "<list|show|use|create>",
+		help: "See the networks this account reaches, and choose which one commands act on",
+		run:  cmdNetwork,
+	},
 }
 
 // lookup finds a command by name.

--- a/cmd/meshp/network.go
+++ b/cmd/meshp/network.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/meshpnet/meshp/internal/cliapi"
+	"github.com/meshpnet/meshp/internal/clicred"
+)
+
+// The second noun (ADR-0032), and the one that makes the first pleasant: `meshp device
+// list` needed --network on every invocation for anybody who can see more than one.
+//
+// `use` is the only verb here with no endpoint behind it. Which network somebody is working
+// on is not a fact about the deployment — two people signed into the same control plane are
+// each looking at their own — so it belongs beside their credential and not in the database.
+
+func cmdNetwork(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: meshp network <list|show|use|create>")
+	}
+	switch args[0] {
+	case "list":
+		return cmdNetworkList(ctx, args[1:])
+	case "show":
+		return cmdNetworkShow(ctx, args[1:])
+	case "use":
+		return cmdNetworkUse(ctx, args[1:])
+	case "create":
+		return cmdNetworkCreate(ctx, args[1:])
+	default:
+		return fmt.Errorf("unknown verb %q; meshp network takes list, show, use or create", args[0])
+	}
+}
+
+// allNetworks reads what this account can see.
+func allNetworks(ctx context.Context, client *cliapi.Client) ([]network, error) {
+	var body struct {
+		Networks []network `json:"networks"`
+	}
+	err := client.Do(ctx, "GET", "/api/v1/networks", nil, &body)
+	sort.Slice(body.Networks, func(i, j int) bool {
+		return body.Networks[i].qualified() < body.Networks[j].qualified()
+	})
+	return body.Networks, err
+}
+
+func cmdNetworkList(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp network list", flag.ContinueOnError)
+	if _, err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	client, cred, err := signedIn()
+	if err != nil {
+		return err
+	}
+	networks, err := allNetworks(ctx, client)
+	if err != nil {
+		return err
+	}
+	if len(networks) == 0 {
+		fmt.Println("This account can see no networks.")
+		return nil
+	}
+
+	// The chosen one is marked rather than listed apart, so the list stays in one order and
+	// somebody can see at a glance which of these `meshp device list` would act on.
+	chosen, _ := chooseNetwork(ctx, client, "", cred.Network)
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "\tNETWORK\tNAME\tDEVICES")
+	for _, n := range networks {
+		mark := " "
+		if n.ID == chosen.ID {
+			mark = "*"
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d\n", mark, n.qualified(), n.Name, n.ActiveDeviceCount)
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	if chosen.ID != "" {
+		fmt.Printf("\n* is what commands use here. Change it with 'meshp network use <name>'.\n")
+	}
+	return nil
+}
+
+func cmdNetworkShow(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp network show", flag.ContinueOnError)
+	rest, err := parseFlags(fs, args)
+	if err != nil {
+		return err
+	}
+	want := ""
+	if len(rest) == 1 {
+		want = rest[0]
+	} else if len(rest) > 1 {
+		return errors.New("usage: meshp network show [<name>]")
+	}
+
+	client, cred, err := signedIn()
+	if err != nil {
+		return err
+	}
+	net, err := chooseNetwork(ctx, client, want, cred.Network)
+	if err != nil {
+		return err
+	}
+
+	var body struct {
+		Network struct {
+			StateVersion int64 `json:"state_version"`
+		} `json:"network"`
+		Devices []struct {
+			State string `json:"state"`
+		} `json:"devices"`
+		RouteGroups []struct {
+			Slug        string   `json:"slug"`
+			Kind        string   `json:"kind"`
+			Prefixes    []string `json:"prefixes"`
+			Advertisers []struct {
+				DeviceName string `json:"device_name"`
+				Health     string `json:"health"`
+			} `json:"advertisers"`
+		} `json:"route_groups"`
+		FaultCount int `json:"fault_count"`
+	}
+	if err := client.Do(ctx, "GET", "/api/v1/networks/"+net.ID+"/overview", nil, &body); err != nil {
+		return err
+	}
+
+	active := 0
+	for _, d := range body.Devices {
+		if d.State == "active" {
+			active++
+		}
+	}
+
+	fmt.Printf("%s  %s\n", net.qualified(), net.Name)
+	fmt.Printf("  version   %d\n", body.Network.StateVersion)
+	fmt.Printf("  devices   %d active, %d listed\n", active, len(body.Devices))
+	// Said even when it is zero. "faults 0" is an answer; a line that appears only when
+	// something is wrong makes its absence ambiguous with not having looked.
+	fmt.Printf("  faults    %d\n", body.FaultCount)
+
+	if len(body.RouteGroups) == 0 {
+		fmt.Println("  routes    none")
+		return nil
+	}
+	fmt.Println("  routes")
+	for _, g := range body.RouteGroups {
+		carried := strings.Join(g.Prefixes, ", ")
+		if carried == "" {
+			carried = "no prefixes"
+		}
+		fmt.Printf("    %-14s %-8s %s\n", g.Slug, g.Kind, carried)
+		for _, a := range g.Advertisers {
+			// Which advertiser is *chosen* is not shown, and cannot be: desired state
+			// carries an ordered list of candidates and the agent decides which is alive
+			// (ADR-0003), so no such fact exists server-side. The page has the same rule.
+			fmt.Printf("      %-12s %s\n", a.DeviceName, a.Health)
+		}
+	}
+	return nil
+}
+
+func cmdNetworkUse(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp network use", flag.ContinueOnError)
+	clear := fs.Bool("clear", false, "Forget the choice, and go back to being asked")
+	rest, err := parseFlags(fs, args)
+	if err != nil {
+		return err
+	}
+
+	cred, err := clicred.Load()
+	if errors.Is(err, clicred.ErrNotSignedIn) {
+		return errors.New("not signed in; run 'meshp login'")
+	}
+	if err != nil {
+		return err
+	}
+
+	if *clear {
+		cred.Network = ""
+		if err := clicred.Save(cred); err != nil {
+			return err
+		}
+		fmt.Println("Forgotten. Commands will ask again where there is more than one network.")
+		return nil
+	}
+
+	if len(rest) == 0 {
+		if cred.Network == "" {
+			fmt.Println("No network chosen. Pick one with 'meshp network use <name>'.")
+			return nil
+		}
+		fmt.Println(cred.Network)
+		return nil
+	}
+	if len(rest) != 1 {
+		return errors.New("usage: meshp network use [<name>] [--clear]")
+	}
+
+	client, _, err := signedIn()
+	if err != nil {
+		return err
+	}
+	// Resolved before it is stored, so a typo fails here rather than on the next command
+	// that tries to use it.
+	net, err := chooseNetwork(ctx, client, rest[0], "")
+	if err != nil {
+		return err
+	}
+	cred.Network = rest[0]
+	if err := clicred.Save(cred); err != nil {
+		return err
+	}
+	fmt.Printf("Using %s. Commands here act on it unless --network says otherwise.\n", net.qualified())
+	return nil
+}
+
+func cmdNetworkCreate(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp network create", flag.ContinueOnError)
+	name := fs.String("name", "", "What people read; defaults to the slug")
+	pools := fs.String("pool", "", "Address pools devices are given addresses from, comma separated")
+	rest, err := parseFlags(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
+		return errors.New("usage: meshp network create <slug> --pool 10.90.0.0/16 [--name x]")
+	}
+	if *pools == "" {
+		// Refused rather than defaulted. An address pool decides what every device in this
+		// network is numbered from and what it will collide with elsewhere (ADR-0005), and
+		// picking one on somebody's behalf is picking it for years.
+		return errors.New("--pool is needed: a network with no address pool can give no device an address")
+	}
+
+	client, _, err := signedIn()
+	if err != nil {
+		return err
+	}
+
+	var me struct {
+		OrganizationID string `json:"organization_id"`
+	}
+	if err := client.Do(ctx, "GET", "/api/v1/me", nil, &me); err != nil {
+		return err
+	}
+	if me.OrganizationID == "" {
+		return errors.New("this credential belongs to no organisation, so there is nothing to create a network in")
+	}
+
+	var pool []string
+	for _, p := range strings.Split(*pools, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			pool = append(pool, p)
+		}
+	}
+	title := *name
+	if title == "" {
+		title = rest[0]
+	}
+
+	body := map[string]any{
+		"organization_id": me.OrganizationID,
+		"slug":            rest[0],
+		"name":            title,
+		"address_pools":   pool,
+	}
+	var out network
+	if err := client.Do(ctx, "POST", "/api/v1/networks", body, &out); err != nil {
+		return err
+	}
+	fmt.Printf("Created %s. Add a device with 'meshp device list --network %s' once one has joined.\n",
+		rest[0], rest[0])
+	return nil
+}

--- a/cmd/meshp/usage_test.go
+++ b/cmd/meshp/usage_test.go
@@ -57,10 +57,10 @@ func TestEveryCommandThatExistsIsOffered(t *testing.T) {
 // such command — which is true — rather than an apology for an offer that should not have
 // been made.
 func TestTheNounsThatWereNeverBuiltAreNotCommands(t *testing.T) {
-	// `device` has left this list, which is what closing the gap looks like from here
-	// (#226). The rest are still advertised nowhere and answer unknown command.
+	// `device` and `network` have left this list, which is what closing the gap looks like
+	// from here. The rest are still advertised nowhere and answer unknown command.
 	for _, name := range []string{
-		"network", "user", "group", "acl",
+		"user", "group", "acl",
 		"dns", "route-group", "exit", "relay", "token",
 	} {
 		if _, found := lookup(name); found {

--- a/internal/clicred/clicred.go
+++ b/internal/clicred/clicred.go
@@ -38,6 +38,13 @@ type Credential struct {
 	TokenID string `json:"token_id,omitempty"`
 	// Email is who this is, for the CLI to say so without asking the control plane.
 	Email string `json:"email,omitempty"`
+	// Network is what `meshp network use` chose, so a command about a network does not
+	// need --network every time.
+	//
+	// Stored as whatever was typed — a slug, an org/slug, or an id — rather than resolved
+	// to an id. It is what a person will recognise if they read this file, and a slug that
+	// stops resolving is a clearer failure than a UUID that names nothing.
+	Network string `json:"network,omitempty"`
 }
 
 // Path is where the credential lives.


### PR DESCRIPTION
The second noun, and the one that makes the first usable: after #226, anybody who can see more than one network had to type `--network` on every invocation.

```
meshp network list
meshp network show [<name>]
meshp network use  [<name>] [--clear]
meshp network create <slug> --pool 10.90.0.0/16 [--name x]
```

`list`, `show` and `create` are clients of routes that already exist. **`use` is the only verb here with nothing behind it** — which network somebody is working on is not a fact about the deployment (two people signed into the same control plane are each looking at their own), so it lives beside their credential rather than in the database.

## Three sources, in order

What the command said → what `use` chose → inference, when there is exactly one.

**A remembered choice that no longer resolves is an error, not a fallback.** It names a network somebody deliberately selected, and quietly acting on a different one because that selection went stale is the failure the ordering exists to prevent:

```
meshp: 'meshp network use' chose "branch" and there is no such network now;
       pick another with 'meshp network use', or 'meshp network use --clear'
```

The message says how to get out, since the file holding the choice isn't somewhere anybody would think to look.

## Two smaller judgements

`create` **refuses without `--pool`** rather than defaulting one. An address pool decides what every device in the network is numbered from and what it collides with elsewhere (ADR-0005) — picking one on somebody's behalf is picking it for years.

`show` says `faults 0` rather than omitting the line when nothing is wrong, because an absent line is ambiguous with not having looked. It does not say which advertiser is *chosen*, because no such fact exists server-side (ADR-0003) — the page has the same rule.

## It also fixes `meshp login --token` reporting nobody

`GET /api/v1/me` answers with different names depending on what asks: a **session** is a person and carries `email`; a **token** is a person acting through a machine and carries `owner`. `login` read only `email`, which for a token is not an error — it is an empty string.

So it has been printing `Signed in to … as ` with nobody named since #214. The same trap the token id fell into during ADR-0031's implementation, in the endpoint next door. Now reads both.

## Driven against a real control plane

Bootstrapped one, created two networks, and:

- `device list` **refused to guess** between them
- chose one with `use` and watched it stop asking; `network list` marks it with `*`
- `--network` still overrode the choice
- **deleted the chosen network out from under the CLI** and got the refusal rather than a silent fallback
- `--clear` recovered, and inference took over for the one that remained

## Tests

Four more on the precedence. Mutation-tested — ignoring the remembered choice, letting it beat an explicit flag, and falling back to inference when stale each fail exactly one test.

`make lint` 0 issues · `go test ./...` clean · 21 page tests · `make reachability` clean · cross-compiles for all three.

Seven nouns left: `user`, `group`, `acl`, `dns`, `route-group`, `exit`, `relay`, `token`.