### PR TITLE
feat(acl): see what a device would enforce before publishing

### DIFF
--- a/cmd/meshp/acl.go
+++ b/cmd/meshp/acl.go
@@ -25,13 +25,12 @@ import (
 // sent, and shown as a diff against what is live — three things `curl` does not do, which
 // is the bar §3 set for replacing it.
 //
-// `acl test` is deliberately not here. A faithful dry-run has to compile the document the
-// way the control plane will, and that means store.PolicyDevices — which decides who a
-// policy resolves against, excluding the revoked, the suspended and the addressless. The
-// CLI cannot reproduce that without becoming a second implementation of a rule that must
-// not drift (ADR-0023), and the tags selectors match on are not on the devices endpoint at
-// all. It wants a dry-run route that both this and the page call, which is a capability
-// landing in every client at once (ADR-0032 §5) rather than a verb bolted on here.
+// `acl test` asks the control plane rather than compiling here. A faithful dry-run has to
+// resolve the policy against store.PolicyDevices — which decides who a policy applies to,
+// excluding the revoked, the suspended and the addressless — and the tags selectors match
+// on are not on the devices endpoint at all. Compiling locally would be a second
+// implementation of a rule that must not drift (ADR-0023) answering with confidence it has
+// not earned.
 
 // policyDoc is what GET /networks/{id}/acl answers.
 type policyDoc struct {
@@ -42,7 +41,7 @@ type policyDoc struct {
 
 func cmdACL(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: meshp acl <show|edit|apply|versions>")
+		return errors.New("usage: meshp acl <show|edit|test|apply|versions>")
 	}
 	switch args[0] {
 	case "show":
@@ -53,8 +52,10 @@ func cmdACL(ctx context.Context, args []string) error {
 		return cmdACLApply(ctx, args[1:])
 	case "versions":
 		return cmdACLVersions(ctx, args[1:])
+	case "test":
+		return cmdACLTest(ctx, args[1:])
 	default:
-		return fmt.Errorf("unknown verb %q; meshp acl takes show, edit, apply or versions", args[0])
+		return fmt.Errorf("unknown verb %q; meshp acl takes show, edit, test, apply or versions", args[0])
 	}
 }
 
@@ -474,4 +475,108 @@ func longestCommon(a, b []string) []string {
 		}
 	}
 	return out
+}
+
+// cmdACLTest asks what a device would enforce.
+func cmdACLTest(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp acl test", flag.ContinueOnError)
+	wantNetwork := fs.String("network", "", "Which network, by slug or id")
+	file := fs.String("file", "", "Test this document instead of the one in force")
+	rest, err := parseFlags(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
+		return errors.New("usage: meshp acl test <device> [--file p.json] [--network n]")
+	}
+
+	client, cred, err := signedIn()
+	if err != nil {
+		return err
+	}
+	net, err := chooseNetwork(ctx, client, *wantNetwork, cred.Network)
+	if err != nil {
+		return err
+	}
+
+	body := map[string]any{"device": rest[0]}
+	if *file != "" {
+		proposed, err := os.ReadFile(*file)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", *file, err)
+		}
+		// Parsed here first, for the reason publishing gives: the author is here, and a
+		// malformed document should cost a message rather than a round trip.
+		if _, err := acl.Parse(proposed); err != nil {
+			return fmt.Errorf("that document is not a policy: %w", err)
+		}
+		body["document"] = json.RawMessage(proposed)
+	}
+
+	var out struct {
+		Device      string `json:"device"`
+		DefaultDeny bool   `json:"default_deny"`
+		Filter      struct {
+			Inbound  []filterRule `json:"inbound"`
+			Outbound []filterRule `json:"outbound"`
+		} `json:"filter"`
+	}
+	if err := client.Do(ctx, "POST", "/api/v1/networks/"+net.ID+"/acl/test", body, &out); err != nil {
+		return err
+	}
+
+	source := "the policy in force"
+	if *file != "" {
+		source = *file
+	}
+	fmt.Printf("%s in %s, under %s:\n", out.Device, net.qualified(), source)
+	if out.DefaultDeny {
+		fmt.Println("  everything not listed below is refused")
+	} else {
+		fmt.Println("  everything is permitted; the rules below add nothing")
+	}
+	printRules("inbound", out.Filter.Inbound)
+	printRules("outbound", out.Filter.Outbound)
+	return nil
+}
+
+// filterRule is one rule of a compiled packet filter.
+type filterRule struct {
+	Src      []string `json:"src_prefixes"`
+	Dst      []string `json:"dst_prefixes"`
+	Protocol string   `json:"protocol"`
+	Ports    []string `json:"ports"`
+	Allow    bool     `json:"allow"`
+}
+
+// printRules renders one direction of a filter, in prefixes rather than in selectors.
+//
+// Prefixes because that is what the device enforces. A dry-run that echoed the tags back
+// would be showing the document again, and the whole question is what the document turned
+// into.
+func printRules(direction string, rules []filterRule) {
+	if len(rules) == 0 {
+		fmt.Printf("  %s: nothing\n", direction)
+		return
+	}
+	fmt.Printf("  %s:\n", direction)
+	for _, r := range rules {
+		verb := "allow"
+		if !r.Allow {
+			verb = "deny"
+		}
+		ports := ""
+		if len(r.Ports) > 0 {
+			ports = " ports " + strings.Join(r.Ports, ",")
+		}
+		fmt.Printf("    %-5s %-8s %s -> %s%s\n",
+			verb, r.Protocol, orAny(r.Src), orAny(r.Dst), ports)
+	}
+}
+
+func orAny(prefixes []string) string {
+	if len(prefixes) == 0 {
+		return "anywhere"
+	}
+	return strings.Join(prefixes, ",")
 }

--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -70,7 +70,7 @@ var commands = []command{
 		run:  cmdNetwork,
 	},
 	{
-		name: "acl", args: "<show|edit|apply|versions>",
+		name: "acl", args: "<show|edit|test|apply|versions>",
 		help: "Read and publish a network's access policy",
 		run:  cmdACL,
 	},

--- a/docs/testing/the-page.md
+++ b/docs/testing/the-page.md
@@ -80,13 +80,22 @@ mutation-tested — the code was broken deliberately and the test was required t
 
 `web/render.test.js` covers the wiring: that the buttons this page actually builds carry
 those keys, are addressed by the right id — a membership for revoking, a device for
-forgetting — and are drawn only for somebody holding the permission. It reaches them because
+forgetting, a membership again for a policy dry-run — and are drawn only for somebody
+holding the permission. It reaches them because
 `app.js` no longer starts the page when it is imported; `main.js` does that, and is what
 `index.html` loads.
 
 What jsdom cannot reach is layout, the focus ring and text selection. So the checks here
 still cover the **browser behaviours** — 1, 2 and 5, which are about what survives a redraw
 on a real screen rather than about what a reconciler does to a tree.
+
+9. **An answer survives the page it is drawn on.** With a policy published, pick a device
+   in *Access policy* and ask what it enforces. Leave it there for a quarter of a minute,
+   then `POST /fixture` a fault onto another device so the table reorders under it. The
+   compiled filter is still on screen and still names the device you asked about. *It lives
+   in the page's own state rather than in the node it was drawn into, for the same reason a
+   minted token does: every render describes the whole page, so an answer held only in the
+   DOM goes at the next poll — which is a second or two after somebody starts reading it.*
 
 ## Note on running this
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -259,6 +259,11 @@ func (s *Server) routes() []route {
 			handler: s.handleGetPolicy, kind: guardNetwork, perm: authz.NetworkACLRead},
 		{pattern: "PUT /api/v1/networks/{networkID}/acl",
 			handler: s.handlePublishPolicy, kind: guardNetwork, perm: authz.NetworkACLWrite},
+		// A dry-run: what would this device enforce, given this document. Behind acl.write
+		// because it is a step in publishing — see handleTestPolicy.
+		{pattern: "POST /api/v1/networks/{networkID}/acl/test",
+			handler: s.handleTestPolicy, kind: guardNetwork, perm: authz.NetworkACLWrite},
+
 		{pattern: "GET /api/v1/networks/{networkID}/acl/versions",
 			handler: s.handleListPolicyVersions, kind: guardNetwork, perm: authz.NetworkACLRead},
 

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
 
 	"github.com/meshpnet/meshp/internal/acl"
 	"github.com/meshpnet/meshp/internal/httpx"
@@ -135,4 +138,189 @@ func (s *Server) handleListPolicyVersions(w http.ResponseWriter, r *http.Request
 		out = append(out, entry)
 	}
 	httpx.WriteJSON(w, s.log, http.StatusOK, map[string]any{"policies": out})
+}
+
+// handleTestPolicy compiles a policy for one device without publishing it.
+//
+// The question this answers is the one nobody could ask before: given this document, what
+// would that device actually enforce? A policy is written in selectors and read by people;
+// what reaches a device is a packet filter in prefixes, and the step between them is where
+// a rule that does not do what its author meant goes unnoticed until somebody cannot reach
+// something.
+//
+// Compiled the way the session builder compiles it, from store.PolicyDevices and
+// acl.Compile, so the answer is what the device would be sent rather than a second
+// implementation's opinion of it (ADR-0023). The one difference is how the subject is
+// found: the session knows a membership row without a key and matches on address, and this
+// has the key and matches on that. Both land on the same device.
+//
+// Behind acl.write rather than acl.read. A dry-run is a step in publishing and the people
+// who take it are the people who publish — and a caller supplying an arbitrary document
+// could otherwise probe which devices carry which tags, which reading the policy does not
+// tell them.
+func (s *Server) handleTestPolicy(w http.ResponseWriter, r *http.Request) {
+	networkID, ok := s.pathUUID(w, r, "networkID")
+	if !ok {
+		return
+	}
+
+	var req struct {
+		// Device names the subject: a membership id, a device id, or a device name.
+		Device string `json:"device"`
+		// Document is the policy to test. Omitted means the one in force, which is how
+		// somebody asks "what is this device enforcing right now".
+		Document json.RawMessage `json:"document,omitempty"`
+	}
+	payload, err := io.ReadAll(io.LimitReader(r.Body, maxPolicyBytes+1))
+	if err != nil {
+		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request", "could not read the body")
+		return
+	}
+	if len(payload) > maxPolicyBytes {
+		httpx.Error(w, s.log, http.StatusRequestEntityTooLarge, "too_large",
+			"that policy is larger than this control plane will accept")
+		return
+	}
+	if err := json.Unmarshal(payload, &req); err != nil {
+		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request", "body must be JSON")
+		return
+	}
+	if req.Device == "" {
+		httpx.Error(w, s.log, http.StatusBadRequest, "bad_request",
+			"name a device to compile for: a membership id, a device id, or its name")
+		return
+	}
+
+	doc, ok := s.policyToTest(w, r, networkID, req.Document)
+	if !ok {
+		return
+	}
+
+	subject, found, err := s.subjectOf(r, networkID, req.Device)
+	if err != nil {
+		s.respondError(w, r, err)
+		return
+	}
+	if !found {
+		httpx.Error(w, s.log, http.StatusNotFound, "not_found",
+			"no device in this network is named by that, or it holds no address")
+		return
+	}
+
+	devices, err := s.store.PolicyDevices(r.Context(), networkID)
+	if err != nil {
+		s.respondError(w, r, err)
+		return
+	}
+	self, ok := selfByKey(devices, subject.key)
+	if !ok {
+		// In the network but not among the devices a policy resolves against: revoked,
+		// suspended, or holding no address. Compiling from a guess would be worse than
+		// saying so.
+		httpx.Error(w, s.log, http.StatusConflict, "not_in_policy",
+			"that device is in this network but not among the devices its policy applies to")
+		return
+	}
+
+	filter, err := acl.Compile(doc, self, devices)
+	if err != nil {
+		httpx.Error(w, s.log, http.StatusBadRequest, "invalid_policy", err.Error())
+		return
+	}
+
+	httpx.WriteJSON(w, s.log, http.StatusOK, map[string]any{
+		"device":        subject.name,
+		"membership_id": subject.membershipID,
+		// What the device is told, rendered as it is sent. A caller comparing this against
+		// what a device reports is comparing the same thing.
+		"filter": filter,
+		// Said explicitly, because an empty rule list means two opposite things depending
+		// on it and somebody reading a dry-run needs to know which.
+		"default_deny": filter.GetDefaultDeny(),
+	})
+}
+
+// policyToTest is the document a dry-run should compile: the one supplied, or the one in
+// force when none was.
+func (s *Server) policyToTest(w http.ResponseWriter, r *http.Request, networkID uuid.UUID,
+	supplied json.RawMessage) (acl.Document, bool) {
+
+	if len(supplied) > 0 {
+		doc, err := acl.Parse(supplied)
+		if err != nil {
+			// Verbatim, for the reason handlePublishPolicy gives: this is an administrator
+			// holding this network's token, and the reason is the whole value.
+			httpx.Error(w, s.log, http.StatusBadRequest, "invalid_policy", err.Error())
+			return acl.Document{}, false
+		}
+		return doc, true
+	}
+
+	policy, err := s.store.ActivePolicy(r.Context(), networkID)
+	if errors.Is(err, store.ErrNoPolicy) {
+		httpx.Error(w, s.log, http.StatusNotFound, "no_policy",
+			"this network has no policy to test; supply a document, or publish one")
+		return acl.Document{}, false
+	}
+	if err != nil {
+		s.respondError(w, r, err)
+		return acl.Document{}, false
+	}
+	return policy.Document, true
+}
+
+// subject is the device a dry-run is about.
+type subject struct {
+	membershipID uuid.UUID
+	name         string
+	key          string
+}
+
+// subjectOf finds the device a dry-run names.
+//
+// By membership id, device id, or name, which is what the CLI accepts and what somebody
+// asking this question has. An ambiguous name is refused rather than resolved: compiling
+// for whichever of two devices called "laptop" sorted first would answer a question nobody
+// asked.
+func (s *Server) subjectOf(r *http.Request, networkID uuid.UUID, want string) (subject, bool, error) {
+	rows, err := s.store.Queries().ListMembershipsForNetwork(r.Context(), networkID)
+	if err != nil {
+		return subject{}, false, err
+	}
+
+	var byName []subject
+	for _, row := range rows {
+		key := ""
+		if row.WireguardPublicKey != nil {
+			key = *row.WireguardPublicKey
+		}
+		found := subject{membershipID: row.MembershipID, name: row.DeviceName, key: key}
+		if row.MembershipID.String() == want || row.DeviceID.String() == want {
+			return found, true, nil
+		}
+		if strings.EqualFold(row.DeviceName, want) {
+			byName = append(byName, found)
+		}
+	}
+	if len(byName) == 1 {
+		return byName[0], true, nil
+	}
+	return subject{}, false, nil
+}
+
+// selfByKey finds a device among those a policy resolves against.
+//
+// By WireGuard key, which is what acl.Device is identified by. The session builder matches
+// on address instead, because the membership row it holds carries addresses and not a key
+// — a difference in what each caller has, not in which device is found.
+func selfByKey(devices []acl.Device, key string) (acl.Device, bool) {
+	if key == "" {
+		return acl.Device{}, false
+	}
+	for _, device := range devices {
+		if device.Key == key {
+			return device, true
+		}
+	}
+	return acl.Device{}, false
 }

--- a/internal/api/policytest_test.go
+++ b/internal/api/policytest_test.go
@@ -1,0 +1,168 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// testPolicy asks what a device would enforce, given a document or the one in force.
+func (h *harness) testPolicy(body string) (int, map[string]any) {
+	h.t.Helper()
+	req, _ := http.NewRequest(http.MethodPost,
+		h.server.URL+"/api/v1/networks/"+h.netID.String()+"/acl/test", bytes.NewReader([]byte(body)))
+	req.Header.Set("Authorization", "Bearer "+testAdminToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var out map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	return resp.StatusCode, out
+}
+
+// rulesOf pulls one direction out of a compiled filter.
+func rulesOf(t *testing.T, body map[string]any, direction string) []any {
+	t.Helper()
+	filter, ok := body["filter"].(map[string]any)
+	if !ok {
+		t.Fatalf("no filter in the answer: %v", body)
+	}
+	rules, _ := filter[direction].([]any)
+	return rules
+}
+
+// The question the route exists for: a policy is written in selectors and what reaches a
+// device is prefixes, and nobody could see the second before publishing the first.
+func TestADryRunCompilesAProposedPolicyWithoutPublishingIt(t *testing.T) {
+	h := newHarness(t)
+	alice := h.enrol("alice")
+	h.enrol("bob")
+
+	proposed := `{"version":1,"rules":[{"src":["*"],"dst":["*"],"protocol":"any"}]}`
+	status, body := h.testPolicy(`{"device":"alice","document":` + proposed + `}`)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %v", status, body)
+	}
+	if body["device"] != "alice" {
+		t.Errorf("device = %v, want alice", body["device"])
+	}
+	if body["membership_id"] != alice.MembershipID.String() {
+		t.Errorf("membership_id = %v, want alice's", body["membership_id"])
+	}
+	if len(rulesOf(t, body, "inbound")) == 0 {
+		t.Error("a permit-everything policy compiled to no inbound rules")
+	}
+
+	// And nothing was published: the network still has no policy.
+	resp := h.getPolicy()
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("the dry-run published something: GET /acl = %d, want 404", resp.StatusCode)
+	}
+}
+
+// Omitting the document asks what a device is enforcing right now.
+func TestADryRunWithNoDocumentUsesTheOneInForce(t *testing.T) {
+	h := newHarness(t)
+	h.enrol("alice")
+
+	resp := h.putPolicy(`{"version":1,"rules":[{"src":["*"],"dst":["*"],"protocol":"any"}]}`)
+	_ = resp.Body.Close()
+
+	status, body := h.testPolicy(`{"device":"alice"}`)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %v", status, body)
+	}
+	if len(rulesOf(t, body, "inbound")) == 0 {
+		t.Error("the live policy compiled to nothing")
+	}
+}
+
+func TestADryRunWithNoDocumentAndNoPolicySaysSo(t *testing.T) {
+	h := newHarness(t)
+	h.enrol("alice")
+
+	status, body := h.testPolicy(`{"device":"alice"}`)
+	if status != http.StatusNotFound {
+		t.Errorf("status = %d, want 404: %v", status, body)
+	}
+	if body["error"] != "no_policy" {
+		t.Errorf("error = %v, want no_policy", body["error"])
+	}
+}
+
+// The reason reaches the author, the same way publishing does. Guessing at why a policy was
+// refused is the thing this endpoint exists to stop.
+func TestADryRunOnAnInvalidDocumentGivesTheReason(t *testing.T) {
+	h := newHarness(t)
+	h.enrol("alice")
+
+	status, body := h.testPolicy(`{"device":"alice","document":{"version":1,"rules":[{"src":["*"],"dst":["*"],"protocol":"icmp","ports":["22"]}]}}`)
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %v", status, body)
+	}
+	if msg, _ := body["message"].(string); msg == "" {
+		t.Errorf("no reason given: %v", body)
+	}
+}
+
+func TestADryRunNeedsADeviceToCompileFor(t *testing.T) {
+	h := newHarness(t)
+	status, body := h.testPolicy(`{}`)
+	if status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: %v", status, body)
+	}
+}
+
+func TestADryRunForADeviceThatIsNotThereIs404(t *testing.T) {
+	h := newHarness(t)
+	h.enrol("alice")
+
+	status, _ := h.testPolicy(`{"device":"nobody","document":{"version":1,"rules":[]}}`)
+	if status != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", status)
+	}
+}
+
+// Compiling for whichever of two devices called "laptop" sorted first would answer a
+// question nobody asked.
+func TestADryRunRefusesAnAmbiguousName(t *testing.T) {
+	h := newHarness(t)
+	h.enrol("laptop")
+	h.enrol("laptop")
+
+	status, _ := h.testPolicy(`{"device":"laptop","document":{"version":1,"rules":[]}}`)
+	if status != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 for an ambiguous name", status)
+	}
+}
+
+// A device is addressable by its ids as well, which is what a script holds.
+func TestADryRunTakesEitherIdAsWellAsAName(t *testing.T) {
+	h := newHarness(t)
+	alice := h.enrol("alice")
+
+	for _, id := range []string{alice.MembershipID.String(), alice.DeviceID.String()} {
+		status, body := h.testPolicy(`{"device":"` + id + `","document":{"version":1,"rules":[]}}`)
+		if status != http.StatusOK {
+			t.Errorf("device=%s: status = %d, want 200: %v", id, status, body)
+		}
+	}
+}
+
+// The compiled filter says what it denies by default, because an empty rule list means two
+// opposite things depending on it.
+func TestADryRunSaysWhetherItDeniesByDefault(t *testing.T) {
+	h := newHarness(t)
+	h.enrol("alice")
+
+	_, body := h.testPolicy(`{"device":"alice","document":{"version":1,"rules":[]}}`)
+	if _, ok := body["default_deny"]; !ok {
+		t.Errorf("the answer does not say whether it denies by default: %v", body)
+	}
+}

--- a/web/app.js
+++ b/web/app.js
@@ -50,6 +50,15 @@ let mintedToken = null;
 /** Which network that token was minted for, so moving away clears it. */
 let shownFor = null;
 
+/**
+ * The last policy dry-run, held here rather than only in the node it was drawn into.
+ *
+ * Same reason as a minted token: every render describes the whole page, so an answer that
+ * lived only in the DOM would vanish the first time a poll redrew the panel — which happens
+ * every few seconds, and is exactly when somebody is reading it.
+ */
+let policyTest = null;
+
 /** Last successful overview, kept so a failed poll can keep showing it — marked stale. */
 let lastGood = null;
 /** What was rendered beside it, so the page can redraw itself without polling again. */
@@ -482,6 +491,113 @@ function forgetButton(device, organizationID) {
   return button;
 }
 
+/**
+ * What a device would enforce, asked of the control plane rather than worked out here.
+ *
+ * A policy is written in selectors and what reaches a device is a packet filter in
+ * prefixes, and the step between them is where a rule that does not do what its author
+ * meant goes unnoticed until somebody cannot reach something. The compile belongs to the
+ * control plane — it resolves against the devices a policy applies to, excluding the
+ * revoked and the addressless, and this page has no business holding a second opinion of
+ * that (ADR-0023).
+ */
+function renderPolicyTest(devices) {
+  if (!may("network.acl.write")) return null;
+
+  const eligible = devices.filter((d) => d.state === "active");
+  if (eligible.length === 0) return null;
+
+  const picker = el(
+    "select",
+    { id: "acl-test-device" },
+    eligible.map((d) =>
+      el("option", { value: d.membership_id, "data-key": d.membership_id }, d.device_name),
+    ),
+  );
+  if (policyTest && eligible.some((d) => d.membership_id === policyTest.membershipID)) {
+    picker.value = policyTest.membershipID;
+  }
+
+  const button = el("button", { type: "button" }, "What does it enforce?");
+  button.addEventListener("click", () => {
+    // Read at the moment of the click. The node outlives the render that built it, so the
+    // device chosen is whatever the picker says now.
+    const membershipID = picker.value;
+    policyTest = null;
+    act(button, async () => {
+      const body = await api(
+        `/api/v1/networks/${encodeURIComponent(currentNetworkID())}/acl/test`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ device: membershipID }),
+        },
+      );
+      policyTest = {
+        membershipID,
+        device: body.device,
+        defaultDeny: body.default_deny,
+        inbound: (body.filter && body.filter.inbound) || [],
+        outbound: (body.filter && body.filter.outbound) || [],
+      };
+      renderFromLastGood();
+    });
+  });
+
+  return el(
+    "div",
+    { class: "panel", "data-key": "acl-test" },
+    el("h3", {}, "Access policy"),
+    el("p", { class: "note" },
+      "What the control plane would send this device, compiled from the policy in force."),
+    picker,
+    " ",
+    button,
+    policyTest ? renderPolicyResult() : null,
+  );
+}
+
+/** The compiled filter, in the prefixes a device enforces rather than the tags somebody wrote. */
+function renderPolicyResult() {
+  const direction = (label, rules) =>
+    el(
+      "div",
+      { "data-key": label },
+      el("div", { class: "note" }, label),
+      rules.length === 0
+        ? el("div", { class: "addr" }, "nothing")
+        : el(
+            "ul",
+            { class: "faults" },
+            rules.map((r, i) =>
+              el(
+                "li",
+                { "data-key": `${label}-${i}` },
+                `${r.allow ? "allow" : "deny"} ${r.protocol || "any"} ` +
+                  `${(r.src_prefixes || []).join(",") || "anywhere"} \u2192 ` +
+                  `${(r.dst_prefixes || []).join(",") || "anywhere"}` +
+                  ((r.ports || []).length ? ` ports ${r.ports.join(",")}` : ""),
+              ),
+            ),
+          ),
+    );
+
+  return el(
+    "div",
+    { class: "result", "data-key": "acl-result" },
+    el("div", {}, el("strong", {}, policyTest.device)),
+    el(
+      "div",
+      { class: "note" },
+      policyTest.defaultDeny
+        ? "Everything not listed is refused."
+        : "Everything is permitted; these rules add nothing.",
+    ),
+    direction("inbound", policyTest.inbound),
+    direction("outbound", policyTest.outbound),
+  );
+}
+
 /** The panel that mints an enrolment token, and shows it exactly once. */
 function renderAddDevice() {
   if (!may("network.enrollment_tokens.write")) return null;
@@ -578,6 +694,7 @@ function renderOverview(data, networks, history) {
       : el("div", { class: "panel note", "data-key": "groups" }, "This network has no route groups."),
     el("h2", { "data-key": "devices-heading" }, "Devices"),
     renderAddDevice(),
+    renderPolicyTest(devices),
     el(
       "div",
       { class: "panel", "data-key": "devices" },
@@ -1011,6 +1128,7 @@ export function bootstrap() {
     unlimited = false;
     mintedToken = null;
     shownFor = null;
+    policyTest = null;
     renderFreshness(null);
     renderSignIn("Signed out.");
   });
@@ -1023,4 +1141,12 @@ export function bootstrap() {
 // in spirit: these are the renderers whose output the reconciler depends on, and the keys
 // they carry are the difference between a button that means what it says and one that
 // inherited somebody else's click handler (#218).
-export { renderDevices, revokeButton, forgetButton, organizationOf, may, fetchPermissions };
+export {
+  renderDevices,
+  revokeButton,
+  forgetButton,
+  organizationOf,
+  may,
+  fetchPermissions,
+  renderPolicyTest,
+};

--- a/web/render.test.js
+++ b/web/render.test.js
@@ -133,3 +133,34 @@ test("the organisation is read from the network the page is showing", () => {
   assert.equal(organizationOf({ network: { id: "missing" } }, networks), null);
   assert.equal(organizationOf(data, undefined), null);
 });
+
+// --- the policy dry-run -------------------------------------------------------------------
+
+const { renderPolicyTest } = await import("./app.js");
+
+test("the dry-run panel is absent for somebody who may not publish a policy", async () => {
+  await granting("network.devices.revoke");
+  assert.equal(renderPolicyTest([device()]), null);
+});
+
+test("the dry-run offers only devices a policy could apply to", async () => {
+  await granting("network.acl.write");
+
+  // A revoked device is not among the devices a policy resolves against, so offering it
+  // would be offering a question the control plane answers with a refusal.
+  assert.equal(renderPolicyTest([device({ state: "revoked" })]), null);
+
+  const panel = renderPolicyTest([
+    device({ state: "active", device_name: "alpha" }),
+    device({ state: "revoked", device_name: "bravo", membership_id: "m-2" }),
+  ]);
+  const options = [...panel.querySelectorAll("option")].map((o) => o.textContent);
+  assert.deepEqual(options, ["alpha"]);
+});
+
+test("the dry-run addresses a device by its membership, which is what the route takes", async () => {
+  await granting("network.acl.write");
+  const d = device();
+  const panel = renderPolicyTest([d]);
+  assert.equal(panel.querySelector("option").value, d.membership_id);
+});

--- a/web/testdata/fixture.py
+++ b/web/testdata/fixture.py
@@ -30,7 +30,7 @@ IDS = {n: "%s-0000-0000-0000-00000000000%d" % ("a" * 8, i) for i, n in enumerate
 DEVICE_IDS = {n: "%s-0000-0000-0000-00000000000%d" % ("d" * 8, i) for i, n in enumerate(NAMES)}
 
 state = {"fault": None, "rename": {}, "revoked": [], "forgotten": [], "tick": 0,
-         "fail_mint": False, "slow_mint": 0}
+         "fail_mint": False, "slow_mint": 0, "acl_fault": False}
 lock = threading.Lock()
 
 
@@ -134,6 +134,28 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         raw = self.rfile.read(int(self.headers.get("content-length") or 0))
+        path = urlparse(self.path).path
+
+        # A compiled filter, as POST /networks/{id}/acl/test answers one. Canned rather than
+        # computed: the page's job is to render what the control plane worked out, and a
+        # fixture that compiled a policy itself would be testing the wrong half.
+        if path.endswith("/acl/test"):
+            body = json.loads(raw or b"{}")
+            with lock:
+                if state["acl_fault"]:
+                    return self.send_json({"error": "invalid_policy",
+                                           "message": "rule 0: names ports with protocol \"icmp\""}, 400)
+                name = next((n for n, i in IDS.items() if i == body.get("device")), body.get("device"))
+            return self.send_json({
+                "device": name,
+                "default_deny": True,
+                "filter": {
+                    "inbound": [{"src_prefixes": ["100.80.0.3/32"], "dst_prefixes": ["100.80.0.2/32"],
+                                 "protocol": "tcp", "ports": ["5432"], "allow": True}],
+                    "outbound": [],
+                },
+            })
+
         if self.path == "/fixture":
             with lock:
                 state.update(json.loads(raw or b"{}"))


### PR DESCRIPTION
A policy is written in **selectors**; what reaches a device is a **packet filter in prefixes**. The step between them is where a rule that doesn't do what its author meant goes unnoticed until somebody can't reach something — and nothing could show it. `meshp acl` shipped without `test` in #228 precisely because a faithful dry-run couldn't be built in one client.

`POST /networks/{id}/acl/test` compiles a document for one device and returns the filter, storing nothing. Omit the document to ask what a device is enforcing *right now*.

## What it looks like

```
$ meshp acl test dbserver --file proposed.json
dbserver in acme/hq, under proposed.json:
  everything not listed below is refused
  inbound:
    allow tcp      10.90.0.3/32 -> 10.90.0.2/32 ports 5432
  outbound: nothing

$ meshp acl test laptop --file proposed.json
laptop in acme/hq, under proposed.json:
  inbound: nothing
  outbound:
    allow tcp      10.90.0.3/32 -> 10.90.0.2/32 ports 5432
```

`tag:laptop` and `tag:server` resolved into the addresses actually allocated, and each device shown its own side of the rule. That is the thing nobody could see before.

## Compiled the way the control plane compiles it

`store.PolicyDevices` — which decides who a policy applies to, excluding the revoked, the suspended and the addressless — then `acl.Compile`. Same inputs as the session builder, so the answer is **what the device would be sent** rather than a second implementation's opinion of it (ADR-0023).

One difference, documented where it lives: the session holds a membership row without a key and matches on address; this has the key and matches on that. Both land on the same device and feed the same compile.

**Behind `acl.write`, not `acl.read`.** A dry-run is a step in publishing and the people who take it are the people who publish — and a caller supplying an arbitrary document could otherwise probe which devices carry which tags, which reading the policy does not tell them.

## Both clients, which is why the endpoint waited

ADR-0032 §5 asks for capability landing everywhere at once. `meshp acl test <device> [--file p.json]`, and the page grows an **Access policy** panel asking the same question of the same route.

The page holds the answer in its own state rather than in the node it was drawn into — same reason a minted token is: every render describes the whole page, so an answer held only in the DOM goes at the next poll, a second or two after somebody starts reading it. Manual check 9 covers that.

## Driven against a real control plane

Two tagged devices and a rule between them. The dry-run resolved the tags into real addresses and gave each device its own side. **Nothing was published by asking** — `acl show` still reported no policy afterwards. Then publishing and asking again gave the same answer.

## Tests

Nine API, three page. Mutation-tested: resolving an ambiguous name, ignoring a supplied document, ignoring the permission, offering revoked devices, and addressing a device by the wrong id each fail exactly the tests that should catch them.

The fixture answers the new route — a page tested against a control plane that doesn't have it is a page tested against the wrong one.

`make lint` 0 issues · `go test ./...` clean · 24 page tests · `make reachability` clean · cross-compiles for all three.