### PR TITLE
feat(web): the policy is edited on the page, as a document

### DIFF
--- a/docs/testing/the-page.md
+++ b/docs/testing/the-page.md
@@ -97,6 +97,15 @@ on a real screen rather than about what a reconciler does to a tree.
    minted token does: every render describes the whole page, so an answer held only in the
    DOM goes at the next poll — which is a second or two after somebody starts reading it.*
 
+10. **Typing survives the page redrawing itself.** In *Access policy*, change a line in the
+    document and leave it. The poll keeps landing — the header counts up — and what you
+    typed is still there, with the cursor where you left it. Then `POST /fixture` with
+    `{"acl_fault":true}` and publish: the control plane's own reason appears above the
+    button, verbatim, rather than a message this page wrote. *The text lives in the page's
+    state rather than in the node it was drawn into; a textarea's contents are a property
+    the attribute loop cannot see, which is the same reason the network picker needed
+    handling.*
+
 ## Note on running this
 
 The fixture sends `cache-control: no-store`, so an edit to `app.js` is picked up by a reload.

--- a/web/app.css
+++ b/web/app.css
@@ -271,3 +271,31 @@ button.quiet {
   color: var(--ink);
   cursor: pointer;
 }
+
+/* --- the policy editor ------------------------------------------------------------- */
+
+/* Monospace and roomy: this is a document somebody is reading for what it says, and JSON
+   read in a proportional font is JSON misread. */
+#acl-document {
+  display: block;
+  width: 100%;
+  margin: 0.75rem 0;
+  padding: 0.6rem 0.7rem;
+  font: 0.85rem/1.5 var(--mono);
+  color: var(--ink);
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  resize: vertical;
+}
+
+/* The diff carries a mark as well as a colour, because colour is never the only signal. */
+ul.diff {
+  font: 0.85rem/1.45 var(--mono);
+  white-space: pre;
+  overflow-x: auto;
+}
+ul.diff li { margin: 0; }
+ul.diff li.same { color: var(--muted); }
+ul.diff li.gone { color: var(--bad); }
+ul.diff li.new { color: var(--ok); }

--- a/web/app.js
+++ b/web/app.js
@@ -59,6 +59,18 @@ let shownFor = null;
  */
 let policyTest = null;
 
+/**
+ * The policy as it is being edited, and the one the control plane holds.
+ *
+ * `policyText` is what is in the box, so a poll redrawing the panel draws what somebody has
+ * typed rather than what the network last published. `policyLive` is what to diff against
+ * and what tells the difference between "no changes" and "no policy".
+ */
+let policyText = null;
+let policyLive = null;
+/** What the control plane said when it refused the last document, shown verbatim. */
+let policyError = null;
+
 /** Last successful overview, kept so a failed poll can keep showing it — marked stale. */
 let lastGood = null;
 /** What was rendered beside it, so the page can redraw itself without polling again. */
@@ -492,6 +504,188 @@ function forgetButton(device, organizationID) {
 }
 
 /**
+ * The policy, edited as a document (ADR-0032 §3).
+ *
+ * Text rather than a form. An access policy is something somebody composes, and a form that
+ * reconstructed it from checkboxes would be a second grammar for the same thing — one that
+ * can express less than the document does and gets the rest subtly wrong. What is stored is
+ * what is reviewed.
+ *
+ * Nothing here decides whether a policy is valid. The control plane parses it, and asking is
+ * a dry-run: the same call that shows what a device would enforce refuses a document it
+ * cannot compile, with the reason. A page holding its own opinion of what a policy means
+ * would be a second implementation of the thing that decides who can reach what.
+ */
+function renderPolicyEditor() {
+  if (!may("network.acl.write")) return null;
+
+  const box = el("textarea", {
+    id: "acl-document",
+    "data-key": "acl-document",
+    rows: 14,
+    spellcheck: "false",
+  }, policyText ?? "");
+  box.addEventListener("input", () => {
+    // Into module state, so the next poll redraws what is being typed rather than replacing
+    // it with what the network published.
+    policyText = box.value;
+    policyError = null;
+    renderFromLastGood();
+  });
+
+  const changed = policyText !== null && policyText !== policyLive;
+
+  const publish = el(
+    "button",
+    { class: "primary", type: "button", disabled: !changed },
+    policyLive === null ? "Publish the first policy" : "Publish",
+  );
+  publish.addEventListener("click", () => {
+    const document_ = policyText;
+    if (!window.confirm(
+      policyLive === null
+        ? "Publish this? Everything it does not permit stops being reachable."
+        : "Publish this policy? Every device in the network is told immediately.",
+    )) {
+      return;
+    }
+    act(publish, async () => {
+      try {
+        await api(`/api/v1/networks/${encodeURIComponent(currentNetworkID())}/acl`, {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: document_,
+        });
+      } catch (err) {
+        // The control plane's own words. "rule 3: names ports with protocol icmp" is the
+        // difference between fixing a policy and guessing at it, and it is the one place
+        // where a detailed error is the whole value.
+        policyError = reason(err);
+        renderFromLastGood();
+        throw err;
+      }
+      // Both cleared so the refresh below reads them back from the control plane.
+      //
+      // A policy is stored parsed, so what comes back is canonical however it was typed —
+      // and keeping the typed text while the live copy became canonical left the editor
+      // reporting changes to a document it had just published. The same disagreement the
+      // CLI's diff had, arriving from the other side.
+      policyText = null;
+      policyLive = null;
+      policyError = null;
+      policyTest = null;
+    }, { refresh: true });
+  });
+
+  return el(
+    "div",
+    { class: "panel", "data-key": "acl-editor" },
+    el("h3", {}, "Access policy"),
+    policyLive === null
+      ? el("p", { class: "note" },
+          "This network has no policy, so every device may reach every other. " +
+          "Publishing one makes everything it does not permit unreachable.")
+      : null,
+    box,
+    policyError ? el("p", { class: "error" }, policyError) : null,
+    changed ? renderPolicyDiff() : el("p", { class: "note" }, "No changes."),
+    publish,
+  );
+}
+
+/** What publishing would change, line by line. */
+function renderPolicyDiff() {
+  const rows = diffLines(policyLive ?? "", policyText ?? "");
+  return el(
+    "div",
+    { class: "result", "data-key": "acl-diff" },
+    el("div", { class: "note" }, "Changes"),
+    el(
+      "ul",
+      { class: "faults diff" },
+      rows.map((row, i) =>
+        el("li", { class: row.kind, "data-key": `d-${i}` }, `${row.mark} ${row.text}`),
+      ),
+    ),
+  );
+}
+
+/**
+ * A line diff, showing only what moved and the lines around it.
+ *
+ * The shared ends are trimmed first, so an edit to one rule is a handful of lines however
+ * long the document is — and the middle is capped, because the subsequence below is O(n*m)
+ * over text somebody is typing into.
+ */
+function diffLines(before, after) {
+  const split = (s) => (s === "" ? [] : s.replace(/\n$/, "").split("\n"));
+  let old = split(before);
+  let next = split(after);
+
+  const head = [];
+  const tail = [];
+  while (old.length && next.length && old[0] === next[0]) {
+    head.push(old.shift());
+    next.shift();
+  }
+  while (old.length && next.length && old[old.length - 1] === next[next.length - 1]) {
+    tail.unshift(old.pop());
+    next.pop();
+  }
+
+  const rows = [];
+  // Only the last few unchanged lines before the change, and the first few after: the rest
+  // is a document somebody can already see in the box above.
+  for (const text of head.slice(-2)) rows.push({ mark: " ", kind: "same", text });
+
+  if (old.length > 400 || next.length > 400) {
+    rows.push({ mark: "…", kind: "same", text: `${old.length} lines replaced by ${next.length}` });
+  } else {
+    const common = commonLines(old, next);
+    let i = 0;
+    let j = 0;
+    for (const line of common) {
+      while (i < old.length && old[i] !== line) rows.push({ mark: "-", kind: "gone", text: old[i++] });
+      while (j < next.length && next[j] !== line) rows.push({ mark: "+", kind: "new", text: next[j++] });
+      rows.push({ mark: " ", kind: "same", text: line });
+      i++;
+      j++;
+    }
+    for (; i < old.length; i++) rows.push({ mark: "-", kind: "gone", text: old[i] });
+    for (; j < next.length; j++) rows.push({ mark: "+", kind: "new", text: next[j] });
+  }
+
+  for (const text of tail.slice(0, 2)) rows.push({ mark: " ", kind: "same", text });
+  return rows;
+}
+
+/** The longest common subsequence of two line lists. */
+function commonLines(a, b) {
+  const table = Array.from({ length: a.length + 1 }, () => new Int32Array(b.length + 1));
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      table[i][j] =
+        a[i] === b[j]
+          ? table[i + 1][j + 1] + 1
+          : Math.max(table[i + 1][j], table[i][j + 1]);
+    }
+  }
+  const out = [];
+  for (let i = 0, j = 0; i < a.length && j < b.length; ) {
+    if (a[i] === b[j]) {
+      out.push(a[i]);
+      i++;
+      j++;
+    } else if (table[i + 1][j] >= table[i][j + 1]) {
+      i++;
+    } else {
+      j++;
+    }
+  }
+  return out;
+}
+
+/**
  * What a device would enforce, asked of the control plane rather than worked out here.
  *
  * A policy is written in selectors and what reaches a device is a packet filter in
@@ -524,15 +718,41 @@ function renderPolicyTest(devices) {
     // device chosen is whatever the picker says now.
     const membershipID = picker.value;
     policyTest = null;
+
+    // The body has to be JSON to carry a document, so text that is not JSON cannot be sent
+    // at all. Said here rather than as a failed request, because this is the one class of
+    // mistake the page can name without asking.
+    let proposed;
+    if (policyText !== null && policyText !== policyLive) {
+      try {
+        proposed = JSON.parse(policyText);
+      } catch (err) {
+        policyError = `That is not JSON yet: ${err.message}`;
+        renderFromLastGood();
+        return;
+      }
+    }
+
     act(button, async () => {
       const body = await api(
         `/api/v1/networks/${encodeURIComponent(currentNetworkID())}/acl/test`,
         {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({ device: membershipID }),
+          // The document being edited, not the one in force. Checking what is live is
+        // available by not having changed anything; checking what you are about to publish
+        // is the question worth asking.
+        // The document being edited, not the one in force. Checking what is live is
+        // available by not having changed anything; checking what you are about to publish
+        // is the question worth asking.
+        body: JSON.stringify(
+          proposed === undefined
+            ? { device: membershipID }
+            : { device: membershipID, document: proposed },
+        ),
         },
       );
+      policyError = null;
       policyTest = {
         membershipID,
         device: body.device,
@@ -694,6 +914,7 @@ function renderOverview(data, networks, history) {
       : el("div", { class: "panel note", "data-key": "groups" }, "This network has no route groups."),
     el("h2", { "data-key": "devices-heading" }, "Devices"),
     renderAddDevice(),
+    renderPolicyEditor(),
     renderPolicyTest(devices),
     el(
       "div",
@@ -954,6 +1175,35 @@ async function fetchHistory(networkID) {
  * anything is worse off than before this slice; somebody staring at an error where the
  * network used to be is worse off than that.
  */
+/**
+ * Reads the policy in force, once for the network being shown.
+ *
+ * A failure leaves the editor empty rather than guessing: an editor pre-filled with a
+ * document the control plane did not send is one somebody could publish believing it was
+ * already live.
+ */
+async function fetchPolicy(networkID) {
+  if (!may("network.acl.write")) return;
+  try {
+    const body = await api(`/api/v1/networks/${encodeURIComponent(networkID)}/acl`);
+    policyLive = JSON.stringify(body.document, null, 2) + "\n";
+  } catch (err) {
+    // A network with no policy is unfiltered, which is a state rather than a failure.
+    policyLive = err.status === 404 ? null : policyLive;
+  }
+  if (policyText === null) policyText = policyLive ?? starterPolicy;
+}
+
+/** What an editor offers a network that has none: deny nothing, written out. */
+const starterPolicy = `{
+  "version": 1,
+  "comment": "Every device may reach every other. Narrow this.",
+  "rules": [
+    { "src": ["*"], "dst": ["*"], "protocol": "any" }
+  ]
+}
+`;
+
 async function fetchPermissions(networkID) {
   try {
     const body = await api(`/api/v1/me/permissions?network=${encodeURIComponent(networkID)}`);
@@ -1082,10 +1332,19 @@ async function start() {
   // is already reading — and never present-then-absent, which would be worse.
   await fetchPermissions(networkID);
   if (networkID !== shownFor) {
-    // A token minted for one network must not still be on screen while another is shown.
+    // A token minted for one network must not still be on screen while another is shown,
+    // and neither must a policy: an editor holding one network's document while another is
+    // named above it is one publish away from the wrong network.
     mintedToken = null;
+    policyText = null;
+    policyLive = null;
+    policyError = null;
+    policyTest = null;
     shownFor = networkID;
   }
+  // Once per network rather than per poll, like the permissions above: a policy changes
+  // rarely, and re-reading it every few seconds would overwrite what somebody is typing.
+  await fetchPolicy(networkID);
   poll(networkID, networks);
 }
 
@@ -1129,6 +1388,9 @@ export function bootstrap() {
     mintedToken = null;
     shownFor = null;
     policyTest = null;
+    policyText = null;
+    policyLive = null;
+    policyError = null;
     renderFreshness(null);
     renderSignIn("Signed out.");
   });
@@ -1149,4 +1411,6 @@ export {
   may,
   fetchPermissions,
   renderPolicyTest,
+  renderPolicyEditor,
+  diffLines,
 };

--- a/web/dom.js
+++ b/web/dom.js
@@ -71,6 +71,11 @@ function wanted(nodes) {
 // spread through twenty renderers. It is deliberately not a framework: it has no components,
 // no state and no lifecycle, and it is only ever called with a tree somebody just built.
 
+/** Whether this element's current contents live in a property rather than in its markup. */
+function holdsAValue(node) {
+  return node.tagName === "SELECT" || node.tagName === "TEXTAREA";
+}
+
 /** What identifies a node between renders, where its position is not enough. */
 function keyOf(node) {
   return node.nodeType === Node.ELEMENT_NODE ? node.getAttribute("data-key") : null;
@@ -109,14 +114,19 @@ function morph(live, next) {
   for (const attr of [...live.attributes]) {
     if (!next.hasAttribute(attr.name)) live.removeAttribute(attr.name);
   }
-  // Which option is selected is a property, not an attribute, so the loop above cannot see
-  // it, and without it the picker would go on naming the network somebody navigated away
-  // from. Read before the children are reconciled, not after: morphChildren() takes nodes
-  // out of `next` as it uses them, so by the time it returns `next` no longer holds the
-  // option this is asking about.
-  const chosen = live.tagName === "SELECT" ? next.value : null;
+  // What a control currently holds is a property, not an attribute, so the loop above
+  // cannot see it — without this the picker would go on naming the network somebody
+  // navigated away from, and a textarea would keep whatever text it was first drawn with.
+  //
+  // Read before the children are reconciled, not after: morphChildren() takes nodes out of
+  // `next` as it uses them, so by the time it returns `next` no longer holds the option
+  // this is asking about. A textarea's text is its child, which is the same problem.
+  //
+  // Assigned only when it differs. A textarea is a thing somebody types into, and writing
+  // the same string back would move their cursor to the end every few seconds.
+  const held = holdsAValue(live) ? next.value : null;
   morphChildren(live, next);
-  if (chosen !== null && live.value !== chosen) live.value = chosen;
+  if (held !== null && live.value !== held) live.value = held;
 }
 
 /**
@@ -173,4 +183,4 @@ function morphChildren(live, next) {
   }
 }
 
-export { el, wanted, keyOf, isTransient, comparable, morph, morphChildren };
+export { el, wanted, keyOf, isTransient, comparable, morph, morphChildren, holdsAValue };

--- a/web/dom.test.js
+++ b/web/dom.test.js
@@ -165,3 +165,21 @@ test("the picker keeps naming the network on screen", () => {
   assert.deepEqual([...live.options].map((o) => o.value), ["one", "two"]);
   assert.equal(live.value, "two");
 });
+
+test("a textarea keeps what somebody typed into it", () => {
+  // Its text is a child node, so a render that redraws the panel would otherwise reconcile
+  // it back to whatever the page last decided it should be — every few seconds, under
+  // somebody's cursor.
+  const live = el("textarea", { "data-key": "policy" }, "original");
+  live.value = "half a sentence somebody is still writing";
+
+  morph(live, el("textarea", { "data-key": "policy" }, "half a sentence somebody is still writing"));
+  assert.equal(live.value, "half a sentence somebody is still writing");
+});
+
+test("a textarea does take a value the page deliberately changed", () => {
+  const live = el("textarea", { "data-key": "policy" }, "old");
+  live.value = "old";
+  morph(live, el("textarea", { "data-key": "policy" }, "loaded from the control plane"));
+  assert.equal(live.value, "loaded from the control plane");
+});

--- a/web/render.test.js
+++ b/web/render.test.js
@@ -164,3 +164,74 @@ test("the dry-run addresses a device by its membership, which is what the route 
   const panel = renderPolicyTest([d]);
   assert.equal(panel.querySelector("option").value, d.membership_id);
 });
+
+// --- the policy editor --------------------------------------------------------------------
+
+const { renderPolicyEditor, diffLines } = await import("./app.js");
+
+test("the editor is absent for somebody who may not publish a policy", async () => {
+  await granting("network.devices.revoke");
+  assert.equal(renderPolicyEditor(), null);
+});
+
+test("the editor is a box holding the document, not a form describing it", async () => {
+  await granting("network.acl.write");
+  const panel = renderPolicyEditor();
+  const box = panel.querySelector("textarea#acl-document");
+  assert.ok(box, "there is no document to edit");
+  // Keyed, so a poll reconciles it rather than replacing the node somebody is typing into.
+  assert.equal(box.dataset.key, "acl-document");
+});
+
+test("a diff shows the line that changed and the ones around it", () => {
+  // Long enough that trimming matters: a real policy is dozens of lines and the change is
+  // one of them, so showing the document back is showing the box above again.
+  const lead = Array.from({ length: 20 }, (_, i) => `  "pad${i}": ${i},`).join("\n");
+  const rows = diffLines(`{\n${lead}\n  "comment": "old",\n  "rules": []\n}\n`,
+                         `{\n${lead}\n  "comment": "new",\n  "rules": []\n}\n`);
+  const marks = rows.map((r) => r.mark + r.text.trim());
+  assert.ok(marks.includes(`-"comment": "old",`), `no removal: ${marks.join(" | ")}`);
+  assert.ok(marks.includes(`+"comment": "new",`), `no addition: ${marks.join(" | ")}`);
+  assert.ok(rows.filter((r) => r.kind === "same").length <= 4,
+    `${rows.filter((r) => r.kind === "same").length} context lines from a 24-line document`);
+});
+
+test("a first policy is all additions", () => {
+  const rows = diffLines("", '{\n  "version": 1\n}\n');
+  assert.equal(rows.filter((r) => r.kind === "gone").length, 0);
+  assert.ok(rows.some((r) => r.kind === "new"));
+});
+
+test("an unchanged document produces no marks", () => {
+  const doc = '{\n  "version": 1\n}\n';
+  const rows = diffLines(doc, doc);
+  assert.equal(rows.filter((r) => r.kind !== "same").length, 0);
+});
+
+// A rule inserted in the middle must read as an insertion, not as everything below it
+// being rewritten — the same property the CLI's diff has, for the same reason.
+test("an insertion does not rewrite what follows", () => {
+  const rows = diffLines("a\nb\nc\nd\ne\n", "a\nb\nINSERTED\nc\nd\ne\n");
+  assert.equal(rows.filter((r) => r.kind === "gone").length, 0);
+  assert.equal(rows.filter((r) => r.kind === "new").length, 1);
+});
+
+// Two changes with unchanged lines between them, which trimming the ends cannot collapse.
+// Without matching by subsequence the middle reads as five lines replaced by five rather
+// than as two lines that moved — and the test above cannot tell, because one change at the
+// edge is trimmed away before the subsequence is reached.
+test("lines between two changes are recognised rather than rewritten", () => {
+  const rows = diffLines("a\nb\nc\nd\ne\nf\ng\n", "a\nX\nc\nd\ne\nY\ng\n");
+  const gone = rows.filter((r) => r.kind === "gone").map((r) => r.text);
+  const added = rows.filter((r) => r.kind === "new").map((r) => r.text);
+  assert.deepEqual(gone, ["b", "f"], `removed ${gone.join(",")}`);
+  assert.deepEqual(added, ["X", "Y"], `added ${added.join(",")}`);
+});
+
+// The subsequence is O(n*m) over text somebody is typing into, so it is bounded.
+test("two wholly different documents are summarised rather than compared", () => {
+  const before = Array.from({ length: 500 }, (_, i) => `old ${i}`).join("\n");
+  const after = Array.from({ length: 500 }, (_, i) => `new ${i}`).join("\n");
+  const rows = diffLines(before, after);
+  assert.ok(rows.some((r) => r.text.includes("lines replaced by")), "it tried the full compare");
+});

--- a/web/testdata/fixture.py
+++ b/web/testdata/fixture.py
@@ -30,7 +30,8 @@ IDS = {n: "%s-0000-0000-0000-00000000000%d" % ("a" * 8, i) for i, n in enumerate
 DEVICE_IDS = {n: "%s-0000-0000-0000-00000000000%d" % ("d" * 8, i) for i, n in enumerate(NAMES)}
 
 state = {"fault": None, "rename": {}, "revoked": [], "forgotten": [], "tick": 0,
-         "fail_mint": False, "slow_mint": 0, "acl_fault": False}
+         "fail_mint": False, "slow_mint": 0, "acl_fault": False,
+         "policy": None, "policy_version": 0}
 lock = threading.Lock()
 
 
@@ -115,6 +116,15 @@ class Handler(BaseHTTPRequestHandler):
                 return self.send_json({"permissions": [], "unlimited": True})
             if path == "/api/v1/networks":
                 return self.send_json(NETWORKS)
+            if path.endswith("/acl"):
+                # A network with no policy answers 404, which is a state rather than a
+                # failure — the page has to tell those apart.
+                if state["policy"] is None:
+                    return self.send_json({"error": "no_policy",
+                                           "message": "this network has no policy"}, 404)
+                return self.send_json({"version": state["policy_version"],
+                                       "created_at": "2026-09-02T00:00:00Z",
+                                       "document": state["policy"]})
         name = "index.html" if path in ("/", "") else path.lstrip("/")
         try:
             with open(os.path.join(ROOT, name), "rb") as fh:
@@ -170,6 +180,25 @@ class Handler(BaseHTTPRequestHandler):
             time.sleep(state["slow_mint"])
             return self.send_json({"token": "mp_" + "k" * 40})
         self.send_json({"error": "not_found"}, 404)
+
+    def do_PUT(self):
+        raw = self.rfile.read(int(self.headers.get("content-length") or 0))
+        path = urlparse(self.path).path
+        if not path.endswith("/acl"):
+            return self.send_json({"error": "not_found"}, 404)
+        with lock:
+            if state["acl_fault"]:
+                # The control plane's own words, which is what the page shows verbatim.
+                return self.send_json({"error": "invalid_policy",
+                                       "message": "rule 0: names ports with protocol \"icmp\""}, 400)
+            try:
+                state["policy"] = json.loads(raw or b"{}")
+            except ValueError:
+                return self.send_json({"error": "invalid_policy",
+                                       "message": "that is not JSON"}, 400)
+            state["policy_version"] += 1
+            return self.send_json({"status": "published",
+                                   "version": state["policy_version"]})
 
     def do_DELETE(self):
         path = urlparse(self.path).path


### PR DESCRIPTION
The other half of ADR-0032 §3. #229 gave the page a dry-run; this gives it the thing being dry-run — the document itself, in a box, diffed against what is live.

**Text rather than a form**, which is what §3 asked for and why it took an ADR to overturn ADR-0022 §5. An access policy is something somebody composes; a form reconstructing it from checkboxes would be a second grammar for the same thing — one that expresses less than the document does and gets the rest subtly wrong. What is stored is what is reviewed.

## Nothing here decides whether a policy is valid

The page names the one class of mistake it can tell — text that is not JSON cannot go in a JSON body — and everything else is the control plane's answer, verbatim:

```
That is not JSON yet: Expected property name or '}' in JSON at position 2
rule 0: names ports with protocol "icmp"
```

The first is the page's; the second is the control plane's. A page holding its own opinion of what a policy means would be a second implementation of the thing that decides who can reach what.

The dry-run now tests **what is in the box** rather than what is in force, which is the question worth asking. Checking the live policy is still available by not having changed anything.

## `morph` learned about `textarea`, which it needed to

What a control currently holds is a property rather than an attribute — the reason the network picker needed handling — and a textarea's text is its child node besides. Without this, a poll reconciles the box back to what the page last decided it should be, **every few seconds, under somebody's cursor**. Assigned only when it differs, for the same reason.

## It hit the CLI's bug from the other side

A policy is stored parsed, so what comes back is canonical however it was typed. Keeping the typed text while the live copy became canonical left the editor **reporting changes to a document it had just published**. Both are re-read from the control plane after a publish now.

Same disagreement #228 fixed in the CLI's diff, arriving from the opposite direction.

## Two tests could not fail at first

The context test used a document short enough that trimming the shared ends changed nothing. The insertion test put its change where trimming removed it *before the subsequence was reached* — so neither noticed when the subsequence was replaced with an empty list.

Rewritten: a longer document, and two changes separated by lines that have to be recognised rather than rewritten. Both now fail under mutation, along with the permission gate and the cap.

## Driven against the fixture

Which now answers `GET` and `PUT /acl`. A first policy from the starter, published and read back canonically · an edit showing only the line that moved · typing surviving four polls · the dry-run carrying the edited document · both refusal paths.

Manual check 10 covers what jsdom cannot: that the cursor stays where it was.

`make lint` 0 issues · `go test ./...` clean · **34 page tests** · `make reachability` clean.