### PR TITLE
fix(web): lay the page out around what somebody came for

### DIFF
--- a/web/app.css
+++ b/web/app.css
@@ -79,13 +79,26 @@ main { max-width: 1100px; margin: 0 auto; padding: 16px; }
   background: var(--panel);
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  padding: 16px;
-  margin-bottom: 16px;
+  padding: 14px 16px;
+  margin-bottom: 12px;
 }
 
+/* A panel holding one control does not need to look like a section. */
+.panel.slim { padding: 10px 16px; }
+
 h1 { font-size: 20px; margin: 0 0 4px; }
-h2 { font-size: 15px; margin: 24px 0 10px; color: var(--muted); font-weight: 600; }
+h2 {
+  font-size: 13px;
+  margin: 28px 0 10px;
+  color: var(--muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+h2:first-of-type { margin-top: 22px; }
+h3 { font-size: 15px; margin: 0 0 10px; font-weight: 600; }
 p { margin: 0 0 12px; }
+p:last-child { margin-bottom: 0; }
 
 code, .mono { font-family: var(--mono); font-size: 13px; }
 
@@ -96,6 +109,7 @@ code, .mono { font-family: var(--mono); font-size: 13px; }
   gap: 10px;
   flex-wrap: wrap;
   border-left: 4px solid var(--ok);
+  padding: 18px 20px;
 }
 .verdict.problems { border-left-color: var(--bad); }
 .verdict h1 { font-size: 22px; }
@@ -105,8 +119,8 @@ code, .mono { font-family: var(--mono); font-size: 13px; }
  * device carries which prefixes is a relationship and reads badly as rows. */
 .group {
   display: grid;
-  grid-template-columns: minmax(220px, 1fr) 2fr;
-  gap: 16px;
+  grid-template-columns: minmax(200px, 260px) minmax(0, 1fr);
+  gap: 24px;
   align-items: start;
 }
 @media (max-width: 700px) {
@@ -170,22 +184,35 @@ form.signin { display: flex; flex-direction: column; gap: 2px; align-items: stre
 form.signin button.primary { margin-top: 14px; align-self: flex-start; }
 input[type="password"], input[type="email"], input[type="text"], select {
   font: inherit;
-  padding: 8px 10px;
+  padding: 7px 10px;
   border: 1px solid var(--line);
   border-radius: 8px;
   background: var(--bg);
   color: var(--ink);
-  min-width: 260px;
 }
-button.primary {
+input[type="password"], input[type="email"], input[type="text"] { min-width: 260px; }
+
+/* Controls that belong on one line, wrapping rather than overflowing on a phone. */
+.row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-top: 14px; }
+.row > .result { flex-basis: 100%; }
+button {
   font: inherit;
-  padding: 8px 14px;
-  border: 1px solid transparent;
+  padding: 7px 13px;
+  border: 1px solid var(--line);
   border-radius: 8px;
-  background: var(--ink);
-  color: var(--panel);
+  background: var(--panel);
+  color: var(--ink);
   cursor: pointer;
 }
+button:hover:not(:disabled) { border-color: var(--muted); }
+button:disabled { opacity: 0.5; cursor: default; }
+
+button.primary {
+  border-color: transparent;
+  background: var(--ink);
+  color: var(--panel);
+}
+button.primary:hover:not(:disabled) { opacity: 0.85; }
 .error { color: var(--bad); }
 
 .picker { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
@@ -218,13 +245,10 @@ th.actions {
 }
 
 button.danger {
-  background: transparent;
-  border: 1px solid var(--bad);
+  border-color: color-mix(in srgb, var(--bad) 45%, var(--line));
   color: var(--bad);
-  border-radius: 4px;
-  padding: 0.2rem 0.6rem;
-  font: inherit;
-  cursor: pointer;
+  padding: 4px 10px;
+  font-size: 13px;
 }
 
 button.danger:hover:not(:disabled) {

--- a/web/app.js
+++ b/web/app.js
@@ -522,7 +522,7 @@ function renderPolicyEditor() {
   const box = el("textarea", {
     id: "acl-document",
     "data-key": "acl-document",
-    rows: 14,
+    rows: 10,
     spellcheck: "false",
   }, policyText ?? "");
   box.addEventListener("input", () => {
@@ -580,7 +580,6 @@ function renderPolicyEditor() {
   return el(
     "div",
     { class: "panel", "data-key": "acl-editor" },
-    el("h3", {}, "Access policy"),
     policyLive === null
       ? el("p", { class: "note" },
           "This network has no policy, so every device may reach every other. " +
@@ -766,15 +765,32 @@ function renderPolicyTest(devices) {
 
   return el(
     "div",
-    { class: "panel", "data-key": "acl-test" },
-    el("h3", {}, "Access policy"),
-    el("p", { class: "note" },
-      "What the control plane would send this device, compiled from the policy in force."),
+    { class: "row", "data-key": "acl-test" },
+    el("label", { class: "note", for: "acl-test-device" }, "Compile it for"),
     picker,
-    " ",
     button,
     policyTest ? renderPolicyResult() : null,
   );
+}
+
+/**
+ * The policy, and the two things somebody does with it.
+ *
+ * One panel because it is one job: the document is edited and then checked against a
+ * device, and splitting them put the same heading on the page twice with a card boundary
+ * between two halves of the same sentence.
+ */
+function renderPolicy(devices) {
+  const editor = renderPolicyEditor();
+  if (editor === null) {
+    return el("div", { class: "panel note", "data-key": "acl" },
+      "You may not change this network's policy.");
+  }
+  // The dry-run inside the same panel, under a rule: it is the last step of publishing,
+  // not a separate feature.
+  const test = renderPolicyTest(devices);
+  if (test !== null) editor.append(test);
+  return editor;
 }
 
 /** The compiled filter, in the prefixes a device enforces rather than the tags somebody wrote. */
@@ -849,8 +865,7 @@ function renderAddDevice() {
 
   return el(
     "div",
-    { class: "panel", "data-key": "add-device" },
-    el("h3", {}, "Add a device"),
+    { class: mintedToken ? "panel" : "panel slim", "data-key": "add-device" },
     button,
     mintedToken ? renderMintedToken() : null,
   );
@@ -905,17 +920,18 @@ function renderOverview(data, networks, history) {
 
   // Keyed section by section, so that a panel which comes and goes — the one that mints a
   // token exists only for somebody who may mint one — moves nothing else on the page.
+  // Ordered by what somebody came for. The verdict answers the question the page exists to
+  // answer; the devices are what they look at next; the things that change the network come
+  // after the things that describe it, and the trail is last because it is history.
+  //
+  // A heading owns what follows it. "Devices" used to sit above three panels that were not
+  // devices, with the table below them — which is the sort of thing that reads as a page
+  // nobody laid out.
   update(
     renderNetworkBar(data, networks),
     renderVerdict(data, data.fault_count || 0),
-    el("h2", { "data-key": "carried-heading" }, "What is carried, and by what"),
-    data.route_groups.length
-      ? el("div", { "data-key": "groups" }, data.route_groups.map(renderGroup))
-      : el("div", { class: "panel note", "data-key": "groups" }, "This network has no route groups."),
+
     el("h2", { "data-key": "devices-heading" }, "Devices"),
-    renderAddDevice(),
-    renderPolicyEditor(),
-    renderPolicyTest(devices),
     el(
       "div",
       { class: "panel", "data-key": "devices" },
@@ -928,6 +944,16 @@ function renderOverview(data, networks, history) {
           )
         : null,
     ),
+    renderAddDevice(),
+
+    el("h2", { "data-key": "carried-heading" }, "What is carried, and by what"),
+    data.route_groups.length
+      ? el("div", { "data-key": "groups" }, data.route_groups.map(renderGroup))
+      : el("div", { class: "panel note", "data-key": "groups" }, "This network has no route groups."),
+
+    el("h2", { "data-key": "policy-heading" }, "Access policy"),
+    renderPolicy(devices),
+
     el("h2", { "data-key": "history-heading" }, "What has happened"),
     renderHistory(history),
   );
@@ -1006,7 +1032,7 @@ function renderNetworkBar(data, networks) {
 
   return el(
     "div",
-    { class: "panel picker", "data-key": "picker" },
+    { class: "panel slim picker", "data-key": "picker" },
     el("label", { for: "network" }, "Network"),
     select,
     el("span", { class: "note" }, `state version ${data.network.state_version}`),


### PR DESCRIPTION
It read as **eight identical cards in whatever order they were written**. That is what "vibe coded" describes, and it was accurate.

## The heading did not own what followed it

"Devices" sat above the panel that *adds* one, then the policy editor, then the dry-run — with the actual devices table three panels further down.

Devices are now under Devices, and they come first. The verdict answers the question the page exists for; the table is what somebody looks at next; the things that *change* a network follow the things that *describe* it; the trail is last because it is history.

## Two panels were both titled "Access policy"

I introduced that in #230 and should have caught it. They are one job — a document is edited and then checked against a device — so they are one panel, with the dry-run reading as the last step of publishing rather than a separate feature.

## Not every button was styled

`button.primary` and `button.danger` existed and nothing else did, so **"What does it enforce?" shipped in #229 as the browser's default control** next to two designed ones. That single detail did more to make the page look unfinished than anything else on it.

There is a base style now and both are variants of it — which is also why the revoke button no longer carries its own radius and padding.

## Panels holding one control looked like sections

The network picker and the enrolment button each had a full card. Both are slim now, and the picker reads as navigation rather than content.

## And the smaller things

Headings are uppercase and spaced rather than grey text the same size as the notes *inside* panels — there were two competing systems and no way to tell where one thing ended and the next began. The select is no longer 260px wide, having inherited a minimum meant for sign-in fields. The route groups had a fixed `2fr` that stranded the right half of a wide screen.

## Result

At 1100px the page went from **1831px tall to 1564px**, with the devices table above the fold rather than below a fourteen-row textarea.

Checked in both themes and at 375px, where the table scrolls inside its own container and the page does not. All 34 page tests pass — this is layout and style, not behaviour.

**Not in this PR:** the topology view. That is the standing requirement and the thing that would make this look like a network product rather than a well-ordered list, and it deserves its own change.