### PR TITLE
feat(web): the network, as a picture

### DIFF
--- a/web/app.css
+++ b/web/app.css
@@ -323,3 +323,46 @@ ul.diff li { margin: 0; }
 ul.diff li.same { color: var(--muted); }
 ul.diff li.gone { color: var(--bad); }
 ul.diff li.new { color: var(--ok); }
+
+/* --- the network, as a picture ------------------------------------------------------ */
+
+/* Everything relays (ADR-0002), so this is a hub. It is drawn rather than described
+   because the shape of a network is the one thing a table cannot show, and because the hub
+   being visible is honest about why throughput is what it is. */
+.topology { padding: 8px 16px 14px; }
+/* Its natural size where there is room, scaled down where there is not. The width and
+   height attributes carry that size; this only stops it overflowing a narrow screen. */
+.topology svg { display: block; max-width: 100%; height: auto; margin: 0 auto; }
+
+.topology .spoke { stroke: var(--line); stroke-width: 1.5; }
+.topology .spoke.bad { stroke: color-mix(in srgb, var(--bad) 55%, var(--line)); }
+.topology .spoke.warn { stroke: color-mix(in srgb, var(--warn) 55%, var(--line)); }
+
+.topology .hub { fill: var(--bg); stroke: var(--muted); stroke-width: 1.5; }
+.topology .hub-label {
+  text-anchor: middle;
+  fill: var(--muted);
+  font: 500 11px/1 var(--sans);
+}
+
+.topology .node { fill: var(--panel); stroke-width: 2; }
+.topology .node.ok { stroke: var(--ok); }
+.topology .node.warn { stroke: var(--warn); }
+.topology .node.bad { stroke: var(--bad); fill: var(--bad); }
+.topology .node.unknown { stroke: var(--unknown); }
+
+/* The mark, not only the colour. A reader who cannot see the red still sees the ! */
+.topology .node-mark {
+  text-anchor: middle;
+  fill: var(--panel);
+  font: 700 9px/1 var(--sans);
+}
+
+.topology .node-label {
+  fill: var(--ink);
+  font: 500 11px/1 var(--sans);
+  dominant-baseline: middle;
+}
+.topology .node-label.end { text-anchor: end; }
+/* One node standing for many, drawn as more than one thing. */
+.topology .node.many { fill: var(--bg); stroke-dasharray: 3 2; }

--- a/web/app.js
+++ b/web/app.js
@@ -504,6 +504,214 @@ function forgetButton(device, organizationID) {
 }
 
 /**
+ * The network as a picture.
+ *
+ * Everything relays (ADR-0002), so this is a hub and not a mesh. Drawing device-to-device
+ * links would show paths that do not exist — the one thing a diagram of a network must not
+ * do — and the hub is worth seeing for itself: it is why throughput is what it is, and it
+ * is what a direct path would eventually remove.
+ *
+ * What the picture is for is the question this page exists to answer: is anything
+ * unreachable, and what is carrying for it. So a device that is faulted or that carries a
+ * prefix is drawn and named, and the rest are dots. At five hundred devices a ring of five
+ * hundred labels is decoration; a ring of five hundred dots with the interesting ones
+ * called out is a diagram.
+ *
+ * Nothing here says which advertiser is *chosen*. The server owns the order and the agent
+ * owns the choice (ADR-0003), so no such fact exists to draw.
+ */
+function renderTopology(data, devices) {
+  const carriers = new Map();
+  for (const group of data.route_groups || []) {
+    for (const advertiser of group.advertisers || []) {
+      const carried = carriers.get(advertiser.membership_id) || [];
+      carried.push(group.slug);
+      carriers.set(advertiser.membership_id, carried);
+    }
+  }
+
+  const nodes = devices.map((device) => {
+    const faults = (device.faults || []).length;
+    const carrying = carriers.get(device.membership_id) || [];
+    return {
+      id: device.membership_id,
+      name: device.device_name,
+      faults,
+      carrying,
+      // Named when it is worth naming. Everything else is a dot, which is what lets this
+      // stay legible at the five hundred devices one overview carries.
+      notable: faults > 0 || carrying.length > 0,
+      state: device.state !== "active" ? "unknown" : deviceHealth(device),
+    };
+  });
+
+  if (nodes.length === 0) {
+    return el("div", { class: "panel note", "data-key": "topology" },
+      "No devices have joined this network yet.");
+  }
+
+  // Notable first, so the labelled ones sit together at the top of the ring rather than
+  // being scattered by whatever order the list arrived in.
+  nodes.sort((a, b) => (b.notable ? 1 : 0) - (a.notable ? 1 : 0));
+
+  // Past a couple of dozen, everything gets its own dot and none of them can be read: at
+  // the five hundred devices one overview carries they are three pixels apart. So the ones
+  // worth seeing are drawn and the rest are counted, which is what the picture was for —
+  // is anything unreachable, and what is carrying for it. A ring of five hundred identical
+  // dots answers neither.
+  const drawn = [];
+  let summarised = 0;
+  for (const node of nodes) {
+    if (nodes.length <= 24 || node.notable) drawn.push(node);
+    else summarised++;
+  }
+  if (summarised > 0) {
+    drawn.push({
+      id: "others",
+      name: `${summarised} more, all well`,
+      faults: 0,
+      carrying: [],
+      notable: true,
+      state: "ok",
+      many: true,
+    });
+  }
+
+  // Enough room for the labels to sit outside the ring without crowding, and no more. A
+  // ring wide enough for forty devices drawn around four is mostly empty panel.
+  const radius = Math.max(105, Math.min(240, 60 + drawn.length * 9));
+
+  const placed = drawn.map((node, i) => {
+    // From the top, clockwise. Starting at twelve o'clock puts the first notable device
+    // where somebody looks first.
+    const angle = (i / drawn.length) * 2 * Math.PI - Math.PI / 2;
+    return { ...node, x: radius * Math.cos(angle), y: radius * Math.sin(angle), angle };
+  });
+
+  // The viewBox is the content, measured, rather than a fixed canvas the content sits
+  // somewhere inside. Labels are the widest thing here and they are what decides it.
+  let minX = -40;
+  let maxX = 40;
+  let minY = -40;
+  let maxY = 40;
+  for (const node of placed) {
+    const right = Math.cos(node.angle) >= 0;
+    // Estimated rather than measured: nothing is in the document yet, and a label's width
+    // only has to be close enough that it is not clipped.
+    const width = node.notable ? labelWidth(node) : 0;
+    minX = Math.min(minX, node.x - 10 - (right ? 0 : width));
+    maxX = Math.max(maxX, node.x + 10 + (right ? width : 0));
+    minY = Math.min(minY, node.y - 12);
+    maxY = Math.max(maxY, node.y + 12);
+  }
+  const pad = 12;
+  const boxW = maxX - minX + pad * 2;
+  const boxH = maxY - minY + pad * 2;
+  const svg = elNS("svg", {
+    viewBox: `${minX - pad} ${minY - pad} ${boxW} ${boxH}`,
+    // Its natural size in pixels as well, so a user unit is a pixel and the labels render
+    // at the size they are set in. With only a viewBox the browser scales to the container,
+    // which made a four-device diagram twice life size and a forty-device one half.
+    width: Math.round(boxW),
+    height: Math.round(boxH),
+    role: "img",
+    "aria-label":
+      `${nodes.length} device${nodes.length === 1 ? "" : "s"}, each reaching the others ` +
+      `through a relay. ${nodes.filter((n) => n.faults).length} with something wrong.`,
+  });
+
+  const centre = 0;
+  const cy = 0;
+
+  // Spokes first, so nodes draw over them.
+  for (const node of placed) {
+    svg.append(elNS("line", {
+      x1: centre, y1: cy, x2: node.x, y2: node.y,
+      class: `spoke ${node.state}`,
+      "data-key": `spoke-${node.id}`,
+    }));
+  }
+
+  svg.append(
+    elNS("circle", { cx: centre, cy, r: 22, class: "hub", "data-key": "hub" }),
+    elNS("text", { x: centre, y: cy + 4, class: "hub-label", "data-key": "hub-label" }, "relay"),
+  );
+
+  for (const node of placed) {
+    const right = Math.cos(node.angle) >= 0;
+    svg.append(
+      elNS("circle", {
+        cx: node.x, cy: node.y, r: node.many ? 11 : node.notable ? 7 : 4,
+        class: `node ${node.state}${node.many ? " many" : ""}`,
+        "data-key": `node-${node.id}`,
+      }),
+    );
+    // A fault is marked as well as coloured, because colour is never the only signal.
+    if (node.faults > 0) {
+      svg.append(elNS("text", {
+        x: node.x, y: node.y + 4, class: "node-mark", "data-key": `mark-${node.id}`,
+      }, "!"));
+    }
+    if (node.notable) {
+      const label = node.carrying.length
+        ? `${node.name} · ${node.carrying.join(", ")}`
+        : node.name;
+      svg.append(elNS("text", {
+        x: node.x + (right ? 13 : -13),
+        y: node.y + 4,
+        class: `node-label ${right ? "" : "end"}`,
+        "data-key": `label-${node.id}`,
+      }, label));
+    }
+  }
+
+  return el(
+    "div",
+    { class: "panel topology", "data-key": "topology" },
+    svg,
+    el("p", { class: "note" },
+      "Every device reaches every other through a relay; nothing discovers a direct path " +
+      "yet (ADR-0002). " +
+      (summarised > 0
+        ? "Devices carrying a prefix or reporting a fault are drawn; the rest are counted."
+        : "Named devices are the ones carrying a prefix or reporting a fault.")),
+  );
+}
+
+/** Roughly how wide a label will be, for deciding the viewBox before anything is drawn. */
+function labelWidth(node) {
+  const text = node.carrying.length ? `${node.name} · ${node.carrying.join(", ")}` : node.name;
+  return text.length * 6 + 8;
+}
+
+/** How a device reads, in one word, for the diagram. */
+function deviceHealth(device) {
+  if ((device.faults || []).length > 0) return "bad";
+  if (!device.connected) return "warn";
+  return "ok";
+}
+
+/**
+ * el() for SVG, which needs its own namespace.
+ *
+ * Separate rather than a flag on el(): every caller of el() builds HTML, and a boolean that
+ * changes which document tree a node belongs to is the kind of argument somebody gets wrong
+ * once and then cannot find.
+ */
+function elNS(tag, attrs = {}, ...children) {
+  const node = document.createElementNS("http://www.w3.org/2000/svg", tag);
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value === null || value === undefined || value === false) continue;
+    node.setAttribute(key, value);
+  }
+  for (const child of children.flat()) {
+    if (child === null || child === undefined || child === false) continue;
+    node.append(typeof child === "string" ? document.createTextNode(child) : child);
+  }
+  return node;
+}
+
+/**
  * The policy, edited as a document (ADR-0032 §3).
  *
  * Text rather than a form. An access policy is something somebody composes, and a form that
@@ -930,6 +1138,7 @@ function renderOverview(data, networks, history) {
   update(
     renderNetworkBar(data, networks),
     renderVerdict(data, data.fault_count || 0),
+    renderTopology(data, devices),
 
     el("h2", { "data-key": "devices-heading" }, "Devices"),
     el(
@@ -1439,4 +1648,5 @@ export {
   renderPolicyTest,
   renderPolicyEditor,
   diffLines,
+  renderTopology,
 };

--- a/web/render.test.js
+++ b/web/render.test.js
@@ -235,3 +235,95 @@ test("two wholly different documents are summarised rather than compared", () =>
   const rows = diffLines(before, after);
   assert.ok(rows.some((r) => r.text.includes("lines replaced by")), "it tried the full compare");
 });
+
+// --- the network, as a picture ------------------------------------------------------------
+
+const { renderTopology } = await import("./app.js");
+
+/** A network of n devices, with the given indexes faulted and carrying. */
+function network(n, { faults = [], carrying = [] } = {}) {
+  const devices = Array.from({ length: n }, (_, i) => ({
+    membership_id: `m${i}`,
+    device_id: `d${i}`,
+    device_name: `dev${i}`,
+    state: "active",
+    connected: true,
+    faults: faults.includes(i) ? [{ message: "has not applied its configuration" }] : [],
+  }));
+  const data = {
+    route_groups: carrying.length
+      ? [{ slug: "office", advertisers: carrying.map((i) => ({ membership_id: `m${i}` })) }]
+      : [],
+  };
+  return { data, devices };
+}
+
+const drawOf = (n, opts) => {
+  const { data, devices } = network(n, opts);
+  return renderTopology(data, devices).querySelector("svg");
+};
+
+// The property that matters most. Everything relays (ADR-0002), so a line between two
+// devices would be a path that does not exist — the one thing a diagram of a network must
+// not draw. Every line here starts at the hub.
+test("no line joins two devices, because no such path exists", () => {
+  const svg = drawOf(8, { faults: [1], carrying: [0, 2] });
+  const hub = svg.querySelector("circle.hub");
+  const cx = Number(hub.getAttribute("cx"));
+  const cy = Number(hub.getAttribute("cy"));
+
+  const lines = [...svg.querySelectorAll("line")];
+  assert.ok(lines.length > 0, "nothing was drawn");
+  for (const line of lines) {
+    assert.equal(Number(line.getAttribute("x1")), cx, "a line does not start at the relay");
+    assert.equal(Number(line.getAttribute("y1")), cy, "a line does not start at the relay");
+  }
+});
+
+test("a small network draws every device", () => {
+  assert.equal(drawOf(6).querySelectorAll("circle.node").length, 6);
+});
+
+test("only devices worth naming are named", () => {
+  const svg = drawOf(6, { faults: [1], carrying: [0] });
+  const labels = [...svg.querySelectorAll(".node-label")].map((t) => t.textContent);
+  assert.equal(labels.length, 2, `labelled ${labels.join(", ")}`);
+  assert.ok(labels.some((l) => l.startsWith("dev1")), "the faulted device is not named");
+  assert.ok(labels.some((l) => l.includes("office")), "the carrier does not say what it carries");
+});
+
+// At the five hundred devices one overview carries, a ring of five hundred dots is three
+// pixels apart and answers nothing.
+test("a large network draws what matters and counts the rest", () => {
+  const svg = drawOf(500, { faults: [1], carrying: [0, 2] });
+  assert.equal(svg.querySelectorAll("circle.node.many").length, 1);
+  // Three notable devices and the one standing for everyone else.
+  assert.equal(svg.querySelectorAll("circle.node").length, 4);
+  const summary = [...svg.querySelectorAll(".node-label")].find((t) => t.textContent.includes("more"));
+  assert.ok(summary, "the devices not drawn are not accounted for");
+  assert.ok(summary.textContent.startsWith("497"), `said ${summary.textContent}`);
+});
+
+// Colour is never the only signal — a stated rule of this stylesheet, and a fault is the
+// one thing on the page somebody must not miss.
+test("a fault carries a mark as well as a colour", () => {
+  const svg = drawOf(6, { faults: [1] });
+  assert.equal(svg.querySelectorAll(".node-mark").length, 1);
+  assert.equal(svg.querySelector(".node-mark").textContent, "!");
+});
+
+test("the diagram is sized to what it drew, so its labels are never clipped", () => {
+  const svg = drawOf(6, { carrying: [0] });
+  const [x, y, w, h] = svg.getAttribute("viewBox").split(" ").map(Number);
+  assert.ok(w > 0 && h > 0);
+  // The width and height attributes carry the same size, so a user unit is a pixel and the
+  // text renders at the size it is set in rather than scaled to the container.
+  assert.equal(Number(svg.getAttribute("width")), Math.round(w));
+  assert.equal(Number(svg.getAttribute("height")), Math.round(h));
+});
+
+test("a network with no devices says so rather than drawing an empty ring", () => {
+  const panel = renderTopology({ route_groups: [] }, []);
+  assert.equal(panel.querySelector("svg"), null);
+  assert.match(panel.textContent, /no devices/i);
+});


### PR DESCRIPTION
The standing requirement since `web/` was an empty directory: the page should give a **visual view of the network** rather than a list of tables. This is that, for one network.

## It is a hub, because that is what the network is

Everything relays (ADR-0002), so a line between two devices would be **a path that does not exist** — the one thing a diagram of a network must not draw.

A test asserts every line starts at the relay, and it is the test worth having here: this drawing is easy to make prettier by making it a lie.

Seeing the hub is worth something on its own. It is why throughput is what it is, and it is what a direct path would eventually remove — the largest gap this project has, drawn rather than described.

## It scales by drawing what the page is for

A device that **carries a prefix or reports a fault** is drawn and named; the rest are dots. Past two dozen the dots stop being drawn and are counted instead:

| devices | drawn | labelled |
|---|---|---|
| 6 | 6 | the faulted one and the carrier |
| 12 | 12 | same |
| 60 | 3 + "57 more, all well" | 4 |
| 500 | 3 + "497 more, all well" | 4 |

At 500 a ring of identical dots is 3px apart and answers neither of the questions this page exists to ask.

## A sizing bug I caused and caught

The viewBox is measured from what was drawn rather than being a fixed canvas the content sits inside — but with **only** a viewBox the browser scales to the container, so a four-device diagram rendered at twice life size and a forty-device one at half. The `width` and `height` attributes now carry the same number, so a user unit is a pixel and the labels render at the size they are set in.

That is the sort of thing that looks like nobody checked, because nobody had.

## What it refuses to say

Nothing indicates which advertiser is *chosen*. The server owns the order and the agent owns the choice (ADR-0003), so no such fact exists — and a diagram is where inventing one would be easiest and least visible.

A fault carries a **mark as well as a colour**, which is this stylesheet's own stated rule and matters most on the one thing somebody must not miss.

## Checks

Eight tests, mutation-tested — joining two devices, drawing everything however many there are, naming every device, and marking a fault by colour alone each fail exactly the test that should catch them.

Both themes · 375px, where it scales to 9.8px labels without the page scrolling sideways · across polls, where the keyed nodes mean the diagram does not blink every five seconds.

41 page tests pass.