### PR TITLE
fix(web): sign in down a column, not across a screen

### DIFF
--- a/web/app.css
+++ b/web/app.css
@@ -86,6 +86,12 @@ main { max-width: 1100px; margin: 0 auto; padding: 16px; }
 /* A panel holding one control does not need to look like a section. */
 .panel.slim { padding: 10px 16px; }
 
+/* A form is read down a column, not across a screen. Sign-in spanning the full width of a
+   desktop put a password field a thousand pixels wide, which is the first thing anybody
+   sees of this control plane. */
+.panel.narrow { max-width: 420px; margin-left: auto; margin-right: auto; }
+.panel.narrow input { width: 100%; min-width: 0; }
+
 h1 { font-size: 20px; margin: 0 0 4px; }
 h2 {
   font-size: 13px;

--- a/web/app.js
+++ b/web/app.js
@@ -1351,7 +1351,7 @@ function renderSignIn(message, options = {}) {
   show(
     el(
       "div",
-      { class: "panel" },
+      { class: "panel narrow" },
       el("h1", {}, "Sign in"),
       el(
         "p",


### PR DESCRIPTION
The sign-in panel spanned the full width of the page — on a desktop that is a **password field a thousand pixels wide**. It is the first thing anybody sees of this control plane.

The inputs carry a 260px minimum to stop them collapsing, and nothing stopped them stretching. Constrained to a 420px column and centred; the inputs fill it rather than carrying their own minimum, so the form is one shape at every width.

41 page tests pass.