### PR TITLE
feat(cli): meshp acl, a policy edited as a document

### DIFF
--- a/cmd/meshp/acl.go
+++ b/cmd/meshp/acl.go
@@ -1,0 +1,420 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/acl"
+	"github.com/meshpnet/meshp/internal/cliapi"
+)
+
+// The access policy, as a document rather than a form (ADR-0032 §3).
+//
+// That section is about the page and applies here for the same reason: a policy is text
+// somebody composes, and the failure worth designing against is publishing one that is
+// subtly not what was meant. So the document is edited as itself, parsed before it can be
+// sent, and shown as a diff against what is live — three things `curl` does not do, which
+// is the bar §3 set for replacing it.
+//
+// `acl test` is deliberately not here. A faithful dry-run has to compile the document the
+// way the control plane will, and that means store.PolicyDevices — which decides who a
+// policy resolves against, excluding the revoked, the suspended and the addressless. The
+// CLI cannot reproduce that without becoming a second implementation of a rule that must
+// not drift (ADR-0023), and the tags selectors match on are not on the devices endpoint at
+// all. It wants a dry-run route that both this and the page call, which is a capability
+// landing in every client at once (ADR-0032 §5) rather than a verb bolted on here.
+
+// policyDoc is what GET /networks/{id}/acl answers.
+type policyDoc struct {
+	Version   int             `json:"version"`
+	CreatedAt time.Time       `json:"created_at"`
+	Document  json.RawMessage `json:"document"`
+}
+
+func cmdACL(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: meshp acl <show|edit|apply|versions>")
+	}
+	switch args[0] {
+	case "show":
+		return cmdACLShow(ctx, args[1:])
+	case "edit":
+		return cmdACLEdit(ctx, args[1:])
+	case "apply":
+		return cmdACLApply(ctx, args[1:])
+	case "versions":
+		return cmdACLVersions(ctx, args[1:])
+	default:
+		return fmt.Errorf("unknown verb %q; meshp acl takes show, edit, apply or versions", args[0])
+	}
+}
+
+// livePolicy reads the document in force, and says so when there is none.
+//
+// A network with no policy is unfiltered rather than closed, which is a fact worth stating
+// plainly every time: somebody who reads "not found" and assumes the default is deny has
+// the network backwards.
+func livePolicy(ctx context.Context, client *cliapi.Client, networkID string) (policyDoc, bool, error) {
+	var out policyDoc
+	err := client.Do(ctx, "GET", "/api/v1/networks/"+networkID+"/acl", nil, &out)
+	var apiErr *cliapi.Error
+	if errors.As(err, &apiErr) && apiErr.Code == "no_policy" {
+		return policyDoc{}, false, nil
+	}
+	if err != nil {
+		return policyDoc{}, false, err
+	}
+	return out, true, nil
+}
+
+// indented is the document as somebody would want to edit it.
+func indented(raw json.RawMessage) ([]byte, error) {
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, raw, "", "  "); err != nil {
+		return nil, fmt.Errorf("the control plane sent a document that will not re-indent: %w", err)
+	}
+	return append(pretty.Bytes(), '\n'), nil
+}
+
+// canonical renders a parsed document the way the control plane will hand it back, so that
+// a diff shows what changed rather than how it was typed.
+func canonical(doc acl.Document) ([]byte, error) {
+	encoded, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("re-encoding the policy: %w", err)
+	}
+	return append(encoded, '\n'), nil
+}
+
+// starterPolicy is what `acl edit` offers a network that has none.
+//
+// Deny-nothing, written out, rather than an empty file. A person editing from blank has to
+// know the schema before they can start; a person editing from this has to change one line,
+// and the one they change is the one that decides what is allowed.
+const starterPolicy = `{
+  "version": 1,
+  "comment": "Every device may reach every other. Narrow this.",
+  "rules": [
+    { "src": ["*"], "dst": ["*"], "protocol": "any" }
+  ]
+}
+`
+
+func cmdACLShow(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp acl show", flag.ContinueOnError)
+	wantNetwork := fs.String("network", "", "Which network, by slug or id")
+	if _, err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	client, cred, err := signedIn()
+	if err != nil {
+		return err
+	}
+	net, err := chooseNetwork(ctx, client, *wantNetwork, cred.Network)
+	if err != nil {
+		return err
+	}
+	policy, exists, err := livePolicy(ctx, client, net.ID)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		fmt.Printf("%s has no policy, so every device may reach every other.\n", net.qualified())
+		return nil
+	}
+	pretty, err := indented(policy.Document)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "# %s, version %d, published %s\n",
+		net.qualified(), policy.Version, policy.CreatedAt.Format(time.RFC3339))
+	_, err = os.Stdout.Write(pretty)
+	return err
+}
+
+func cmdACLVersions(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp acl versions", flag.ContinueOnError)
+	wantNetwork := fs.String("network", "", "Which network, by slug or id")
+	if _, err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	client, cred, err := signedIn()
+	if err != nil {
+		return err
+	}
+	net, err := chooseNetwork(ctx, client, *wantNetwork, cred.Network)
+	if err != nil {
+		return err
+	}
+	var body struct {
+		Policies []struct {
+			Version   int       `json:"version"`
+			Active    bool      `json:"active"`
+			CreatedAt time.Time `json:"created_at"`
+		} `json:"policies"`
+	}
+	if err := client.Do(ctx, "GET", "/api/v1/networks/"+net.ID+"/acl/versions", nil, &body); err != nil {
+		return err
+	}
+	if len(body.Policies) == 0 {
+		fmt.Printf("%s has never had a policy.\n", net.qualified())
+		return nil
+	}
+	for _, p := range body.Policies {
+		mark := " "
+		if p.Active {
+			mark = "*"
+		}
+		fmt.Printf("%s %-4d %s\n", mark, p.Version, p.CreatedAt.Format(time.RFC3339))
+	}
+	return nil
+}
+
+func cmdACLApply(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp acl apply", flag.ContinueOnError)
+	wantNetwork := fs.String("network", "", "Which network, by slug or id")
+	yes := fs.Bool("yes", false, "Do not ask")
+	rest, err := parseFlags(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
+		return errors.New("usage: meshp acl apply <file> [--network n]")
+	}
+
+	proposed, err := os.ReadFile(rest[0])
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", rest[0], err)
+	}
+
+	client, cred, err := signedIn()
+	if err != nil {
+		return err
+	}
+	net, err := chooseNetwork(ctx, client, *wantNetwork, cred.Network)
+	if err != nil {
+		return err
+	}
+	return publishPolicy(ctx, client, net, proposed, *yes)
+}
+
+func cmdACLEdit(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp acl edit", flag.ContinueOnError)
+	wantNetwork := fs.String("network", "", "Which network, by slug or id")
+	yes := fs.Bool("yes", false, "Do not ask before publishing")
+	if _, err := parseFlags(fs, args); err != nil {
+		return err
+	}
+
+	client, cred, err := signedIn()
+	if err != nil {
+		return err
+	}
+	net, err := chooseNetwork(ctx, client, *wantNetwork, cred.Network)
+	if err != nil {
+		return err
+	}
+	policy, exists, err := livePolicy(ctx, client, net.ID)
+	if err != nil {
+		return err
+	}
+
+	before := []byte(starterPolicy)
+	if exists {
+		if before, err = indented(policy.Document); err != nil {
+			return err
+		}
+	}
+
+	edited, err := editInEditor(ctx, before, net.qualified())
+	if err != nil {
+		return err
+	}
+	if string(edited) == string(before) {
+		fmt.Println("Unchanged. Nothing published.")
+		return nil
+	}
+	return publishPolicy(ctx, client, net, edited, *yes)
+}
+
+// publishPolicy validates, shows what changes, asks, and sends.
+func publishPolicy(ctx context.Context, client *cliapi.Client, net network, proposed []byte, yes bool) error {
+	// Parsed here as well as by the control plane, which will reject it anyway. Locally is
+	// where the author is: a malformed document should cost a message, not a round trip and
+	// a 400 whose body somebody has to go and read.
+	doc, err := acl.Parse(proposed)
+	if err != nil {
+		return fmt.Errorf("that document is not a policy: %w", err)
+	}
+
+	// Compared in the form the control plane keeps, not the form it was written in.
+	//
+	// A policy is stored parsed, so what comes back is canonical JSON however it was typed.
+	// Diffing a hand-written file against that shows every line as changed the moment the
+	// two disagree about whitespace — applying a byte-identical file a second time produced
+	// a twenty-line diff, which is a diff nobody can read for what actually moved.
+	after, err := canonical(doc)
+	if err != nil {
+		return err
+	}
+
+	live, exists, err := livePolicy(ctx, client, net.ID)
+	if err != nil {
+		return err
+	}
+	var before []byte
+	if exists {
+		if before, err = indented(live.Document); err != nil {
+			return err
+		}
+	}
+
+	if string(before) == string(after) {
+		// Refused rather than published. An identical policy would be a new version with
+		// the same content, and a history where half the entries changed nothing is one
+		// nobody can read backwards to find when something did.
+		fmt.Printf("%s already has exactly this policy. Nothing published.\n", net.qualified())
+		return nil
+	}
+
+	// The change, not the new blob. Publishing an access policy by looking at the whole
+	// document means reading it for what somebody meant to change, and that is how a rule
+	// nobody intended goes live.
+	fmt.Print(diff(string(before), string(after)))
+	if !exists {
+		fmt.Printf("\n%s has no policy today, so this is the first: everything not permitted below stops being reachable.\n",
+			net.qualified())
+	}
+	if err := confirm(yes, fmt.Sprintf("Publish this to %s?", net.qualified())); err != nil {
+		return err
+	}
+
+	var out struct {
+		Version int `json:"version"`
+	}
+	if err := client.Do(ctx, "PUT", "/api/v1/networks/"+net.ID+"/acl", json.RawMessage(after), &out); err != nil {
+		return err
+	}
+	fmt.Printf("Published version %d to %s. Every device in it is being told.\n", out.Version, net.qualified())
+	return nil
+}
+
+// editInEditor writes the document to a file, opens $EDITOR on it, and reads it back.
+func editInEditor(ctx context.Context, current []byte, label string) ([]byte, error) {
+	editor := os.Getenv("MESHP_EDITOR")
+	if editor == "" {
+		editor = os.Getenv("VISUAL")
+	}
+	if editor == "" {
+		editor = os.Getenv("EDITOR")
+	}
+	if editor == "" {
+		return nil, errors.New("no editor: set EDITOR, or use 'meshp acl apply <file>'")
+	}
+
+	dir, err := os.MkdirTemp("", "meshp-acl")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	// Named for the network, because an editor tab saying `policy.json` is one somebody can
+	// publish to the wrong place.
+	path := filepath.Join(dir, strings.ReplaceAll(label, "/", "-")+".acl.json")
+	if err := os.WriteFile(path, current, 0o600); err != nil {
+		return nil, err
+	}
+
+	// Through a shell, so EDITOR can carry arguments the way it does everywhere else.
+	cmd := exec.CommandContext(ctx, "sh", "-c", editor+" \"$1\"", "sh", path)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("%s exited without saving: %w", editor, err)
+	}
+	return os.ReadFile(path)
+}
+
+// diff renders a line diff, marking what goes and what arrives.
+//
+// Its own rather than shelling out to diff(1): this runs on Windows too, and a policy is
+// small enough that the simplest thing that shows the change is enough.
+func diff(before, after string) string {
+	// Split after trimming the trailing newline. A document ends with one, and splitting on
+	// it otherwise yields a final empty element that renders as a context line made of two
+	// spaces — a line the document does not have.
+	old, next := lines(before), lines(after)
+	common := longestCommon(old, next)
+
+	var b strings.Builder
+	i, j := 0, 0
+	for _, line := range common {
+		for i < len(old) && old[i] != line {
+			fmt.Fprintf(&b, "- %s\n", old[i])
+			i++
+		}
+		for j < len(next) && next[j] != line {
+			fmt.Fprintf(&b, "+ %s\n", next[j])
+			j++
+		}
+		fmt.Fprintf(&b, "  %s\n", line)
+		i++
+		j++
+	}
+	for ; i < len(old); i++ {
+		fmt.Fprintf(&b, "- %s\n", old[i])
+	}
+	for ; j < len(next); j++ {
+		fmt.Fprintf(&b, "+ %s\n", next[j])
+	}
+	return b.String()
+}
+
+// lines splits a document, without inventing a final empty one.
+func lines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(strings.TrimSuffix(s, "\n"), "\n")
+}
+
+// longestCommon is the longest common subsequence of two line lists.
+func longestCommon(a, b []string) []string {
+	table := make([][]int, len(a)+1)
+	for i := range table {
+		table[i] = make([]int, len(b)+1)
+	}
+	for i := len(a) - 1; i >= 0; i-- {
+		for j := len(b) - 1; j >= 0; j-- {
+			if a[i] == b[j] {
+				table[i][j] = table[i+1][j+1] + 1
+			} else if table[i+1][j] >= table[i][j+1] {
+				table[i][j] = table[i+1][j]
+			} else {
+				table[i][j] = table[i][j+1]
+			}
+		}
+	}
+	var out []string
+	for i, j := 0, 0; i < len(a) && j < len(b); {
+		switch {
+		case a[i] == b[j]:
+			out = append(out, a[i])
+			i++
+			j++
+		case table[i+1][j] >= table[i][j+1]:
+			i++
+		default:
+			j++
+		}
+	}
+	return out
+}

--- a/cmd/meshp/acl.go
+++ b/cmd/meshp/acl.go
@@ -251,6 +251,11 @@ func publishPolicy(ctx context.Context, client *cliapi.Client, net network, prop
 	// Parsed here as well as by the control plane, which will reject it anyway. Locally is
 	// where the author is: a malformed document should cost a message, not a round trip and
 	// a 400 whose body somebody has to go and read.
+	if len(proposed) > maxPolicyBytes {
+		return fmt.Errorf(
+			"that policy is %d bytes and this control plane accepts %d; nothing was sent",
+			len(proposed), maxPolicyBytes)
+	}
 	doc, err := acl.Parse(proposed)
 	if err != nil {
 		return fmt.Errorf("that document is not a policy: %w", err)
@@ -343,39 +348,88 @@ func editInEditor(ctx context.Context, current []byte, label string) ([]byte, er
 	return os.ReadFile(path)
 }
 
+// maxPolicyBytes is what the control plane accepts (internal/api/policy.go), refused here
+// as well. Locally is where the author is: a document too large to publish should cost a
+// message rather than a round trip and a 413.
+const maxPolicyBytes = 1 << 20
+
+// maxDiffLines bounds the part of a document compared line by line.
+//
+// The subsequence below is O(n*m) in time and memory, and its input is a file somebody
+// named on the command line. Trimming the common prefix and suffix first means a policy
+// edit — a rule changed, a rule added — compares only the handful of lines around the
+// change however long the document is, so this cap is reached only by two documents that
+// genuinely differ almost everywhere. Then a summary is more use than ten thousand marked
+// lines nobody will read.
+const maxDiffLines = 2000
+
 // diff renders a line diff, marking what goes and what arrives.
 //
 // Its own rather than shelling out to diff(1): this runs on Windows too, and a policy is
 // small enough that the simplest thing that shows the change is enough.
 func diff(before, after string) string {
-	// Split after trimming the trailing newline. A document ends with one, and splitting on
-	// it otherwise yields a final empty element that renders as a context line made of two
-	// spaces — a line the document does not have.
 	old, next := lines(before), lines(after)
-	common := longestCommon(old, next)
+
+	// The shared ends, which for an edited policy is nearly all of it. Done first so the
+	// expensive part below sees only what actually differs.
+	var head, tail []string
+	for len(old) > 0 && len(next) > 0 && old[0] == next[0] {
+		head = append(head, old[0])
+		old, next = old[1:], next[1:]
+	}
+	for len(old) > 0 && len(next) > 0 && old[len(old)-1] == next[len(next)-1] {
+		tail = append([]string{old[len(old)-1]}, tail...)
+		old, next = old[:len(old)-1], next[:len(next)-1]
+	}
 
 	var b strings.Builder
+	for _, line := range head {
+		fmt.Fprintf(&b, "  %s\n", line)
+	}
+
+	if len(old) > maxDiffLines || len(next) > maxDiffLines {
+		// Bounded rather than attempted. Two documents differing over this many lines are
+		// not being reviewed line by line by anybody.
+		fmt.Fprintf(&b, "… %d lines replaced by %d, which is too much to show as a diff\n",
+			len(old), len(next))
+	} else {
+		for _, line := range middle(old, next) {
+			b.WriteString(line)
+		}
+	}
+
+	for _, line := range tail {
+		fmt.Fprintf(&b, "  %s\n", line)
+	}
+	return b.String()
+}
+
+// middle renders the part that differs, matching what it can by subsequence.
+func middle(old, next []string) []string {
+	common := longestCommon(old, next)
+
+	var out []string
 	i, j := 0, 0
 	for _, line := range common {
 		for i < len(old) && old[i] != line {
-			fmt.Fprintf(&b, "- %s\n", old[i])
+			out = append(out, fmt.Sprintf("- %s\n", old[i]))
 			i++
 		}
 		for j < len(next) && next[j] != line {
-			fmt.Fprintf(&b, "+ %s\n", next[j])
+			out = append(out, fmt.Sprintf("+ %s\n", next[j]))
 			j++
 		}
-		fmt.Fprintf(&b, "  %s\n", line)
+		out = append(out, fmt.Sprintf("  %s\n", line))
 		i++
 		j++
 	}
 	for ; i < len(old); i++ {
-		fmt.Fprintf(&b, "- %s\n", old[i])
+		out = append(out, fmt.Sprintf("- %s\n", old[i]))
 	}
 	for ; j < len(next); j++ {
-		fmt.Fprintf(&b, "+ %s\n", next[j])
+		out = append(out, fmt.Sprintf("+ %s\n", next[j]))
 	}
-	return b.String()
+	return out
 }
 
 // lines splits a document, without inventing a final empty one.
@@ -387,10 +441,13 @@ func lines(s string) []string {
 }
 
 // longestCommon is the longest common subsequence of two line lists.
+//
+// Callers bound the input; see maxDiffLines. int32 rather than int because the table is the
+// product of two lengths and the counts it holds cannot exceed either of them.
 func longestCommon(a, b []string) []string {
-	table := make([][]int, len(a)+1)
+	table := make([][]int32, len(a)+1)
 	for i := range table {
-		table[i] = make([]int, len(b)+1)
+		table[i] = make([]int32, len(b)+1)
 	}
 	for i := len(a) - 1; i >= 0; i-- {
 		for j := len(b) - 1; j >= 0; j-- {

--- a/cmd/meshp/acl_test.go
+++ b/cmd/meshp/acl_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/meshpnet/meshp/internal/acl"
+)
+
+func TestDiffShowsOnlyWhatChanged(t *testing.T) {
+	before := "a\nb\nc\n"
+	after := "a\nB\nc\n"
+
+	got := diff(before, after)
+	want := []string{"  a", "- b", "+ B", "  c"}
+	for _, line := range want {
+		if !strings.Contains(got, line+"\n") {
+			t.Errorf("the diff has no %q line:\n%s", line, got)
+		}
+	}
+	// The unchanged lines are context, not noise: two of three survive unmarked, and exactly
+	// one line is removed and one added.
+	removed, added, kept := countDiff(got)
+	if removed != 1 || added != 1 || kept != 2 {
+		t.Errorf("removed=%d added=%d kept=%d, want 1/1/2:\n%s", removed, added, kept, got)
+	}
+}
+
+// countDiff counts the three kinds of line in a rendered diff.
+func countDiff(out string) (removed, added, kept int) {
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		switch {
+		case strings.HasPrefix(line, "- "):
+			removed++
+		case strings.HasPrefix(line, "+ "):
+			added++
+		case strings.HasPrefix(line, "  "):
+			kept++
+		}
+	}
+	return removed, added, kept
+}
+
+func TestDiffOnAFirstPolicyIsAllAdditions(t *testing.T) {
+	got := diff("", "{\n  \"version\": 1\n}\n")
+	if strings.Contains(got, "\n- ") || strings.HasPrefix(got, "- ") {
+		t.Errorf("a first policy removed something:\n%s", got)
+	}
+	if !strings.Contains(got, `+   "version": 1`) {
+		t.Errorf("the new line is not marked as added:\n%s", got)
+	}
+}
+
+func TestDiffOfAnUnchangedDocumentMarksNothing(t *testing.T) {
+	doc := "{\n  \"version\": 1\n}\n"
+	got := diff(doc, doc)
+	for _, mark := range []string{"\n- ", "\n+ "} {
+		if strings.Contains(got, mark) {
+			t.Errorf("an unchanged document produced a change:\n%s", got)
+		}
+	}
+}
+
+// A rule inserted in the middle must read as an insertion rather than as every line below
+// it having been rewritten — which is the whole reason this is a subsequence diff and not a
+// line-by-line comparison.
+func TestDiffOfAnInsertionDoesNotRewriteTheRest(t *testing.T) {
+	before := "one\ntwo\nthree\n"
+	after := "one\nINSERTED\ntwo\nthree\n"
+
+	got := diff(before, after)
+	if strings.Contains(got, "- two") || strings.Contains(got, "- three") {
+		t.Errorf("an insertion was shown as rewriting what followed:\n%s", got)
+	}
+	if !strings.Contains(got, "+ INSERTED") {
+		t.Errorf("the inserted line is not marked:\n%s", got)
+	}
+}
+
+func TestLongestCommonFindsTheSharedRun(t *testing.T) {
+	got := longestCommon([]string{"a", "b", "c", "d"}, []string{"a", "x", "c", "d"})
+	want := []string{"a", "c", "d"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+// The starter is what somebody edits from when a network has never had a policy, so it has
+// to be a document the control plane would accept — otherwise the first thing an editor
+// shows is something that cannot be published.
+func TestTheStarterPolicyIsAValidPolicy(t *testing.T) {
+	if _, err := acl.Parse([]byte(starterPolicy)); err != nil {
+		t.Fatalf("the starter policy does not parse: %v", err)
+	}
+}
+
+// The same policy written two ways must canonicalise to one thing.
+//
+// A policy is stored parsed, so what comes back is canonical however it was typed. Diffing
+// a hand-written file against that showed every line as changed the moment the two
+// disagreed about whitespace: applying a byte-identical file a second time produced a
+// twenty-line diff, and a diff nobody can read for what moved is not a diff.
+func TestFormattingDoesNotShowAsAChange(t *testing.T) {
+	compact := []byte(`{"version":1,"rules":[{"src":["*"],"dst":["tag:db"],"protocol":"tcp","ports":["5432"]}]}`)
+	spread := []byte(`{
+	  "version": 1,
+	  "rules": [
+	    {
+	      "src": [ "*" ],
+	      "dst": [ "tag:db" ],
+	      "protocol": "tcp",
+	      "ports": [ "5432" ]
+	    }
+	  ]
+	}`)
+
+	one, err := acl.Parse(compact)
+	if err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	two, err := acl.Parse(spread)
+	if err != nil {
+		t.Fatalf("spread: %v", err)
+	}
+
+	a, err := canonical(one)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := canonical(two)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(a) != string(b) {
+		t.Errorf("the same policy canonicalised two ways:\n%s\n---\n%s", a, b)
+	}
+	if d := diff(string(a), string(b)); strings.Contains(d, "\n+ ") || strings.Contains(d, "\n- ") {
+		t.Errorf("identical policies produced a diff:\n%s", d)
+	}
+}
+
+// And a real change still shows, so the normalisation has not flattened everything.
+func TestARealChangeStillShows(t *testing.T) {
+	before, err := acl.Parse([]byte(`{"version":1,"rules":[{"src":["*"],"dst":["tag:db"],"protocol":"any"}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := acl.Parse([]byte(`{"version":1,"rules":[{"src":["*"],"dst":["tag:web"],"protocol":"any"}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, _ := canonical(before)
+	b, _ := canonical(after)
+
+	d := diff(string(a), string(b))
+	if !strings.Contains(d, `- `) || !strings.Contains(d, `+ `) {
+		t.Errorf("a changed destination did not show:\n%s", d)
+	}
+	if !strings.Contains(d, "tag:web") {
+		t.Errorf("the new value is not in the diff:\n%s", d)
+	}
+}

--- a/cmd/meshp/acl_test.go
+++ b/cmd/meshp/acl_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -163,5 +164,49 @@ func TestARealChangeStillShows(t *testing.T) {
 	}
 	if !strings.Contains(d, "tag:web") {
 		t.Errorf("the new value is not in the diff:\n%s", d)
+	}
+}
+
+// The subsequence is O(n*m) in time and memory over a file somebody named on the command
+// line. Trimming the shared ends means an ordinary edit never reaches it, and the cap means
+// two wholly different documents cannot make the CLI allocate without bound — which is what
+// CodeQL objected to, and it was right to.
+func TestAnEditOnlyComparesWhatChanged(t *testing.T) {
+	// Far more lines than the cap, differing in exactly one of them.
+	var before, after strings.Builder
+	for i := 0; i < maxDiffLines*3; i++ {
+		fmt.Fprintf(&before, "line %d\n", i)
+		if i == maxDiffLines {
+			after.WriteString("CHANGED\n")
+			continue
+		}
+		fmt.Fprintf(&after, "line %d\n", i)
+	}
+
+	got := diff(before.String(), after.String())
+	if strings.Contains(got, "too much to show as a diff") {
+		t.Fatal("a one-line change was treated as a wholesale replacement")
+	}
+	removed, added, _ := countDiff(got)
+	if removed != 1 || added != 1 {
+		t.Errorf("removed=%d added=%d, want 1/1", removed, added)
+	}
+}
+
+func TestTwoWhollyDifferentDocumentsAreSummarisedRatherThanCompared(t *testing.T) {
+	var before, after strings.Builder
+	for i := 0; i < maxDiffLines+10; i++ {
+		fmt.Fprintf(&before, "old %d\n", i)
+		fmt.Fprintf(&after, "new %d\n", i)
+	}
+
+	got := diff(before.String(), after.String())
+	if !strings.Contains(got, "too much to show as a diff") {
+		t.Errorf("an unbounded comparison was attempted:\n%s", got[:200])
+	}
+	// And it says how big the two sides were, so the summary is an answer rather than a
+	// refusal.
+	if !strings.Contains(got, fmt.Sprintf("%d lines replaced by %d", maxDiffLines+10, maxDiffLines+10)) {
+		t.Errorf("the summary does not say how much changed:\n%s", got)
 	}
 }

--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -69,6 +69,11 @@ var commands = []command{
 		help: "See the networks this account reaches, and choose which one commands act on",
 		run:  cmdNetwork,
 	},
+	{
+		name: "acl", args: "<show|edit|apply|versions>",
+		help: "Read and publish a network's access policy",
+		run:  cmdACL,
+	},
 }
 
 // lookup finds a command by name.

--- a/cmd/meshp/usage_test.go
+++ b/cmd/meshp/usage_test.go
@@ -60,7 +60,7 @@ func TestTheNounsThatWereNeverBuiltAreNotCommands(t *testing.T) {
 	// `device` and `network` have left this list, which is what closing the gap looks like
 	// from here. The rest are still advertised nowhere and answer unknown command.
 	for _, name := range []string{
-		"user", "group", "acl",
+		"user", "group",
 		"dns", "route-group", "exit", "relay", "token",
 	} {
 		if _, found := lookup(name); found {


### PR DESCRIPTION
The third noun, and the one ADR-0032 §3 was written about. That section is about the page and applies here for the same reason: an access policy is **text somebody composes**, and the failure worth designing against is publishing one that is subtly not what was meant.

```
meshp acl show     [--network n]
meshp acl edit     [--network n] [--yes]
meshp acl apply    <file> [--network n] [--yes]
meshp acl versions [--network n]
```

So the document is edited as itself, parsed before it can be sent, and shown as a diff against what is live. Three things `curl` does not do — the bar §3 set for replacing it.

## The diff compares canonical forms, and running it is how I found out

A policy is stored **parsed**, so what comes back is canonical JSON however it was typed. Diffing a hand-written file against that showed every line as changed the moment the two disagreed about whitespace. Applying a **byte-identical file a second time** produced this:

```
  {
    "version": 1,
+   "comment": "first",
    "rules": [
-     {
-       "src": [
-         "*"
...
```

A diff nobody can read for what actually moved is not a diff. Both sides are now normalised the way the control plane hands them back, so the same change reads:

```
        "protocol": "tcp",
        "ports": [ "22", "443" ]
+     },
+     {
+       "src": [ "tag:admin" ],
```

And an identical policy is now **refused rather than published** — a history where half the entries changed nothing is one nobody can read backwards to find when something did.

## Parsing locally is not redundancy

The control plane rejects a bad document anyway. But locally is where the author is, and a malformed policy should cost a message rather than a round trip and a 400 whose body somebody has to go and read. It caught my own test fixture writing ports as numbers.

## `acl test` is deliberately absent

A faithful dry-run has to compile the document **the way the control plane will**, which means `store.PolicyDevices` — the rule deciding who a policy resolves against, excluding the revoked, the suspended and the addressless. Reproducing that here would be a second implementation of something that must not drift (ADR-0023), and the **tags selectors match on are not on the devices endpoint at all**, so a client-side compile would silently mismatch every tag rule — a wrong answer rather than no answer.

It wants a dry-run route that this *and the page* call, which is a capability landing in every client at once (ADR-0032 §5) rather than a verb bolted on here. That's the next piece of work, not a gap in this one.

## Smaller decisions

`edit` on a network with no policy opens a **deny-nothing starter** rather than an empty file — editing from blank means knowing the schema first; editing from this means changing the one line that decides what is allowed. It says out loud that a first policy makes everything not permitted unreachable.

The diff is a **subsequence diff**, so a rule inserted in the middle reads as an insertion rather than as everything below it being rewritten. Written here rather than shelling out to `diff(1)`, because this runs on Windows too.

## Driven against a real control plane

Applied a first policy and read the warning · applied it again and got the no-op · added a rule and read a diff showing only that rule · edited through `$EDITOR` with and without a change · edited a network that had no policy into having one · checked the missing-editor path.

## Tests

Eleven, mutation-tested — comparing line by line instead of by subsequence, letting the trailing-newline artifact back in, and breaking the starter policy each fail exactly the tests that should catch them.

`make lint` 0 issues · `go test ./...` clean · 21 page tests · `make reachability` clean · cross-compiles for all three.

Six nouns left: `user`, `group`, `dns`, `route-group`, `exit`, `relay`, `token`.