### PR TITLE
feat(cli): meshp dns and meshp token

### DIFF
--- a/cmd/meshp/dns.go
+++ b/cmd/meshp/dns.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/meshpnet/meshp/internal/cliapi"
+)
+
+// The names an administrator writes down (ADR-0021 §2).
+//
+// Nothing derives these from the peer list: a device's own name resolves already, and these
+// are the extra ones somebody chose — `db.hq.meshp.internal` pointing at whichever machine
+// is the database this month. So they are edited, and this is where.
+
+type dnsRecord struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	FQDN  string `json:"fqdn"`
+	Type  string `json:"type"`
+	Value string `json:"value"`
+	TTL   int    `json:"ttl_seconds"`
+}
+
+func cmdDNS(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: meshp dns <list|add|remove>")
+	}
+	switch args[0] {
+	case "list":
+		return cmdDNSList(ctx, args[1:])
+	case "add":
+		return cmdDNSAdd(ctx, args[1:])
+	case "remove":
+		return cmdDNSRemove(ctx, args[1:])
+	default:
+		return fmt.Errorf("unknown verb %q; meshp dns takes list, add or remove", args[0])
+	}
+}
+
+// dnsRecords reads a network's records.
+func dnsRecords(ctx context.Context, client *cliapi.Client, networkID string) ([]dnsRecord, error) {
+	var body struct {
+		Records []dnsRecord `json:"records"`
+	}
+	err := client.Do(ctx, "GET", "/api/v1/networks/"+networkID+"/dns-records", nil, &body)
+	return body.Records, err
+}
+
+func cmdDNSList(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp dns list", flag.ContinueOnError)
+	wantNetwork := fs.String("network", "", "Which network, by slug or id")
+	// One name can carry several records, and then a name is not enough to remove one. Off
+	// by default because a column of UUIDs is noise for the reading this command is mostly
+	// for; named in the error that needs it.
+	ids := fs.Bool("ids", false, "Show record ids, which 'dns remove' takes when a name is ambiguous")
+	if _, err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	client, cred, err := signedIn()
+	if err != nil {
+		return err
+	}
+	net, err := chooseNetwork(ctx, client, *wantNetwork, cred.Network)
+	if err != nil {
+		return err
+	}
+	records, err := dnsRecords(ctx, client, net.ID)
+	if err != nil {
+		return err
+	}
+	if len(records) == 0 {
+		fmt.Printf("%s has no names beyond the ones devices resolve for themselves.\n", net.qualified())
+		return nil
+	}
+
+	// The fully qualified name, because that is what somebody types into a browser — the
+	// short name is what they typed into `dns add` and is only half the answer.
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	if *ids {
+		_, _ = fmt.Fprintln(w, "NAME\tTYPE\tVALUE\tTTL\tID")
+	} else {
+		_, _ = fmt.Fprintln(w, "NAME\tTYPE\tVALUE\tTTL")
+	}
+	for _, r := range records {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%ds", r.FQDN, r.Type, r.Value, r.TTL)
+		if *ids {
+			_, _ = fmt.Fprintf(w, "\t%s", r.ID)
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+	return w.Flush()
+}
+
+func cmdDNSAdd(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp dns add", flag.ContinueOnError)
+	wantNetwork := fs.String("network", "", "Which network, by slug or id")
+	recordType := fs.String("type", "A", "A, AAAA or CNAME")
+	rest, err := parseFlags(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 2 {
+		return errors.New("usage: meshp dns add <name> <value> [--type A] [--network n]")
+	}
+
+	client, cred, err := signedIn()
+	if err != nil {
+		return err
+	}
+	net, err := chooseNetwork(ctx, client, *wantNetwork, cred.Network)
+	if err != nil {
+		return err
+	}
+
+	var out dnsRecord
+	body := map[string]any{
+		"name":  rest[0],
+		"type":  strings.ToUpper(*recordType),
+		"value": rest[1],
+	}
+	if err := client.Do(ctx, "POST",
+		"/api/v1/networks/"+net.ID+"/dns-records", body, &out); err != nil {
+		return err
+	}
+	fmt.Printf("%s resolves to %s. Every device in %s is being told.\n",
+		out.FQDN, out.Value, net.qualified())
+	return nil
+}
+
+func cmdDNSRemove(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp dns remove", flag.ContinueOnError)
+	wantNetwork := fs.String("network", "", "Which network, by slug or id")
+	yes := fs.Bool("yes", false, "Do not ask")
+	rest, err := parseFlags(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
+		return errors.New("usage: meshp dns remove <name> [--network n]")
+	}
+
+	client, cred, err := signedIn()
+	if err != nil {
+		return err
+	}
+	net, err := chooseNetwork(ctx, client, *wantNetwork, cred.Network)
+	if err != nil {
+		return err
+	}
+	records, err := dnsRecords(ctx, client, net.ID)
+	if err != nil {
+		return err
+	}
+	target, err := findRecord(records, rest[0])
+	if err != nil {
+		return err
+	}
+
+	if err := confirm(*yes, fmt.Sprintf(
+		"Remove %s, which resolves to %s? Devices stop resolving it immediately.",
+		target.FQDN, target.Value)); err != nil {
+		return err
+	}
+	if err := client.Do(ctx, "DELETE",
+		"/api/v1/networks/"+net.ID+"/dns-records/"+target.ID, nil, nil); err != nil {
+		return err
+	}
+	fmt.Printf("Removed %s.\n", target.FQDN)
+	return nil
+}
+
+// findRecord resolves a name that may be short, fully qualified, or an id.
+//
+// Both forms, because `dns list` prints the long one and `dns add` took the short one, and
+// requiring somebody to convert between two things the tool showed them is the sort of
+// friction that makes a command line worse than the curl it replaced.
+func findRecord(records []dnsRecord, want string) (dnsRecord, error) {
+	var matched []dnsRecord
+	for _, r := range records {
+		if r.ID == want {
+			return r, nil
+		}
+		if strings.EqualFold(r.Name, want) || strings.EqualFold(r.FQDN, want) {
+			matched = append(matched, r)
+		}
+	}
+	switch len(matched) {
+	case 1:
+		return matched[0], nil
+	case 0:
+		return dnsRecord{}, fmt.Errorf("no name %q in this network", want)
+	default:
+		// One name can carry several records — two A records for a pair of machines is the
+		// ordinary way to say "either of these". Removing whichever came back first would
+		// take away half an answer.
+		return dnsRecord{}, fmt.Errorf(
+			"%q has %d records; name one by its id, which 'meshp dns list --ids' prints",
+			want, len(matched))
+	}
+}

--- a/cmd/meshp/dnstoken_test.go
+++ b/cmd/meshp/dnstoken_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- names -------------------------------------------------------------------------------
+
+func TestFindRecordTakesEitherFormItPrinted(t *testing.T) {
+	records := []dnsRecord{
+		{ID: "r1", Name: "db", FQDN: "db.hq.meshp.internal", Value: "10.0.0.2"},
+		{ID: "r2", Name: "web", FQDN: "web.hq.meshp.internal", Value: "10.0.0.3"},
+	}
+	// `dns add` takes the short name and `dns list` prints the long one; requiring somebody
+	// to convert between two things the tool showed them is friction the curl did not have.
+	for _, want := range []string{"db", "db.hq.meshp.internal", "DB", "r1"} {
+		got, err := findRecord(records, want)
+		if err != nil {
+			t.Fatalf("findRecord(%q): %v", want, err)
+		}
+		if got.ID != "r1" {
+			t.Errorf("findRecord(%q) = %s, want r1", want, got.ID)
+		}
+	}
+}
+
+// One name can carry several records — two A records for a pair of machines is the ordinary
+// way to say "either of these" — and removing whichever came back first takes away half an
+// answer.
+func TestFindRecordRefusesANameThatCarriesSeveral(t *testing.T) {
+	records := []dnsRecord{
+		{ID: "r1", Name: "db", FQDN: "db.hq.meshp.internal", Value: "10.0.0.2"},
+		{ID: "r2", Name: "db", FQDN: "db.hq.meshp.internal", Value: "10.0.0.3"},
+	}
+	_, err := findRecord(records, "db")
+	if err == nil {
+		t.Fatal("an ambiguous name resolved")
+	}
+	if !strings.Contains(err.Error(), "--ids") {
+		t.Errorf("the error does not say how to get the ids: %v", err)
+	}
+}
+
+func TestFindRecordSaysWhenThereIsNoSuchName(t *testing.T) {
+	_, err := findRecord([]dnsRecord{{Name: "db"}}, "web")
+	if err == nil || !strings.Contains(err.Error(), "web") {
+		t.Errorf("want an error naming what was asked for, got %v", err)
+	}
+}
+
+// --- tokens ------------------------------------------------------------------------------
+
+func TestFindTokenTakesANameOrAnId(t *testing.T) {
+	tokens := []apiToken{{ID: "t1", Name: "ci"}, {ID: "t2", Name: "laptop"}}
+	for _, want := range []string{"ci", "CI", "t1"} {
+		got, err := findToken(tokens, want)
+		if err != nil {
+			t.Fatalf("findToken(%q): %v", want, err)
+		}
+		if got.ID != "t1" {
+			t.Errorf("findToken(%q) = %s, want t1", want, got.ID)
+		}
+	}
+}
+
+// Names are unique per person only among tokens that are live (migration 0016), so a name
+// somebody reuses after revoking matches both — and the live one is the one they mean.
+func TestFindTokenPrefersTheLiveOneOverItsRevokedNamesakes(t *testing.T) {
+	tokens := []apiToken{
+		{ID: "old", Name: "ci", Revoked: true},
+		{ID: "new", Name: "ci"},
+		{ID: "older", Name: "ci", Revoked: true},
+	}
+	got, err := findToken(tokens, "ci")
+	if err != nil {
+		t.Fatalf("findToken: %v", err)
+	}
+	if got.ID != "new" {
+		t.Errorf("resolved to %s, want the live one", got.ID)
+	}
+}
+
+func TestFindTokenRefusesWhenSeveralAreLive(t *testing.T) {
+	tokens := []apiToken{{ID: "a", Name: "ci"}, {ID: "b", Name: "ci"}}
+	if _, err := findToken(tokens, "ci"); err == nil {
+		t.Fatal("two live tokens of the same name resolved")
+	}
+}
+
+func TestFindTokenSaysWhenYouHoldNoSuchThing(t *testing.T) {
+	_, err := findToken([]apiToken{{Name: "ci"}}, "deploy")
+	if err == nil || !strings.Contains(err.Error(), "deploy") {
+		t.Errorf("want an error naming what was asked for, got %v", err)
+	}
+}
+
+// The column exists to answer "is anything still using this". The control plane records the
+// timestamp only when it has drifted by more than a minute, so a precise rendering would
+// invite reading it as a precision it does not have.
+func TestLastUsedIsCoarseAndSaysNeverWhenItNeverWas(t *testing.T) {
+	if got := lastUsed(nil); got != "never" {
+		t.Errorf("lastUsed(nil) = %q, want never", got)
+	}
+	recent := time.Now().Add(-10 * time.Minute)
+	if got := lastUsed(&recent); got != "within the hour" {
+		t.Errorf("ten minutes ago = %q", got)
+	}
+	yesterday := time.Now().Add(-30 * time.Hour)
+	if got := lastUsed(&yesterday); !strings.HasSuffix(got, "d ago") {
+		t.Errorf("thirty hours ago = %q, want days", got)
+	}
+}

--- a/cmd/meshp/login.go
+++ b/cmd/meshp/login.go
@@ -44,7 +44,7 @@ func cmdLogin(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	password, err := askForPassword()
+	password, err := askForPassword("use --token for a script")
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func cmdLogout(ctx context.Context, args []string) error {
 	fmt.Println("because a token may not revoke itself.")
 	fmt.Println("Press enter to skip.")
 
-	password, err := askForPassword()
+	password, err := askForPassword("use --local to forget it here without revoking it")
 	if err != nil || password == "" {
 		remainsValid(cred)
 		return nil
@@ -232,10 +232,12 @@ func askFor(label, given string) (string, error) {
 	return strings.TrimSpace(line), nil
 }
 
-// askForPassword reads without echoing.
-func askForPassword() (string, error) {
+// `instead` says what a script should do, because that differs by caller: signing in has
+// --token, and managing tokens has nothing — the control plane will not let a token manage
+// tokens, which is the property that makes one revocable.
+func askForPassword(instead string) (string, error) {
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		return "", errors.New("no terminal to ask for a password; use --token for a script")
+		return "", fmt.Errorf("no terminal to ask for a password; %s", instead)
 	}
 	fmt.Print("Password: ")
 	raw, err := term.ReadPassword(int(os.Stdin.Fd()))

--- a/cmd/meshp/main.go
+++ b/cmd/meshp/main.go
@@ -74,6 +74,16 @@ var commands = []command{
 		help: "Read and publish a network's access policy",
 		run:  cmdACL,
 	},
+	{
+		name: "dns", args: "<list|add|remove>",
+		help: "The names an administrator writes down, beyond the ones devices resolve",
+		run:  cmdDNS,
+	},
+	{
+		name: "token", args: "<list|create|revoke>",
+		help: "API tokens you hold, which is what 'meshp login' mints",
+		run:  cmdToken,
+	},
 }
 
 // lookup finds a command by name.

--- a/cmd/meshp/token.go
+++ b/cmd/meshp/token.go
@@ -1,0 +1,293 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/meshpnet/meshp/internal/cliapi"
+	"github.com/meshpnet/meshp/internal/clicred"
+)
+
+// API tokens: the credential a machine holds, and the one this CLI signs in with.
+//
+// Not enrolment tokens, which are the one-time secret a device redeems to join a network.
+// They share a word and nothing else — one is a person acting through a machine (ADR-0024
+// §2), the other is a device proving it was invited — and `meshp login` mints the kind this
+// noun manages, which is what settles which one `meshp token` should mean.
+//
+// **Every verb here signs in with a password rather than using the stored token.** That is
+// not a choice this file made: `/api/v1/me/tokens` is behind guardSignedIn, and the control
+// plane says why when a token tries it —
+//
+//	an API token cannot do this on its owner's behalf; a token that could mint a token
+//	would survive its own revocation
+//
+// which is the property worth having. So these commands do what `meshp login` does: open a
+// session, act, close it. It costs a password prompt, and the alternative is a credential
+// that cannot be taken away from whoever holds it.
+
+// withSession runs something as the signed-in person rather than as the stored token.
+func withSession(ctx context.Context, run func(*session) error) error {
+	cred, err := clicred.Load()
+	if errors.Is(err, clicred.ErrNotSignedIn) {
+		return errors.New("not signed in; run 'meshp login'")
+	}
+	if err != nil {
+		return err
+	}
+	client, err := cliapi.New(cred.ControlURL, "")
+	if err != nil {
+		return err
+	}
+
+	email := cred.Email
+	if email == "" {
+		// A credential from `login --token` before #227 knew who it belonged to.
+		if email, err = askFor("Email", ""); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintf(os.Stderr, "Signing in as %s to manage tokens.\n", email)
+	password, err := askForPassword(
+		"and an API token cannot manage tokens, so there is no scripted way to do this")
+	if err != nil {
+		return err
+	}
+	sess, err := openSession(ctx, client, email, password)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = sess.close(ctx) }()
+	return run(sess)
+}
+
+type apiToken struct {
+	ID         string     `json:"token_id"`
+	Name       string     `json:"name"`
+	Scope      string     `json:"scope"`
+	Owner      string     `json:"owner"`
+	Revoked    bool       `json:"revoked"`
+	ExpiresAt  time.Time  `json:"expires_at"`
+	CreatedAt  time.Time  `json:"created_at"`
+	LastUsedAt *time.Time `json:"last_used_at"`
+}
+
+func cmdToken(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: meshp token <list|create|revoke>")
+	}
+	switch args[0] {
+	case "list":
+		return cmdTokenList(ctx, args[1:])
+	case "create":
+		return cmdTokenCreate(ctx, args[1:])
+	case "revoke":
+		return cmdTokenRevoke(ctx, args[1:])
+	default:
+		return fmt.Errorf("unknown verb %q; meshp token takes list, create or revoke", args[0])
+	}
+}
+
+func cmdTokenList(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp token list", flag.ContinueOnError)
+	if _, err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	cred, _ := clicred.Load()
+	var body struct {
+		Tokens []apiToken `json:"tokens"`
+	}
+	if err := withSession(ctx, func(s *session) error {
+		return s.client.DoWithCookie(ctx, "GET", "/api/v1/me/tokens", s.cookie, nil, &body)
+	}); err != nil {
+		return err
+	}
+	if len(body.Tokens) == 0 {
+		fmt.Println("You hold no API tokens.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "\tNAME\tSCOPE\tLAST USED\tEXPIRES")
+	for _, t := range body.Tokens {
+		// The one this command is running on is marked, because revoking it is the one
+		// mistake here that locks somebody out of the thing they are using to fix it.
+		mark := " "
+		if t.ID == cred.TokenID {
+			mark = "*"
+		}
+		state := t.ExpiresAt.Format("2006-01-02")
+		if t.Revoked {
+			state = "revoked"
+		} else if time.Now().After(t.ExpiresAt) {
+			state = "expired"
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", mark, t.Name, t.Scope, lastUsed(t.LastUsedAt), state)
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	if cred.TokenID != "" {
+		fmt.Println("\n* is the one this command signed in with.")
+	}
+	return nil
+}
+
+// lastUsed says how long ago, or that it never was.
+//
+// Coarse on purpose: the column exists to answer "is anything still using this", and a
+// timestamp to the second invites reading it as a precise fact when the control plane
+// records it only when it has drifted by more than a minute.
+func lastUsed(at *time.Time) string {
+	if at == nil {
+		return "never"
+	}
+	d := time.Since(*at)
+	switch {
+	case d < time.Hour:
+		return "within the hour"
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}
+
+func cmdTokenCreate(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp token create", flag.ContinueOnError)
+	name := fs.String("name", "", "What to call it, so a list of tokens can be pruned")
+	rest, err := parseFlags(fs, args)
+	if err != nil {
+		return err
+	}
+	if *name == "" && len(rest) == 1 {
+		*name = rest[0]
+	}
+	if *name == "" {
+		return errors.New("usage: meshp token create <name>")
+	}
+
+	// The whole catalogue, intersected per request with what the owner actually holds
+	// (ADR-0024 §2). Asking for everything and receiving what the person has is what stops
+	// a token being narrower than the person driving it for no reason they chose.
+	var out struct {
+		ID    string `json:"token_id"`
+		Name  string `json:"name"`
+		Token string `json:"token"`
+	}
+	if err := withSession(ctx, func(s *session) error {
+		scope, err := s.permissions(ctx)
+		if err != nil {
+			return err
+		}
+		body := map[string]any{"name": *name, "permissions": scope}
+		return s.client.DoWithCookie(ctx, "POST", "/api/v1/me/tokens", s.cookie, body, &out)
+	}); err != nil {
+		return err
+	}
+
+	// Once, and to stdout alone, so `meshp token create ci > token` gives a file holding
+	// the secret and nothing else. The control plane keeps a hash; this is the only moment
+	// the value exists.
+	fmt.Fprintf(os.Stderr, "%s. This is the only time it is shown.\n", out.Name)
+	fmt.Println(out.Token)
+	return nil
+}
+
+func cmdTokenRevoke(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("meshp token revoke", flag.ContinueOnError)
+	yes := fs.Bool("yes", false, "Do not ask")
+	rest, err := parseFlags(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
+		return errors.New("usage: meshp token revoke <name|id>")
+	}
+
+	cred, _ := clicred.Load()
+	var body struct {
+		Tokens []apiToken `json:"tokens"`
+	}
+	var target apiToken
+	if err := withSession(ctx, func(s *session) error {
+		if err := s.client.DoWithCookie(ctx, "GET", "/api/v1/me/tokens", s.cookie, nil, &body); err != nil {
+			return err
+		}
+		found, err := findToken(body.Tokens, rest[0])
+		if err != nil {
+			return err
+		}
+		target = found
+		if target.Revoked {
+			return nil
+		}
+
+		question := fmt.Sprintf("Revoke %s? Anything using it stops working immediately.", target.Name)
+		if target.ID == cred.TokenID {
+			// The one thing here that locks somebody out of the tool they would fix it with.
+			question = fmt.Sprintf(
+				"%s is the token this machine signed in with. Revoking it signs you out "+
+					"here, and you will need 'meshp login' again. Continue?", target.Name)
+		}
+		if err := confirm(*yes, question); err != nil {
+			return err
+		}
+		return s.client.DoWithCookie(ctx, "DELETE", "/api/v1/me/tokens/"+target.ID, s.cookie, nil, nil)
+	}); err != nil {
+		return err
+	}
+	if target.Revoked {
+		fmt.Printf("%s is already revoked.\n", target.Name)
+		return nil
+	}
+	fmt.Printf("Revoked %s.\n", target.Name)
+
+	if target.ID == cred.TokenID {
+		// The stored credential is now a secret that opens nothing. Left behind it would
+		// make the next command fail with a refusal rather than with "not signed in".
+		if err := clicred.Forget(); err != nil {
+			return fmt.Errorf("revoked, but the local credential could not be removed: %w", err)
+		}
+		fmt.Println("Signed out here. Run 'meshp login' to sign in again.")
+	}
+	return nil
+}
+
+// findToken resolves a name or an id, and refuses a name that names two.
+func findToken(tokens []apiToken, want string) (apiToken, error) {
+	var matched []apiToken
+	for _, t := range tokens {
+		if t.ID == want {
+			return t, nil
+		}
+		if strings.EqualFold(t.Name, want) {
+			matched = append(matched, t)
+		}
+	}
+	switch len(matched) {
+	case 1:
+		return matched[0], nil
+	case 0:
+		return apiToken{}, fmt.Errorf("you hold no token called %q", want)
+	default:
+		// Names are unique per person among tokens that are live, so this is a live one and
+		// its revoked namesakes (migration 0016).
+		var live []apiToken
+		for _, t := range matched {
+			if !t.Revoked {
+				live = append(live, t)
+			}
+		}
+		if len(live) == 1 {
+			return live[0], nil
+		}
+		return apiToken{}, fmt.Errorf("%q names %d tokens; name one by its id", want, len(matched))
+	}
+}

--- a/cmd/meshp/usage_test.go
+++ b/cmd/meshp/usage_test.go
@@ -60,8 +60,7 @@ func TestTheNounsThatWereNeverBuiltAreNotCommands(t *testing.T) {
 	// `device` and `network` have left this list, which is what closing the gap looks like
 	// from here. The rest are still advertised nowhere and answer unknown command.
 	for _, name := range []string{
-		"user", "group",
-		"dns", "route-group", "exit", "relay", "token",
+		"user", "group", "route-group", "exit", "relay",
 	} {
 		if _, found := lookup(name); found {
 			t.Errorf("%q resolves; if it is implemented it belongs in the help", name)


### PR DESCRIPTION
Two more nouns against routes the API already had.

```
meshp dns   list [--ids] · add <name> <value> [--type A] · remove <name|fqdn|id>
meshp token list · create <name> · revoke <name|id>
```

## dns

Edits the names an administrator writes down (ADR-0021 §2) — the ones nothing derives from the peer list.

`remove` takes **either form the tool printed**: `add` was given a short name and `list` shows the fully qualified one, and making somebody convert between two things they were just shown is friction the curl did not have.

One name can carry several records — two A records for a pair of machines is the ordinary way to say "either of these" — so removing by name refuses when it is ambiguous and points at `dns list --ids`.

**That flag exists because the error message named it.** I wrote a message describing a flag nobody had implemented, which is exactly what #224 was about, and it was easier to do than I would like.

## token

API tokens: the credential a machine holds, not the enrolment token a device redeems. They share a word and nothing else, and `meshp login` mints the kind this noun manages — which settles the ambiguity the old help text left.

### Every verb signs in with a password, and that was a discovery

`/api/v1/me/tokens` is behind `guardSignedIn`. **Running it is how I found out** — the control plane refuses a token and says why:

> an API token cannot do this on its owner's behalf; a token that could mint a token would survive its own revocation

That is the property that makes a credential revocable at all. So these commands do what `meshp login` does: open a session, act, close it.

The token this machine signed in with is **marked in the list**, because revoking it is the single mistake here that locks somebody out of the tool they would fix it with. When they do it anyway, the local credential is forgotten, so the next command says "not signed in" rather than failing with a refusal.

### And a message that was lying

`askForPassword` now takes what a script should do instead, because that differs by caller. `meshp token list` was telling people to *"use --token for a script"* — which is `login`'s advice, and here is precisely what cannot work.

## Checks

Eight tests, mutation-tested — resolving an ambiguous record, dropping the fully qualified form, letting a revoked namesake win over the live token, and making last-used precise each fail exactly the test that should catch them.

Driven against a real control plane: names added and removed by short form, fully qualified form and id; a name made ambiguous on purpose and watched to refuse; and the token verbs confirmed to explain what they need rather than failing at the API.

`make lint` 0 issues · `go test ./...` clean · 41 page tests · `make reachability` clean · cross-compiles for all three.

Five nouns left: `user`, `group`, `route-group`, `exit`, `relay`.